### PR TITLE
Disable -allowProvisioningUpdates argument in Fastlane

### DIFF
--- a/packages/mobile/fastlane/Fastfile
+++ b/packages/mobile/fastlane/Fastfile
@@ -78,7 +78,7 @@ platform :ios do
       workspace: 'ios/celo.xcworkspace',
       scheme: "celo-#{options[:environment]}",
       configuration: "Release",
-      xcargs: "-allowProvisioningUpdates",
+      # xcargs: "-allowProvisioningUpdates",
       output_directory: "build",
       # verbose: true
      ) 


### PR DESCRIPTION
### Description

Disable `-allowProvisioningUpdates` argument in Fastlane

### Other changes

None.

### Tested

This was tested in the https://github.com/valora-inc/wallet/tree/np/update-fastlane-version-variant branch while debugging. I am isolating the change to its own PR.

### How others should test

Unnecessary.

### Related issues

N/A.

### Backwards compatibility

N/A.