### PR TITLE
Use isLoading to disable withdrawal button

### DIFF
--- a/packages/mobile/src/exchange/WithdrawCeloReviewScreen.tsx
+++ b/packages/mobile/src/exchange/WithdrawCeloReviewScreen.tsx
@@ -67,6 +67,7 @@ function WithdrawCeloReviewScreen({ route }: Props) {
         />
       </View>
       <Button
+        disabled={isLoading}
         onPress={onConfirmWithdraw}
         text={t(`global:withdraw`)}
         type={BtnTypes.TERTIARY}


### PR DESCRIPTION
### Description

A small fix for #939 to prevent the user from being able to tap withdrawal twice triggering a double withdrawal.

### Tested

Tested locally on iOS and Android Emulators

### How others should test

1. Start a withdrawal and attempt to tap the button multiple times to trigger a double withdrawal
2. Start a withdrawal and when prompted for the pin entry click bank and see that withdrawal becomes enabled again.

### Related issues

- Fixes #939

### Backwards compatibility

This is a minor change and should be backward compatible