### PR TITLE
Label invite rewards correctly in the feed

### DIFF
--- a/packages/mobile/locales/en-US/walletFlow5.json
+++ b/packages/mobile/locales/en-US/walletFlow5.json
@@ -91,6 +91,8 @@
   "feedItemCeloRewardReceivedTitle": "Earned CELO",
   "feedItemRewardReceivedTitle": "CELO Network",
   "feedItemRewardReceivedInfo": "Weekly Earnings",
+  "feedItemInviteRewardReceivedTitle": "CELO Network",
+  "feedItemInviteRewardReceivedInfo": "Reward Received",
   "feedItemReceivedTitle": "{{displayName}}",
   "feedItemReceivedInfo": "{{comment}}",
   "feedItemReceivedInfo_noComment": "Payment Received",

--- a/packages/mobile/src/config.ts
+++ b/packages/mobile/src/config.ts
@@ -144,7 +144,7 @@ export const SPEND_MERCHANT_LINKS: SpendMerchant[] = [
 export const VALORA_LOGO_URL =
   'https://storage.googleapis.com/celo-mobile-mainnet.appspot.com/images/valora-icon.png'
 export const CELO_LOGO_URL =
-  'https://firebasestorage.googleapis.com/v0/b/celo-mobile-mainnet.appspot.com/o/images%2Fcelo.png?alt=media'
+  'https://firebasestorage.googleapis.com/v0/b/celo-mobile-mainnet.appspot.com/o/images%2Fcelo.jpeg?alt=media'
 
 export const SIMPLEX_URI = 'https://valoraapp.com/simplex'
 export const SIMPLEX_FEES_URL =

--- a/packages/mobile/src/firebase/firebase.ts
+++ b/packages/mobile/src/firebase/firebase.ts
@@ -295,13 +295,21 @@ export async function fetchLostAccounts() {
 }
 
 export async function fetchRewardsSenders() {
+  return fetchListFromFirebase('rewardsSenders')
+}
+
+export async function fetchInviteRewardsSenders() {
+  return fetchListFromFirebase('inviteRewardAddresses')
+}
+
+async function fetchListFromFirebase(path: string) {
   if (!FIREBASE_ENABLED) {
     return []
   }
   return eventChannel((emit: any) => {
     const onValueChange = firebase
       .database()
-      .ref('rewardsSenders')
+      .ref(path)
       .on(
         VALUE_CHANGE_HOOK,
         (snapshot) => {
@@ -312,7 +320,7 @@ export async function fetchRewardsSenders() {
         }
       )
 
-    return () => firebase.database().ref('rewardsSenders').off(VALUE_CHANGE_HOOK, onValueChange)
+    return () => firebase.database().ref(path).off(VALUE_CHANGE_HOOK, onValueChange)
   })
 }
 

--- a/packages/mobile/src/recipients/reducer.ts
+++ b/packages/mobile/src/recipients/reducer.ts
@@ -72,6 +72,10 @@ export const valoraRecipientCacheSelector = (state: RootState) =>
 export const rewardsSendersSelector = (state: RootState) => state.recipients.rewardsSenders
 export const inviteRewardsSendersSelector = (state: RootState) =>
   state.recipients.inviteRewardsSenders
+export const allRewardsSendersSelector = (state: RootState) => [
+  ...state.recipients.rewardsSenders,
+  ...state.recipients.inviteRewardsSenders,
+]
 
 export const recipientInfoSelector = (state: RootState) => {
   return {

--- a/packages/mobile/src/recipients/reducer.ts
+++ b/packages/mobile/src/recipients/reducer.ts
@@ -13,12 +13,14 @@ export interface State {
   // and includes CIP8 profile data if available
   valoraRecipientCache: AddressToRecipient
   rewardsSenders: string[]
+  inviteRewardsSenders: string[]
 }
 
 const initialState: State = {
   phoneRecipientCache: {},
   valoraRecipientCache: {},
   rewardsSenders: [],
+  inviteRewardsSenders: [],
 }
 
 const rehydrate = createAction<any>(REHYDRATE)
@@ -29,6 +31,9 @@ export const updateValoraRecipientCache = createAction<AddressToRecipient>(
   'RECIPIENTS/SET_VALORA_RECIPIENT_CACHE'
 )
 export const rewardsSendersFetched = createAction<string[]>('RECIPIENTS/REWARDS_SENDERS_FETCHED')
+export const inviteRewardsSendersFetched = createAction<string[]>(
+  'RECIPIENTS/INVITE_REWARDS_SENDERS_FETCHED'
+)
 
 export const recipientsReducer = createReducer(initialState, (builder) => {
   builder
@@ -54,6 +59,10 @@ export const recipientsReducer = createReducer(initialState, (builder) => {
       ...state,
       rewardsSenders: action.payload,
     }))
+    .addCase(inviteRewardsSendersFetched, (state, action) => ({
+      ...state,
+      inviteRewardsSenders: action.payload,
+    }))
 })
 
 export const phoneRecipientCacheSelector = (state: RootState) =>
@@ -61,6 +70,8 @@ export const phoneRecipientCacheSelector = (state: RootState) =>
 export const valoraRecipientCacheSelector = (state: RootState) =>
   state.recipients.valoraRecipientCache
 export const rewardsSendersSelector = (state: RootState) => state.recipients.rewardsSenders
+export const inviteRewardsSendersSelector = (state: RootState) =>
+  state.recipients.inviteRewardsSenders
 
 export const recipientInfoSelector = (state: RootState) => {
   return {

--- a/packages/mobile/src/recipients/saga.ts
+++ b/packages/mobile/src/recipients/saga.ts
@@ -1,6 +1,6 @@
 import { call, cancelled, put, spawn, take } from 'redux-saga/effects'
-import { fetchRewardsSenders } from 'src/firebase/firebase'
-import { rewardsSendersFetched } from 'src/recipients/reducer'
+import { fetchInviteRewardsSenders, fetchRewardsSenders } from 'src/firebase/firebase'
+import { inviteRewardsSendersFetched, rewardsSendersFetched } from 'src/recipients/reducer'
 import Logger from 'src/utils/Logger'
 
 const TAG = 'recipientsSaga'
@@ -25,6 +25,27 @@ function* fetchRewardsSendersSaga() {
   }
 }
 
+function* fetchInviteRewardsSendersSaga() {
+  const rewardsSendersChannel = yield call(fetchInviteRewardsSenders)
+  if (!rewardsSendersChannel) {
+    return
+  }
+  try {
+    while (true) {
+      const rewardsSenders: string[] = yield take(rewardsSendersChannel)
+      yield put(inviteRewardsSendersFetched(rewardsSenders))
+      Logger.info(`${TAG}@fetchInviteRewardsSendersSaga`, rewardsSenders)
+    }
+  } catch (error) {
+    Logger.error(`${TAG}@fetchInviteRewardsSendersSaga`, error)
+  } finally {
+    if (yield cancelled()) {
+      rewardsSendersChannel.close()
+    }
+  }
+}
+
 export function* recipientsSaga() {
   yield spawn(fetchRewardsSendersSaga)
+  yield spawn(fetchInviteRewardsSendersSaga)
 }

--- a/packages/mobile/src/transactions/TransactionReview.tsx
+++ b/packages/mobile/src/transactions/TransactionReview.tsx
@@ -11,7 +11,7 @@ import { HeaderTitleWithSubtitle, headerWithBackButton } from 'src/navigator/Hea
 import { Screens } from 'src/navigator/Screens'
 import { StackParamList } from 'src/navigator/types'
 import { getRecipientFromAddress, RecipientInfo } from 'src/recipients/recipient'
-import { recipientInfoSelector, rewardsSendersSelector } from 'src/recipients/reducer'
+import { allRewardsSendersSelector, recipientInfoSelector } from 'src/recipients/reducer'
 import { RootState } from 'src/redux/reducers'
 import useSelector from 'src/redux/useSelector'
 import TransferConfirmationCard, {
@@ -79,7 +79,7 @@ function TransactionReview({ navigation, route, addressHasChanged, recipientInfo
     confirmationProps,
   } = route.params
   const addressToDisplayName = useSelector(addressToDisplayNameSelector)
-  const rewardsSenders = useSelector(rewardsSendersSelector)
+  const rewardsSenders = useSelector(allRewardsSendersSelector)
 
   useLayoutEffect(() => {
     const dateTimeStatus = getDatetimeDisplayString(timestamp, i18n)

--- a/packages/mobile/src/transactions/TransferFeedItem.tsx
+++ b/packages/mobile/src/transactions/TransferFeedItem.tsx
@@ -10,7 +10,7 @@ import { Namespaces } from 'src/i18n'
 import { addressToDisplayNameSelector, AddressToE164NumberType } from 'src/identity/reducer'
 import { InviteDetails } from 'src/invite/actions'
 import { getRecipientFromAddress, NumberToRecipient, RecipientInfo } from 'src/recipients/recipient'
-import { rewardsSendersSelector } from 'src/recipients/reducer'
+import { inviteRewardsSendersSelector, rewardsSendersSelector } from 'src/recipients/reducer'
 import { navigateToPaymentTransferReview } from 'src/transactions/actions'
 import TransactionFeedItem from 'src/transactions/TransactionFeedItem'
 import TransferFeedIcon from 'src/transactions/TransferFeedIcon'
@@ -61,6 +61,7 @@ export function TransferFeedItem(props: Props) {
   const { t } = useTranslation(Namespaces.walletFlow5)
   const addressToDisplayName = useSelector(addressToDisplayNameSelector)
   const rewardsSenders = useSelector(rewardsSendersSelector)
+  const inviteRewardSenders = useSelector(inviteRewardsSendersSelector)
   const txHashToFeedInfo = useSelector(txHashToFeedInfoSelector)
 
   const onPress = () => {
@@ -98,6 +99,7 @@ export function TransferFeedItem(props: Props) {
     recipientInfo,
     addressToDisplayName[address]?.isCeloRewardSender ?? false,
     rewardsSenders.includes(address),
+    inviteRewardSenders.includes(address),
     txHashToFeedInfo[hash],
     amount.currencyCode
   )

--- a/packages/mobile/src/transactions/transferFeedUtils.ts
+++ b/packages/mobile/src/transactions/transferFeedUtils.ts
@@ -105,6 +105,7 @@ export function getTransferFeedParams(
   recipientInfo: RecipientInfo,
   isCeloRewardSender: boolean,
   isRewardSender: boolean,
+  isInviteRewardSender: boolean,
   providerInfo: ProviderFeedInfo | undefined,
   currency: string
 ) {
@@ -177,6 +178,10 @@ export function getTransferFeedParams(
       } else if (isRewardSender) {
         title = t('feedItemRewardReceivedTitle')
         info = t('feedItemRewardReceivedInfo')
+        Object.assign(recipient, { thumbnailPath: CELO_LOGO_URL })
+      } else if (isInviteRewardSender) {
+        title = t('feedItemInviteRewardReceivedTitle')
+        info = t('feedItemInviteRewardReceivedInfo')
         Object.assign(recipient, { thumbnailPath: CELO_LOGO_URL })
       } else if (providerInfo) {
         title = t('feedItemReceivedTitle', { displayName })

--- a/packages/mobile/test/schemas.ts
+++ b/packages/mobile/test/schemas.ts
@@ -718,6 +718,10 @@ export const v17Schema = {
       allowedDeployers: [],
     },
   },
+  recipients: {
+    ...v16Schema.recipients,
+    inviteRewardsSenders: [],
+  },
 }
 
 export function getLatestSchema(): Partial<RootState> {


### PR DESCRIPTION
### Description

We are now fetching the list of `inviteRewardsSenders` from Firebase to show the correct name/description from transactions coming from addresses used to distribute invite rewards.

### Other changes

- Changed `CELO_LOGO_URL` to use a jpeg with a white background.

### Tested

Manually


### How others should test

- Invite someone to Valora (in alfajores only for now) 
- Verify with their phone number and claim the money sent
- Check that you received the reward in the account you used to send the invitation
- Verify that the sender of the invite reward says "CELO Network" and the description "Reward received"

### Related issues

- Fixes #986

### Backwards compatibility

_Brief explanation of why these changes are/are not backwards compatible._