### PR TITLE
Fetch token balances using Blockscout

### DIFF
--- a/packages/mobile/.env.alfajores
+++ b/packages/mobile/.env.alfajores
@@ -19,3 +19,4 @@ GETH_USE_FULL_NODE_DISCOVERY=true
 GETH_USE_STATIC_NODES=true
 # Only for development, use with caution
 GETH_START_HTTP_RPC_SERVER=false
+BLOCKSCOUT_BASE_URL=https://alfajores-blockscout.celo-testnet.org/api

--- a/packages/mobile/.env.alfajoresdev
+++ b/packages/mobile/.env.alfajoresdev
@@ -21,3 +21,4 @@ GETH_USE_FULL_NODE_DISCOVERY=true
 GETH_USE_STATIC_NODES=true
 # Only for development, use with caution
 GETH_START_HTTP_RPC_SERVER=false
+BLOCKSCOUT_BASE_URL=https://alfajores-blockscout.celo-testnet.org/api

--- a/packages/mobile/.env.mainnet
+++ b/packages/mobile/.env.mainnet
@@ -19,3 +19,4 @@ GETH_USE_FULL_NODE_DISCOVERY=true
 GETH_USE_STATIC_NODES=true
 # Only for development, use with caution
 GETH_START_HTTP_RPC_SERVER=false
+BLOCKSCOUT_BASE_URL=https://explorer.celo.org/api

--- a/packages/mobile/.env.mainnetdev
+++ b/packages/mobile/.env.mainnetdev
@@ -21,3 +21,4 @@ GETH_USE_FULL_NODE_DISCOVERY=true
 GETH_USE_STATIC_NODES=true
 # Only for development, use with caution
 GETH_START_HTTP_RPC_SERVER=false
+BLOCKSCOUT_BASE_URL=https://explorer.celo.org/api

--- a/packages/mobile/src/config.ts
+++ b/packages/mobile/src/config.ts
@@ -64,6 +64,7 @@ export const DEFAULT_FORNO_URL =
   DEFAULT_TESTNET === 'mainnet'
     ? 'https://forno.celo.org/'
     : 'https://alfajores-forno.celo-testnet.org/'
+export const BLOCKSCOUT_BASE_URL = Config.BLOCKSCOUT_BASE_URL
 
 // FEATURE FLAGS
 export const FIREBASE_ENABLED = stringToBoolean(Config.FIREBASE_ENABLED || 'true')

--- a/packages/mobile/src/escrow/saga.ts
+++ b/packages/mobile/src/escrow/saga.ts
@@ -41,7 +41,7 @@ import { VerificationStatus } from 'src/identity/types'
 import { NUM_ATTESTATIONS_REQUIRED } from 'src/identity/verification'
 import { navigateHome } from 'src/navigator/NavigationService'
 import { fetchStableBalances } from 'src/stableToken/actions'
-import { TokenBalance } from 'src/tokens/reducer'
+import { fetchTokenBalances, TokenBalance } from 'src/tokens/reducer'
 import {
   getCurrencyAddress,
   getERC20TokenContract,
@@ -324,6 +324,7 @@ function* withdrawFromEscrow(komenciActive: boolean = false) {
     }
 
     yield put(fetchStableBalances())
+    yield put(fetchTokenBalances())
     Logger.showMessage(i18n.t('inviteFlow11:transferDollarsToAccount'))
     ValoraAnalytics.track(OnboardingEvents.escrow_redeem_complete)
   } catch (e) {

--- a/packages/mobile/src/home/saga.ts
+++ b/packages/mobile/src/home/saga.ts
@@ -20,6 +20,7 @@ import { shouldFetchCurrentRate } from 'src/localCurrency/selectors'
 import { withTimeout } from 'src/redux/sagas-helpers'
 import { shouldUpdateBalance } from 'src/redux/selectors'
 import { fetchStableBalances } from 'src/stableToken/actions'
+import { fetchTokenBalances } from 'src/tokens/reducer'
 import { Actions as TransactionActions } from 'src/transactions/actions'
 import Logger from 'src/utils/Logger'
 import { getConnectedAccount } from 'src/web3/saga'
@@ -42,6 +43,7 @@ export function withLoading<Fn extends (...args: any[]) => any>(fn: Fn, ...args:
 export function* refreshBalances() {
   Logger.debug(TAG, 'Fetching all balances')
   yield call(getConnectedAccount)
+  yield put(fetchTokenBalances())
   yield put(fetchStableBalances())
   yield put(fetchGoldBalance())
   yield put(fetchSentEscrowPayments())

--- a/packages/mobile/src/send/SendAmount/index.tsx
+++ b/packages/mobile/src/send/SendAmount/index.tsx
@@ -33,13 +33,13 @@ import SendAmountHeader from 'src/send/SendAmount/SendAmountHeader'
 import SendAmountValue from 'src/send/SendAmount/SendAmountValue'
 import useTransactionCallbacks from 'src/send/SendAmount/useTransactionCallbacks'
 import DisconnectBanner from 'src/shared/DisconnectBanner'
-import { fetchStableBalances } from 'src/stableToken/actions'
 import {
   useAmountAsUsd,
   useLocalToTokenAmount,
   useTokenInfo,
   useTokenToLocalAmount,
 } from 'src/tokens/hooks'
+import { fetchTokenBalances } from 'src/tokens/reducer'
 import { defaultTokenSelector } from 'src/tokens/selectors'
 import { Currency } from 'src/utils/currencies'
 
@@ -108,7 +108,7 @@ function SendAmount(props: Props) {
   const dispatch = useDispatch()
 
   useEffect(() => {
-    dispatch(fetchStableBalances())
+    dispatch(fetchTokenBalances())
     if (recipient.address) {
       return
     }

--- a/packages/mobile/src/tokens/reducer.ts
+++ b/packages/mobile/src/tokens/reducer.ts
@@ -40,6 +40,7 @@ export const initialState = {
 
 const rehydrate = createAction<any>(REHYDRATE)
 export const setTokenBalances = createAction<StoredTokenBalances>('TOKENS/SET_TOKEN_BALANCES')
+export const fetchTokenBalances = createAction('TOKENS/FETCH_TOKEN_BALANCES')
 
 export const reducer = createReducer(initialState, (builder) => {
   builder

--- a/packages/mobile/src/transactions/saga.ts
+++ b/packages/mobile/src/transactions/saga.ts
@@ -18,6 +18,7 @@ import { addressToE164NumberSelector } from 'src/identity/selectors'
 import { AddressToRecipient, NumberToRecipient } from 'src/recipients/recipient'
 import { phoneRecipientCacheSelector, updateValoraRecipientCache } from 'src/recipients/reducer'
 import { fetchStableBalances } from 'src/stableToken/actions'
+import { fetchTokenBalances } from 'src/tokens/reducer'
 import {
   Actions,
   addHashToStandbyTransaction,
@@ -115,6 +116,8 @@ export function* sendAndMonitorTransaction<T>(
     if (STABLE_CURRENCIES.some((stableCurrency) => balancesAffected.has(stableCurrency))) {
       yield put(fetchStableBalances())
     }
+    // TODO: Consider only fetching the balance of the used token.
+    yield put(fetchTokenBalances())
     return { receipt: txReceipt }
   } catch (error) {
     Logger.error(TAG + '@sendAndMonitorTransaction', `Error sending tx ${context.id}`, error)

--- a/packages/mobile/test/values.ts
+++ b/packages/mobile/test/values.ts
@@ -449,28 +449,15 @@ export const mockTokenBalances = {
     decimals: 18,
     balance: '0',
   },
-}
-
-export const mockTokenBalances2 = {
-  '0x00400FcbF0816bebB94654259de7273f4A05c762': {
-    usdPrice: '0.1',
-    address: '0x00400FcbF0816bebB94654259de7273f4A05c762',
-    symbol: 'POOF',
+  '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1': {
+    usdPrice: '1.001',
+    address: '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
+    symbol: 'cUSD',
     imageUrl:
-      'https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_POOF.png',
-    name: 'Poof Governance Token',
+      'https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_cUSD.png',
+    name: 'Celo Dollar',
     decimals: 18,
-    balance: '5',
-  },
-  '0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F': {
-    usdPrice: '1.16',
-    address: '0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F',
-    symbol: 'cEUR',
-    imageUrl:
-      'https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_cEUR.png',
-    name: 'Celo Euro',
-    decimals: 18,
-    balance: null,
+    balance: '0',
   },
 }
 


### PR DESCRIPTION
### Description

Before this PR when fetching balances we were querying the balance directly from the token contracts.
This has the advantage that it's querying directly from Forno or other nodes that are more likely to be up to date than blockscout, which sometimes has a delay to update balances.

However, the disadvantage was that we were making one request per each token. If there are not a lot of tokens this is fine, but there are 42 tokens already on https://github.com/Ubeswap/default-token-list/blob/master/ubeswap.token-list.json and this number will continue to grow. Making so many requests each time we want to fetch balances looks like too much.

Another possible solution longer-term is indexing and updating the balances of our users ourselves using the indexer. This would give us control over the latency for block updates while not having to make so many requests at the same time.

### Other changes

Created an action which re-fetches the token balances and called it in the places where the old ones used to be called.

### Tested

Manually and with unit tests.

### How others should test

Nothing to test directly here, just make sure the balances show up and are up to date after making a transfer.
### Related issues

- Part of #1126

### Backwards compatibility

N/A