### PR TITLE
Fix Ruby String Interpolation 

### DIFF
--- a/packages/mobile/fastlane/Fastfile
+++ b/packages/mobile/fastlane/Fastfile
@@ -76,7 +76,9 @@ platform :ios do
   lane :build do |options|
     gym(
       workspace: 'ios/celo.xcworkspace',
-      scheme: 'celo-#{options[:environment]}',
+      # Needs double quotes because Ruby differentiates
+      # https://stackoverflow.com/questions/6395288/double-vs-single-quotes
+      scheme: "celo-#{options[:environment]}",
       configuration: 'Release',
       # xcargs: '-allowProvisioningUpdates',
       output_directory: 'build',


### PR DESCRIPTION
### Description

Ruby why. I didn't know that there was a difference between single and double quotes in Ruby but apparently single quotes removes the ability to do string interpolation. Undoing a driveby change from #1039.

### Other changes

Just this.

### Tested

Will be tested shortly but should work.

### How others should test

N/A.

### Related issues

N/A.

### Backwards compatibility

N/A.