### PR TITLE
Android: target API level 30

### DIFF
--- a/packages/mobile/android/build.gradle
+++ b/packages/mobile/android/build.gradle
@@ -2,11 +2,11 @@
 
 buildscript {
     ext {
-        buildToolsVersion = "29.0.2"
+        buildToolsVersion = "30.0.2"
         minSdkVersion = 21
-        compileSdkVersion = 29
-        targetSdkVersion = 29
-        supportLibVersion = "28.0.0"
+        compileSdkVersion = 30
+        targetSdkVersion = 30
+        supportLibVersion = "30.0.0"
         kotlinVersion = "1.5.10"
         // Change this to change the geth version
         celoClientDirectory = new File(rootProject.projectDir, '../../../node_modules/@celo/client/build/bin')


### PR DESCRIPTION
### Description

API level 30 is needed all for all app updates after November 1, 2021.

### Tested

App compiles and works.

### How others should test

App works.

### Related issues

- Fixes #1330

### Backwards compatibility

Yes