### PR TITLE
Add Leak Canary

### DIFF
--- a/packages/mobile/android/app/build.gradle
+++ b/packages/mobile/android/app/build.gradle
@@ -302,6 +302,7 @@ dependencies {
     debugImplementation("com.facebook.flipper:flipper-fresco-plugin:${FLIPPER_VERSION}") {
         exclude group:'com.facebook.flipper'
     }
+    debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.7'
 
     if (enableHermes) {
         def hermesPath = "../../../../node_modules/hermes-engine/android/";


### PR DESCRIPTION
### Description

Adds [Leak Canary](https://square.github.io/leakcanary) to Android Dev builds to help spot memory leaks.

### Other changes

N/A

### Tested

Android Dev build running and Leak Canary reporting results.

1. Run Valora on Android in Dev Mode.
2. Navigate to device home screen and open 'Leaks'.

![Screen Shot 2021-11-01 at 9 59 18 AM](https://user-images.githubusercontent.com/26950305/139710450-edb40d81-7d0f-40a7-8e7f-02aff6a5df7b.png)

### How others should test

N/A

### Related issues

- Fixes #1344

### Backwards compatibility

Leak canary only runs in dev builds and is backwards compatible.