### PR TITLE
Replace "account key" with "Recovery Phrase" throughout the codebase

### DIFF
--- a/packages/mobile/e2e/src/usecases/NewAccountOnboarding.js
+++ b/packages/mobile/e2e/src/usecases/NewAccountOnboarding.js
@@ -50,7 +50,7 @@ export default NewAccountOnboarding = () => {
 
   // Ideally this wouldn't be dependent on the previous test
   // Skip setup on android for now
-  it('Setup Account Key', async () => {
+  it('Setup Recovery Phrase', async () => {
     await element(by.id('Hamburger')).tap()
     await element(by.id('DrawerItem/Recovery Phrase')).tap()
 

--- a/packages/mobile/e2e/src/usecases/OnRamps.js
+++ b/packages/mobile/e2e/src/usecases/OnRamps.js
@@ -58,7 +58,7 @@ export default onRamps = () => {
         await element(by.text('Next')).tap()
       })
 
-      it('Then Should Display Exchanges & Account Key', async () => {
+      it('Then Should Display Exchanges & Recovery Phrase', async () => {
         await waitFor(element(by.id('Bittrex')))
           .toBeVisible()
           .withTimeout(20000)
@@ -119,7 +119,7 @@ export default onRamps = () => {
         await element(by.text('Next')).tap()
       })
 
-      it('Then Should Display Exchanges & Account Key', async () => {
+      it('Then Should Display Exchanges & Recovery Phrase', async () => {
         await waitFor(element(by.id('Binance')))
           .toBeVisible()
           .withTimeout(20000)

--- a/packages/mobile/e2e/src/usecases/ResetAccount.js
+++ b/packages/mobile/e2e/src/usecases/ResetAccount.js
@@ -9,7 +9,7 @@ export default ResetAccount = () => {
     await dismissBanners()
   })
 
-  it('Reset Account by doing the Account Key quiz', async () => {
+  it('Reset Account by doing the Recovery Phrase quiz', async () => {
     // This test has very high flakiness on Android. I did my best to fix it, but
     // locally it works every time but on CI it fails 50%+ of the time.
     // TODO: Keep investigating the source of flakiness of this test on Android.

--- a/packages/mobile/e2e/src/usecases/SetAccountKey.js
+++ b/packages/mobile/e2e/src/usecases/SetAccountKey.js
@@ -1,8 +1,8 @@
 import { enterPinUi } from '../utils/utils'
 
 export default SetAccountKey = () => {
-  it('Go to the Account Key tab and set it up', async () => {
-    // Android doesn't support the getAttributes method, so we can't get the account key.
+  it('Go to the Recovery Phrase tab and set it up', async () => {
+    // Android doesn't support the getAttributes method, so we can't get the Recovery Phrase.
     if (device.getPlatform() === 'android') {
       return
     }

--- a/packages/mobile/fastlane/metadata/android/en-US/full_description.txt
+++ b/packages/mobile/fastlane/metadata/android/en-US/full_description.txt
@@ -10,7 +10,7 @@ SAVE & SPEND STABLE VALUE
 Send, request, and save Celo Dollars, which are stable relative to US Dollars. Easily verify ownership of your phone number to get started. After that, sending or requesting payment from a friend is easy - all you need is their phone number and a small fee.
 
 SAFE & SECURE
-Securely send value to any mobile phone number or receive value at your phone number. To keep your value secure, protect your wallet with an Account Key. This key protects your funds so that only you can access them -- don’t lose it!
+Securely send value to any mobile phone number or receive value at your phone number. To keep your value secure, protect your wallet with a Recovery Phrase. This key protects your funds so that only you can access them -- don’t lose it!
 
 EXCHANGE FOR CELO GOLD
 Exchange Celo Dollars for Celo Gold.

--- a/packages/mobile/src/analytics/Events.tsx
+++ b/packages/mobile/src/analytics/Events.tsx
@@ -81,8 +81,8 @@ export enum OnboardingEvents {
 
   backup_quiz_start = 'backup_quiz_start',
   backup_quiz_progress = 'backup_quiz_progress', // whenever the backspace is pressed or word is chosen
-  backup_quiz_complete = 'backup_quiz_complete', // (Count # of successful Account Key confirmations Backup_Quiz)
-  backup_quiz_incorrect = 'backup_quiz_incorrect', // (Count # of failed Account Key confirmations Backup_Quiz)
+  backup_quiz_complete = 'backup_quiz_complete', // (Count # of successful Recovery Phrase confirmations Backup_Quiz)
+  backup_quiz_incorrect = 'backup_quiz_incorrect', // (Count # of failed Recovery Phrase confirmations Backup_Quiz)
 
   celo_education_start = 'celo_education_start',
   celo_education_scroll = 'celo_education_scroll',

--- a/packages/mobile/src/backup/BackupComplete.tsx
+++ b/packages/mobile/src/backup/BackupComplete.tsx
@@ -27,7 +27,7 @@ const mapStateToProps = (state: RootState): StateProps => {
 }
 
 /**
- * Component shown to the user upon completion of the Account Key setup flow. Informs the user that
+ * Component shown to the user upon completion of the Recovery Phrase setup flow. Informs the user that
  * they've successfully completed the backup process and automatically returns them to where they
  * came from.
  */

--- a/packages/mobile/src/backup/BackupIntroduction.tsx
+++ b/packages/mobile/src/backup/BackupIntroduction.tsx
@@ -39,7 +39,7 @@ const mapStateToProps = (state: RootState): StateProps => {
 }
 
 /**
- * Component displayed to the user when entering account key flow from the settings menu or a
+ * Component displayed to the user when entering Recovery Phrase flow from the settings menu or a
  * notification. Displays content to the user depending on whether they have set up their account
  * key backup already.
  */
@@ -70,8 +70,8 @@ interface AccountKeyStartProps {
 }
 
 /**
- * Component displayed to the user when entering account key flow prior to a successful completion.
- * Introduces the user to the account key and invites them to set it up
+ * Component displayed to the user when entering Recovery Phrase flow prior to a successful completion.
+ * Introduces the user to the Recovery Phrase and invites them to set it up
  */
 function AccountKeyIntro({ onPrimaryPress }: AccountKeyStartProps) {
   const { t } = useTranslation(Namespaces.backupKeyFlow6)
@@ -86,9 +86,9 @@ function AccountKeyIntro({ onPrimaryPress }: AccountKeyStartProps) {
 }
 
 /**
- * Component displayed to the user when entering the account key flow after having successfully set
- * up their backup. Displays their account key and provides an option to learn more about the
- * account key, which brings them to the account key education flow.
+ * Component displayed to the user when entering the Recovery Phrase flow after having successfully set
+ * up their backup. Displays their Recovery Phrase and provides an option to learn more about the
+ * Recovery Phrase, which brings them to the Recovery Phrase education flow.
  */
 function AccountKeyPostSetup() {
   const accountKey = useAccountKey()

--- a/packages/mobile/src/backup/selectors.test.ts
+++ b/packages/mobile/src/backup/selectors.test.ts
@@ -30,21 +30,21 @@ describe('backup/selectors', () => {
   })
 
   describe('shouldForceBackupSelector', () => {
-    it("should not force account key prompt if enough time hasn't passed since creation", () => {
+    it("should not force Recovery Phrase prompt if enough time hasn't passed since creation", () => {
       // Account created 12 hours ago, no delay and no backup.
       expect(
         shouldForceBackupSelector(mockState(mockCurrentTime - ONE_DAY_IN_MILLIS * 0.5, null, false))
       ).toBe(false)
     })
 
-    it('should force account key prompt if enough time passed since account creation', () => {
+    it('should force Recovery Phrase prompt if enough time passed since account creation', () => {
       // Account created 36 hours ago, no delay and no backup.
       expect(
         shouldForceBackupSelector(mockState(mockCurrentTime - ONE_DAY_IN_MILLIS * 1.5, null, false))
       ).toBe(true)
     })
 
-    it('should not force account key prompt if delay button was just pressed', () => {
+    it('should not force Recovery Phrase prompt if delay button was just pressed', () => {
       // Account created 36 hours ago, delay pressed less than an hour ago and no backup.
       expect(
         shouldForceBackupSelector(
@@ -53,7 +53,7 @@ describe('backup/selectors', () => {
       ).toBe(false)
     })
 
-    it('should force account key prompt if delay button was pressed a while ago', () => {
+    it('should force Recovery Phrase prompt if delay button was pressed a while ago', () => {
       // Account created 36 hours ago, delay pressed over an hour ago and no backup.
       expect(
         shouldForceBackupSelector(
@@ -62,7 +62,7 @@ describe('backup/selectors', () => {
       ).toBe(true)
     })
 
-    it('should not force account key prompt if backup was already completed', () => {
+    it('should not force Recovery Phrase prompt if backup was already completed', () => {
       // Account already backed up.
       expect(
         shouldForceBackupSelector(mockState(mockCurrentTime - ONE_DAY_IN_MILLIS * 1.5, null, true))

--- a/packages/mobile/src/backup/utils.ts
+++ b/packages/mobile/src/backup/utils.ts
@@ -72,7 +72,7 @@ export async function getStoredMnemonic(
 export function onGetMnemonicFail(viewError: (error: ErrorMessages) => void, context?: string) {
   viewError(ErrorMessages.FAILED_FETCH_MNEMONIC)
   ValoraAnalytics.track(OnboardingEvents.backup_error, {
-    error: 'Failed to retrieve Account Key',
+    error: 'Failed to retrieve Recovery Phrase',
     context,
   })
 }

--- a/packages/mobile/src/import/ImportWallet.tsx
+++ b/packages/mobile/src/import/ImportWallet.tsx
@@ -39,7 +39,7 @@ import Logger from 'src/utils/Logger'
 
 const AVERAGE_WORD_WIDTH = 80
 const AVERAGE_SEED_WIDTH = AVERAGE_WORD_WIDTH * 24
-// Estimated number of lines needed to enter the account key
+// Estimated number of lines needed to enter the Recovery Phrase
 const NUMBER_OF_LINES = Math.ceil(AVERAGE_SEED_WIDTH / Dimensions.get('window').width)
 
 type Props = StackScreenProps<StackParamList, Screens.ImportWallet>


### PR DESCRIPTION
### Description

Replace `account key` with `Recovery Phrase` in error messages, comments, tests, etc.
