### PR TITLE
Add Release Automation workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,4 +27,7 @@ jobs:
         with:
           node-version: '12'
           check-latest: true
+      - run: |
+          brew tap wix/brew
+          brew install applesimutils
       - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '12.5'
+          xcode-version: '12.5.1'
       - uses: actions/setup-node@v2
         with:
           node-version: '12'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,3 +32,4 @@ jobs:
           brew install applesimutils
       - uses: actions/checkout@v2
       - run: yarn
+      - run: yarn build:wallet

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,3 +31,4 @@ jobs:
           brew tap wix/brew
           brew install applesimutils
       - uses: actions/checkout@v2
+      - run: yarn

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,23 @@
+name: Release
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: 'Log level'     
+        required: true
+        default: 'warning'
+      tags:
+        description: 'Release'
+
+jobs:
+  testflight:
+    name: TestFlight
+    runs-on: macos-10.15
+    steps:
+      - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,5 +32,7 @@ jobs:
           brew install applesimutils
       - uses: actions/checkout@v2
       - run: yarn
-      - run: bundle install
+      - run: |
+          cd packages/mobile
+          bundle install
       - run: yarn build:wallet

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,4 +20,11 @@ jobs:
     name: TestFlight
     runs-on: macos-10.15
     steps:
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '12.5'
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '12'
+          check-latest: true
       - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,11 +18,11 @@ on:
 jobs:
   testflight:
     name: TestFlight
-    runs-on: macos-10.15
+    runs-on: macos-11
     steps:
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: latest-stable
+          xcode-version: '12.5.1'
       - uses: actions/setup-node@v2
         with:
           node-version: '12'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '12.5.1'
+          xcode-version: latest-stable
       - uses: actions/setup-node@v2
         with:
           node-version: '12'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,4 +32,5 @@ jobs:
           brew install applesimutils
       - uses: actions/checkout@v2
       - run: yarn
+      - run: bundle install
       - run: yarn build:wallet


### PR DESCRIPTION
### Description

**Work in Progress!!! DO NOT REVIEW!**

This is the introduction PR for the automated release process using GitHub Actions. It will configure the environment, build the iOS and Android apps, and upload the build to TestFlight and Google Play Console.

### Other changes

No minor changes.

### Tested

This will be replacing the manual release process. It will be tested thoroughly to ensure same input equals same output. This will be replaced once testing has been done to explain how it was tested.

### How others should test

Please verify the results and report any discrepancies to @noisypigeon.

### Related issues

- Consolidates #957.
- Implements #958.
- Implements #959.
- Implements #960.

### Backwards compatibility

The Release Process document will be rewritten to work along side this automated process. It will still be possible to do releases manually but it would be preferred to reach out to @noisypigeon and debug any issues that arise.