### PR TITLE
[WalletConnect] Fix using incorrect param for `personal_sign` requests

### DIFF
--- a/packages/mobile/src/walletConnect/request.test.ts
+++ b/packages/mobile/src/walletConnect/request.test.ts
@@ -8,6 +8,10 @@ import { createMockStore } from 'test/utils'
 import { mockWallet } from 'test/values'
 
 const signTransactionRequest = { method: SupportedActions.eth_signTransaction, params: [] }
+const personalSignRequest = {
+  method: SupportedActions.personal_sign,
+  params: ['Some message', '0xdeadbeef'],
+}
 
 describe(handleRequest, () => {
   it('unlocks the wallet address when a MTW address is set', async () => {
@@ -27,6 +31,18 @@ describe(handleRequest, () => {
       .provide([[call(getWallet), mockWallet]])
       .withState(state)
       .call(unlockAccount, '0xwallet')
+      .run()
+  })
+
+  it('supports personal_sign', async () => {
+    const state = createMockStore({
+      web3: { account: '0xWALLET', mtwAddress: undefined },
+    }).getState()
+    await expectSaga(handleRequest, personalSignRequest)
+      .provide([[call(getWallet), mockWallet]])
+      .withState(state)
+      .call(unlockAccount, '0xwallet')
+      .call([mockWallet, 'signPersonalMessage'], '0xwallet', 'Some message')
       .run()
   })
 })

--- a/packages/mobile/src/walletConnect/request.ts
+++ b/packages/mobile/src/walletConnect/request.ts
@@ -88,7 +88,7 @@ export function* handleRequest({ method, params }: { method: string; params: any
       )
       return receipt.transactionHash
     case SupportedActions.personal_sign:
-      return (yield call(wallet.signPersonalMessage.bind(wallet), account, params[1])) as string
+      return (yield call([wallet, 'signPersonalMessage'], account, params[0])) as string
     case SupportedActions.eth_sign:
       const web3: Web3 = yield call(getWeb3)
       return (yield call(web3.eth.sign.bind(web3), params[1], account)) as string


### PR DESCRIPTION
### Description

For `personal_sign` requests, we were signing the address (`params[1]`) instead of the message (`params[0]`): https://github.com/valora-inc/wallet/blob/bc43a8b981cb8e1bcc17e8d1dd984f25bd3ed832/packages/mobile/src/walletConnect/request.ts#L91

See https://docs.walletconnect.org/json-rpc-api-methods/ethereum#personal_sign

### Tested

Tested on https://react-app.walletconnect.org/
Result is now valid:
<img width="995" alt="Screenshot 2021-10-19 at 15 06 39" src="https://user-images.githubusercontent.com/57791/137915606-860dee22-61ce-4c8b-b7f5-d905d03e8c2c.png">

Side note: For `eth_signTypedData`,  https://react-app.walletconnect.org/ (WC v2) doesn't yet say the result is valid.
But it is valid when testing using https://celo-walletconnect.vercel.app/ (WC v1).
Not sure why. Need to investigate.

### How others should test

N/A

### Related issues

- Discussed on [Slack](https://valora-app.slack.com/archives/C02E114V346/p1634647011128400)

### Backwards compatibility

We're doing the right thing now. Previous versions were not.