### PR TITLE
GDPR compliance about location data with CleverTap

### DIFF
--- a/packages/mobile/src/analytics/ValoraAnalytics.ts
+++ b/packages/mobile/src/analytics/ValoraAnalytics.ts
@@ -2,7 +2,6 @@ import Analytics, { Analytics as analytics } from '@segment/analytics-react-nati
 import Adjust from '@segment/analytics-react-native-adjust'
 import CleverTapSegment from '@segment/analytics-react-native-clevertap'
 import Firebase from '@segment/analytics-react-native-firebase'
-import CleverTap from 'clevertap-react-native'
 import { sha256 } from 'ethereumjs-util'
 import { Platform } from 'react-native'
 import DeviceInfo from 'react-native-device-info'
@@ -84,8 +83,6 @@ class ValoraAnalytics {
       }
 
       Logger.info(TAG, 'Segment Analytics Integration initialized!')
-
-      CleverTap.enableDeviceNetworkInfoReporting(true)
     } catch (error) {
       Logger.error(TAG, `Segment setup error: ${error.message}\n`, error)
     }

--- a/packages/mobile/src/analytics/saga.ts
+++ b/packages/mobile/src/analytics/saga.ts
@@ -2,17 +2,25 @@ import { call, select, spawn, take } from 'redux-saga/effects'
 import { createSelector } from 'reselect'
 import { nameSelector } from 'src/account/selectors'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
+import { userLocationDataSelector } from 'src/networkInfo/selectors'
 import { defaultCurrencySelector } from 'src/stableToken/selectors'
 import { accountAddressSelector, currentAccountSelector } from 'src/web3/selectors'
 
 export const getCurrentUserTraits = createSelector(
-  [currentAccountSelector, accountAddressSelector, defaultCurrencySelector, nameSelector],
-  (walletAddress, accountAddress, currency, name) => {
+  [
+    currentAccountSelector,
+    accountAddressSelector,
+    defaultCurrencySelector,
+    nameSelector,
+    userLocationDataSelector,
+  ],
+  (walletAddress, accountAddress, currency, name, { countryCodeAlpha2 }) => {
     return {
       accountAddress,
       walletAddress,
       currency,
       name,
+      countryCodeAlpha2,
     }
   }
 )


### PR DESCRIPTION
### Description

`CleverTap.enableDeviceNetworkInfoReporting(true)` is not GDPR compliant.
Instead we pass the country code.

### Tested

`countryCodeAlpha2` appears in CleverTap user profiles.

### How others should test

N/A

### Related issues

Discussed [on Slack](https://valora-app.slack.com/archives/C029Z1QMD7B/p1634130299224000).

### Backwards compatibility

Yes