### PR TITLE
Clean up in-app notification showing logic

### DIFF
--- a/packages/mobile/src/home/WalletHome.test.tsx
+++ b/packages/mobile/src/home/WalletHome.test.tsx
@@ -39,8 +39,6 @@ describe('Testnet banner', () => {
           appConnected={true}
           address={null}
           recipientCache={{}}
-          activeNotificationCount={0}
-          callToActNotification={false}
           numberVerified={true}
           importContacts={jest.fn()}
           {...getMockI18nProps()}
@@ -70,8 +68,6 @@ describe('Testnet banner', () => {
           appConnected={false}
           address={null}
           recipientCache={{}}
-          activeNotificationCount={0}
-          callToActNotification={false}
           numberVerified={true}
           importContacts={jest.fn()}
           {...getMockI18nProps()}
@@ -93,8 +89,6 @@ describe('Testnet banner', () => {
           appConnected={true}
           address={null}
           recipientCache={{}}
-          activeNotificationCount={0}
-          callToActNotification={false}
           numberVerified={true}
           importContacts={jest.fn()}
           {...getMockI18nProps()}

--- a/packages/mobile/src/home/WalletHome.tsx
+++ b/packages/mobile/src/home/WalletHome.tsx
@@ -1,4 +1,3 @@
-import SectionHead from '@celo/react-components/components/SectionHead'
 import colors from '@celo/react-components/styles/colors'
 import _ from 'lodash'
 import * as React from 'react'
@@ -9,7 +8,6 @@ import {
   RefreshControl,
   RefreshControlProps,
   SectionList,
-  SectionListData,
   StyleSheet,
 } from 'react-native'
 import Animated from 'react-native-reanimated'
@@ -20,7 +18,6 @@ import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import { ALERT_BANNER_DURATION, DEFAULT_TESTNET, SHOW_TESTNET_BANNER } from 'src/config'
 import { refreshAllBalances, setLoading } from 'src/home/actions'
 import NotificationBox from 'src/home/NotificationBox'
-import { callToActNotificationSelector, getActiveNotificationCount } from 'src/home/selectors'
 import SendOrRequestBar from 'src/home/SendOrRequestBar'
 import { Namespaces, withTranslation } from 'src/i18n'
 import Logo from 'src/icons/Logo'
@@ -39,8 +36,6 @@ import { currentAccountSelector } from 'src/web3/selectors'
 interface StateProps {
   loading: boolean
   address?: string | null
-  activeNotificationCount: number
-  callToActNotification: boolean
   recipientCache: NumberToRecipient
   appConnected: boolean
   numberVerified: boolean
@@ -67,8 +62,6 @@ const mapDispatchToProps = {
 const mapStateToProps = (state: RootState): StateProps => ({
   loading: state.home.loading,
   address: currentAccountSelector(state),
-  activeNotificationCount: getActiveNotificationCount(state),
-  callToActNotification: callToActNotificationSelector(state),
   recipientCache: phoneRecipientCacheSelector(state),
   appConnected: isAppConnected(state),
   numberVerified: state.app.numberVerified,
@@ -133,13 +126,6 @@ export class WalletHome extends React.Component<Props, State> {
     }
   }
 
-  renderSection = ({ section: { title } }: { section: SectionListData<any> }) => {
-    if (!title) {
-      return null
-    }
-    return <SectionHead text={title} />
-  }
-
   keyExtractor = (_item: any, index: number) => {
     return index.toString()
   }
@@ -156,8 +142,6 @@ export class WalletHome extends React.Component<Props, State> {
   }
 
   render() {
-    const { activeNotificationCount, callToActNotification } = this.props
-
     const refresh: React.ReactElement<RefreshControlProps> = (
       <RefreshControl
         refreshing={this.props.loading}
@@ -168,12 +152,10 @@ export class WalletHome extends React.Component<Props, State> {
 
     const sections = []
 
-    if (activeNotificationCount > 0 || callToActNotification) {
-      sections.push({
-        data: [{}],
-        renderItem: () => <NotificationBox key={'NotificationBox'} />,
-      })
-    }
+    sections.push({
+      data: [{}],
+      renderItem: () => <NotificationBox key={'NotificationBox'} />,
+    })
 
     sections.push({
       data: [{}],
@@ -191,8 +173,6 @@ export class WalletHome extends React.Component<Props, State> {
           refreshing={this.props.loading}
           style={styles.container}
           sections={sections}
-          stickySectionHeadersEnabled={false}
-          renderSectionHeader={this.renderSection}
           keyExtractor={this.keyExtractor}
         />
         <SendOrRequestBar />

--- a/packages/mobile/src/home/__snapshots__/WalletHome.test.tsx.snap
+++ b/packages/mobile/src/home/__snapshots__/WalletHome.test.tsx.snap
@@ -125,6 +125,12 @@ exports[`Testnet banner Renders when connected with backup complete 1`] = `
           ],
           "renderItem": [Function],
         },
+        Object {
+          "data": Array [
+            Object {},
+          ],
+          "renderItem": [Function],
+        },
       ]
     }
     disableVirtualization={false}
@@ -168,6 +174,411 @@ exports[`Testnet banner Renders when connected with backup complete 1`] = `
   >
     <RCTRefreshControl />
     <View>
+      <View
+        onLayout={[Function]}
+        style={null}
+      />
+      <View
+        onLayout={[Function]}
+        style={null}
+      >
+        <View
+          style={
+            Object {
+              "maxWidth": 750,
+              "width": 750,
+            }
+          }
+        >
+          <RCTScrollView
+            horizontal={true}
+            onScroll={[Function]}
+            pagingEnabled={true}
+            showsHorizontalScrollIndicator={false}
+          >
+            <View>
+              <View
+                style={
+                  Object {
+                    "margin": 16,
+                    "marginBottom": 24,
+                    "width": 718,
+                  }
+                }
+              >
+                <View
+                  style={
+                    Array [
+                      Object {
+                        "backgroundColor": "#FFFFFF",
+                        "padding": 16,
+                      },
+                      Object {
+                        "borderRadius": 8,
+                      },
+                      Object {
+                        "elevation": 12,
+                        "shadowColor": "rgba(156, 164, 169, 0.4)",
+                        "shadowOffset": Object {
+                          "height": 2,
+                          "width": 0,
+                        },
+                        "shadowOpacity": 1,
+                        "shadowRadius": 12,
+                      },
+                      Array [
+                        Object {
+                          "flex": 1,
+                          "minHeight": 144,
+                        },
+                        Object {},
+                      ],
+                    ]
+                  }
+                >
+                  <View
+                    style={
+                      Object {
+                        "flex": 1,
+                        "flexDirection": "row",
+                      }
+                    }
+                  >
+                    <View
+                      style={
+                        Object {
+                          "flex": 1,
+                          "justifyContent": "space-between",
+                        }
+                      }
+                    >
+                      <Text
+                        style={
+                          Array [
+                            Object {
+                              "color": "#2E3338",
+                              "fontFamily": "Inter-Regular",
+                              "fontSize": 18,
+                              "lineHeight": 24,
+                            },
+                            Object {},
+                          ]
+                        }
+                        testID="undefined/Text"
+                      >
+                        backupKeyFlow6:backupKeyNotification
+                      </Text>
+                      <View
+                        style={
+                          Object {
+                            "flexDirection": "row",
+                            "flexWrap": "wrap",
+                            "justifyContent": "flex-start",
+                          }
+                        }
+                        testID="undefined/CallToActions"
+                      >
+                        <View
+                          accessible={true}
+                          focusable={true}
+                          nativeBackgroundAndroid={
+                            Object {
+                              "attribute": "selectableItemBackgroundBorderless",
+                              "rippleRadius": undefined,
+                              "type": "ThemeAttrAndroid",
+                            }
+                          }
+                          onClick={[Function]}
+                          onResponderGrant={[Function]}
+                          onResponderMove={[Function]}
+                          onResponderRelease={[Function]}
+                          onResponderTerminate={[Function]}
+                          onResponderTerminationRequest={[Function]}
+                          onStartShouldSetResponder={[Function]}
+                          testID="undefined/CallToActions/backupKeyFlow6:introPrimaryAction/Button"
+                        >
+                          <Text
+                            style={
+                              Array [
+                                Object {
+                                  "color": "#1AB775",
+                                  "fontFamily": "Inter-SemiBold",
+                                  "fontSize": 16,
+                                  "lineHeight": 22,
+                                },
+                                Object {
+                                  "fontSize": 14,
+                                  "lineHeight": 16,
+                                  "marginRight": 24,
+                                  "minHeight": 16,
+                                  "minWidth": 48,
+                                },
+                              ]
+                            }
+                          >
+                            backupKeyFlow6:introPrimaryAction
+                          </Text>
+                        </View>
+                      </View>
+                    </View>
+                    <View
+                      style={
+                        Object {
+                          "alignItems": "center",
+                          "justifyContent": "center",
+                          "marginLeft": 12,
+                          "width": 80,
+                        }
+                      }
+                    >
+                      <Image
+                        resizeMode="contain"
+                        source={
+                          Object {
+                            "testUri": "../../../packages/mobile/src/images/backup-key.png",
+                          }
+                        }
+                        testID="undefined/Icon"
+                      />
+                    </View>
+                  </View>
+                </View>
+              </View>
+              <View
+                style={
+                  Object {
+                    "margin": 16,
+                    "marginBottom": 24,
+                    "width": 718,
+                  }
+                }
+              >
+                <View
+                  style={
+                    Array [
+                      Object {
+                        "backgroundColor": "#FFFFFF",
+                        "padding": 16,
+                      },
+                      Object {
+                        "borderRadius": 8,
+                      },
+                      Object {
+                        "elevation": 12,
+                        "shadowColor": "rgba(156, 164, 169, 0.4)",
+                        "shadowOffset": Object {
+                          "height": 2,
+                          "width": 0,
+                        },
+                        "shadowOpacity": 1,
+                        "shadowRadius": 12,
+                      },
+                      Array [
+                        Object {
+                          "flex": 1,
+                          "minHeight": 144,
+                        },
+                        Object {},
+                      ],
+                    ]
+                  }
+                >
+                  <View
+                    style={
+                      Object {
+                        "flex": 1,
+                        "flexDirection": "row",
+                      }
+                    }
+                  >
+                    <View
+                      style={
+                        Object {
+                          "flex": 1,
+                          "justifyContent": "space-between",
+                        }
+                      }
+                    >
+                      <Text
+                        style={
+                          Array [
+                            Object {
+                              "color": "#2E3338",
+                              "fontFamily": "Inter-Regular",
+                              "fontSize": 18,
+                              "lineHeight": 24,
+                            },
+                            Object {},
+                          ]
+                        }
+                        testID="undefined/Text"
+                      >
+                        exchangeFlow9:whatIsGold
+                      </Text>
+                      <View
+                        style={
+                          Object {
+                            "flexDirection": "row",
+                            "flexWrap": "wrap",
+                            "justifyContent": "flex-start",
+                          }
+                        }
+                        testID="undefined/CallToActions"
+                      >
+                        <View
+                          accessible={true}
+                          focusable={true}
+                          nativeBackgroundAndroid={
+                            Object {
+                              "attribute": "selectableItemBackgroundBorderless",
+                              "rippleRadius": undefined,
+                              "type": "ThemeAttrAndroid",
+                            }
+                          }
+                          onClick={[Function]}
+                          onResponderGrant={[Function]}
+                          onResponderMove={[Function]}
+                          onResponderRelease={[Function]}
+                          onResponderTerminate={[Function]}
+                          onResponderTerminationRequest={[Function]}
+                          onStartShouldSetResponder={[Function]}
+                          testID="undefined/CallToActions/learnMore/Button"
+                        >
+                          <Text
+                            style={
+                              Array [
+                                Object {
+                                  "color": "#1AB775",
+                                  "fontFamily": "Inter-SemiBold",
+                                  "fontSize": 16,
+                                  "lineHeight": 22,
+                                },
+                                Object {
+                                  "fontSize": 14,
+                                  "lineHeight": 16,
+                                  "marginRight": 24,
+                                  "minHeight": 16,
+                                  "minWidth": 48,
+                                },
+                              ]
+                            }
+                          >
+                            learnMore
+                          </Text>
+                        </View>
+                        <View
+                          accessible={true}
+                          focusable={true}
+                          nativeBackgroundAndroid={
+                            Object {
+                              "attribute": "selectableItemBackgroundBorderless",
+                              "rippleRadius": undefined,
+                              "type": "ThemeAttrAndroid",
+                            }
+                          }
+                          onClick={[Function]}
+                          onResponderGrant={[Function]}
+                          onResponderMove={[Function]}
+                          onResponderRelease={[Function]}
+                          onResponderTerminate={[Function]}
+                          onResponderTerminationRequest={[Function]}
+                          onStartShouldSetResponder={[Function]}
+                          testID="undefined/CallToActions/global:dismiss/Button"
+                        >
+                          <Text
+                            style={
+                              Array [
+                                Object {
+                                  "color": "#1AB775",
+                                  "fontFamily": "Inter-SemiBold",
+                                  "fontSize": 16,
+                                  "lineHeight": 22,
+                                },
+                                Object {
+                                  "fontSize": 14,
+                                  "lineHeight": 16,
+                                  "marginRight": 24,
+                                  "minHeight": 16,
+                                  "minWidth": 48,
+                                },
+                              ]
+                            }
+                          >
+                            global:dismiss
+                          </Text>
+                        </View>
+                      </View>
+                    </View>
+                    <View
+                      style={
+                        Object {
+                          "alignItems": "center",
+                          "justifyContent": "center",
+                          "marginLeft": 12,
+                          "width": 80,
+                        }
+                      }
+                    >
+                      <Image
+                        resizeMode="contain"
+                        source={
+                          Object {
+                            "testUri": "../../../packages/mobile/src/images/learn-celo.png",
+                          }
+                        }
+                        testID="undefined/Icon"
+                      />
+                    </View>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </RCTScrollView>
+          <View
+            style={
+              Array [
+                Object {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "justifyContent": "center",
+                },
+                Object {
+                  "paddingBottom": 16,
+                },
+              ]
+            }
+          >
+            <View
+              style={
+                Object {
+                  "backgroundColor": "#2E3338",
+                  "borderRadius": 5,
+                  "flex": 0,
+                  "height": 5,
+                  "marginHorizontal": 3,
+                  "width": 5,
+                }
+              }
+            />
+            <View
+              style={
+                Object {
+                  "backgroundColor": "#9CA4A9",
+                  "borderRadius": 5,
+                  "flex": 0,
+                  "height": 5,
+                  "marginHorizontal": 3,
+                  "width": 5,
+                }
+              }
+            />
+          </View>
+        </View>
+      </View>
+      <View
+        onLayout={[Function]}
+        style={null}
+      />
       <View
         onLayout={[Function]}
         style={null}
@@ -537,6 +948,12 @@ exports[`Testnet banner Renders when disconnected 1`] = `
           ],
           "renderItem": [Function],
         },
+        Object {
+          "data": Array [
+            Object {},
+          ],
+          "renderItem": [Function],
+        },
       ]
     }
     disableVirtualization={false}
@@ -580,6 +997,411 @@ exports[`Testnet banner Renders when disconnected 1`] = `
   >
     <RCTRefreshControl />
     <View>
+      <View
+        onLayout={[Function]}
+        style={null}
+      />
+      <View
+        onLayout={[Function]}
+        style={null}
+      >
+        <View
+          style={
+            Object {
+              "maxWidth": 750,
+              "width": 750,
+            }
+          }
+        >
+          <RCTScrollView
+            horizontal={true}
+            onScroll={[Function]}
+            pagingEnabled={true}
+            showsHorizontalScrollIndicator={false}
+          >
+            <View>
+              <View
+                style={
+                  Object {
+                    "margin": 16,
+                    "marginBottom": 24,
+                    "width": 718,
+                  }
+                }
+              >
+                <View
+                  style={
+                    Array [
+                      Object {
+                        "backgroundColor": "#FFFFFF",
+                        "padding": 16,
+                      },
+                      Object {
+                        "borderRadius": 8,
+                      },
+                      Object {
+                        "elevation": 12,
+                        "shadowColor": "rgba(156, 164, 169, 0.4)",
+                        "shadowOffset": Object {
+                          "height": 2,
+                          "width": 0,
+                        },
+                        "shadowOpacity": 1,
+                        "shadowRadius": 12,
+                      },
+                      Array [
+                        Object {
+                          "flex": 1,
+                          "minHeight": 144,
+                        },
+                        Object {},
+                      ],
+                    ]
+                  }
+                >
+                  <View
+                    style={
+                      Object {
+                        "flex": 1,
+                        "flexDirection": "row",
+                      }
+                    }
+                  >
+                    <View
+                      style={
+                        Object {
+                          "flex": 1,
+                          "justifyContent": "space-between",
+                        }
+                      }
+                    >
+                      <Text
+                        style={
+                          Array [
+                            Object {
+                              "color": "#2E3338",
+                              "fontFamily": "Inter-Regular",
+                              "fontSize": 18,
+                              "lineHeight": 24,
+                            },
+                            Object {},
+                          ]
+                        }
+                        testID="undefined/Text"
+                      >
+                        backupKeyFlow6:backupKeyNotification
+                      </Text>
+                      <View
+                        style={
+                          Object {
+                            "flexDirection": "row",
+                            "flexWrap": "wrap",
+                            "justifyContent": "flex-start",
+                          }
+                        }
+                        testID="undefined/CallToActions"
+                      >
+                        <View
+                          accessible={true}
+                          focusable={true}
+                          nativeBackgroundAndroid={
+                            Object {
+                              "attribute": "selectableItemBackgroundBorderless",
+                              "rippleRadius": undefined,
+                              "type": "ThemeAttrAndroid",
+                            }
+                          }
+                          onClick={[Function]}
+                          onResponderGrant={[Function]}
+                          onResponderMove={[Function]}
+                          onResponderRelease={[Function]}
+                          onResponderTerminate={[Function]}
+                          onResponderTerminationRequest={[Function]}
+                          onStartShouldSetResponder={[Function]}
+                          testID="undefined/CallToActions/backupKeyFlow6:introPrimaryAction/Button"
+                        >
+                          <Text
+                            style={
+                              Array [
+                                Object {
+                                  "color": "#1AB775",
+                                  "fontFamily": "Inter-SemiBold",
+                                  "fontSize": 16,
+                                  "lineHeight": 22,
+                                },
+                                Object {
+                                  "fontSize": 14,
+                                  "lineHeight": 16,
+                                  "marginRight": 24,
+                                  "minHeight": 16,
+                                  "minWidth": 48,
+                                },
+                              ]
+                            }
+                          >
+                            backupKeyFlow6:introPrimaryAction
+                          </Text>
+                        </View>
+                      </View>
+                    </View>
+                    <View
+                      style={
+                        Object {
+                          "alignItems": "center",
+                          "justifyContent": "center",
+                          "marginLeft": 12,
+                          "width": 80,
+                        }
+                      }
+                    >
+                      <Image
+                        resizeMode="contain"
+                        source={
+                          Object {
+                            "testUri": "../../../packages/mobile/src/images/backup-key.png",
+                          }
+                        }
+                        testID="undefined/Icon"
+                      />
+                    </View>
+                  </View>
+                </View>
+              </View>
+              <View
+                style={
+                  Object {
+                    "margin": 16,
+                    "marginBottom": 24,
+                    "width": 718,
+                  }
+                }
+              >
+                <View
+                  style={
+                    Array [
+                      Object {
+                        "backgroundColor": "#FFFFFF",
+                        "padding": 16,
+                      },
+                      Object {
+                        "borderRadius": 8,
+                      },
+                      Object {
+                        "elevation": 12,
+                        "shadowColor": "rgba(156, 164, 169, 0.4)",
+                        "shadowOffset": Object {
+                          "height": 2,
+                          "width": 0,
+                        },
+                        "shadowOpacity": 1,
+                        "shadowRadius": 12,
+                      },
+                      Array [
+                        Object {
+                          "flex": 1,
+                          "minHeight": 144,
+                        },
+                        Object {},
+                      ],
+                    ]
+                  }
+                >
+                  <View
+                    style={
+                      Object {
+                        "flex": 1,
+                        "flexDirection": "row",
+                      }
+                    }
+                  >
+                    <View
+                      style={
+                        Object {
+                          "flex": 1,
+                          "justifyContent": "space-between",
+                        }
+                      }
+                    >
+                      <Text
+                        style={
+                          Array [
+                            Object {
+                              "color": "#2E3338",
+                              "fontFamily": "Inter-Regular",
+                              "fontSize": 18,
+                              "lineHeight": 24,
+                            },
+                            Object {},
+                          ]
+                        }
+                        testID="undefined/Text"
+                      >
+                        exchangeFlow9:whatIsGold
+                      </Text>
+                      <View
+                        style={
+                          Object {
+                            "flexDirection": "row",
+                            "flexWrap": "wrap",
+                            "justifyContent": "flex-start",
+                          }
+                        }
+                        testID="undefined/CallToActions"
+                      >
+                        <View
+                          accessible={true}
+                          focusable={true}
+                          nativeBackgroundAndroid={
+                            Object {
+                              "attribute": "selectableItemBackgroundBorderless",
+                              "rippleRadius": undefined,
+                              "type": "ThemeAttrAndroid",
+                            }
+                          }
+                          onClick={[Function]}
+                          onResponderGrant={[Function]}
+                          onResponderMove={[Function]}
+                          onResponderRelease={[Function]}
+                          onResponderTerminate={[Function]}
+                          onResponderTerminationRequest={[Function]}
+                          onStartShouldSetResponder={[Function]}
+                          testID="undefined/CallToActions/learnMore/Button"
+                        >
+                          <Text
+                            style={
+                              Array [
+                                Object {
+                                  "color": "#1AB775",
+                                  "fontFamily": "Inter-SemiBold",
+                                  "fontSize": 16,
+                                  "lineHeight": 22,
+                                },
+                                Object {
+                                  "fontSize": 14,
+                                  "lineHeight": 16,
+                                  "marginRight": 24,
+                                  "minHeight": 16,
+                                  "minWidth": 48,
+                                },
+                              ]
+                            }
+                          >
+                            learnMore
+                          </Text>
+                        </View>
+                        <View
+                          accessible={true}
+                          focusable={true}
+                          nativeBackgroundAndroid={
+                            Object {
+                              "attribute": "selectableItemBackgroundBorderless",
+                              "rippleRadius": undefined,
+                              "type": "ThemeAttrAndroid",
+                            }
+                          }
+                          onClick={[Function]}
+                          onResponderGrant={[Function]}
+                          onResponderMove={[Function]}
+                          onResponderRelease={[Function]}
+                          onResponderTerminate={[Function]}
+                          onResponderTerminationRequest={[Function]}
+                          onStartShouldSetResponder={[Function]}
+                          testID="undefined/CallToActions/global:dismiss/Button"
+                        >
+                          <Text
+                            style={
+                              Array [
+                                Object {
+                                  "color": "#1AB775",
+                                  "fontFamily": "Inter-SemiBold",
+                                  "fontSize": 16,
+                                  "lineHeight": 22,
+                                },
+                                Object {
+                                  "fontSize": 14,
+                                  "lineHeight": 16,
+                                  "marginRight": 24,
+                                  "minHeight": 16,
+                                  "minWidth": 48,
+                                },
+                              ]
+                            }
+                          >
+                            global:dismiss
+                          </Text>
+                        </View>
+                      </View>
+                    </View>
+                    <View
+                      style={
+                        Object {
+                          "alignItems": "center",
+                          "justifyContent": "center",
+                          "marginLeft": 12,
+                          "width": 80,
+                        }
+                      }
+                    >
+                      <Image
+                        resizeMode="contain"
+                        source={
+                          Object {
+                            "testUri": "../../../packages/mobile/src/images/learn-celo.png",
+                          }
+                        }
+                        testID="undefined/Icon"
+                      />
+                    </View>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </RCTScrollView>
+          <View
+            style={
+              Array [
+                Object {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "justifyContent": "center",
+                },
+                Object {
+                  "paddingBottom": 16,
+                },
+              ]
+            }
+          >
+            <View
+              style={
+                Object {
+                  "backgroundColor": "#2E3338",
+                  "borderRadius": 5,
+                  "flex": 0,
+                  "height": 5,
+                  "marginHorizontal": 3,
+                  "width": 5,
+                }
+              }
+            />
+            <View
+              style={
+                Object {
+                  "backgroundColor": "#9CA4A9",
+                  "borderRadius": 5,
+                  "flex": 0,
+                  "height": 5,
+                  "marginHorizontal": 3,
+                  "width": 5,
+                }
+              }
+            />
+          </View>
+        </View>
+      </View>
+      <View
+        onLayout={[Function]}
+        style={null}
+      />
       <View
         onLayout={[Function]}
         style={null}
@@ -949,6 +1771,12 @@ exports[`Testnet banner Shows testnet banner for 5 seconds 1`] = `
           ],
           "renderItem": [Function],
         },
+        Object {
+          "data": Array [
+            Object {},
+          ],
+          "renderItem": [Function],
+        },
       ]
     }
     disableVirtualization={false}
@@ -992,6 +1820,184 @@ exports[`Testnet banner Shows testnet banner for 5 seconds 1`] = `
   >
     <RCTRefreshControl />
     <View>
+      <View
+        onLayout={[Function]}
+        style={null}
+      />
+      <View
+        onLayout={[Function]}
+        style={null}
+      >
+        <View
+          style={
+            Object {
+              "maxWidth": 750,
+              "width": 750,
+            }
+          }
+        >
+          <RCTScrollView
+            horizontal={true}
+            onScroll={[Function]}
+            pagingEnabled={true}
+            showsHorizontalScrollIndicator={false}
+          >
+            <View>
+              <View
+                style={
+                  Object {
+                    "margin": 16,
+                    "marginBottom": 24,
+                    "width": 718,
+                  }
+                }
+              >
+                <View
+                  style={
+                    Array [
+                      Object {
+                        "backgroundColor": "#FFFFFF",
+                        "padding": 16,
+                      },
+                      Object {
+                        "borderRadius": 8,
+                      },
+                      Object {
+                        "elevation": 12,
+                        "shadowColor": "rgba(156, 164, 169, 0.4)",
+                        "shadowOffset": Object {
+                          "height": 2,
+                          "width": 0,
+                        },
+                        "shadowOpacity": 1,
+                        "shadowRadius": 12,
+                      },
+                      Array [
+                        Object {
+                          "flex": 1,
+                          "minHeight": 144,
+                        },
+                        Object {},
+                      ],
+                    ]
+                  }
+                >
+                  <View
+                    style={
+                      Object {
+                        "flex": 1,
+                        "flexDirection": "row",
+                      }
+                    }
+                  >
+                    <View
+                      style={
+                        Object {
+                          "flex": 1,
+                          "justifyContent": "space-between",
+                        }
+                      }
+                    >
+                      <Text
+                        style={
+                          Array [
+                            Object {
+                              "color": "#2E3338",
+                              "fontFamily": "Inter-Regular",
+                              "fontSize": 18,
+                              "lineHeight": 24,
+                            },
+                            Object {},
+                          ]
+                        }
+                        testID="undefined/Text"
+                      >
+                        backupKeyFlow6:backupKeyNotification
+                      </Text>
+                      <View
+                        style={
+                          Object {
+                            "flexDirection": "row",
+                            "flexWrap": "wrap",
+                            "justifyContent": "flex-start",
+                          }
+                        }
+                        testID="undefined/CallToActions"
+                      >
+                        <View
+                          accessible={true}
+                          focusable={true}
+                          nativeBackgroundAndroid={
+                            Object {
+                              "attribute": "selectableItemBackgroundBorderless",
+                              "rippleRadius": undefined,
+                              "type": "ThemeAttrAndroid",
+                            }
+                          }
+                          onClick={[Function]}
+                          onResponderGrant={[Function]}
+                          onResponderMove={[Function]}
+                          onResponderRelease={[Function]}
+                          onResponderTerminate={[Function]}
+                          onResponderTerminationRequest={[Function]}
+                          onStartShouldSetResponder={[Function]}
+                          testID="undefined/CallToActions/backupKeyFlow6:introPrimaryAction/Button"
+                        >
+                          <Text
+                            style={
+                              Array [
+                                Object {
+                                  "color": "#1AB775",
+                                  "fontFamily": "Inter-SemiBold",
+                                  "fontSize": 16,
+                                  "lineHeight": 22,
+                                },
+                                Object {
+                                  "fontSize": 14,
+                                  "lineHeight": 16,
+                                  "marginRight": 24,
+                                  "minHeight": 16,
+                                  "minWidth": 48,
+                                },
+                              ]
+                            }
+                          >
+                            backupKeyFlow6:introPrimaryAction
+                          </Text>
+                        </View>
+                      </View>
+                    </View>
+                    <View
+                      style={
+                        Object {
+                          "alignItems": "center",
+                          "justifyContent": "center",
+                          "marginLeft": 12,
+                          "width": 80,
+                        }
+                      }
+                    >
+                      <Image
+                        resizeMode="contain"
+                        source={
+                          Object {
+                            "testUri": "../../../packages/mobile/src/images/backup-key.png",
+                          }
+                        }
+                        testID="undefined/Icon"
+                      />
+                    </View>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </RCTScrollView>
+        </View>
+      </View>
+      <View
+        onLayout={[Function]}
+        style={null}
+      />
       <View
         onLayout={[Function]}
         style={null}

--- a/packages/mobile/src/home/selectors.ts
+++ b/packages/mobile/src/home/selectors.ts
@@ -1,41 +1,9 @@
 import _ from 'lodash'
 import DeviceInfo from 'react-native-device-info'
 import { createSelector } from 'reselect'
-import { getReclaimableEscrowPayments } from 'src/escrow/reducer'
 import { userLocationDataSelector } from 'src/networkInfo/selectors'
-import {
-  getIncomingPaymentRequests,
-  getOutgoingPaymentRequests,
-} from 'src/paymentRequest/selectors'
 import { RootState } from 'src/redux/reducers'
 import { isVersionInRange } from 'src/utils/versionCheck'
-
-// TODO: De-dupe this with NotificationBox
-// It's not great that we must edit this and NotificationBox whenever introducing new notifications
-export const getActiveNotificationCount = createSelector(
-  [
-    getIncomingPaymentRequests,
-    getOutgoingPaymentRequests,
-    getReclaimableEscrowPayments,
-    (state) => state.account.backupCompleted,
-  ],
-  (incomingPaymentReqs, outgoingPaymentRequests, reclaimableEscrowPayments, backupCompleted) => {
-    return (
-      incomingPaymentReqs.length +
-      outgoingPaymentRequests.length +
-      reclaimableEscrowPayments.length +
-      (backupCompleted ? 0 : 1)
-    )
-  }
-)
-
-export const callToActNotificationSelector = (state: RootState) => {
-  return (
-    !state.account.backupCompleted ||
-    !state.goldToken.educationCompleted ||
-    (!state.app.numberVerified && !state.account.dismissedGetVerified)
-  )
-}
 
 const homeNotificationsSelector = (state: RootState) => state.home.notifications
 


### PR DESCRIPTION
### Description

Cleaned up the logic to decide when the `NotificationBox` should show up or not. The logic was already implemented in the `NotificationBox` itself but was repeated with a bug on the `WalletHome`. I just removed the check from `WalletHome`.

### Other changes

Removed some old code around section headers (none of them have headers)

### Tested

Manually locally.

### How others should test

Dismiss all non-remote notifications and check that remote notifications still show up.
You should also go through the CELO education screens since that was also required before for remote notifications not to show up 🍝  

### Related issues

- Fixes #1230

### Backwards compatibility

N/A