### PR TITLE
Add Loading & success/error messages for WalletConnect

### DIFF
--- a/packages/mobile/locales/en-US/walletConnect.json
+++ b/packages/mobile/locales/en-US/walletConnect.json
@@ -3,6 +3,9 @@
   "cancel": "Cancel",
   "allow": "Allow",
 
+  "loadingFromScan": "Scanning",
+  "loadingFromDeeplink": "Connecting",
+
   "action": {
     "asking": "This application is asking to perform the following action",
     "operation": "Operation",
@@ -33,5 +36,11 @@
 
   "disconnect": "Disconnect",
   "disconnectTitle": "Disconnect {{dappName}}?",
-  "disconnectBody": "Are you sure you want to disconnect from {{dappName}}?"
+  "disconnectBody": "Are you sure you want to disconnect from {{dappName}}?",
+
+  "connectionSuccess": "Success! Please go back to {{dappName}} to continue",
+  "timeoutTitle": "Time out!",
+  "timeoutSubtitle": "Your connection timed out. Please check your internet connection & try again",
+
+  "goBackButton": "Go Back"
 }

--- a/packages/mobile/src/navigator/NavigationService.ts
+++ b/packages/mobile/src/navigator/NavigationService.ts
@@ -1,7 +1,7 @@
 // (https://github.com/react-navigation/react-navigation/issues/1439)
 
 import { NavigationActions, StackActions } from '@react-navigation/compat'
-import { CommonActions, NavigationContainerRef } from '@react-navigation/native'
+import { CommonActions, NavigationContainerRef, NavigationState } from '@react-navigation/native'
 import { createRef, MutableRefObject } from 'react'
 import sleep from 'sleep-promise'
 import { PincodeType } from 'src/account/reducer'
@@ -155,6 +155,29 @@ export function navigateBack(params?: object) {
     .catch((reason) => {
       Logger.error(`${TAG}@navigateBack`, `Navigation failure: ${reason}`)
     })
+}
+
+const getActiveRouteState = function (route: NavigationState): NavigationState {
+  if (!route.routes || route.routes.length === 0 || route.index >= route.routes.length) {
+    // TODO: React Navigation types are hard :(
+    // @ts-ignore
+    return route.state
+  }
+
+  const childActiveRoute = (route.routes[route.index] as unknown) as NavigationState
+  return getActiveRouteState(childActiveRoute)
+}
+
+export async function isScreenOnForeground(screen: Screens) {
+  await ensureNavigator()
+  let state = navigationRef.current?.getRootState()
+  if (!state) {
+    return false
+  }
+  const activeRouteState = getActiveRouteState(state)
+  // Note: The '?' in the following line shouldn't be necessary, but are there anyways to be defensive
+  // because of the ts-ignore on getActiveRouteState.
+  return activeRouteState?.routes[activeRouteState?.routes.length - 1]?.name === screen
 }
 
 interface NavigateHomeOptions {

--- a/packages/mobile/src/navigator/Navigator.tsx
+++ b/packages/mobile/src/navigator/Navigator.tsx
@@ -103,6 +103,8 @@ import VerificationEducationScreen from 'src/verify/VerificationEducationScreen'
 import VerificationInputScreen from 'src/verify/VerificationInputScreen'
 import VerificationLoadingScreen from 'src/verify/VerificationLoadingScreen'
 import WalletConnectActionRequestScreen from 'src/walletConnect/screens/ActionRequest'
+import WalletConnectLoading from 'src/walletConnect/screens/Loading'
+import WalletConnectResult from 'src/walletConnect/screens/Result'
 import WalletConnectSessionRequestScreen from 'src/walletConnect/screens/SessionRequest'
 import WalletConnectSessionsScreen from 'src/walletConnect/screens/Sessions'
 
@@ -147,6 +149,16 @@ const commonScreens = (Navigator: typeof Stack) => {
         name={Screens.DappKitTxDataScreen}
         component={DappKitTxDataScreen}
         options={DappKitTxDataScreen.navigationOptions}
+      />
+      <Navigator.Screen
+        name={Screens.WalletConnectLoading}
+        component={WalletConnectLoading}
+        options={WalletConnectLoading.navigationOptions}
+      />
+      <Navigator.Screen
+        name={Screens.WalletConnectResult}
+        component={WalletConnectResult}
+        options={WalletConnectResult.navigationOptions}
       />
       <Navigator.Screen
         name={Screens.WalletConnectSessionRequest}

--- a/packages/mobile/src/navigator/Screens.tsx
+++ b/packages/mobile/src/navigator/Screens.tsx
@@ -75,6 +75,8 @@ export enum Screens {
   VerificationInputScreen = 'VerificationInputScreen',
   VerificationLoadingScreen = 'VerificationLoadingScreen',
   WalletHome = 'WalletHome',
+  WalletConnectLoading = 'WalletConnectLoading',
+  WalletConnectResult = 'WalletConnectResult',
   WalletConnectSessionRequest = 'WalletConnectSessionRequest',
   WalletConnectSessions = 'WalletConnectSessions',
   WalletConnectActionRequest = 'WalletConnectActionRequest',

--- a/packages/mobile/src/navigator/types.tsx
+++ b/packages/mobile/src/navigator/types.tsx
@@ -1,6 +1,6 @@
 import { AccountAuthRequest, Countries, SignTxRequest, TxToSignParam } from '@celo/utils'
 import BigNumber from 'bignumber.js'
-import { SendOrigin } from 'src/analytics/types'
+import { SendOrigin, WalletConnectPairingOrigin } from 'src/analytics/types'
 import { EscrowedPayment } from 'src/escrow/actions'
 import { ExchangeConfirmationCardProps } from 'src/exchange/ExchangeConfirmationCard'
 import { PaymentMethod } from 'src/fiatExchanges/FiatExchangeOptions'
@@ -248,6 +248,11 @@ export type StackParamList = {
   [Screens.VerificationLoadingScreen]: { withoutRevealing: boolean }
   [Screens.OnboardingEducationScreen]: undefined
   [Screens.OnboardingSuccessScreen]: undefined
+  [Screens.WalletConnectLoading]: { origin: WalletConnectPairingOrigin }
+  [Screens.WalletConnectResult]: {
+    title: string
+    subtitle: string
+  }
   [Screens.WalletConnectSessionRequest]: PendingSession
   [Screens.WalletConnectSessions]: undefined
   [Screens.WalletConnectActionRequest]: PendingAction & {

--- a/packages/mobile/src/qrcode/utils.ts
+++ b/packages/mobile/src/qrcode/utils.ts
@@ -107,6 +107,7 @@ export function* handleBarcode(
 ) {
   const walletConnectEnabled: boolean = yield select(walletConnectEnabledSelector)
   if (barcode.data.startsWith('wc:') && walletConnectEnabled) {
+    navigate(Screens.WalletConnectLoading, { origin: WalletConnectPairingOrigin.Scan })
     yield call(initialiseWalletConnect, barcode.data, WalletConnectPairingOrigin.Scan)
     return
   }

--- a/packages/mobile/src/walletConnect/screens/Loading.tsx
+++ b/packages/mobile/src/walletConnect/screens/Loading.tsx
@@ -1,0 +1,67 @@
+import colors from '@celo/react-components/styles/colors'
+import fontStyles from '@celo/react-components/styles/fonts'
+import variables from '@celo/react-components/styles/variables'
+import { StackScreenProps } from '@react-navigation/stack'
+import React, { useEffect } from 'react'
+import { useTranslation } from 'react-i18next'
+import { ActivityIndicator, StyleSheet, Text, View } from 'react-native'
+import { WalletConnectPairingOrigin } from 'src/analytics/types'
+import { Namespaces } from 'src/i18n'
+import { headerWithBackButton } from 'src/navigator/Headers'
+import { isScreenOnForeground, navigate } from 'src/navigator/NavigationService'
+import { Screens } from 'src/navigator/Screens'
+import { StackParamList } from 'src/navigator/types'
+
+const CONNECTION_TIMEOUT = 10_000
+
+type Props = StackScreenProps<StackParamList, Screens.WalletConnectLoading>
+
+function Loading({ route }: Props) {
+  const { t } = useTranslation(Namespaces.walletConnect)
+
+  useEffect(() => {
+    const timer = setTimeout(async () => {
+      if (await isScreenOnForeground(Screens.WalletConnectLoading)) {
+        navigate(Screens.WalletConnectResult, {
+          title: t('timeoutTitle'),
+          subtitle: t('timeoutSubtitle'),
+        })
+      }
+    }, CONNECTION_TIMEOUT)
+
+    return () => clearTimeout(timer)
+  }, [])
+
+  const fromScan = route.params.origin === WalletConnectPairingOrigin.Scan
+
+  return (
+    <View style={styles.container}>
+      <ActivityIndicator size="small" color={colors.greenBrand} />
+      <Text style={styles.connecting}>
+        {fromScan ? t('loadingFromScan') : t('loadingFromDeeplink')}
+      </Text>
+    </View>
+  )
+}
+
+Loading.navigationOptions = () => {
+  return {
+    ...headerWithBackButton,
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    paddingHorizontal: variables.contentPadding,
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  connecting: {
+    ...fontStyles.label,
+    color: colors.gray4,
+    marginTop: 20,
+  },
+})
+
+export default Loading

--- a/packages/mobile/src/walletConnect/screens/Result.tsx
+++ b/packages/mobile/src/walletConnect/screens/Result.tsx
@@ -1,0 +1,52 @@
+import Button, { BtnTypes } from '@celo/react-components/components/Button'
+import colors from '@celo/react-components/styles/colors'
+import fontStyles from '@celo/react-components/styles/fonts'
+import variables from '@celo/react-components/styles/variables'
+import { StackScreenProps } from '@react-navigation/stack'
+import React from 'react'
+import { useTranslation } from 'react-i18next'
+import { StyleSheet, Text, View } from 'react-native'
+import { Namespaces } from 'src/i18n'
+import { noHeader } from 'src/navigator/Headers'
+import { navigateHome } from 'src/navigator/NavigationService'
+import { Screens } from 'src/navigator/Screens'
+import { StackParamList } from 'src/navigator/types'
+
+type Props = StackScreenProps<StackParamList, Screens.WalletConnectResult>
+
+function Result({ route }: Props) {
+  const { t } = useTranslation(Namespaces.walletConnect)
+  const { title, subtitle } = route.params
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>{title}</Text>
+      <Text style={styles.subtitle}>{subtitle}</Text>
+      <Button onPress={navigateHome} text={t('goBackButton')} type={BtnTypes.SECONDARY} />
+    </View>
+  )
+}
+
+Result.navigationOptions = noHeader
+
+const styles = StyleSheet.create({
+  container: {
+    paddingHorizontal: variables.contentPadding,
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  title: {
+    ...fontStyles.h1,
+    textAlign: 'center',
+  },
+  subtitle: {
+    ...fontStyles.regular,
+    color: colors.gray4,
+    textAlign: 'center',
+    marginTop: 16,
+    marginBottom: 24,
+  },
+})
+
+export default Result

--- a/packages/mobile/src/walletConnect/v2/saga.ts
+++ b/packages/mobile/src/walletConnect/v2/saga.ts
@@ -7,13 +7,14 @@ import { SessionTypes } from '@walletconnect/types-v2'
 import { Error as WalletConnectError, ERROR as WalletConnectErrors } from '@walletconnect/utils-v2'
 import { EventChannel, eventChannel } from 'redux-saga'
 import { call, put, select, take, takeEvery, takeLeading } from 'redux-saga/effects'
+import { showMessage } from 'src/alert/actions'
 import { WalletConnectEvents } from 'src/analytics/Events'
 import { WalletConnectPairingOrigin } from 'src/analytics/types'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import { APP_NAME, WEB_LINK } from 'src/brandingConfig'
 import networkConfig from 'src/geth/networkConfig'
 import i18n from 'src/i18n'
-import { navigate, navigateBack } from 'src/navigator/NavigationService'
+import { navigate, navigateHome } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import Logger from 'src/utils/Logger'
 import { handleRequest } from 'src/walletConnect/request'
@@ -131,6 +132,11 @@ export function* acceptSession({ session }: AcceptSession) {
     ValoraAnalytics.track(WalletConnectEvents.wc_session_approve_success, {
       ...defautTrackedProperties,
     })
+    yield put(
+      showMessage(
+        i18n.t('walletConnect:connectionSuccess', { dappName: session.proposer.metadata.name })
+      )
+    )
   } catch (e) {
     Logger.debug(TAG + '@acceptSession', e.message)
     ValoraAnalytics.track(WalletConnectEvents.wc_session_approve_error, {
@@ -139,7 +145,7 @@ export function* acceptSession({ session }: AcceptSession) {
     })
   }
 
-  yield call(handlePendingState)
+  yield call(handlePendingStateOrNavigateBack)
 }
 
 export function* denySession({ session }: DenySession) {
@@ -199,7 +205,7 @@ function* handlePendingStateOrNavigateBack() {
   if (hasPendingState) {
     yield call(handlePendingState)
   } else {
-    navigateBack()
+    navigateHome()
   }
 }
 
@@ -263,6 +269,11 @@ export function* acceptRequest({ request }: AcceptRequest): any {
         error: error.type,
       })
     } else {
+      yield put(
+        showMessage(
+          i18n.t('walletConnect:connectionSuccess', { dappName: session.peer.metadata.name })
+        )
+      )
       ValoraAnalytics.track(WalletConnectEvents.wc_request_accept_success, {
         ...defautTrackedProperties,
       })

--- a/packages/mobile/src/walletConnect/walletConnect.ts
+++ b/packages/mobile/src/walletConnect/walletConnect.ts
@@ -7,6 +7,7 @@ import { initialiseWalletConnect } from 'src/walletConnect/saga'
 const WC_PREFIX = 'wc:'
 const DEEPLINK_PREFIX = 'celo://wallet/wc?uri='
 const UNIVERSAL_LINK_PREFIX = 'https://valoraapp.com/wc?uri='
+const UNIVERSAL_LINK_PREFIX_WITHOUT_URI = 'https://valoraapp.com/wc'
 
 /**
  * See https://docs.walletconnect.org/v/2.0/mobile-linking for exactly
@@ -38,7 +39,7 @@ export function* handleWalletConnectDeepLink(deepLink: string) {
 }
 
 export function isWalletConnectDeepLink(deepLink: string) {
-  return [WC_PREFIX, DEEPLINK_PREFIX, UNIVERSAL_LINK_PREFIX].some((prefix) =>
+  return [WC_PREFIX, DEEPLINK_PREFIX, UNIVERSAL_LINK_PREFIX_WITHOUT_URI].some((prefix) =>
     decodeURIComponent(deepLink).startsWith(prefix)
   )
 }

--- a/packages/mobile/src/walletConnect/walletConnect.ts
+++ b/packages/mobile/src/walletConnect/walletConnect.ts
@@ -1,5 +1,7 @@
 import { call } from 'redux-saga/effects'
 import { WalletConnectPairingOrigin } from 'src/analytics/types'
+import { navigate } from 'src/navigator/NavigationService'
+import { Screens } from 'src/navigator/Screens'
 import { initialiseWalletConnect } from 'src/walletConnect/saga'
 
 const WC_PREFIX = 'wc:'
@@ -31,6 +33,7 @@ export function* handleWalletConnectDeepLink(deepLink: string) {
     yield call(initialiseWalletConnect, link, WalletConnectPairingOrigin.Deeplink)
   }
 
+  navigate(Screens.WalletConnectLoading, { origin: WalletConnectPairingOrigin.Deeplink })
   // action request, we can do nothing
 }
 


### PR DESCRIPTION
### Description

Added a loading screen and an error screen for the WalletConnect flow and a success message when everything goes well.

Figma file: https://www.figma.com/file/U1Xd3uOPGFfcZnYeLMhx0o/Wallet-Connect-Fixes?node-id=606%3A291
There are a few differences with the designs:
- When running into an error, there is no 'retry' button. The retry needs to be done from the dapp, so it's just a 'go back' button (and therefore removed the 'Cancel' button since it does the same thing).
- In the success case, instead of creating a screen I am showing a success message using the top notification thing. The reason for this is that when using dapps we're often signing a lot of things and having that screen there all the time might get annoying. There were two buttons in the mockup, 'Manage connections' and 'Cancel' and in a normal case a user probably doesn't want to do either. I thought the top notification was a good balance of showing the user something while not disrupting what they were doing too much, but I'm open to suggestions.

There are also a few missing error cases which we'll need to do in follow up PRs:
- No internet connection
- Dapp cancelled transaction

Happy path:

https://user-images.githubusercontent.com/6062888/133554832-e57f1de6-2515-413d-9fb4-c5974066bd81.mov

Timeout case:

https://user-images.githubusercontent.com/6062888/133554873-cf738cc3-5608-4274-80b7-650fe74e6d0e.mov


### Other changes

N/A

### Tested

Tested manually ONLY USING V1. V2 has not been tested because it is not working currently.

### How others should test

- Open https://celo-walletconnect.vercel.app
- Try connecting to Valora
- See that the loading screen shows up and you are then redirected to the allow connection screen.

Some other things to test are to cancel the connection, to disconnect and re-connect several times, to turn off internet connection and try.

### Related issues

- Part of #1068

### Backwards compatibility

N/A