### PR TITLE
CEUR display from providers

### DIFF
--- a/packages/mobile/locales/en-US/fiatExchangeFlow.json
+++ b/packages/mobile/locales/en-US/fiatExchangeFlow.json
@@ -68,6 +68,7 @@
   "findMerchants": "Find local merchants near you",
   "celoDeposit": "CELO Purchase",
   "cUsdDeposit": "cUSD Purchase",
+  "cEurDeposit": "cEUR Purchase",
   "providerUnavailable": "Not currently available",
   "pricePer": "Price per {{coin}}",
   "feeDiscount": "Fee Discount",

--- a/packages/mobile/src/transactions/TransferFeedItem.test.tsx
+++ b/packages/mobile/src/transactions/TransferFeedItem.test.tsx
@@ -362,7 +362,7 @@ describe('transfer feed item renders correctly', () => {
     )
     expect(tree).toMatchSnapshot()
   })
-  it('for known received', () => {
+  it('for known received cUSD', () => {
     const tree = render(
       <Provider store={mockStore}>
         <TransferFeedItem
@@ -372,6 +372,33 @@ describe('transfer feed item renders correctly', () => {
           type={TokenTransactionType.Received}
           hash={'0x'}
           amount={{ value: '100', currencyCode: 'cUSD', localAmount: null }}
+          address={mockAccount}
+          timestamp={1}
+          commentKey={null}
+          addressToE164Number={mockAddressToE164Number}
+          phoneRecipientCache={mockPhoneRecipientCache}
+          recipientInfo={mockRecipientInfo}
+          recentTxRecipientsCache={{}}
+          invitees={[]}
+          account={''}
+          defaultImage={null}
+          defaultName={null}
+          {...getMockI18nProps()}
+        />
+      </Provider>
+    )
+    expect(tree).toMatchSnapshot()
+  })
+  it('for known received cEUR', () => {
+    const tree = render(
+      <Provider store={mockStore}>
+        <TransferFeedItem
+          __typename="TokenTransfer"
+          status={TransactionStatus.Complete}
+          comment={''}
+          type={TokenTransactionType.Received}
+          hash={'0x'}
+          amount={{ value: '100', currencyCode: 'cEUR', localAmount: null }}
           address={mockAccount}
           timestamp={1}
           commentKey={null}

--- a/packages/mobile/src/transactions/__snapshots__/TransferFeedItem.test.tsx.snap
+++ b/packages/mobile/src/transactions/__snapshots__/TransferFeedItem.test.tsx.snap
@@ -263,7 +263,172 @@ exports[`transfer feed item renders correctly for faucet 1`] = `
 </View>
 `;
 
-exports[`transfer feed item renders correctly for known received 1`] = `
+exports[`transfer feed item renders correctly for known received cEUR 1`] = `
+<View
+  accessible={true}
+  focusable={true}
+  nativeBackgroundAndroid={
+    Object {
+      "attribute": "selectableItemBackground",
+      "rippleRadius": undefined,
+      "type": "ThemeAttrAndroid",
+    }
+  }
+  onClick={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+>
+  <View
+    style={
+      Object {
+        "flex": 1,
+        "flexDirection": "row",
+        "justifyContent": "space-between",
+        "paddingHorizontal": 16,
+        "paddingVertical": 12,
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "alignItems": "center",
+          "flexDirection": "column",
+        }
+      }
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "justifyContent": "center",
+            },
+            undefined,
+          ]
+        }
+      >
+        <View
+          style={
+            Array [
+              Object {
+                "alignItems": "center",
+                "justifyContent": "center",
+              },
+              Object {
+                "backgroundColor": "hsl(0, 53%, 93%)",
+                "borderRadius": 20,
+                "height": 40,
+                "width": 40,
+              },
+            ]
+          }
+        >
+          <Text
+            allowFontScaling={false}
+            style={
+              Array [
+                Object {
+                  "color": "#FFFFFF",
+                  "fontFamily": "Inter-Medium",
+                  "fontSize": 16,
+                },
+                Object {
+                  "color": "hsl(0, 67%, 24%)",
+                  "fontSize": 20,
+                },
+              ]
+            }
+          >
+            J
+          </Text>
+        </View>
+      </View>
+    </View>
+    <View
+      style={
+        Object {
+          "flex": 1,
+          "marginLeft": 16,
+        }
+      }
+    >
+      <View
+        style={
+          Object {
+            "flexDirection": "row",
+            "marginTop": -1,
+          }
+        }
+      >
+        <Text
+          style={
+            Object {
+              "color": "#2E3338",
+              "flexShrink": 1,
+              "fontFamily": "Inter-Medium",
+              "fontSize": 16,
+              "lineHeight": 22,
+            }
+          }
+        >
+          feedItemReceivedTitle, {"displayName":"John Doe"}
+        </Text>
+        <Text
+          style={
+            Array [
+              Array [
+                Object {
+                  "color": "#2E3338",
+                  "flexWrap": "wrap",
+                  "fontFamily": "Inter-Medium",
+                  "fontSize": 16,
+                  "lineHeight": 22,
+                  "marginLeft": "auto",
+                  "paddingLeft": 10,
+                  "textAlign": "right",
+                  "width": "40%",
+                },
+                Object {
+                  "color": "#1AB775",
+                },
+              ],
+              Object {
+                "color": "#1AB775",
+              },
+            ]
+          }
+          testID="FeedItemAmountDisplay/value"
+        >
+          +
+          $
+          2.00
+        </Text>
+      </View>
+      <Text
+        style={
+          Object {
+            "color": "#9CA4A9",
+            "fontFamily": "Inter-Regular",
+            "fontSize": 14,
+            "lineHeight": 18,
+            "paddingTop": 2,
+          }
+        }
+      >
+        feedItemReceivedInfo, {"context":"noComment","comment":""}
+      </Text>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`transfer feed item renders correctly for known received cUSD 1`] = `
 <View
   accessible={true}
   focusable={true}

--- a/packages/mobile/src/transactions/__snapshots__/TransferFeedItem.test.tsx.snap
+++ b/packages/mobile/src/transactions/__snapshots__/TransferFeedItem.test.tsx.snap
@@ -407,7 +407,7 @@ exports[`transfer feed item renders correctly for known received cEUR 1`] = `
         >
           +
           $
-          2.00
+          200.00
         </Text>
       </View>
       <Text

--- a/packages/mobile/src/transactions/transferFeedUtils.ts
+++ b/packages/mobile/src/transactions/transferFeedUtils.ts
@@ -192,10 +192,17 @@ export function getTransferFeedParams(
         Object.assign(recipient, { thumbnailPath: CELO_LOGO_URL })
       } else if (providerInfo) {
         title = t('feedItemReceivedTitle', { displayName })
-        info =
-          currency.toLowerCase() === 'celo'
-            ? t('fiatExchangeFlow:celoDeposit')
-            : t('fiatExchangeFlow:cUsdDeposit')
+        switch (currency.toLowerCase()) {
+          case 'cusd':
+            info = t('fiatExchangeFlow:cUsdDeposit')
+            break
+          case 'ceur':
+            info = t('fiatExchangeFlow:cEurDeposit')
+            break
+          default:
+            info = t('fiatExchangeFlow:celoDeposit')
+            break
+        }
       } else {
         title = t('feedItemReceivedTitle', { displayName })
         info = t('feedItemReceivedInfo', { context: !comment ? 'noComment' : null, comment })


### PR DESCRIPTION
### Description

Fixes issue where cEUR purchases from providers were displaying with cUSD text.

### Other changes

- Added snapshot test for cEUR received.

### Tested

- Unit test added and run.

### How others should test

Using [Ramp Staging](https://ri-widget-staging.firebaseapp.com/) select cEUR and follow the default purchase flow. When selecting payment options select 'manual bank transfer'. If issue arise refer to [Releasing Purchases Manually](https://ri-widget-staging.firebaseapp.com/).

### Related issues

- Fixes https://github.com/valora-inc/support-issues/issues/37

### Backwards compatibility

This change is backwards compatible.