### PR TITLE
Fix for Flakey E2E Test

### DIFF
--- a/packages/mobile/e2e/src/usecases/Support.js
+++ b/packages/mobile/e2e/src/usecases/Support.js
@@ -33,6 +33,9 @@ export default Support = () => {
   }
 
   it('Send Message to Support', async () => {
+    await waitFor(element(by.id('Hamburger')))
+      .toBeVisible()
+      .withTimeout(5000)
     await element(by.id('Hamburger')).tap()
     await scrollIntoView('Help', 'SettingsScrollView')
     await waitFor(element(by.id('Help')))
@@ -51,6 +54,5 @@ export default Support = () => {
     await expect(element(by.id('MessageEntry'))).toHaveText('This is a test from Valora')
     const imagePath = await device.takeScreenshot('Support')
     await pixelDiff(imagePath, `./e2e/assets/${await getDeviceModel()}/Support.png`)
-    // TODO: Email Client needed for emulators Send Request after briefing support if appropriate
   })
 }


### PR DESCRIPTION
### Description

A few small fixes to the E2E tests to make them less flakey:
- Add wait to hamburger menu item for support tests

### Tested

- Ran locally and in CI - [Results for this PR in the actions tab
](https://github.com/valora-inc/wallet/actions/workflows/e2e.yml?query=branch%3Atomm%2Fe2e-fixes)

### Backwards compatibility

This change is to e2e tests only and is backwards compatible. 