### PR TITLE
Tweak mobile's .eslintrc.js config to parse all the ts{x} files

### DIFF
--- a/packages/mobile/.eslintrc.js
+++ b/packages/mobile/.eslintrc.js
@@ -1,7 +1,7 @@
 module.exports = {
   extends: ['@valora/eslint-config-typescript'],
   parserOptions: {
-    project: './tsconfig.json',
+    project: './tsconfig.eslint.json',
   },
   ignorePatterns: ['**/__mocks__/**', '**/lcov-report/**', 'vendor', '.bundle'],
 }

--- a/packages/mobile/tsconfig.eslint.json
+++ b/packages/mobile/tsconfig.eslint.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    ".",
+  ]
+}


### PR DESCRIPTION
A few of our linter options require a full AST. So even though we don't compile
all the ts files we still need to tell eslint how to generate an AST.

This is most relevant to developers using an IDE plugin the linting.