### PR TITLE
Return EOA address on WalletConnect

### DIFF
--- a/packages/mobile/src/walletConnect/saga.ts
+++ b/packages/mobile/src/walletConnect/saga.ts
@@ -51,7 +51,7 @@ import {
   selectSessions,
 } from 'src/walletConnect/selectors'
 import { getContractKit, getWallet } from 'src/web3/contracts'
-import { getAccount, unlockAccount } from 'src/web3/saga'
+import { getWalletAddress, unlockAccount } from 'src/web3/saga'
 import { currentAccountSelector } from 'src/web3/selectors'
 
 const TAG = 'WalletConnect/saga'
@@ -64,7 +64,7 @@ export function* acceptSession({ session }: AcceptSession) {
       throw new Error('missing client')
     }
 
-    const account: string = yield call(getAccount)
+    const address: string = yield call(getWalletAddress)
     const response: SessionTypes.Response = {
       metadata: {
         name: APP_NAME,
@@ -73,7 +73,7 @@ export function* acceptSession({ session }: AcceptSession) {
         icons: [appendPath(WEB_LINK, '/favicon.ico')],
       },
       state: {
-        accounts: [`${account}@celo:${networkConfig.networkId}`],
+        accounts: [`${address}@celo:${networkConfig.networkId}`],
       },
     }
 

--- a/packages/mobile/src/walletConnect/saga.ts
+++ b/packages/mobile/src/walletConnect/saga.ts
@@ -51,7 +51,7 @@ import {
   selectSessions,
 } from 'src/walletConnect/selectors'
 import { getContractKit, getWallet } from 'src/web3/contracts'
-import { getAccountAddress, unlockAccount } from 'src/web3/saga'
+import { getAccount, unlockAccount } from 'src/web3/saga'
 import { currentAccountSelector } from 'src/web3/selectors'
 
 const TAG = 'WalletConnect/saga'
@@ -64,7 +64,7 @@ export function* acceptSession({ session }: AcceptSession) {
       throw new Error('missing client')
     }
 
-    const account: string = yield call(getAccountAddress)
+    const account: string = yield call(getAccount)
     const response: SessionTypes.Response = {
       metadata: {
         name: APP_NAME,

--- a/packages/mobile/src/web3/saga.ts
+++ b/packages/mobile/src/web3/saga.ts
@@ -263,6 +263,8 @@ export function* getWalletAddress() {
   }
 }
 
+// deprecated, please use |getWalletAddress| instead.
+// This needs to be refactored and removed since the name is misleading.
 export const getAccount = getWalletAddress
 
 export enum UnlockResult {

--- a/packages/mobile/src/web3/saga.ts
+++ b/packages/mobile/src/web3/saga.ts
@@ -248,7 +248,7 @@ export function* assignAccountFromPrivateKey(privateKey: string, mnemonic: strin
 }
 
 // Wait for account to exist and then return it
-export function* getAccount() {
+export function* getWalletAddress() {
   while (true) {
     const account = yield select(currentAccountSelector)
     if (account) {
@@ -262,6 +262,8 @@ export function* getAccount() {
     }
   }
 }
+
+export const getAccount = getWalletAddress
 
 export enum UnlockResult {
   SUCCESS,


### PR DESCRIPTION
### Description

In the WalletConnect integration we are returning the MTW address instead of the EOA. This is super dangerous! Users that connect using WalletConnect might end up making transactions to the MTW address and recovering the funds might be a bit painful (they wouldn't be lost, but it would be annoying).

### Other changes

N/A

### Tested

Using [use-contractkit](http://use-contractkit.vercel.app/)

### How others should test

Hard to test because [the public version of use-contractkit](http://use-contractkit.vercel.app/) doesn't work (I tested with a local version with some minor changes). If it did work one could simply connect your account in that website and check that the address listed is the EOA.

### Related issues

- Fixes #1075

### Backwards compatibility

N/A