### PR TITLE
Modify quote fetching for better error handling

### DIFF
--- a/packages/cloud-functions/src/cico/Moonpay.test.ts
+++ b/packages/cloud-functions/src/cico/Moonpay.test.ts
@@ -119,6 +119,25 @@ describe('Moonpay', () => {
     ])
   })
 
+  it('does not fetch quotes when digital asset is cEUR', async () => {
+    const fiatCurrency = 'USD'
+    const digitalAsset = DigitalAsset.CEUR
+    const userCountry = 'US'
+
+    fetchMock.mockResponse(
+      createMoonpayQuoteResponse(fiatCurrency, digitalAsset, 'credit_debit_card')
+    )
+
+    const quotes = await Moonpay.fetchQuote(
+      digitalAsset,
+      fiatCurrency,
+      FIAT_CASH_IN_AMOUNT,
+      userCountry
+    )
+
+    expect(quotes).toEqual([])
+  })
+
   it("fetches quotes correctly when fiatCurrency is not native to the user's location", async () => {
     const fiatCurrency = 'PHP'
     const digitalAsset = DigitalAsset.CUSD

--- a/packages/cloud-functions/src/cico/Moonpay.ts
+++ b/packages/cloud-functions/src/cico/Moonpay.ts
@@ -59,6 +59,11 @@ export const Moonpay = {
         throw Error('Purchase amount not provided')
       }
 
+      if (digitalAsset === DigitalAsset.CEUR) {
+        console.info('Moonpay does not yet support cEUR')
+        return []
+      }
+
       const { localCurrency, localAmount, exchangeRate } = await Moonpay.convertToLocalCurrency(
         userCountry,
         fiatCurrency,

--- a/packages/cloud-functions/src/cico/Ramp.test.ts
+++ b/packages/cloud-functions/src/cico/Ramp.test.ts
@@ -90,6 +90,30 @@ describe('Ramp', () => {
     ])
   })
 
+  it('fetches quotes correctly when digital asset is cEUR', async () => {
+    const fiatCurrency = 'USD'
+    const digitalAsset = DigitalAsset.CEUR
+    const userCountry = 'US'
+
+    fetchMock.mockResponse(createRampQuoteResponse(fiatCurrency, digitalAsset, 'CARD_PAYMENT'))
+
+    const quotes = await Ramp.fetchQuote(
+      digitalAsset,
+      fiatCurrency,
+      FIAT_CASH_IN_AMOUNT,
+      userCountry
+    )
+
+    expect(quotes).toEqual([
+      {
+        paymentMethod: PaymentMethod.Card,
+        fiatFee: FIAT_FEE_AMOUNT,
+        returnedAmount: CRYPTO_AMOUNT_ACQUIRED,
+        digitalAsset,
+      },
+    ])
+  })
+
   it("fetches quotes correctly when fiatCurrency is not native to the user's location", async () => {
     const fiatCurrency = 'PHP'
     const digitalAsset = DigitalAsset.CUSD

--- a/packages/cloud-functions/src/cico/Simplex.ts
+++ b/packages/cloud-functions/src/cico/Simplex.ts
@@ -60,6 +60,11 @@ export const Simplex = {
         throw Error('No purchase amount provided')
       }
 
+      if (currencyToBuy === DigitalAsset.CEUR) {
+        console.info('Simplex does not yet support cEUR')
+        return
+      }
+
       const userUuid = await getOrCreateUuid(userAddress)
       const simplexQuote: SimplexQuote = await Simplex.post(
         `${SIMPLEX_DATA.api_url}/wallet/merchant/v2/quote`,
@@ -77,7 +82,7 @@ export const Simplex = {
 
       return simplexQuote
     } catch (error) {
-      console.error('Error fetching Simplex quote: ', error)
+      console.error(`Error fetching Simplex quote for address ${userAddress}: `, error)
     }
   },
   fetchPaymentRequest: async (
@@ -141,7 +146,7 @@ export const Simplex = {
       const simplexPaymentData: SimplexPaymentData = { paymentId, orderId, checkoutHtml }
       return simplexPaymentData
     } catch (error) {
-      console.error('Error fetching Simplex payment request: ', error)
+      console.error(`Error fetching Simplex payment request for address ${userAddress}: `, error)
     }
   },
   generateCheckoutForm: (paymentId: string) => `
@@ -177,9 +182,17 @@ export const Simplex = {
         throw new Error(`Response body ${JSON.stringify(data)}`)
       }
 
+      // Need to manually check for an error field because Simplex doesn't change the status code
+      if (data?.error) {
+        throw new Error(data.error)
+      }
+
       return data
     } catch (error) {
-      console.info(`Simplex post request failed.\nURL: ${path}\n`, error)
+      console.info(
+        `Simplex post request failed.\nURL: ${path} Body: ${JSON.stringify(body)}\n`,
+        error
+      )
       throw error
     }
   },

--- a/packages/cloud-functions/src/cico/Transak.test.ts
+++ b/packages/cloud-functions/src/cico/Transak.test.ts
@@ -115,6 +115,25 @@ describe('Transak', () => {
     ])
   })
 
+  it('does not fetch quotes when digital asset is cEUR', async () => {
+    const fiatCurrency = 'USD'
+    const digitalAsset = DigitalAsset.CEUR
+    const userCountry = 'US'
+
+    fetchMock.mockResponse(
+      createTransakQuoteResponse(fiatCurrency, digitalAsset, 'credit_debit_card')
+    )
+
+    const quotes = await Transak.fetchQuote(
+      digitalAsset,
+      fiatCurrency,
+      FIAT_CASH_IN_AMOUNT,
+      userCountry
+    )
+
+    expect(quotes).toEqual([])
+  })
+
   it("fetches quotes correctly when fiatCurrency is not native to the user's location", async () => {
     const fiatCurrency = 'PHP'
     const digitalAsset = DigitalAsset.CUSD

--- a/packages/cloud-functions/src/cico/Transak.ts
+++ b/packages/cloud-functions/src/cico/Transak.ts
@@ -48,6 +48,11 @@ export const Transak = {
         throw Error('Purchase amount not provided')
       }
 
+      if (digitalAsset === DigitalAsset.CEUR) {
+        console.info('Transak does not yet support cEUR')
+        return []
+      }
+
       const { localCurrency, localAmount, exchangeRate } = await Transak.convertToLocalCurrency(
         userCountry,
         fiatCurrency,

--- a/packages/cloud-functions/src/cico/Xanpool.test.ts
+++ b/packages/cloud-functions/src/cico/Xanpool.test.ts
@@ -90,6 +90,24 @@ describe('Xanpool', () => {
     ])
   })
 
+  it('does not fetch quotes when digital asset is cEUR', async () => {
+    const fiatCurrency = 'PHP'
+    const digitalAsset = DigitalAsset.CEUR
+    const userCountry = 'PH'
+
+    fetchMock.mockResponse(createXanpoolQuoteResponse(fiatCurrency))
+
+    const quotes = await Xanpool.fetchQuote(
+      'buy',
+      digitalAsset,
+      fiatCurrency,
+      FIAT_CASH_IN_AMOUNT,
+      userCountry
+    )
+
+    expect(quotes).toEqual([])
+  })
+
   it("fetches quotes correctly when fiatCurrency is not native to the user's location", async () => {
     const fiatCurrency = 'USD'
     const digitalAsset = DigitalAsset.CUSD

--- a/packages/cloud-functions/src/cico/Xanpool.ts
+++ b/packages/cloud-functions/src/cico/Xanpool.ts
@@ -37,6 +37,11 @@ export const Xanpool = {
         amount
       )
 
+      if (digitalAsset === DigitalAsset.CEUR) {
+        console.info('Xanpool does not yet support cEUR')
+        return []
+      }
+
       if (!XANPOOL_DATA.supported_currencies.includes(localCurrency)) {
         throw Error('Currency not supported')
       }

--- a/packages/cloud-functions/src/config.ts
+++ b/packages/cloud-functions/src/config.ts
@@ -78,6 +78,7 @@ export enum FiatCurrency {
 export enum DigitalAsset {
   CELO = 'CELO',
   CUSD = 'CUSD',
+  CEUR = 'CEUR',
 }
 
 export const FETCH_TIMEOUT_DURATION = 10000 // 10 seconds


### PR DESCRIPTION
### Description
This PR does two things to make make the quote fetching cloud-function handle errors a little better:
1. Add an explicit check for an error from the Simplex quote endpoint. It appears that Simplex doesn't always properly change the response status code to reflect an error so we need to explicitly check for an error object
2. Short circuit cEUR quote fetching for providers that don't support cEUR

### Other changes
N/A

### Tested
Yes

### How others should test
N/A

### Related issues
N/A

### Backwards compatibility
Yes