### PR TITLE
Update gitignore following the removal of the indexer to avoid accidentally leaking secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,4 @@ packages/docs/_book/
 packages/provider-url-service/*
 packages/moonpay-auth/*
 packages/komencikit/*
+packages/indexer/*


### PR DESCRIPTION
### Description

Follow up to #993, this updates the `gitignore` so we don't accidentally leak the secrets (happened in the past when folks switch branch and commit everything without checking).