### PR TITLE
Use dappName

### DIFF
--- a/packages/mobile/src/walletConnect/screens/Sessions.tsx
+++ b/packages/mobile/src/walletConnect/screens/Sessions.tsx
@@ -64,7 +64,7 @@ function Sessions() {
     closeModal()
   }
 
-  const appName =
+  const dappName =
     highlighted && 'topic' in highlighted
       ? highlighted?.peer.metadata.name
       : highlighted?.peerMeta?.name
@@ -72,7 +72,7 @@ function Sessions() {
     <ScrollView testID="WalletConnectSessionsView">
       <Dialog
         title={t('disconnectTitle', {
-          appName,
+          dappName,
         })}
         actionPress={closeSession}
         actionText={t('disconnect')}
@@ -80,7 +80,7 @@ function Sessions() {
         secondaryActionPress={closeModal}
         isVisible={!!highlighted}
       >
-        {t('disconnectBody', { appName })}
+        {t('disconnectBody', { dappName })}
       </Dialog>
 
       <View style={styles.container}>


### PR DESCRIPTION
### Description

A small fix to use the dappName when disconnecting.

### Tested

Tested locally

### How others should test

Follow the reproduction steps outlined in #1204.

### Related issues

- Fixes #1204

### Backwards compatibility

This change is backwards compatible.