### PR TITLE
Some cEUR invite fixes

### DIFF
--- a/packages/mobile/locales/en-US/walletFlow5.json
+++ b/packages/mobile/locales/en-US/walletFlow5.json
@@ -57,8 +57,7 @@
   "escrowedPaymentReminderSummaryDetails_exactly2Items": "<0></0> and <1></1> haven't accepted their invitations yet",
   "escrowedPaymentReminderSummaryDetails_exactly3Items": "<0></0>, <1></1> and one other haven't accepted their invitations yet",
   "escrowedPaymentReminderSummaryDetails_moreThan3Items": "<0></0>, <1></1> and others haven't accepted their invitations yet",
-  "escrowedPaymentReminderSms": "A friendly reminder that you haven't yet redeemed your Celo Dollars with {{appName}}! Go to {{link}} and enter your code to get started: {{code}}",
-  "escrowedPaymentReminderSmsNoData": "A friendly reminder that you haven't yet redeemed your Celo Dollars with {{appName}}! Download the mobile app to get started!",
+  "escrowedPaymentReminderSmsNoData": "A friendly reminder that you haven't yet redeemed your {{currency}} with {{appName}}! Download the mobile app to get started!",
   "testnetAlert": {
     "0": "{{testnet}}",
     "1": "A friendly reminder you're using the {{testnet}} network build - the balances are not real"

--- a/packages/mobile/src/escrow/EscrowedPaymentListItem.test.tsx
+++ b/packages/mobile/src/escrow/EscrowedPaymentListItem.test.tsx
@@ -1,9 +1,12 @@
+import BigNumber from 'bignumber.js'
 import * as React from 'react'
 import { Share } from 'react-native'
 import { fireEvent, flushMicrotasksQueue, render } from 'react-native-testing-library'
 import { Provider } from 'react-redux'
 import EscrowedPaymentListItem from 'src/escrow/EscrowedPaymentListItem'
-import { createMockStore } from 'test/utils'
+import { WEI_PER_TOKEN } from 'src/geth/consts'
+import { Currency } from 'src/utils/currencies'
+import { amountFromComponent, createMockStore } from 'test/utils'
 import { mockEscrowedPayment } from 'test/values'
 
 const store = createMockStore()
@@ -13,10 +16,36 @@ describe('EscrowedPaymentReminderNotification', () => {
   it('renders correctly', () => {
     const tree = render(
       <Provider store={store}>
-        <EscrowedPaymentListItem payment={mockEscrowedPayment} />
+        <EscrowedPaymentListItem
+          payment={{
+            ...mockEscrowedPayment,
+            amount: new BigNumber(10).multipliedBy(WEI_PER_TOKEN),
+          }}
+        />
       </Provider>
     )
     expect(tree).toMatchSnapshot()
+    const component = tree.getByTestId('EscrowedPaymentListItem/amount/value')
+    // Local currency exchange rate for cUSD is 1.3
+    expect(amountFromComponent(component)).toEqual('$13.30')
+  })
+
+  it('renders correctly with cEUR', () => {
+    const { getByTestId } = render(
+      <Provider store={store}>
+        <EscrowedPaymentListItem
+          payment={{
+            ...mockEscrowedPayment,
+            amount: new BigNumber(10).multipliedBy(WEI_PER_TOKEN),
+            currency: Currency.Euro,
+          }}
+        />
+      </Provider>
+    )
+
+    const component = getByTestId('EscrowedPaymentListItem/amount/value')
+    // Local currency exchange rate for cEUR is 2
+    expect(amountFromComponent(component)).toEqual('$20.00')
   })
 
   it('opens the share dialog', async () => {

--- a/packages/mobile/src/escrow/EscrowedPaymentListItem.tsx
+++ b/packages/mobile/src/escrow/EscrowedPaymentListItem.tsx
@@ -78,7 +78,7 @@ function EscrowedPaymentListItem({ payment }: Props) {
     <View style={styles.container}>
       <RequestMessagingCard
         title={t('escrowPaymentNotificationTitle', { mobile: nameToShow })}
-        amount={<CurrencyDisplay amount={amount} />}
+        amount={<CurrencyDisplay amount={amount} testID="EscrowedPaymentListItem/amount" />}
         details={payment.message}
         icon={<ContactCircle recipient={recipient} />}
         callToActions={getCTA()}

--- a/packages/mobile/src/escrow/EscrowedPaymentListItem.tsx
+++ b/packages/mobile/src/escrow/EscrowedPaymentListItem.tsx
@@ -33,7 +33,12 @@ function EscrowedPaymentListItem({ payment }: Props) {
     })
 
     try {
-      await Share.share({ message: t('walletFlow5:escrowedPaymentReminderSmsNoData') })
+      await Share.share({
+        message: t('walletFlow5:escrowedPaymentReminderSmsNoData', {
+          currency:
+            payment.currency === Currency.Dollar ? t('global:celoDollars') : t('global:celoEuros'),
+        }),
+      })
     } catch (error) {
       Logger.error(TAG, `Error sending reminder to ${recipient.e164PhoneNumber}`, error)
     }
@@ -66,7 +71,7 @@ function EscrowedPaymentListItem({ payment }: Props) {
   const nameToShow = recipient.name ?? t('global:unknown')
   const amount = {
     value: divideByWei(payment.amount),
-    currencyCode: Currency.Dollar,
+    currencyCode: payment.currency,
   }
 
   return (

--- a/packages/mobile/src/escrow/ReclaimPaymentConfirmationScreen.tsx
+++ b/packages/mobile/src/escrow/ReclaimPaymentConfirmationScreen.tsx
@@ -156,7 +156,7 @@ class ReclaimPaymentConfirmationScreen extends React.Component<Props> {
               } /* TODO get recipient contact details from recipient cache*/
             }
             amount={convertedAmount}
-            currency={Currency.Dollar} // User can only request in Dollars
+            currency={payment.currency}
             feeInfo={asyncFee.result}
             isLoadingFee={asyncFee.loading}
             feeError={asyncFee.error}

--- a/packages/mobile/src/escrow/__snapshots__/EscrowedPaymentListItem.test.tsx.snap
+++ b/packages/mobile/src/escrow/__snapshots__/EscrowedPaymentListItem.test.tsx.snap
@@ -92,12 +92,11 @@ exports[`EscrowedPaymentReminderNotification renders correctly 1`] = `
                 },
               ]
             }
-            testID="undefined/value"
+            testID="EscrowedPaymentListItem/amount/value"
           >
             
-            &lt;
             $
-            0.001
+            13.30
           </Text>
         </Text>
         <Text

--- a/packages/mobile/src/escrow/saga.ts
+++ b/packages/mobile/src/escrow/saga.ts
@@ -37,7 +37,12 @@ import { VerificationStatus } from 'src/identity/types'
 import { NUM_ATTESTATIONS_REQUIRED } from 'src/identity/verification'
 import { navigateHome } from 'src/navigator/NavigationService'
 import { fetchStableBalances } from 'src/stableToken/actions'
-import { getCurrencyAddress, getTokenContract, getTokenContractFromAddress } from 'src/tokens/saga'
+import {
+  getCurrencyAddress,
+  getStableCurrencyFromAddress,
+  getTokenContract,
+  getTokenContractFromAddress,
+} from 'src/tokens/saga'
 import { addStandbyTransaction } from 'src/transactions/actions'
 import { sendAndMonitorTransaction } from 'src/transactions/saga'
 import { sendTransaction } from 'src/transactions/send'
@@ -427,6 +432,11 @@ function* doFetchSentPayments() {
         continue
       }
 
+      const currency: Currency | null = yield call(getStableCurrencyFromAddress, payment.token)
+      if (!currency) {
+        continue
+      }
+
       const escrowPaymentWithRecipient: EscrowedPayment = {
         paymentID: address,
         senderAddress: payment[1],
@@ -434,7 +444,7 @@ function* doFetchSentPayments() {
         // since identifier mapping could be fetched after this is called.
         recipientPhone: recipientPhoneNumber,
         recipientIdentifier: payment.recipientIdentifier,
-        currency: Currency.Dollar, // Only dollars can be escrowed
+        currency,
         amount: payment[3],
         timestamp: payment[6],
         expirySeconds: payment[7],

--- a/packages/mobile/src/tokens/saga.ts
+++ b/packages/mobile/src/tokens/saga.ts
@@ -78,6 +78,26 @@ export async function getTokenContractFromAddress(tokenAddress: string) {
   return contracts.find((contract) => contract.address === tokenAddress)
 }
 
+// TODO: To avoid making three requests each time this function is called, we should store the token
+// addresses in the redux store. We will have to do this while working on multi-token support, so that
+// is a good moment to clean this up.
+export async function getStableCurrencyFromAddress(tokenAddress: string): Promise<Currency | null> {
+  const contractKit = await getContractKitAsync(false)
+  const [celoContract, cUsdContract, cEurContract] = await Promise.all([
+    contractKit.contracts.getGoldToken(),
+    contractKit.contracts.getStableToken(StableToken.cUSD),
+    contractKit.contracts.getStableToken(StableToken.cEUR),
+  ])
+  if (celoContract.address === tokenAddress) {
+    return Currency.Celo
+  } else if (cUsdContract.address === tokenAddress) {
+    return Currency.Dollar
+  } else if (cEurContract.address === tokenAddress) {
+    return Currency.Euro
+  }
+  return null
+}
+
 export function* fetchToken(token: Currency, tag: string) {
   try {
     Logger.debug(tag, `Fetching ${token} balance`)


### PR DESCRIPTION
### Description

Add support for cEUR invites in pending invites. The pending invites flow (showing, reminding and reclaiming) had cUSD hard-coded, now it correctly uses the invite token.

### Other changes

N/A

### Tested

Manually


### How others should test

- Invite someone using cEUR. 
- See that the invite in the pending invitations list shows up with the correct amount.
- Check that the copy when pressing 'Remind' says 'Celo Euros'
- Check that you can reclaim the invite correctly.

### Related issues

- Fixes #977

### Backwards compatibility

N/A