### PR TITLE
WIP adding analytics event for when a notification is sent

### DIFF
--- a/packages/cloud-functions/src/notifications/index.ts
+++ b/packages/cloud-functions/src/notifications/index.ts
@@ -87,6 +87,7 @@ export async function sendNotification(
     ValoraAnalytics.track(AppEvents.push_notification_opened, {
       id: data.id,
       type: data.type,
+      address,
     })
   } catch (error) {
     console.error(

--- a/packages/cloud-functions/src/notifications/index.ts
+++ b/packages/cloud-functions/src/notifications/index.ts
@@ -2,6 +2,8 @@ import * as admin from 'firebase-admin'
 import i18next, { TFunction } from 'i18next'
 import { NOTIFICATIONS_TTL_MS } from '../config'
 import { database, messaging } from '../firebase'
+import ValoraAnalytics from '@celo/mobile/src/analytics/ValoraAnalytics'
+import { AppEvents } from '@celo/mobile/src/analytics/Events'
 
 const TAG = 'Notifications'
 
@@ -82,6 +84,10 @@ export async function sendNotification(
         latency: data.timestamp ? Date.now() - Number(data.timestamp) : null,
       })
     )
+    ValoraAnalytics.track(AppEvents.push_notification_opened, {
+      id: data.id,
+      type: data.type,
+    })
   } catch (error) {
     console.error(
       JSON.stringify({

--- a/packages/cloud-functions/src/notifications/index.ts
+++ b/packages/cloud-functions/src/notifications/index.ts
@@ -84,7 +84,7 @@ export async function sendNotification(
         latency: data.timestamp ? Date.now() - Number(data.timestamp) : null,
       })
     )
-    ValoraAnalytics.track(AppEvents.push_notification_opened, {
+    ValoraAnalytics.track(AppEvents.push_notification_sent, {
       id: data.id,
       type: data.type,
       address,

--- a/packages/mobile/src/analytics/Events.tsx
+++ b/packages/mobile/src/analytics/Events.tsx
@@ -11,6 +11,7 @@ export enum AppEvents {
   fetch_balance_error = 'fetch_balance_error',
   redux_keychain_mismatch = 'redux_keychain_mismatch',
   redux_store_recovery_success = 'redux_store_recovery_success',
+  push_notification_sent = 'push_notification_sent',
   push_notification_opened = 'push_notification_opened',
   android_mobile_services_availability_checked = 'android_mobile_services_availability_checked',
 

--- a/packages/mobile/src/analytics/Properties.tsx
+++ b/packages/mobile/src/analytics/Properties.tsx
@@ -87,6 +87,7 @@ interface AppEventsProperties {
   [AppEvents.push_notification_sent]: {
     id?: string
     type?: string
+    address: string
   }
   [AppEvents.push_notification_opened]: {
     id?: string

--- a/packages/mobile/src/analytics/Properties.tsx
+++ b/packages/mobile/src/analytics/Properties.tsx
@@ -84,6 +84,10 @@ interface AppEventsProperties {
   [AppEvents.redux_store_recovery_success]: {
     account: string
   }
+  [AppEvents.push_notification_sent]: {
+    id?: string
+    type?: string
+  }
   [AppEvents.push_notification_opened]: {
     id?: string
     state: NotificationReceiveState


### PR DESCRIPTION
NOTE this may not work work! (need a valid way to import the analytics event dependencies...)

### Description

Publishing an event when a notification is sent.

I'm playing around with analytics events to learn about how they work and how to add a new one. We have an event for when someone opens a notification, but not for when one is sent, which is important because you can't always rely on a user opening a notification-- sometimes they'll just see it and come into the app "organically" as a result.

### Other changes

na

### Tested

_An explanation of how the changes were tested or an explanation as to why they don't need to be._


### How others should test

_Does this need to be tested by QA in the next release cycle? If so please give a brief explanation of how to test these changes._

### Related issues

- Fixes #[issue number here]

### Backwards compatibility

_Brief explanation of why these changes are/are not backwards compatible._