### PR TITLE
Add prepare_testflight_and_upload lane to Fastfile

### DIFF
--- a/packages/mobile/fastlane/Fastfile
+++ b/packages/mobile/fastlane/Fastfile
@@ -76,10 +76,10 @@ platform :ios do
   lane :build do |options|
     gym(
       workspace: 'ios/celo.xcworkspace',
-      scheme: "celo-#{options[:environment]}",
-      configuration: "Release",
-      # xcargs: "-allowProvisioningUpdates",
-      output_directory: "build",
+      scheme: 'celo-#{options[:environment]}',
+      configuration: 'Release',
+      # xcargs: '-allowProvisioningUpdates',
+      output_directory: 'build',
       # verbose: true
      ) 
   end
@@ -87,9 +87,9 @@ platform :ios do
   desc 'Prepare TestFlight'
   lane :prepare_testflight_and_upload do |options|
     api_key = app_store_connect_api_key(
-      key_id: "3NK3HR2Q69",
-      issuer_id: "dcfc5c64-36b5-46a2-af36-84acc93d2b62",
-      key_filepath: "/Users/runner/work/release-bundler/release-bundler/AuthKey_3NK3HR2Q69.p8",
+      key_id: '3NK3HR2Q69',
+      issuer_id: 'dcfc5c64-36b5-46a2-af36-84acc93d2b62',
+      key_filepath: '/Users/runner/work/release-bundler/release-bundler/AuthKey_3NK3HR2Q69.p8',
       duration: 1200,
     )
     

--- a/packages/mobile/fastlane/Fastfile
+++ b/packages/mobile/fastlane/Fastfile
@@ -83,23 +83,35 @@ platform :ios do
       # verbose: true
      ) 
   end
+  
+  desc 'Prepare TestFlight'
+  lane :prepare_testflight_and_upload do |options|
+    api_key = app_store_connect_api_key(
+      key_id: "3NK3HR2Q69",
+      issuer_id: "dcfc5c64-36b5-46a2-af36-84acc93d2b62",
+      key_filepath: "/Users/runner/work/release-bundler/release-bundler/AuthKey_3NK3HR2Q69.p8",
+      duration: 1200,
+    )
+    
+    upload_to_testflight(
+      api_key: api_key,
+      skip_submission: true,
+      skip_waiting_for_build_processing: true,
+    )
+  end
 
   desc 'Ship Alfajores to TestFlight'
   lane :alfajores do
     env = 'alfajores'
     build(environment: env)
-    upload_to_testflight(
-      skip_waiting_for_build_processing: true,
-    )
+    prepare_testflight_and_upload
   end
 
   desc 'Ship Mainnet to TestFlight'
   lane :mainnet do
     env = 'mainnet'
     build(environment: env)
-    upload_to_testflight(
-      skip_waiting_for_build_processing: true,
-    )
+    prepare_testflight_and_upload
   end
 
 end

--- a/packages/mobile/fastlane/Fastfile
+++ b/packages/mobile/fastlane/Fastfile
@@ -89,7 +89,7 @@ platform :ios do
     api_key = app_store_connect_api_key(
       key_id: '3NK3HR2Q69',
       issuer_id: 'dcfc5c64-36b5-46a2-af36-84acc93d2b62',
-      key_filepath: '/Users/runner/work/release-bundler/release-bundler/AuthKey_3NK3HR2Q69.p8',
+      key_filepath: '/Users/runner/work/release-bundler/release-bundler/certificates/AuthKey_3NK3HR2Q69.p8',
       duration: 1200,
     )
     


### PR DESCRIPTION
### Description

Add prepare_testflight_and_upload lane to Fastfile to upload iOS builds to TestFlight in release-bundler.

### Other changes

No.

### Tested

Tested in https://github.com/valora-inc/release-bundler/actions/runs/1175084552.

### How others should test

Unneeded.

### Related issues

N/A.

### Backwards compatibility

N/A.