### PR TITLE
fixing create account steps

### DIFF
--- a/packages/mobile/locales/en-US/onboarding.json
+++ b/packages/mobile/locales/en-US/onboarding.json
@@ -17,7 +17,9 @@
   },
   "createAccount": "Create Account",
   "restoreAccount": "Restore My Account",
-  "step": "Step {{step}} of 5",
+  "createAccountSteps": "Step {{step}} of 3",
+  "restoreAccountSteps": "Step {{step}} of 4",
+  // "step": "Step {{step}} of 5",
   "selectCountryCode": "Select Country Code",
   "pincodeSet": {
     "create": "Create a PIN",

--- a/packages/mobile/locales/en-US/onboarding.json
+++ b/packages/mobile/locales/en-US/onboarding.json
@@ -19,7 +19,6 @@
   "restoreAccount": "Restore My Account",
   "createAccountSteps": "Step {{step}} of 3",
   "restoreAccountSteps": "Step {{step}} of 4",
-  // "step": "Step {{step}} of 5",
   "selectCountryCode": "Select Country Code",
   "pincodeSet": {
     "create": "Create a PIN",

--- a/packages/mobile/src/account/Profile.tsx
+++ b/packages/mobile/src/account/Profile.tsx
@@ -91,7 +91,7 @@ function Profile({ navigation, route }: Props) {
   )
 }
 
-Profile.navigationOptions = ({ navigation, route }: Props) => {
+Profile.navigationOptions = ({ navigation }: Props) => {
   const onCancel = () => {
     navigation.goBack()
   }

--- a/packages/mobile/src/import/ImportWallet.tsx
+++ b/packages/mobile/src/import/ImportWallet.tsx
@@ -89,7 +89,7 @@ export class ImportWallet extends React.Component<Props, State> {
     headerTitle: () => (
       <HeaderTitleWithSubtitle
         title={i18n.t('nuxNamePin1:importIt')}
-        subTitle={i18n.t('onboarding:step', { step: '3' })}
+        subTitle={i18n.t('onboarding:restoreAccountSteps', { step: '3' })}
       />
     ),
   }

--- a/packages/mobile/src/navigator/Navigator.tsx
+++ b/packages/mobile/src/navigator/Navigator.tsx
@@ -197,16 +197,13 @@ const verificationScreens = (Navigator: typeof Stack) => {
 
 const pincodeSetScreenOptions = ({
   route,
-}: // does route has choseToRestoreAccount? prob not
-// I dont think i understand route., where did it come from?
-{
+}: {
   route: RouteProp<StackParamList, Screens.PincodeSet>
 }) => {
   const changePin = route.params?.changePin
   const title = changePin
     ? i18n.t('onboarding:pincodeSet.changePIN')
     : i18n.t('onboarding:pincodeSet.create')
-  debugger
 
   return {
     ...nuxNavigationOptions,
@@ -217,7 +214,7 @@ const pincodeSetScreenOptions = ({
           changePin
             ? ' '
             : i18n.t(
-                choseToRestoreAccount
+                route.params?.choseToRestoreAccount
                   ? 'onboarding:restoreAccountSteps'
                   : 'onboarding:createAccountSteps',
                 { step: '2' }

--- a/packages/mobile/src/navigator/Navigator.tsx
+++ b/packages/mobile/src/navigator/Navigator.tsx
@@ -197,20 +197,32 @@ const verificationScreens = (Navigator: typeof Stack) => {
 
 const pincodeSetScreenOptions = ({
   route,
-}: {
+}: // does route has choseToRestoreAccount? prob not
+// I dont think i understand route., where did it come from?
+{
   route: RouteProp<StackParamList, Screens.PincodeSet>
 }) => {
   const changePin = route.params?.changePin
   const title = changePin
     ? i18n.t('onboarding:pincodeSet.changePIN')
     : i18n.t('onboarding:pincodeSet.create')
+  debugger
 
   return {
     ...nuxNavigationOptions,
     headerTitle: () => (
       <HeaderTitleWithSubtitle
         title={title}
-        subTitle={changePin ? ' ' : i18n.t('onboarding:step', { step: '2' })}
+        subTitle={
+          changePin
+            ? ' '
+            : i18n.t(
+                choseToRestoreAccount
+                  ? 'onboarding:restoreAccountSteps'
+                  : 'onboarding:createAccountSteps',
+                { step: '2' }
+              )
+        }
       />
     ),
   }

--- a/packages/mobile/src/navigator/Navigator.tsx
+++ b/packages/mobile/src/navigator/Navigator.tsx
@@ -56,12 +56,10 @@ import DrawerNavigator from 'src/navigator/DrawerNavigator'
 import {
   emptyHeader,
   HeaderTitleWithBalance,
-  HeaderTitleWithSubtitle,
   headerWithBackButton,
   headerWithBackEditButtons,
   noHeader,
   noHeaderGestureDisabled,
-  nuxNavigationOptions,
 } from 'src/navigator/Headers'
 import { navigateBack, navigateToExchangeHome } from 'src/navigator/NavigationService'
 import QRNavigator from 'src/navigator/QRNavigator'
@@ -195,36 +193,6 @@ const verificationScreens = (Navigator: typeof Stack) => {
   )
 }
 
-const pincodeSetScreenOptions = ({
-  route,
-}: {
-  route: RouteProp<StackParamList, Screens.PincodeSet>
-}) => {
-  const changePin = route.params?.changePin
-  const title = changePin
-    ? i18n.t('onboarding:pincodeSet.changePIN')
-    : i18n.t('onboarding:pincodeSet.create')
-
-  return {
-    ...nuxNavigationOptions,
-    headerTitle: () => (
-      <HeaderTitleWithSubtitle
-        title={title}
-        subTitle={
-          changePin
-            ? ' '
-            : i18n.t(
-                route.params?.choseToRestoreAccount
-                  ? 'onboarding:restoreAccountSteps'
-                  : 'onboarding:createAccountSteps',
-                { step: '2' }
-              )
-        }
-      />
-    ),
-  }
-}
-
 const nuxScreens = (Navigator: typeof Stack) => (
   <>
     <Navigator.Screen
@@ -245,7 +213,7 @@ const nuxScreens = (Navigator: typeof Stack) => (
     <Navigator.Screen
       name={Screens.PincodeSet}
       component={PincodeSet}
-      options={pincodeSetScreenOptions}
+      options={PincodeSet.navigationOptions}
     />
     <Navigator.Screen
       name={Screens.ImportWallet}

--- a/packages/mobile/src/navigator/types.tsx
+++ b/packages/mobile/src/navigator/types.tsx
@@ -243,7 +243,12 @@ export type StackParamList = {
     origin: SendOrigin
   }
   [Screens.VerificationEducationScreen]:
-    | { showSkipDialog?: boolean; hideOnboardingStep?: boolean; selectedCountryCodeAlpha2?: string }
+    | {
+        showSkipDialog?: boolean
+        hideOnboardingStep?: boolean
+        selectedCountryCodeAlpha2?: string
+        choseToRestoreAccount?: boolean
+      }
     | undefined
   [Screens.VerificationInputScreen]:
     | { showHelpDialog?: boolean; choseToRestoreAccount?: boolean }

--- a/packages/mobile/src/navigator/types.tsx
+++ b/packages/mobile/src/navigator/types.tsx
@@ -166,6 +166,7 @@ export type StackParamList = {
         isVerifying?: boolean
         changePin?: boolean
         komenciAvailable?: boolean
+        choseToRestoreAccount?: boolean
       }
     | undefined
   [Screens.PhoneNumberLookupQuota]: {

--- a/packages/mobile/src/navigator/types.tsx
+++ b/packages/mobile/src/navigator/types.tsx
@@ -245,7 +245,9 @@ export type StackParamList = {
   [Screens.VerificationEducationScreen]:
     | { showSkipDialog?: boolean; hideOnboardingStep?: boolean; selectedCountryCodeAlpha2?: string }
     | undefined
-  [Screens.VerificationInputScreen]: { showHelpDialog: boolean } | undefined
+  [Screens.VerificationInputScreen]:
+    | { showHelpDialog?: boolean; choseToRestoreAccount?: boolean }
+    | undefined
   [Screens.VerificationLoadingScreen]: { withoutRevealing: boolean }
   [Screens.OnboardingEducationScreen]: undefined
   [Screens.OnboardingSuccessScreen]: undefined

--- a/packages/mobile/src/onboarding/registration/NameAndPicture.tsx
+++ b/packages/mobile/src/onboarding/registration/NameAndPicture.tsx
@@ -47,7 +47,12 @@ function NameAndPicture({ navigation }: Props) {
           title={i18n.t(
             choseToRestoreAccount ? 'onboarding:restoreAccount' : 'onboarding:createAccount'
           )}
-          subTitle={i18n.t('onboarding:step', { step: '1' })}
+          subTitle={i18n.t(
+            choseToRestoreAccount
+              ? 'onboarding:restoreAccountSteps'
+              : 'onboarding:createAccountSteps',
+            { step: '1' }
+          )}
         />
       ),
     })

--- a/packages/mobile/src/onboarding/registration/NameAndPicture.tsx
+++ b/packages/mobile/src/onboarding/registration/NameAndPicture.tsx
@@ -62,7 +62,10 @@ function NameAndPicture({ navigation }: Props) {
     if (recoveringFromStoreWipe) {
       navigate(Screens.ImportWallet)
     } else {
-      navigate(Screens.PincodeSet, { komenciAvailable: !!asyncKomenciReadiness.result })
+      navigate(Screens.PincodeSet, {
+        komenciAvailable: !!asyncKomenciReadiness.result,
+        choseToRestoreAccount: !!choseToRestoreAccount,
+      })
     }
   }
 

--- a/packages/mobile/src/onboarding/registration/NameAndPicture.tsx
+++ b/packages/mobile/src/onboarding/registration/NameAndPicture.tsx
@@ -64,7 +64,6 @@ function NameAndPicture({ navigation }: Props) {
     } else {
       navigate(Screens.PincodeSet, {
         komenciAvailable: !!asyncKomenciReadiness.result,
-        choseToRestoreAccount: !!choseToRestoreAccount,
       })
     }
   }

--- a/packages/mobile/src/pincode/PincodeSet.tsx
+++ b/packages/mobile/src/pincode/PincodeSet.tsx
@@ -14,14 +14,14 @@ import { OnboardingEvents, SettingsEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import DevSkipButton from 'src/components/DevSkipButton'
 import i18n, { Namespaces, withTranslation } from 'src/i18n'
-import { nuxNavigationOptions } from 'src/navigator/Headers'
+import { HeaderTitleWithSubtitle, nuxNavigationOptions } from 'src/navigator/Headers'
 import { navigate, navigateClearingStack, navigateHome } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import { StackParamList } from 'src/navigator/types'
 import {
   DEFAULT_CACHE_ACCOUNT,
-  PinBlocklist,
   isPinValid,
+  PinBlocklist,
   updatePin,
 } from 'src/pincode/authentication'
 import { getCachedPin, setCachedPin } from 'src/pincode/PasswordCache'
@@ -69,7 +69,31 @@ const mapDispatchToProps = {
 }
 
 export class PincodeSet extends React.Component<Props, State> {
-  static navigationOptions = nuxNavigationOptions
+  static navigationOptions = ({ route }: ScreenProps) => {
+    const changePin = route.params?.changePin
+    const title = changePin
+      ? i18n.t('onboarding:pincodeSet.changePIN')
+      : i18n.t('onboarding:pincodeSet.create')
+
+    return {
+      ...nuxNavigationOptions,
+      headerTitle: () => (
+        <HeaderTitleWithSubtitle
+          title={title}
+          subTitle={
+            changePin
+              ? ' '
+              : i18n.t(
+                  route.params?.choseToRestoreAccount
+                    ? 'onboarding:restoreAccountSteps'
+                    : 'onboarding:createAccountSteps',
+                  { step: '2' }
+                )
+          }
+        />
+      ),
+    }
+  }
 
   state: State = {
     oldPin: '',
@@ -90,6 +114,9 @@ export class PincodeSet extends React.Component<Props, State> {
     if (this.props.useExpandedBlocklist) {
       this.setState({ blocklist: new PinBlocklist() })
     }
+
+    // Setting choseToRestoreAccount on route param for navigationOptions
+    this.props.navigation.setParams({ choseToRestoreAccount: this.props.choseToRestoreAccount })
   }
 
   isChangingPin() {

--- a/packages/mobile/src/verify/VerificationEducationScreen.tsx
+++ b/packages/mobile/src/verify/VerificationEducationScreen.tsx
@@ -87,6 +87,7 @@ function VerificationEducationScreen({ route, navigation }: Props) {
   const currentState = useSelector(currentStateSelector)
   const shouldUseKomenci = useSelector(shouldUseKomenciSelector)
   const verificationStatus = useSelector(verificationStatusSelector)
+  const choseToRestoreAccount = useTypedSelector((state) => state.account.choseToRestoreAccount)
 
   const onPressStart = async () => {
     if (!canUsePhoneNumber()) {
@@ -150,6 +151,10 @@ function VerificationEducationScreen({ route, navigation }: Props) {
       )
     }
   }, [route.params?.selectedCountryCodeAlpha2])
+
+  useEffect(() => {
+    navigation.setParams({ choseToRestoreAccount })
+  }, [choseToRestoreAccount])
 
   useAsync(async () => {
     await waitUntilSagasFinishLoading()
@@ -374,7 +379,12 @@ VerificationEducationScreen.navigationOptions = ({ navigation, route }: ScreenPr
     : () => (
         <HeaderTitleWithSubtitle
           title={i18n.t('onboarding:verificationEducation.title')}
-          subTitle={i18n.t('onboarding:step', { step: '4' })}
+          subTitle={i18n.t(
+            route.params?.choseToRestoreAccount
+              ? 'onboarding:restoreAccountSteps'
+              : 'onboarding:createAccountSteps',
+            { step: route.params?.choseToRestoreAccount ? '4' : '3' }
+          )}
         />
       )
   return {

--- a/packages/mobile/src/verify/VerificationInputScreen.tsx
+++ b/packages/mobile/src/verify/VerificationInputScreen.tsx
@@ -58,6 +58,7 @@ interface StateProps {
   underlyingError: ErrorMessages | null | undefined
   lastRevealAttempt: number | null
   shortVerificationCodesEnabled: boolean
+  choseToRestoreAccount: boolean | undefined
 }
 
 interface DispatchProps {
@@ -100,6 +101,7 @@ const mapStateToProps = (state: RootState): StateProps => {
     underlyingError: errorSelector(state),
     shortVerificationCodesEnabled: shortVerificationCodesEnabledSelector(state),
     lastRevealAttempt,
+    choseToRestoreAccount: state.account.choseToRestoreAccount,
   }
 }
 
@@ -124,7 +126,12 @@ class VerificationInputScreen extends React.Component<Props, State> {
     headerTitle: () => (
       <HeaderTitleWithSubtitle
         title={i18n.t('onboarding:verificationInput.title')}
-        subTitle={i18n.t('onboarding:step', { step: '4' })}
+        subTitle={i18n.t(
+          this.props.choseToRestoreAccount
+            ? 'onboarding:restoreAccountSteps'
+            : 'onboarding:createAccountSteps',
+          { step: this.props.choseToRestoreAccount ? '4' : '3' }
+        )}
       />
     ),
     headerRight: () => (

--- a/packages/mobile/src/verify/VerificationInputScreen.tsx
+++ b/packages/mobile/src/verify/VerificationInputScreen.tsx
@@ -159,6 +159,9 @@ class VerificationInputScreen extends React.Component<Props, State> {
       }
       this.setState({ timer: timer - 1 })
     }, 1000)
+
+    // Setting choseToRestoreAccount on route param for navigationOptions
+    this.props.navigation.setParams({ choseToRestoreAccount: this.props.choseToRestoreAccount })
   }
 
   componentDidUpdate(prevProps: Props) {

--- a/packages/mobile/src/verify/VerificationInputScreen.tsx
+++ b/packages/mobile/src/verify/VerificationInputScreen.tsx
@@ -117,7 +117,7 @@ function HeaderLeftButton() {
 }
 
 class VerificationInputScreen extends React.Component<Props, State> {
-  static navigationOptions = ({ navigation }: ScreenProps) => ({
+  static navigationOptions = ({ navigation, route }: ScreenProps) => ({
     ...nuxNavigationOptions,
     gestureEnabled: false,
     headerLeft: () => {
@@ -127,10 +127,10 @@ class VerificationInputScreen extends React.Component<Props, State> {
       <HeaderTitleWithSubtitle
         title={i18n.t('onboarding:verificationInput.title')}
         subTitle={i18n.t(
-          this.props.choseToRestoreAccount
+          route.params?.choseToRestoreAccount
             ? 'onboarding:restoreAccountSteps'
             : 'onboarding:createAccountSteps',
-          { step: this.props.choseToRestoreAccount ? '4' : '3' }
+          { step: route.params?.choseToRestoreAccount ? '4' : '3' }
         )}
       />
     ),

--- a/packages/mobile/src/verify/VerificationLoadingScreen.tsx
+++ b/packages/mobile/src/verify/VerificationLoadingScreen.tsx
@@ -46,6 +46,7 @@ const mapStateToProps = (state: RootState) => {
     verificationStatus: state.identity.verificationStatus,
     retryWithForno: state.account.retryVerificationWithForno,
     fornoMode: state.web3.fornoMode,
+    choseToRestoreAccount: state.account.choseToRestoreAccount,
   }
 }
 
@@ -53,7 +54,7 @@ type Props = StackScreenProps<StackParamList, Screens.VerificationLoadingScreen>
 
 export default function VerificationLoadingScreen({ route }: Props) {
   const verificationStatusRef = useRef<VerificationStatus | undefined>()
-  const { fornoMode, retryWithForno, verificationStatus } = useSelector(
+  const { fornoMode, retryWithForno, verificationStatus, choseToRestoreAccount } = useSelector(
     mapStateToProps,
     shallowEqual
   )
@@ -76,7 +77,7 @@ export default function VerificationLoadingScreen({ route }: Props) {
     verificationStatusRef.current = verificationStatus
 
     if (verificationStatus === VerificationStatus.CompletingAttestations) {
-      navigate(Screens.VerificationInputScreen)
+      navigate(Screens.VerificationInputScreen, { choseToRestoreAccount: !!choseToRestoreAccount })
     } else if (verificationStatus === VerificationStatus.Done) {
       navigate(Screens.OnboardingSuccessScreen)
     }
@@ -100,7 +101,7 @@ export default function VerificationLoadingScreen({ route }: Props) {
     if (!isFocused || verificationStatus === VerificationStatus.CompletingAttestations) {
       return
     }
-    navigate(Screens.VerificationInputScreen)
+    navigate(Screens.VerificationInputScreen, { choseToRestoreAccount: !!choseToRestoreAccount })
   }
 
   const onPressLearnMore = () => {

--- a/packages/mobile/src/verify/VerificationLoadingScreen.tsx
+++ b/packages/mobile/src/verify/VerificationLoadingScreen.tsx
@@ -46,7 +46,6 @@ const mapStateToProps = (state: RootState) => {
     verificationStatus: state.identity.verificationStatus,
     retryWithForno: state.account.retryVerificationWithForno,
     fornoMode: state.web3.fornoMode,
-    choseToRestoreAccount: state.account.choseToRestoreAccount,
   }
 }
 
@@ -54,7 +53,7 @@ type Props = StackScreenProps<StackParamList, Screens.VerificationLoadingScreen>
 
 export default function VerificationLoadingScreen({ route }: Props) {
   const verificationStatusRef = useRef<VerificationStatus | undefined>()
-  const { fornoMode, retryWithForno, verificationStatus, choseToRestoreAccount } = useSelector(
+  const { fornoMode, retryWithForno, verificationStatus } = useSelector(
     mapStateToProps,
     shallowEqual
   )
@@ -77,7 +76,7 @@ export default function VerificationLoadingScreen({ route }: Props) {
     verificationStatusRef.current = verificationStatus
 
     if (verificationStatus === VerificationStatus.CompletingAttestations) {
-      navigate(Screens.VerificationInputScreen, { choseToRestoreAccount: !!choseToRestoreAccount })
+      navigate(Screens.VerificationInputScreen)
     } else if (verificationStatus === VerificationStatus.Done) {
       navigate(Screens.OnboardingSuccessScreen)
     }
@@ -101,7 +100,7 @@ export default function VerificationLoadingScreen({ route }: Props) {
     if (!isFocused || verificationStatus === VerificationStatus.CompletingAttestations) {
       return
     }
-    navigate(Screens.VerificationInputScreen, { choseToRestoreAccount: !!choseToRestoreAccount })
+    navigate(Screens.VerificationInputScreen)
   }
 
   const onPressLearnMore = () => {


### PR DESCRIPTION
### Description
Create new account flow has a total of 3 onboarding steps while restoring account has an additional onboarding step of importing the wallet. Therefore, fixing the title of the onboarding flow. 


### Tested

Manually tested, see screenshot attached


### Related issues

- Fixes #394

