### PR TITLE
Remove komencikit VSCode config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,21 +1,4 @@
 {
   "version": "0.2.0",
-  "configurations": [
-    {
-      "name": "Debug Komencikit Tests",
-      "type": "node",
-      "request": "launch",
-      "runtimeArgs": [
-        "--inspect-brk",
-        "${workspaceRoot}/node_modules/.bin/jest",
-        "--rootDir",
-        "${workspaceFolder}/packages/komencikit",
-        "--runInBand",
-        "${workspaceFolder}/packages/komencikit/src/kit.spec.ts",
-      ],
-      "console": "integratedTerminal",
-      "internalConsoleOptions": "neverOpen",
-      "port": 9229
-    }
-  ]
+  "configurations": []
 }


### PR DESCRIPTION
### Description

Remove komencikit VSCode config since komenci has been removed from this repo.

### Other changes

No.

### Tested

N/A.


### How others should test

N/A.

### Related issues

N/A.

### Backwards compatibility

N/A.