### PR TITLE
Edit CICO quote failure logging for better alerting

### DIFF
--- a/packages/cloud-functions/src/bigQuery.ts
+++ b/packages/cloud-functions/src/bigQuery.ts
@@ -15,7 +15,7 @@ export const trackEvent = async (table: string, row: any) => {
 
     await bigQuery.dataset(bigQueryDataset).table(table).insert(row)
   } catch (error) {
-    console.error(`BigQuery error:`, JSON.stringify(error))
+    console.info(`BigQuery error:`, JSON.stringify(error))
     throw error
   }
 }

--- a/packages/cloud-functions/src/cico/Moonpay.ts
+++ b/packages/cloud-functions/src/cico/Moonpay.ts
@@ -82,7 +82,12 @@ export const Moonpay = {
         validPaymentMethods.map((method) => Moonpay.get(`${baseUrl}&paymentMethod=${method}`))
       )
 
-      return Moonpay.processRawQuotes(rawQuotes, exchangeRate)
+      const quotes = Moonpay.processRawQuotes(rawQuotes, exchangeRate)
+      if (!quotes.length) {
+        throw new Error('No quotes succeeded')
+      }
+
+      return quotes
     } catch (error) {
       console.error('Error fetching Moonpay quote: ', error)
       return []
@@ -151,12 +156,12 @@ export const Moonpay = {
       const data = await response.json()
 
       if (!response.ok) {
-        throw Error(`Response body: ${JSON.stringify(data)}`)
+        throw new Error(`Response body: ${JSON.stringify(data)}`)
       }
 
       return data
     } catch (error) {
-      console.error(`Moonpay get request failed.\nURL: ${path}\n`, error)
+      console.info(`Moonpay get request failed.\nURL: ${path}\n`, error)
       return null
     }
   },

--- a/packages/cloud-functions/src/cico/Ramp.ts
+++ b/packages/cloud-functions/src/cico/Ramp.ts
@@ -68,7 +68,12 @@ export const Ramp = {
         )
       )
 
-      return Ramp.processRawQuotes(rawQuotes, exchangeRate)
+      const quotes = Ramp.processRawQuotes(rawQuotes, exchangeRate)
+      if (!quotes.length) {
+        throw new Error('No quotes succeeded')
+      }
+
+      return quotes
     } catch (error) {
       console.error('Error fetching Ramp quote: ', error)
       return []
@@ -137,12 +142,12 @@ export const Ramp = {
       const data = await response.json()
 
       if (!response.ok) {
-        throw Error(`Response body: ${JSON.stringify(data)}`)
+        throw new Error(`Response body: ${JSON.stringify(data)}`)
       }
 
       return data
     } catch (error) {
-      console.error(`Ramp post request failed.\nURL: ${path}\n`, error)
+      console.info(`Ramp post request failed.\nURL: ${path}\n`, error)
       return null
     }
   },

--- a/packages/cloud-functions/src/cico/Simplex.ts
+++ b/packages/cloud-functions/src/cico/Simplex.ts
@@ -174,12 +174,12 @@ export const Simplex = {
 
       const data = await response.json()
       if (!response.ok) {
-        throw Error(`Response body ${JSON.stringify(data)}`)
+        throw new Error(`Response body ${JSON.stringify(data)}`)
       }
 
       return data
     } catch (error) {
-      console.error(`Simplex post request failed.\nURL: ${path}\n`, error)
+      console.info(`Simplex post request failed.\nURL: ${path}\n`, error)
       throw error
     }
   },

--- a/packages/cloud-functions/src/cico/Transak.ts
+++ b/packages/cloud-functions/src/cico/Transak.ts
@@ -72,7 +72,12 @@ export const Transak = {
         validPaymentMethods.map((method) => Transak.get(`${baseUrl}&paymentMethodId=${method}`))
       )
 
-      return Transak.processRawQuotes(rawQuotes, exchangeRate)
+      const quotes = Transak.processRawQuotes(rawQuotes, exchangeRate)
+      if (!quotes.length) {
+        throw new Error('No quotes succeeded')
+      }
+
+      return quotes
     } catch (error) {
       console.error('Error fetching Transak quote: ', error)
       return []
@@ -130,12 +135,12 @@ export const Transak = {
       const response = await fetchWithTimeout(path)
       const data = await response.json()
       if (!response.ok) {
-        throw Error(`Response body: ${JSON.stringify(data)}`)
+        throw new Error(`Response body: ${JSON.stringify(data)}`)
       }
 
       return data.response
     } catch (error) {
-      console.error(`Transak get request failed.\nURL: ${path}\n`, error)
+      console.info(`Transak get request failed.\nURL: ${path}\n`, error)
       return null
     }
   },

--- a/packages/cloud-functions/src/cico/Xanpool.ts
+++ b/packages/cloud-functions/src/cico/Xanpool.ts
@@ -62,9 +62,13 @@ export const Xanpool = {
               crypto: amount,
             }
 
-      const quote = await Xanpool.post(baseUrl, requestBody)
+      const rawQuote = await Xanpool.post(baseUrl, requestBody)
+      const quotes = Xanpool.processRawQuotes(rawQuote, exchangeRate, digitalAsset)
+      if (!quotes.length) {
+        throw new Error('No quotes succeeded')
+      }
 
-      return Xanpool.processRawQuotes(quote, exchangeRate, digitalAsset)
+      return quotes
     } catch (error) {
       console.error('Error fetching Xanpool quote: ', error)
       return []
@@ -115,13 +119,13 @@ export const Xanpool = {
 
       const data = await response.json()
       if (!response.ok) {
-        throw Error(`Response body: ${JSON.stringify(data)}`)
+        throw new Error(`Response body: ${JSON.stringify(data)}`)
       }
 
       const quote: XanpoolQuote = data
       return quote
     } catch (error) {
-      console.error(`Xanpool post request failed.\nURL: ${path}\n`, error)
+      console.info(`Xanpool post request failed.\nURL: ${path}\n`, error)
       return null
     }
   },

--- a/packages/cloud-functions/src/cico/fetchProviders.ts
+++ b/packages/cloud-functions/src/cico/fetchProviders.ts
@@ -168,5 +168,5 @@ export const fetchProviders = functions.https.onRequest(async (request, response
     },
   ]
 
-  response.send(JSON.stringify(providers))
+  response.status(200).send(JSON.stringify(providers))
 })

--- a/packages/cloud-functions/src/cico/fetchUserLocationData.ts
+++ b/packages/cloud-functions/src/cico/fetchUserLocationData.ts
@@ -54,5 +54,5 @@ export const fetchUserLocationData = functions.https.onRequest(async (req, res) 
     region: region_code,
     ipAddress: ip,
   }
-  res.send(JSON.stringify(userLocationData))
+  res.status(200).send(JSON.stringify(userLocationData))
 })


### PR DESCRIPTION
### Description
Reduce the number of `console.error` calls so that it happens at most once per failed quote request. This will allow for better log filtering and reporting.

### Other changes
N/A

### Tested
N/A

### How others should test
N/A

### Related issues
- Fixes #444 

### Backwards compatibility
N/A