### PR TITLE
Switch certificate path to environment variable

### DIFF
--- a/packages/mobile/fastlane/Fastfile
+++ b/packages/mobile/fastlane/Fastfile
@@ -91,7 +91,8 @@ platform :ios do
     api_key = app_store_connect_api_key(
       key_id: "#{ENV['APPLE_CONNECT_KEY_ID']}",
       issuer_id: "#{ENV['APPLE_CONNECT_ISSUER_ID']}",
-      key_filepath: '/Users/runner/work/release-automation/release-automation/temp/AuthKey.p8',
+      # CI path is '/Users/runner/work/release-automation/release-automation/temp/AuthKey.p8'
+      key_filepath: "#{ENV['APPLE_CONNECT_CERTIFICATE_PATH']}",
       duration: 1200,
     )
     


### PR DESCRIPTION
### Description

Related to https://github.com/valora-inc/release-automation/pull/15. Switching certificate path to environment variable stored in Google Secrets Manager.

### Other changes

No.

### Tested

Not needed.

### How others should test

N/A.

### Related issues

N/A.

### Backwards compatibility

N/A.