### PR TITLE
Change copy of rewards screen

### DIFF
--- a/packages/mobile/locales/en-US/consumerIncentives.json
+++ b/packages/mobile/locales/en-US/consumerIncentives.json
@@ -1,20 +1,20 @@
 {
   "title": "A new way to earn",
-  "summary": "Starting now, you’ll earn up to {{percent}}% annually on your cUSD balance.",
+  "summary": "Start earning up to {{percent}}% annually on your cUSD and cEUR balances. Rates may change so cash in on this sweet promotion!",
   "earnWeekly": {
     "header": "Earn Weekly",
     "text": "Send and spend as usual, you’ll earn on the remaining balance."
   },
   "noMinCommitment": {
-    "header": "No minimums, no commitments",
-    "earningText": "Earning is stress free: You’re earning already.",
+    "header": "Earn without commitments",
+    "earningText": "Earning is stress free: Add cUSD or cEUR to your account and start earning on your balances.",
     "connectText": "Earning is stress free: Connect your phone number to start earning."
   },
   "saveMoreEarnMore": {
-    "header": "Save more to earn more",
-    "text": "Earn up to {{maxSaving}} cUSD per year by saving {{rewardsMax}} cUSD."
+    "header": "Cash in to earn more",
+    "text": "Deposit up to {{rewardsMax}} cUSD or {{rewardsMax}} cEUR and earn {{percent}}% anually."
   },
-  "conclusion": "It’s that simple. Start saving for your future today.",
+  "conclusion": "It’s that simple. Start earning today.",
   "addCusd": "Add cUSD",
   "connectNumber": "Connect Number"
 }

--- a/packages/mobile/src/consumerIncentives/ConsumerIncentivesHomeScreen.tsx
+++ b/packages/mobile/src/consumerIncentives/ConsumerIncentivesHomeScreen.tsx
@@ -29,7 +29,6 @@ export default function ConsumerIncentivesHomeScreen(props: Props) {
   const insets = useSafeAreaInsets()
 
   const { rewardsPercent, rewardsMax } = useSelector((state) => state.app)
-  const maxSaving = (rewardsPercent / 100) * rewardsMax
 
   const onPressCTA = () => {
     if (userIsVerified) {
@@ -84,7 +83,7 @@ export default function ConsumerIncentivesHomeScreen(props: Props) {
           <View style={styles.sectionText}>
             <Text style={fontStyles.regular600}>{t('saveMoreEarnMore.header')}</Text>
             <Text style={fontStyles.small}>
-              {t('saveMoreEarnMore.text', { maxSaving, rewardsMax })}
+              {t('saveMoreEarnMore.text', { rewardsMax, percent: rewardsPercent })}
             </Text>
           </View>
         </View>

--- a/packages/mobile/src/consumerIncentives/__snapshots__/ConsumerIncentivesHomeScreen.test.tsx.snap
+++ b/packages/mobile/src/consumerIncentives/__snapshots__/ConsumerIncentivesHomeScreen.test.tsx.snap
@@ -285,7 +285,7 @@ exports[`ConsumerIncentivesHomeScreen renders correctly 1`] = `
               }
             }
           >
-            saveMoreEarnMore.text, {"maxSaving":50,"rewardsMax":1000}
+            saveMoreEarnMore.text, {"rewardsMax":1000,"percent":5}
           </Text>
         </View>
       </View>


### PR DESCRIPTION
### Description

Just copy changes to the rewards screen

<img width="357" alt="Screen Shot 2021-09-02 at 14 25 10" src="https://user-images.githubusercontent.com/6062888/131889278-73089959-0642-43a9-b4e1-a7c503f065f2.png">


### Other changes

N/A

### Tested

Manually

### How others should test

Go to the rewards screen and make sure you see the right copy.

### Related issues

- Fixes #998

### Backwards compatibility

N/A