### PR TITLE
Use valora terms of service link

### DIFF
--- a/packages/mobile/src/onboarding/registration/RegulatoryTerms.tsx
+++ b/packages/mobile/src/onboarding/registration/RegulatoryTerms.tsx
@@ -8,7 +8,7 @@ import { SafeAreaInsetsContext, SafeAreaView } from 'react-native-safe-area-cont
 import { connect } from 'react-redux'
 import { acceptTerms } from 'src/account/actions'
 import DevSkipButton from 'src/components/DevSkipButton'
-import { CELO_TERMS_LINK, DEFAULT_DAILY_PAYMENT_LIMIT_CUSD } from 'src/config'
+import { DEFAULT_DAILY_PAYMENT_LIMIT_CUSD, TOS_LINK } from 'src/config'
 import { Namespaces, withTranslation } from 'src/i18n'
 import Logo, { LogoTypes } from 'src/icons/Logo'
 import { nuxNavigationOptions } from 'src/navigator/Headers'
@@ -45,7 +45,7 @@ export class RegulatoryTerms extends React.Component<Props> {
   }
 
   onPressGoToTerms = () => {
-    navigateToURI(CELO_TERMS_LINK)
+    navigateToURI(TOS_LINK)
   }
 
   render() {


### PR DESCRIPTION
### Description

This updates the terms of service link shown during onboarding.

<img src="https://user-images.githubusercontent.com/57791/131381711-e1d29ab0-b886-4b57-867b-454be6225b12.png" width="50%" />

See https://valora-app.slack.com/archives/CL7BVQPHB/p1630331670018800

This is cherry-picked from the [1.18.1 release branch](https://github.com/valora-inc/wallet/tree/release/wallet/1.18.1).