### PR TITLE
WalletConnect fixes

### DIFF
--- a/packages/mobile/locales/en-US/walletConnect.json
+++ b/packages/mobile/locales/en-US/walletConnect.json
@@ -42,5 +42,6 @@
   "timeoutTitle": "Time out!",
   "timeoutSubtitle": "Your connection timed out. Please check your internet connection & try again",
 
-  "goBackButton": "Go Back"
+  "goBackButton": "Go Back",
+  "v2Unsupported": "This QR code is not supported"
 }

--- a/packages/mobile/src/app/ErrorMessages.ts
+++ b/packages/mobile/src/app/ErrorMessages.ts
@@ -85,4 +85,5 @@ export enum ErrorMessages {
   PROVIDER_FETCH_FAILED = 'providerFetchFailed',
   CASH_OUT_LIMIT_EXCEEDED = 'cashOutLimitExceeded',
   RAISE_LIMIT_EMAIL_NOT_SENT = 'accountScreen10:raiseLimitEmailNotSent',
+  WC2_UNSUPPORTED = 'walletConnect:v2Unsupported',
 }

--- a/packages/mobile/src/walletConnect/saga.ts
+++ b/packages/mobile/src/walletConnect/saga.ts
@@ -1,14 +1,17 @@
 import '@react-native-firebase/database'
 import '@react-native-firebase/messaging'
-import { call, select, spawn } from 'redux-saga/effects'
+import { call, put, select, spawn } from 'redux-saga/effects'
+import { showError } from 'src/alert/actions'
 import { WalletConnectPairingOrigin } from 'src/analytics/types'
+import { ErrorMessages } from 'src/app/ErrorMessages'
 import { walletConnectEnabledSelector } from 'src/app/selectors'
+import { navigateBack } from 'src/navigator/NavigationService'
 import { initialiseWalletConnectV1, walletConnectV1Saga } from 'src/walletConnect/v1/saga'
-import { initialiseWalletConnectV2, walletConnectV2Saga } from 'src/walletConnect/v2/saga'
 
 export function* walletConnectSaga() {
   yield spawn(walletConnectV1Saga)
-  yield spawn(walletConnectV2Saga)
+  // TODO: Add back once it's working
+  // yield spawn(walletConnectV2Saga)
 }
 
 export function* initialiseWalletConnect(uri: string, origin: WalletConnectPairingOrigin) {
@@ -23,7 +26,10 @@ export function* initialiseWalletConnect(uri: string, origin: WalletConnectPairi
       yield call(initialiseWalletConnectV1, uri, origin)
       break
     case '2':
-      yield call(initialiseWalletConnectV2, uri, origin)
+      yield put(showError(ErrorMessages.WC2_UNSUPPORTED))
+      navigateBack()
+      // TODO: Add back once it's working
+      // yield call(initialiseWalletConnectV2, uri, origin)
       break
     default:
       throw new Error(`Unsupported WalletConnect version '${version}'`)

--- a/packages/mobile/src/walletConnect/screens/ActionRequest.tsx
+++ b/packages/mobile/src/walletConnect/screens/ActionRequest.tsx
@@ -1,8 +1,9 @@
 import Button, { BtnSizes, BtnTypes } from '@celo/react-components/components/Button'
+import Times from '@celo/react-components/icons/Times'
 import colors from '@celo/react-components/styles/colors'
 import fontStyles from '@celo/react-components/styles/fonts'
 import { StackScreenProps } from '@react-navigation/stack'
-import React, { useEffect } from 'react'
+import React, { useEffect, useLayoutEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Image, ScrollView, StyleSheet, Text, View } from 'react-native'
 import { TouchableOpacity } from 'react-native-gesture-handler'
@@ -11,6 +12,7 @@ import { useDispatch } from 'react-redux'
 import { Namespaces } from 'src/i18n'
 import { headerWithCloseButton } from 'src/navigator/Headers'
 import { Screens } from 'src/navigator/Screens'
+import { TopBarIconButton } from 'src/navigator/TopBarButton'
 import { StackParamList } from 'src/navigator/types'
 import useStateWithCallback from 'src/utils/useStateWithCallback'
 import { getTranslationFromAction, SupportedActions } from 'src/walletConnect/constants'
@@ -103,6 +105,12 @@ function ActionRequest({ navigation, route: { params: routeParams } }: Props) {
       }),
     [navigation, routeParams, isLoading]
   )
+
+  useLayoutEffect(() => {
+    navigation.setOptions({
+      headerLeft: () => <TopBarIconButton icon={<Times />} onPress={onDeny} />,
+    })
+  }, [])
 
   const { url, name, icon, method, params } = getRequestInfo(routeParams)
   const moreInfoString =

--- a/packages/mobile/src/walletConnect/screens/ActionRequest.tsx
+++ b/packages/mobile/src/walletConnect/screens/ActionRequest.tsx
@@ -1,9 +1,8 @@
 import Button, { BtnSizes, BtnTypes } from '@celo/react-components/components/Button'
-import Times from '@celo/react-components/icons/Times'
 import colors from '@celo/react-components/styles/colors'
 import fontStyles from '@celo/react-components/styles/fonts'
 import { StackScreenProps } from '@react-navigation/stack'
-import React, { useEffect, useLayoutEffect } from 'react'
+import React, { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Image, ScrollView, StyleSheet, Text, View } from 'react-native'
 import { TouchableOpacity } from 'react-native-gesture-handler'
@@ -12,7 +11,6 @@ import { useDispatch } from 'react-redux'
 import { Namespaces } from 'src/i18n'
 import { headerWithCloseButton } from 'src/navigator/Headers'
 import { Screens } from 'src/navigator/Screens'
-import { TopBarIconButton } from 'src/navigator/TopBarButton'
 import { StackParamList } from 'src/navigator/types'
 import useStateWithCallback from 'src/utils/useStateWithCallback'
 import { getTranslationFromAction, SupportedActions } from 'src/walletConnect/constants'
@@ -100,17 +98,11 @@ function ActionRequest({ navigation, route: { params: routeParams } }: Props) {
         if (isLoading) {
           return
         }
-
-        dispatch(denyRequest(routeParams))
+        e.preventDefault()
+        onDeny()
       }),
     [navigation, routeParams, isLoading]
   )
-
-  useLayoutEffect(() => {
-    navigation.setOptions({
-      headerLeft: () => <TopBarIconButton icon={<Times />} onPress={onDeny} />,
-    })
-  }, [])
 
   const { url, name, icon, method, params } = getRequestInfo(routeParams)
   const moreInfoString =

--- a/packages/mobile/src/walletConnect/screens/SessionRequest.tsx
+++ b/packages/mobile/src/walletConnect/screens/SessionRequest.tsx
@@ -109,7 +109,6 @@ function SessionRequest({ navigation, route: { params } }: Props) {
         if (isLoading) {
           return
         }
-        console.log('DENYING!!', e.data.action)
         dispatch(denySession(params))
       }),
     [navigation, params, isLoading]

--- a/packages/mobile/src/walletConnect/screens/SessionRequest.tsx
+++ b/packages/mobile/src/walletConnect/screens/SessionRequest.tsx
@@ -1,8 +1,9 @@
 import Button, { BtnSizes, BtnTypes } from '@celo/react-components/components/Button'
+import Times from '@celo/react-components/icons/Times'
 import colors from '@celo/react-components/styles/colors'
 import fontStyles from '@celo/react-components/styles/fonts'
 import { StackScreenProps } from '@react-navigation/stack'
-import React, { useEffect } from 'react'
+import React, { useEffect, useLayoutEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Image, ScrollView, StyleSheet, Text, View } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
@@ -10,6 +11,7 @@ import { useDispatch } from 'react-redux'
 import { Namespaces } from 'src/i18n'
 import { headerWithCloseButton } from 'src/navigator/Headers'
 import { Screens } from 'src/navigator/Screens'
+import { TopBarIconButton } from 'src/navigator/TopBarButton'
 import { StackParamList } from 'src/navigator/types'
 import useStateWithCallback from 'src/utils/useStateWithCallback'
 import { getTranslationDescriptionFromAction, SupportedActions } from 'src/walletConnect/constants'
@@ -107,11 +109,17 @@ function SessionRequest({ navigation, route: { params } }: Props) {
         if (isLoading) {
           return
         }
-
+        console.log('DENYING!!', e.data.action)
         dispatch(denySession(params))
       }),
     [navigation, params, isLoading]
   )
+
+  useLayoutEffect(() => {
+    navigation.setOptions({
+      headerLeft: () => <TopBarIconButton icon={<Times />} onPress={deny} />,
+    })
+  }, [])
 
   const { url, name, icon, methods } = getRequestInfo(params)
   const fallbackIcon = icon ?? `${url}/favicon.ico`

--- a/packages/mobile/src/walletConnect/screens/SessionRequest.tsx
+++ b/packages/mobile/src/walletConnect/screens/SessionRequest.tsx
@@ -1,9 +1,8 @@
 import Button, { BtnSizes, BtnTypes } from '@celo/react-components/components/Button'
-import Times from '@celo/react-components/icons/Times'
 import colors from '@celo/react-components/styles/colors'
 import fontStyles from '@celo/react-components/styles/fonts'
 import { StackScreenProps } from '@react-navigation/stack'
-import React, { useEffect, useLayoutEffect } from 'react'
+import React, { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Image, ScrollView, StyleSheet, Text, View } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
@@ -11,7 +10,6 @@ import { useDispatch } from 'react-redux'
 import { Namespaces } from 'src/i18n'
 import { headerWithCloseButton } from 'src/navigator/Headers'
 import { Screens } from 'src/navigator/Screens'
-import { TopBarIconButton } from 'src/navigator/TopBarButton'
 import { StackParamList } from 'src/navigator/types'
 import useStateWithCallback from 'src/utils/useStateWithCallback'
 import { getTranslationDescriptionFromAction, SupportedActions } from 'src/walletConnect/constants'
@@ -109,16 +107,11 @@ function SessionRequest({ navigation, route: { params } }: Props) {
         if (isLoading) {
           return
         }
-        dispatch(denySession(params))
+        e.preventDefault()
+        deny()
       }),
     [navigation, params, isLoading]
   )
-
-  useLayoutEffect(() => {
-    navigation.setOptions({
-      headerLeft: () => <TopBarIconButton icon={<Times />} onPress={deny} />,
-    })
-  }, [])
 
   const { url, name, icon, methods } = getRequestInfo(params)
   const fallbackIcon = icon ?? `${url}/favicon.ico`


### PR DESCRIPTION
### Description

- Disable WalletConnect v2 since it's not working anyways and it was causing a crash when scanning QR codes on Android
- Fix a UI glitch when pressing the `X` button in the WC approval screens.

### Other changes

N/A

### Tested

Manually on Android

### How others should test

- Connect on https://celo-walletconnect.vercel.app/ and see that you're able to without problems.
- Try to connect on https://use-contractkit.vercel.app/ and see that you get an error code message.

### Related issues

- Fixes #1186

### Backwards compatibility

N/A