### PR TITLE
Add more coverage reports

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,10 @@ jobs:
       - name: 'Upload Test Results'
         uses: actions/upload-artifact@v2
         with:
-          path: test-results
+          path: |
+            packages/notification-service/coverage/lcov-report
+            packages/cloud-functions/coverage/lcov-report
+            packages/react-components/coverage/lcov-report
       - name: 'Upload to Codecov'
         uses: codecov/codecov-action@v2
         with:

--- a/packages/cloud-functions/package.json
+++ b/packages/cloud-functions/package.json
@@ -14,7 +14,7 @@
     "clean": "tsc -b . --clean",
     "build": "tsc -b .",
     "lint": "eslint --ext=.tsx,.ts src/",
-    "test": "jest"
+    "test": "export TZ=UTC && jest --ci --silent --coverage --maxWorkers=3"
   },
   "dependencies": {
     "@celo/contractkit": "1.2.2-beta",

--- a/packages/notification-service/package.json
+++ b/packages/notification-service/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "build": "tsc",
     "gcp-build": "npm run build",
-    "test": "cp config/config.test.env .env; export TZ=UTC && jest",
+    "test": "cp config/config.test.env .env; export TZ=UTC && jest --ci --silent --coverage --maxWorkers=3",
     "test:watch": "yarn test --watch",
     "lint": "eslint --ext=.tsx,.ts src/ test/",
     "start": "node ./dist/index.js",


### PR DESCRIPTION
### Description

- Adjust test command in notification-service and cloud-functions to produce coverage reports.
- Fixes path to coverage reports from notification-service, cloud-functions and react-components packages. 

### Other changes

- These coverages should now be tracked by Codecov.

### Tested

Tests run locally with `yarn run lerna --ignore @celo/mobile run test` from the wallet root.


### How others should test

N/A

### Backwards compatibility

This change is backwards compatible as it only impacts the creation and uploading of coverage reports.