### PR TITLE
Add analytics events for DappKit

### DIFF
--- a/packages/mobile/src/analytics/Events.tsx
+++ b/packages/mobile/src/analytics/Events.tsx
@@ -469,6 +469,16 @@ export enum WalletConnectEvents {
   wc_request_deny_error = 'wc_request_deny_error', // when the dapp request denial fails
 }
 
+export enum DappKitEvents {
+  dappkit_parse_deeplink_error = 'dappkit_parse_deeplink_error', // when dappkit fails to parse the deeplink
+  dappkit_request_propose = 'dappkit_request_propose', // when the dappkit request screen is displayed to accept/deny a dapp request
+  dappkit_request_cancel = 'dappkit_request_cancel', // when user presses the button to cancel the dapp request
+  dappkit_request_details = 'dappkit_request_details', // when user presses the button to show details of a dapp request
+  dappkit_request_accept_start = 'dappkit_request_accept_start', // when user presses the button to accept a dapp request
+  dappkit_request_accept_success = 'dappkit_request_accept_success', // when the dapp request succeeds
+  dappkit_request_accept_error = 'dappkit_request_accept_error', // when the dapp request fails
+}
+
 export type AnalyticsEventType =
   | AppEvents
   | HomeEvents
@@ -490,3 +500,4 @@ export type AnalyticsEventType =
   | NavigationEvents
   | RewardsEvents
   | WalletConnectEvents
+  | DappKitEvents

--- a/packages/mobile/src/analytics/Properties.tsx
+++ b/packages/mobile/src/analytics/Properties.tsx
@@ -1,9 +1,11 @@
+import { DappKitRequestTypes } from '@celo/utils'
 import { check } from 'react-native-permissions'
 import { PincodeType } from 'src/account/reducer'
 import {
   AppEvents,
   CeloExchangeEvents,
   ContractKitEvents,
+  DappKitEvents,
   EscrowEvents,
   FeeEvents,
   FiatExchangeEvents,
@@ -1012,6 +1014,26 @@ interface WalletConnectProperties {
   }
 }
 
+interface DappKitRequestDefaultProperties {
+  dappName: string
+  dappUrl: string
+  requestType: DappKitRequestTypes
+  requestCallback: string
+  requestId: string
+}
+
+interface DappKitProperties {
+  [DappKitEvents.dappkit_parse_deeplink_error]: { deeplink: string; error: string }
+  [DappKitEvents.dappkit_request_propose]: DappKitRequestDefaultProperties
+  [DappKitEvents.dappkit_request_cancel]: DappKitRequestDefaultProperties
+  [DappKitEvents.dappkit_request_details]: DappKitRequestDefaultProperties
+  [DappKitEvents.dappkit_request_accept_start]: DappKitRequestDefaultProperties
+  [DappKitEvents.dappkit_request_accept_success]: DappKitRequestDefaultProperties
+  [DappKitEvents.dappkit_request_accept_error]: DappKitRequestDefaultProperties & {
+    error: string
+  }
+}
+
 export type AnalyticsPropertiesList = AppEventsProperties &
   HomeEventsProperties &
   SettingsEventsProperties &
@@ -1033,4 +1055,5 @@ export type AnalyticsPropertiesList = AppEventsProperties &
   PerformanceProperties &
   NavigationProperties &
   RewardsProperties &
-  WalletConnectProperties
+  WalletConnectProperties &
+  DappKitProperties

--- a/packages/mobile/src/dappkit/DappKitAccountScreen.tsx
+++ b/packages/mobile/src/dappkit/DappKitAccountScreen.tsx
@@ -9,8 +9,10 @@ import { ScrollView, StyleSheet, Text, View } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { connect } from 'react-redux'
 import { e164NumberSelector } from 'src/account/selectors'
+import { DappKitEvents } from 'src/analytics/Events'
+import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import AccountNumber from 'src/components/AccountNumber'
-import { approveAccountAuth } from 'src/dappkit/dappkit'
+import { approveAccountAuth, getDefaultRequestTrackedProperties } from 'src/dappkit/dappkit'
 import { Namespaces, withTranslation } from 'src/i18n'
 import { noHeader } from 'src/navigator/Headers'
 import { navigateBack, navigateHome } from 'src/navigator/NavigationService'
@@ -70,6 +72,10 @@ class DappKitAccountAuthScreen extends React.Component<Props> {
   }
 
   cancel = () => {
+    ValoraAnalytics.track(
+      DappKitEvents.dappkit_request_cancel,
+      getDefaultRequestTrackedProperties(this.props.route.params.dappKitRequest)
+    )
     navigateBack()
   }
 

--- a/packages/mobile/src/dappkit/DappKitSignTxScreen.tsx
+++ b/packages/mobile/src/dappkit/DappKitSignTxScreen.tsx
@@ -7,7 +7,9 @@ import { WithTranslation } from 'react-i18next'
 import { ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { connect } from 'react-redux'
-import { requestTxSignature } from 'src/dappkit/dappkit'
+import { DappKitEvents } from 'src/analytics/Events'
+import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
+import { getDefaultRequestTrackedProperties, requestTxSignature } from 'src/dappkit/dappkit'
 import { Namespaces, withTranslation } from 'src/i18n'
 import { noHeader } from 'src/navigator/Headers'
 import { navigate, navigateBack, navigateHome } from 'src/navigator/NavigationService'
@@ -57,6 +59,11 @@ class DappKitSignTxScreen extends React.Component<Props> {
   showDetails = () => {
     const request = this.getRequest()
 
+    ValoraAnalytics.track(
+      DappKitEvents.dappkit_request_details,
+      getDefaultRequestTrackedProperties(request)
+    )
+
     // TODO(sallyjyl): figure out which data to pass in for multitx
     navigate(Screens.DappKitTxDataScreen, {
       dappKitData: request.txs[0].txData,
@@ -64,6 +71,10 @@ class DappKitSignTxScreen extends React.Component<Props> {
   }
 
   cancel = () => {
+    ValoraAnalytics.track(
+      DappKitEvents.dappkit_request_cancel,
+      getDefaultRequestTrackedProperties(this.getRequest())
+    )
     navigateBack()
   }
 

--- a/packages/mobile/src/dappkit/dappkit.ts
+++ b/packages/mobile/src/dappkit/dappkit.ts
@@ -63,6 +63,7 @@ export function getDefaultRequestTrackedProperties(request: DappKitRequest) {
 function* respondToAccountAuth(action: ApproveAccountAuthAction) {
   const defaultTrackedProperties = getDefaultRequestTrackedProperties(action.request)
   try {
+    ValoraAnalytics.track(DappKitEvents.dappkit_request_accept_start, defaultTrackedProperties)
     Logger.debug(TAG, 'Approving auth account')
     const account = yield select(currentAccountSelector)
     const phoneNumber = yield select(e164NumberSelector)

--- a/packages/mobile/src/dappkit/dappkit.ts
+++ b/packages/mobile/src/dappkit/dappkit.ts
@@ -1,6 +1,7 @@
 import {
   AccountAuthRequest,
   AccountAuthResponseSuccess,
+  DappKitRequest,
   DappKitRequestTypes,
   parseDappKitRequestDeeplink,
   produceResponseDeeplink,
@@ -9,6 +10,8 @@ import {
 } from '@celo/utils/lib/dappkit'
 import { call, select, takeLeading } from 'redux-saga/effects'
 import { e164NumberSelector } from 'src/account/selectors'
+import { DappKitEvents } from 'src/analytics/Events'
+import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import { e164NumberToSaltSelector } from 'src/identity/reducer'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
@@ -45,61 +48,94 @@ export const requestTxSignature = (request: SignTxRequest): RequestTxSignatureAc
   request,
 })
 
+export function getDefaultRequestTrackedProperties(request: DappKitRequest) {
+  const { type: requestType, callback: requestCallback, requestId, dappName } = request
+  const dappUrl = new URL(requestCallback).origin
+  return {
+    dappName,
+    dappUrl,
+    requestType,
+    requestCallback,
+    requestId,
+  }
+}
+
 function* respondToAccountAuth(action: ApproveAccountAuthAction) {
-  Logger.debug(TAG, 'Approving auth account')
-  const account = yield select(currentAccountSelector)
-  const phoneNumber = yield select(e164NumberSelector)
-  const e164NumberToSalt = yield select(e164NumberToSaltSelector)
-  const pepper = e164NumberToSalt[phoneNumber]
-  navigateToURI(
-    produceResponseDeeplink(
-      action.request,
-      AccountAuthResponseSuccess(account, phoneNumber, pepper)
+  const defaultTrackedProperties = getDefaultRequestTrackedProperties(action.request)
+  try {
+    Logger.debug(TAG, 'Approving auth account')
+    const account = yield select(currentAccountSelector)
+    const phoneNumber = yield select(e164NumberSelector)
+    const e164NumberToSalt = yield select(e164NumberToSaltSelector)
+    const pepper = e164NumberToSalt[phoneNumber]
+    navigateToURI(
+      produceResponseDeeplink(
+        action.request,
+        AccountAuthResponseSuccess(account, phoneNumber, pepper)
+      )
     )
-  )
+    ValoraAnalytics.track(DappKitEvents.dappkit_request_accept_success, defaultTrackedProperties)
+  } catch (error) {
+    Logger.error(TAG, 'Failed to respond to account auth', error)
+    ValoraAnalytics.track(DappKitEvents.dappkit_request_accept_error, {
+      ...defaultTrackedProperties,
+      error: error.message,
+    })
+  }
 }
 
 // TODO Error handling here
 function* produceTxSignature(action: RequestTxSignatureAction) {
-  Logger.debug(TAG, 'Producing tx signature')
+  const defaultTrackedProperties = getDefaultRequestTrackedProperties(action.request)
+  try {
+    ValoraAnalytics.track(DappKitEvents.dappkit_request_accept_start, defaultTrackedProperties)
+    Logger.debug(TAG, 'Producing tx signature')
 
-  yield call(getConnectedUnlockedAccount)
-  const web3 = yield call(getWeb3)
+    yield call(getConnectedUnlockedAccount)
+    const web3 = yield call(getWeb3)
 
-  const rawTxs = yield Promise.all(
-    action.request.txs.map(async (tx) => {
-      // TODO offload this logic to walletkit or contractkit, otherwise they
-      // could diverge again and create another bug
-      // See https://github.com/celo-org/celo-monorepo/issues/3045
+    const rawTxs = yield Promise.all(
+      action.request.txs.map(async (tx) => {
+        // TODO offload this logic to walletkit or contractkit, otherwise they
+        // could diverge again and create another bug
+        // See https://github.com/celo-org/celo-monorepo/issues/3045
 
-      // In walletKit we use web3.eth.getCoinbase() to get gateway fee recipient
-      // but that's throwing errors here. Not sure why, but txs work without it.
-      const gatewayFeeRecipient = undefined
-      const gatewayFee = undefined
-      const gas = Math.round(tx.estimatedGas * 1.5)
+        // In walletKit we use web3.eth.getCoinbase() to get gateway fee recipient
+        // but that's throwing errors here. Not sure why, but txs work without it.
+        const gatewayFeeRecipient = undefined
+        const gatewayFee = undefined
+        const gas = Math.round(tx.estimatedGas * 1.5)
 
-      const params: any = {
-        from: tx.from,
-        gasPrice: '0',
-        gas,
-        data: tx.txData,
-        nonce: tx.nonce,
-        value: tx.value,
-        feeCurrency: tx.feeCurrencyAddress,
-        gatewayFeeRecipient,
-        gatewayFee,
-      }
-      if (tx.to) {
-        params.to = tx.to
-      }
-      Logger.debug(TAG, 'Signing tx with params', JSON.stringify(params))
-      const signedTx = await web3.eth.signTransaction(params)
-      return signedTx.raw
+        const params: any = {
+          from: tx.from,
+          gasPrice: '0',
+          gas,
+          data: tx.txData,
+          nonce: tx.nonce,
+          value: tx.value,
+          feeCurrency: tx.feeCurrencyAddress,
+          gatewayFeeRecipient,
+          gatewayFee,
+        }
+        if (tx.to) {
+          params.to = tx.to
+        }
+        Logger.debug(TAG, 'Signing tx with params', JSON.stringify(params))
+        const signedTx = await web3.eth.signTransaction(params)
+        return signedTx.raw
+      })
+    )
+
+    Logger.debug(TAG, 'Txs signed, opening URL')
+    navigateToURI(produceResponseDeeplink(action.request, SignTxResponseSuccess(rawTxs)))
+    ValoraAnalytics.track(DappKitEvents.dappkit_request_accept_success, defaultTrackedProperties)
+  } catch (error) {
+    Logger.error(TAG, 'Failed to produce tx signature', error)
+    ValoraAnalytics.track(DappKitEvents.dappkit_request_accept_error, {
+      ...defaultTrackedProperties,
+      error: error.message,
     })
-  )
-
-  Logger.debug(TAG, 'Txs signed, opening URL')
-  navigateToURI(produceResponseDeeplink(action.request, SignTxResponseSuccess(rawTxs)))
+  }
 }
 
 export function* dappKitSaga() {
@@ -107,14 +143,22 @@ export function* dappKitSaga() {
   yield takeLeading(actions.REQUEST_TX_SIGNATURE, produceTxSignature)
 }
 
-export function handleDappkitDeepLink(deepLink: string) {
+export function handleDappkitDeepLink(deeplink: string) {
   try {
-    const dappKitRequest = parseDappKitRequestDeeplink(deepLink)
+    const dappKitRequest = parseDappKitRequestDeeplink(deeplink)
     switch (dappKitRequest.type) {
       case DappKitRequestTypes.ACCOUNT_ADDRESS:
+        ValoraAnalytics.track(
+          DappKitEvents.dappkit_request_propose,
+          getDefaultRequestTrackedProperties(dappKitRequest)
+        )
         navigate(Screens.DappKitAccountAuth, { dappKitRequest })
         break
       case DappKitRequestTypes.SIGN_TX:
+        ValoraAnalytics.track(
+          DappKitEvents.dappkit_request_propose,
+          getDefaultRequestTrackedProperties(dappKitRequest)
+        )
         navigate(Screens.DappKitSignTxScreen, { dappKitRequest })
         break
       default:
@@ -124,5 +168,9 @@ export function handleDappkitDeepLink(deepLink: string) {
   } catch (error) {
     navigate(Screens.ErrorScreen, { errorMessage: `Deep link not valid for dappkit: ${error}` })
     Logger.debug(TAG, `Deep link not valid for dappkit: ${error}`)
+    ValoraAnalytics.track(DappKitEvents.dappkit_parse_deeplink_error, {
+      deeplink,
+      error: error.message,
+    })
   }
 }


### PR DESCRIPTION
### Description

This PR adds tracking events for the DappKit flow.

### Tested

Checked correct analytics events were triggered when using [Moola](https://moola.market/) and [Ubeswap](https://ubeswap.org/)

### How others should test

No need to test this.

### Related issues

- Fixes #1198

### Backwards compatibility

Yes