### PR TITLE
Update Exchange e2e tests

### DIFF
--- a/packages/mobile/e2e/src/Exchange.spec.js
+++ b/packages/mobile/e2e/src/Exchange.spec.js
@@ -1,10 +1,10 @@
 import { quickOnboarding } from './utils/utils'
 import ExchangeCelo from './usecases/ExchangeCelo'
 
-describe('Exchange', () => {
+describe('Given Exchange', () => {
   beforeAll(async () => {
     await quickOnboarding()
   })
 
-  describe('CELO', ExchangeCelo)
+  describe('When CELO', ExchangeCelo)
 })

--- a/packages/mobile/e2e/src/Exchange.spec.js
+++ b/packages/mobile/e2e/src/Exchange.spec.js
@@ -6,5 +6,5 @@ describe('Exchange', () => {
     await quickOnboarding()
   })
 
-  describe('Exchange CELO', ExchangeCelo)
+  describe('CELO', ExchangeCelo)
 })

--- a/packages/mobile/e2e/src/usecases/ExchangeCelo.js
+++ b/packages/mobile/e2e/src/usecases/ExchangeCelo.js
@@ -27,7 +27,7 @@ export default ExchangeCelo = () => {
     await celoEducation()
   })
 
-  jest.retryTimes(3)
+  jest.retryTimes(4)
   it('Buy CELO', async () => {
     // Wait for buy button
     await waitFor(element(by.text('Buy')))
@@ -69,7 +69,7 @@ export default ExchangeCelo = () => {
     ).toBeVisible()
   })
 
-  jest.retryTimes(3)
+  jest.retryTimes(4)
   it('Sell CELO', async () => {
     // Wait for buy button
     await waitFor(element(by.text('Sell')))
@@ -111,7 +111,7 @@ export default ExchangeCelo = () => {
     ).toBeVisible()
   })
 
-  jest.retryTimes(3)
+  jest.retryTimes(4)
   it('Withdraw CELO', async () => {
     let celoBalanceBefore = await element(by.id('CeloBalance')).getAttributes()
     // Scroll to the withdraw button

--- a/packages/mobile/e2e/src/usecases/ExchangeCelo.js
+++ b/packages/mobile/e2e/src/usecases/ExchangeCelo.js
@@ -9,7 +9,7 @@ import { celoEducation } from '../utils/celoEducation'
 import { dismissBanners } from '../utils/banners'
 import { reloadReactNative } from '../utils/retries'
 
-const CELO_TO_SELL = 0.025
+const CELO_TO_SELL = 0.002
 const CELO_TO_BUY = 0.045
 const CELO_TO_WITHDRAW = 0.02
 const FEES = 0.001
@@ -28,7 +28,7 @@ export default ExchangeCelo = () => {
   })
 
   jest.retryTimes(4)
-  it('Buy CELO', async () => {
+  it('Then Buy CELO', async () => {
     // Wait for buy button
     await waitFor(element(by.text('Buy')))
       .toBeVisible()
@@ -70,7 +70,7 @@ export default ExchangeCelo = () => {
   })
 
   jest.retryTimes(4)
-  it('Sell CELO', async () => {
+  it('Then Sell CELO', async () => {
     // Wait for buy button
     await waitFor(element(by.text('Sell')))
       .toBeVisible()
@@ -112,7 +112,7 @@ export default ExchangeCelo = () => {
   })
 
   jest.retryTimes(4)
-  it('Withdraw CELO', async () => {
+  it('Then Withdraw CELO', async () => {
     let celoBalanceBefore = await element(by.id('CeloBalance')).getAttributes()
     // Scroll to the withdraw button
     await waitFor(element(by.id('WithdrawCELO')))

--- a/packages/mobile/e2e/src/usecases/ExchangeCelo.js
+++ b/packages/mobile/e2e/src/usecases/ExchangeCelo.js
@@ -1,79 +1,161 @@
-import { enterPinUiIfNecessary } from '../utils/utils'
+import {
+  enterPinUiIfNecessary,
+  isElementVisible,
+  sleep,
+  waitForExpectNotVisible,
+} from '../utils/utils'
 import { DEFAULT_RECIPIENT_ADDRESS } from '../utils/consts'
 import { celoEducation } from '../utils/celoEducation'
 import { dismissBanners } from '../utils/banners'
 import { reloadReactNative } from '../utils/retries'
 
-const CELO_TO_EXCHANGE = 1.1
-const CELO_TO_SEND = '0.001'
+const CELO_TO_SELL = 0.025
+const CELO_TO_BUY = 0.045
+const CELO_TO_WITHDRAW = 0.02
+const FEES = 0.001
 
 export default ExchangeCelo = () => {
   beforeEach(async () => {
     await reloadReactNative()
+    // Tap Banner
     await dismissBanners()
+    // Tap Hamburger Menu
     await element(by.id('Hamburger')).tap()
+    // Tap CELO
     await element(by.id('CELO')).tap()
-  })
-
-  it('Go to CELO screen and through education flow', async () => {
+    // Complete CELO education if present - not the focus of these tests
     await celoEducation()
   })
 
+  jest.retryTimes(3)
   it('Buy CELO', async () => {
+    // Wait for buy button
     await waitFor(element(by.text('Buy')))
       .toBeVisible()
-      .withTimeout(30000)
-    // await expect(element(by.id('BuyCelo'))).toBeVisible()
-
-    // Tap on the buy button, fill the amount, review and confirm.
+      .withTimeout(5000)
+    // Get starting balance
+    let celoBalanceBefore = await element(by.id('CeloBalance')).getAttributes()
+    // Tap Buy
     await element(by.text('Buy')).tap()
-    await element(by.id('ExchangeInput')).replaceText(CELO_TO_EXCHANGE.toString())
+    // Fill in the amount
+    await element(by.id('ExchangeInput')).replaceText(`${CELO_TO_BUY}`)
+    // TODO - Get first exchange rate
+    // Send return key to close keyboard if review button is obscured by keyboard
+    if (!(await isElementVisible('ExchangeReviewButton'))) {
+      await element(by.id('ExchangeInput')).typeText('\n')
+    }
+    // TODO - Get second exchange rate
+    // Sleep for 3 seconds on review
+    await sleep(3 * 1000)
+    // Tap Review
     await element(by.id('ExchangeReviewButton')).tap()
+    // Tap Confirm
     await element(by.id('ConfirmExchange')).tap()
-
+    // Enter PIN
     await enterPinUiIfNecessary()
-
-    // Return to the Exchange CELO screen and check balance
-    // await expect(element(by.text('Purchased')).atIndex(0)).toBeVisible()
-    // await expect(element(by.text(`${CELO_TO_EXCHANGE}`).atIndex(0))).toBeVisible();
+    // Scroll to top of feed
+    await element(by.id('ExchangeScrollView')).scroll(200, 'down')
+    // Wait 10 seconds checking that error banner is not visible each second
+    await waitForExpectNotVisible('errorBanner')
+    // Assert balance is updated
+    await waitFor(element(by.id('CeloBalance')))
+      .toHaveText(`${(+celoBalanceBefore.text + CELO_TO_BUY).toFixed(3)}`)
+      .withTimeout(10 * 1000)
+    // Assert buy amount is present - displays amount after fees
+    await expect(
+      element(
+        by.text(`${(CELO_TO_BUY - FEES).toFixed(3)}`).withAncestor(by.id('TransactionList'))
+      ).atIndex(0)
+    ).toBeVisible()
   })
 
+  jest.retryTimes(3)
   it('Sell CELO', async () => {
-    // Tap on the sell button, fill the amount, review and confirm.
+    // Wait for buy button
+    await waitFor(element(by.text('Sell')))
+      .toBeVisible()
+      .withTimeout(5000)
+    // Get starting balance
+    let celoBalanceBefore = await element(by.id('CeloBalance')).getAttributes()
+    // Tap Sell
     await element(by.text('Sell')).tap()
-    await element(by.id('ExchangeInput')).replaceText(CELO_TO_EXCHANGE.toString())
+    // Fill in the amount
+    await element(by.id('ExchangeInput')).replaceText(`${CELO_TO_SELL}`)
+    // TODO - Get first exchange rate
+    // Send return key to close keyboard if review button is obscured by keyboard
+    if (!(await isElementVisible('ExchangeReviewButton'))) {
+      await element(by.id('ExchangeInput')).typeText('\n')
+    }
+    // TODO - Get second exchange rate
+    // Sleep for 3 seconds on review
+    await sleep(3 * 1000)
+    // Tap Review
     await element(by.id('ExchangeReviewButton')).tap()
+    // Tap Confirm
     await element(by.id('ConfirmExchange')).tap()
-
+    // Enter PIN
     await enterPinUiIfNecessary()
-
-    // Return to the Exchange CELO screen.
-    // await expect(element(by.text('Sold')).atIndex(0)).toBeVisible();
-    // await expect(element(by.text(`-${CELO_TO_EXCHANGE}`)).atIndex(0)).toBeVisible();
+    // Scroll to top of feed
+    await element(by.id('ExchangeScrollView')).scroll(200, 'down')
+    // Wait 10 seconds checking that error banner is not visible each second
+    await waitForExpectNotVisible('errorBanner')
+    // Assert balance is updated
+    await waitFor(element(by.id('CeloBalance')))
+      .toHaveText(`${(+celoBalanceBefore.text - CELO_TO_SELL).toFixed(3)}`)
+      .withTimeout(10 * 1000)
+    // Assert buy amount is present - displays amount sans fees
+    await expect(
+      element(
+        by.text(`-${CELO_TO_SELL.toFixed(3)}`).withAncestor(by.id('TransactionList'))
+      ).atIndex(0)
+    ).toBeVisible()
   })
 
+  jest.retryTimes(3)
   it('Withdraw CELO', async () => {
+    let celoBalanceBefore = await element(by.id('CeloBalance')).getAttributes()
+    // Scroll to the withdraw button
     await waitFor(element(by.id('WithdrawCELO')))
       .toBeVisible()
       .whileElement(by.id('ExchangeScrollView'))
       .scroll(50, 'down')
-
-    // Tap on withdraw, fill data, review and confirm.
+    // Tap withdraw
     await element(by.id('WithdrawCELO')).tap()
+    // Wait on account address entry field
     await waitFor(element(by.id('AccountAddress')))
       .toBeVisible()
-      .withTimeout(10000)
+      .withTimeout(10 * 1000)
+    // Fill in the destination address
     await element(by.id('AccountAddress')).replaceText(DEFAULT_RECIPIENT_ADDRESS)
-    await element(by.id('CeloAmount')).replaceText(CELO_TO_SEND)
+    // Fill in the amount
+    await element(by.id('CeloAmount')).replaceText(`${CELO_TO_WITHDRAW}`)
+    // Send return key to close keyboard if review button is obscured by keyboard
+    if (!(await isElementVisible('WithdrawReviewButton'))) {
+      await element(by.id('ExchangeInput')).typeText('\n')
+    }
+    // Tap Review
     await element(by.id('WithdrawReviewButton')).tap()
+    // Wait for confirm button
     await waitFor(element(by.id('ConfirmWithdrawButton')))
       .toBeVisible()
-      .withTimeout(10000)
+      .withTimeout(1 * 1000)
+    // Tap Confirm
     await element(by.id('ConfirmWithdrawButton')).tap()
-
+    // Enter PIN
     await enterPinUiIfNecessary()
-
-    // Return to the Exchange CELO screen after confirming.
-    await expect(element(by.id('BuyCelo'))).toBeVisible()
+    // Scroll to top of feed
+    await element(by.id('ExchangeScrollView')).scroll(200, 'down')
+    // Wait 10 seconds checking that error banner is not visible each second
+    await waitForExpectNotVisible('errorBanner')
+    // Assert balance is updated
+    await waitFor(element(by.id('CeloBalance')))
+      .toHaveText(`${(+celoBalanceBefore.text - CELO_TO_WITHDRAW).toFixed(3)}`)
+      .withTimeout(10 * 1000)
+    // Assert withdrawal amount is present
+    await expect(
+      element(
+        by.text(`-${CELO_TO_WITHDRAW.toFixed(3)}`).withAncestor(by.id('TransactionList'))
+      ).atIndex(0)
+    ).toBeVisible()
   })
 }

--- a/packages/mobile/e2e/src/usecases/OffRamps.js
+++ b/packages/mobile/e2e/src/usecases/OffRamps.js
@@ -2,7 +2,6 @@ import { dismissBanners } from '../utils/banners'
 import { DEFAULT_RECIPIENT_ADDRESS } from '../utils/consts'
 import { reloadReactNative } from '../utils/retries'
 import { enterPinUiIfNecessary, getDeviceModel, pixelDiff, sleep } from '../utils/utils'
-const jestExpect = require('expect')
 
 export default offRamps = () => {
   beforeEach(async () => {
@@ -63,7 +62,7 @@ export default offRamps = () => {
         await element(by.id('GoToProviderButton')).tap()
       })
 
-      it('Then Should Display Exchanges & Account Key', async () => {
+      it('Then Display Exchanges & Account Address', async () => {
         await waitFor(element(by.id('Bittrex')))
           .toBeVisible()
           .withTimeout(20000)
@@ -88,7 +87,7 @@ export default offRamps = () => {
         await element(by.text('Next')).tap()
       })
 
-      it('Then Bidali Should Display', async () => {
+      it('Then Display Bidali', async () => {
         await expect(element(by.text('Bidali'))).toBeVisible()
         // TODO: Include Check of Screenshot in Nightly Tests
         // await sleep(15000)
@@ -104,7 +103,7 @@ export default offRamps = () => {
         await element(by.id('GoToProviderButton')).tap()
       })
 
-      it('Then Should Display Exchanges & Account Key', async () => {
+      it('Then Display Exchanges & Account Address', async () => {
         await waitFor(element(by.id('Bittrex')))
           .toBeVisible()
           .withTimeout(20000)
@@ -136,23 +135,17 @@ export default offRamps = () => {
         await element(by.id('WithdrawReviewButton')).tap()
       })
 
-      it('Then Should Be Able To Send To Address', async () => {
+      it('Then Send To Address', async () => {
         // Confirm withdrawal for randomAmount
         await element(by.id('ConfirmWithdrawButton')).tap()
         // Enter PIN if necessary
         await enterPinUiIfNecessary()
-        // Use Different Assertions for iOS and Android
-        if (device.getPlatform() === 'ios') {
-          // Get values of all feed values - iOS
-          let valuesSent = await element(by.id('FeedItemAmountDisplay/value')).getAttributes()
-          // Check text amount in the most recent transaction
-          jestExpect(valuesSent.elements[0].text).toEqual(`-${randomAmount} CELO`)
-        } else {
-          // Check that the text of amount at index 0 is visible - Android
-          await waitFor(element(by.text(`-${randomAmount} CELO`)).atIndex(0))
-            .toBeVisible()
-            .withTimeout(5000)
-        }
+        // Assert send transaction is present in feed
+        await expect(
+          element(by.text(`-${randomAmount} CELO`).withAncestor(by.id('TransactionList'))).atIndex(
+            0
+          )
+        ).toBeVisible()
       })
     })
 
@@ -162,7 +155,7 @@ export default offRamps = () => {
         await element(by.id('GoToProviderButton')).tap()
       })
 
-      it('Then Should Display Exchanges & Account Key', async () => {
+      it('Then Display Exchanges & Account Address', async () => {
         await waitFor(element(by.id('Binance')))
           .toBeVisible()
           .withTimeout(20000)

--- a/packages/mobile/e2e/src/utils/utils.js
+++ b/packages/mobile/e2e/src/utils/utils.js
@@ -268,3 +268,12 @@ export async function setUrlDenyList(
     console.warn('Error in setUrlDenyList: ', error)
   }
 }
+
+export async function waitForExpectNotVisible(elementId, secondsToWait = 10) {
+  for (let i in [...Array(secondsToWait).keys()]) {
+    await waitFor(element(by.id(elementId)))
+      .not.toBeVisible()
+      .withTimeout(1000)
+    await expect(element(by.id(elementId))).not.toBeVisible()
+  }
+}

--- a/packages/mobile/src/transactions/TransactionFeed.tsx
+++ b/packages/mobile/src/transactions/TransactionFeed.tsx
@@ -106,10 +106,18 @@ function TransactionFeed({ kind, loading, error, data }: Props) {
         sections={sections}
         keyExtractor={keyExtractor}
         keyboardShouldPersistTaps="always"
+        testID="TransactionList"
       />
     )
   } else {
-    return <FlatList data={data} keyExtractor={keyExtractor} renderItem={renderItem} />
+    return (
+      <FlatList
+        testID="TransactionList"
+        data={data}
+        keyExtractor={keyExtractor}
+        renderItem={renderItem}
+      />
+    )
   }
 }
 

--- a/packages/mobile/src/transactions/__snapshots__/TransactionFeed.test.tsx.snap
+++ b/packages/mobile/src/transactions/__snapshots__/TransactionFeed.test.tsx.snap
@@ -90,6 +90,7 @@ exports[`renders for gold to dollar exchange properly 1`] = `
   renderItem={[Function]}
   scrollEventThrottle={50}
   stickyHeaderIndices={Array []}
+  testID="TransactionList"
   updateCellsBatchingPeriod={50}
   windowSize={21}
 >

--- a/packages/mobile/src/transactions/__snapshots__/TransactionsList.test.tsx.snap
+++ b/packages/mobile/src/transactions/__snapshots__/TransactionsList.test.tsx.snap
@@ -111,6 +111,7 @@ exports[`ignores failed standby transactions 1`] = `
   renderItem={[Function]}
   scrollEventThrottle={50}
   stickyHeaderIndices={Array []}
+  testID="TransactionList"
   updateCellsBatchingPeriod={50}
   windowSize={21}
 >
@@ -708,6 +709,7 @@ exports[`ignores pending standby transactions that are completed in the response
   renderItem={[Function]}
   scrollEventThrottle={50}
   stickyHeaderIndices={Array []}
+  testID="TransactionList"
   updateCellsBatchingPeriod={50}
   windowSize={21}
 >
@@ -1397,6 +1399,7 @@ exports[`renders the received data along with the standby transactions 1`] = `
   renderItem={[Function]}
   scrollEventThrottle={50}
   stickyHeaderIndices={Array []}
+  testID="TransactionList"
   updateCellsBatchingPeriod={50}
   windowSize={21}
 >


### PR DESCRIPTION
### Description

More deterministic e2e tests for CELO exchange
- Check for total balance update
- Better check that error message is not thrown
- Check that new feed item is present
- Retries x4 - Once #1043 is resolved this should be able to be removed.

### Other changes

- Added a utility method for checking for the error banner.
- Update `OffRamps.spec.js` `Then Send To Address` test to used better assertion method.
- Update `OffRamps.spec.js` to use bbd syntax.

### Tested

Tests run locally & observed in CI.

### How others should test

N/A

### Backwards compatibility

This change is backwards compatible.