### PR TITLE
Fix path to Apple Connect p8 certificate

### DIFF
--- a/packages/mobile/fastlane/Fastfile
+++ b/packages/mobile/fastlane/Fastfile
@@ -91,7 +91,7 @@ platform :ios do
     api_key = app_store_connect_api_key(
       key_id: '3NK3HR2Q69',
       issuer_id: 'dcfc5c64-36b5-46a2-af36-84acc93d2b62',
-      key_filepath: '/Users/runner/work/release-automation/release-automation/temp/AuthKey_3NK3HR2Q69.p8',
+      key_filepath: '/Users/runner/work/release-automation/release-automation/temp/AuthKey.p8',
       duration: 1200,
     )
     

--- a/packages/mobile/fastlane/Fastfile
+++ b/packages/mobile/fastlane/Fastfile
@@ -91,7 +91,7 @@ platform :ios do
     api_key = app_store_connect_api_key(
       key_id: '3NK3HR2Q69',
       issuer_id: 'dcfc5c64-36b5-46a2-af36-84acc93d2b62',
-      key_filepath: '/Users/runner/work/release-bundler/release-bundler/certificates/AuthKey_3NK3HR2Q69.p8',
+      key_filepath: '/Users/runner/work/release-automation/release-automation/temp/AuthKey_3NK3HR2Q69.p8',
       duration: 1200,
     )
     

--- a/packages/mobile/fastlane/Fastfile
+++ b/packages/mobile/fastlane/Fastfile
@@ -89,7 +89,7 @@ platform :ios do
   desc 'Prepare TestFlight'
   lane :prepare_testflight_and_upload do |options|
     api_key = app_store_connect_api_key(
-      key_id: '3NK3HR2Q69',
+      key_id: '3B5PGG27Q4',
       issuer_id: 'dcfc5c64-36b5-46a2-af36-84acc93d2b62',
       key_filepath: '/Users/runner/work/release-automation/release-automation/temp/AuthKey.p8',
       duration: 1200,


### PR DESCRIPTION
### Description

Fix path to Apple Connect p8 certificate. This was depending on a file in the release-automation repo but is going to be created dynamically during the build using Google Secrets Manager. This is preparing for that.

### Other changes

No.

### Tested

N/A.

### How others should test

N/A.

### Related issues

N/A.

### Backwards compatibility

N/A.