### PR TITLE
#12 change copy on phone verification screen

### DIFF
--- a/packages/mobile/locales/en-US/nuxVerification2.json
+++ b/packages/mobile/locales/en-US/nuxVerification2.json
@@ -29,8 +29,8 @@
     "section2Body": "To protect your privacy, only an obfuscated version of your phone number is stored on the Celo blockchain."
   },
   "loading": {
-    "confirming": "Confirming…",
-    "pleaseKeepAppOpen": "Please keep the app open",
+    "confirming": "Confirming phone number…",
+    "pleaseKeepAppOpen": "Please don't leave this screen or you'll have to restart",
     "learnMore": "Learn more",
     "card1": "To make sure your phone number is really yours, we're sending you three messages.",
     "card2": "Once your number is confirmed, you can send and receive funds easily to your phone number.",

--- a/packages/mobile/src/verify/VerificationLoadingScreen.tsx
+++ b/packages/mobile/src/verify/VerificationLoadingScreen.tsx
@@ -283,6 +283,8 @@ const styles = StyleSheet.create({
     ...fontStyles.h2,
     color: colors.onboardingBrownLight,
     marginBottom: 40,
+    textAlign: 'center',
+    paddingHorizontal: 24,
   },
   upHandleContainer: {
     alignItems: 'center',

--- a/packages/mobile/src/verify/__snapshots__/VerificationLoadingScreen.test.tsx.snap
+++ b/packages/mobile/src/verify/__snapshots__/VerificationLoadingScreen.test.tsx.snap
@@ -168,6 +168,8 @@ exports[`VerificationLoadingScreen renders correctly 1`] = `
               "fontSize": 22,
               "lineHeight": 28,
               "marginBottom": 40,
+              "paddingHorizontal": 24,
+              "textAlign": "center",
             }
           }
         >
@@ -1060,6 +1062,8 @@ exports[`VerificationLoadingScreen renders correctly with fail modal 1`] = `
               "fontSize": 22,
               "lineHeight": 28,
               "marginBottom": 40,
+              "paddingHorizontal": 24,
+              "textAlign": "center",
             }
           }
         >


### PR DESCRIPTION


### Description

Collaborated with Lukas and Nitya to change the copy during phone number verification so that it's clear to the user that they should not background the app while waiting for phone number verification

### Tested

manually tested

### Related issues

- Fixes #12 
