### PR TITLE
Add feature flags to use for some multi-token support features

### DIFF
--- a/packages/mobile/src/app/reducers.ts
+++ b/packages/mobile/src/app/reducers.ts
@@ -42,6 +42,9 @@ export interface State {
     [lang: string]: string
   }
   cashInButtonExpEnabled: boolean
+  multiTokenShowHomeBalances: boolean
+  multiTokenUseSendFlow: boolean
+  multiTokenUseUpdatedFeed: boolean
 }
 
 const initialState = {
@@ -77,6 +80,9 @@ const initialState = {
   pincodeUseExpandedBlocklist: FEATURE_FLAG_DEFAULTS.pincodeUseExpandedBlocklist,
   rewardPillText: JSON.parse(FEATURE_FLAG_DEFAULTS.rewardPillText),
   cashInButtonExpEnabled: false,
+  multiTokenShowHomeBalances: FEATURE_FLAG_DEFAULTS.multiTokenShowHomeBalances,
+  multiTokenUseSendFlow: FEATURE_FLAG_DEFAULTS.multiTokenUseSendFlow,
+  multiTokenUseUpdatedFeed: FEATURE_FLAG_DEFAULTS.multiTokenUseUpdatedFeed,
 }
 
 export const currentLanguageSelector = (state: RootState) => state.app.language || i18n.language
@@ -190,6 +196,9 @@ export const appReducer = (
         pincodeUseExpandedBlocklist: action.flags.pincodeUseExpandedBlocklist,
         rewardPillText: JSON.parse(action.flags.rewardPillText),
         cashInButtonExpEnabled: action.flags.cashInButtonExpEnabled,
+        multiTokenShowHomeBalances: action.flags.multiTokenShowHomeBalances,
+        multiTokenUseSendFlow: action.flags.multiTokenUseSendFlow,
+        multiTokenUseUpdatedFeed: action.flags.multiTokenUseUpdatedFeed,
       }
     case Actions.TOGGLE_INVITE_MODAL:
       return {

--- a/packages/mobile/src/app/saga.ts
+++ b/packages/mobile/src/app/saga.ts
@@ -164,6 +164,9 @@ export interface RemoteFeatureFlags {
   pincodeUseExpandedBlocklist: boolean
   rewardPillText: string
   cashInButtonExpEnabled: boolean
+  multiTokenShowHomeBalances: boolean
+  multiTokenUseSendFlow: boolean
+  multiTokenUseUpdatedFeed: boolean
 }
 
 export function* appRemoteFeatureFlagSaga() {

--- a/packages/mobile/src/app/selectors.ts
+++ b/packages/mobile/src/app/selectors.ts
@@ -100,3 +100,9 @@ export const huaweiMobileServicesAvailableSelector = (state: RootState) =>
   state.app.huaweiMobileServicesAvailable
 
 export const rewardPillTextSelector = (state: RootState) => state.app.rewardPillText
+
+export const multiTokenShowHomeBalancesSelector = (state: RootState) =>
+  state.app.multiTokenShowHomeBalances
+export const multiTokenUseSendFlowSelector = (state: RootState) => state.app.multiTokenUseSendFlow
+export const multiTokenUseUpdatedFeedSelector = (state: RootState) =>
+  state.app.multiTokenUseUpdatedFeed

--- a/packages/mobile/src/firebase/featureFlagDefaults.e2e.ts
+++ b/packages/mobile/src/firebase/featureFlagDefaults.e2e.ts
@@ -29,4 +29,7 @@ export const FEATURE_FLAG_DEFAULTS: Omit<
   rewardPillText: JSON.stringify({ en: 'Earn', pt: 'Ganhar', es: 'Gana' }),
   cashInButtonExpEnabled: false,
   logPhoneNumberTypeEnabled: false,
+  multiTokenShowHomeBalances: false,
+  multiTokenUseSendFlow: false,
+  multiTokenUseUpdatedFeed: false,
 }

--- a/packages/mobile/src/firebase/featureFlagDefaults.ts
+++ b/packages/mobile/src/firebase/featureFlagDefaults.ts
@@ -28,4 +28,7 @@ export const FEATURE_FLAG_DEFAULTS: Omit<
   rewardPillText: JSON.stringify({ en: 'Earn', pt: 'Ganhar', es: 'Gana' }),
   cashInButtonExpEnabled: false,
   logPhoneNumberTypeEnabled: false,
+  multiTokenShowHomeBalances: false,
+  multiTokenUseSendFlow: false,
+  multiTokenUseUpdatedFeed: false,
 }

--- a/packages/mobile/src/firebase/firebase.ts
+++ b/packages/mobile/src/firebase/firebase.ts
@@ -281,6 +281,9 @@ export async function fetchRemoteFeatureFlags(): Promise<RemoteFeatureFlags | nu
       rewardPillText: flags.rewardPillText.asString(),
       cashInButtonExpEnabled: flags.cashInButtonExpEnabled.asBoolean(),
       logPhoneNumberTypeEnabled: flags.logPhoneNumberTypeEnabled.asBoolean(),
+      multiTokenShowHomeBalances: flags.multiTokenShowHomeBalances.asBoolean(),
+      multiTokenUseSendFlow: flags.multiTokenUseSendFlow.asBoolean(),
+      multiTokenUseUpdatedFeed: flags.multiTokenUseUpdatedFeed.asBoolean(),
     }
   } else {
     Logger.debug('No new configs were fetched from the backend.')

--- a/packages/mobile/src/firebase/firebase.ts
+++ b/packages/mobile/src/firebase/firebase.ts
@@ -243,7 +243,7 @@ export async function fetchRemoteFeatureFlags(): Promise<RemoteFeatureFlags | nu
   await remoteConfig().setDefaults(FEATURE_FLAG_DEFAULTS)
   // Cache values for 1 hour. The default is 12 hours.
   // https://rnfirebase.io/remote-config/usage
-  await remoteConfig().setConfigSettings({ minimumFetchIntervalMillis: 60 * 60 * 1000 })
+  await remoteConfig().setConfigSettings({ minimumFetchIntervalMillis: 0 })
   const fetchedRemotely = await remoteConfig().fetchAndActivate()
 
   if (fetchedRemotely) {

--- a/packages/mobile/src/flags.ts
+++ b/packages/mobile/src/flags.ts
@@ -7,7 +7,6 @@ export const features = {
   SHOW_CASH_OUT: true,
   PNP_USE_DEK_FOR_AUTH: true,
   SHOW_INVITE_MENU_ITEM: false,
-  USE_TOKEN_SEND_FLOW: false,
 }
 
 // Country specific features, unlisted countries are set to `false` by default

--- a/packages/mobile/src/redux/migrations.ts
+++ b/packages/mobile/src/redux/migrations.ts
@@ -327,4 +327,5 @@ export const migrations = {
     }
     return state
   },
+  20: (state: any) => state,
 }

--- a/packages/mobile/src/redux/store.ts
+++ b/packages/mobile/src/redux/store.ts
@@ -19,7 +19,7 @@ let lastEventTime = Date.now()
 
 const persistConfig: any = {
   key: 'root',
-  version: 19, // default is -1, increment as we make migrations
+  version: 20, // default is -1, increment as we make migrations
   keyPrefix: `reduxStore-`, // the redux-persist default is `persist:` which doesn't work with some file systems.
   storage: FSStorage(),
   blacklist: ['geth', 'networkInfo', 'alert', 'fees', 'imports'],

--- a/packages/mobile/src/send/Send.tsx
+++ b/packages/mobile/src/send/Send.tsx
@@ -12,9 +12,8 @@ import { hideAlert } from 'src/alert/actions'
 import { RequestEvents, SendEvents } from 'src/analytics/Events'
 import { SendOrigin } from 'src/analytics/types'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
-import { verificationPossibleSelector } from 'src/app/selectors'
+import { multiTokenUseSendFlowSelector, verificationPossibleSelector } from 'src/app/selectors'
 import { estimateFee, FeeType } from 'src/fees/actions'
-import { features } from 'src/flags'
 import { Namespaces } from 'src/i18n'
 import ContactPermission from 'src/icons/ContactPermission'
 import { importContacts } from 'src/identity/actions'
@@ -65,6 +64,7 @@ function Send({ route }: Props) {
   const [recentFiltered, setRecentFiltered] = useState(() => recentRecipients)
 
   const verificationPossible = useSelector(verificationPossibleSelector)
+  const multiTokenUseSendFlow = useSelector(multiTokenUseSendFlowSelector)
 
   const dispatch = useDispatch()
 
@@ -126,7 +126,8 @@ function Send({ route }: Props) {
         }
       )
 
-      if (features.USE_TOKEN_SEND_FLOW) {
+      // TODO: Add payment request support in the new flow.
+      if (multiTokenUseSendFlow && !isOutgoingPaymentRequest) {
         navigate(Screens.SendAmount, {
           recipient,
           isOutgoingPaymentRequest,

--- a/packages/mobile/src/send/saga.test.ts
+++ b/packages/mobile/src/send/saga.test.ts
@@ -81,6 +81,7 @@ describe(watchQrCodeDetections, () => {
     const data: QrCode = { type: BarcodeTypes.QR_CODE, data: urlFromUriData(mockQrCodeData) }
 
     await expectSaga(watchQrCodeDetections)
+      .withState(createMockStore({ app: { multiTokenUseSendFlow: false } }).getState())
       .provide([
         [select(e164NumberToAddressSelector), mockE164NumberToAddress],
         [select(recipientInfoSelector), mockRecipientInfo],
@@ -110,6 +111,7 @@ describe(watchQrCodeDetections, () => {
     }
 
     await expectSaga(watchQrCodeDetections)
+      .withState(createMockStore({ app: { multiTokenUseSendFlow: false } }).getState())
       .provide([
         [select(e164NumberToAddressSelector), {}],
         [select(recipientInfoSelector), mockRecipientInfo],
@@ -138,6 +140,7 @@ describe(watchQrCodeDetections, () => {
     }
 
     await expectSaga(watchQrCodeDetections)
+      .withState(createMockStore({ app: { multiTokenUseSendFlow: false } }).getState())
       .provide([
         [select(e164NumberToAddressSelector), {}],
         [select(recipientInfoSelector), mockRecipientInfo],
@@ -163,6 +166,7 @@ describe(watchQrCodeDetections, () => {
     const data: QrCode = { type: BarcodeTypes.QR_CODE, data: INVALID_QR }
 
     await expectSaga(watchQrCodeDetections)
+      .withState(createMockStore({ app: { multiTokenUseSendFlow: false } }).getState())
       .provide([
         [select(e164NumberToAddressSelector), {}],
         [select(recipientInfoSelector), mockRecipientInfo],
@@ -182,6 +186,7 @@ describe(watchQrCodeDetections, () => {
     const data: QrCode = { type: BarcodeTypes.QR_CODE, data: urlFromUriData(INVALID_QR_ADDRESS) }
 
     await expectSaga(watchQrCodeDetections)
+      .withState(createMockStore({ app: { multiTokenUseSendFlow: false } }).getState())
       .provide([
         [select(e164NumberToAddressSelector), {}],
         [select(recipientInfoSelector), mockRecipientInfo],
@@ -201,6 +206,7 @@ describe(watchQrCodeDetections, () => {
       transactionData: mockTransactionData,
     }
     await expectSaga(watchQrCodeDetections)
+      .withState(createMockStore({ app: { multiTokenUseSendFlow: false } }).getState())
       .provide([
         [select(e164NumberToAddressSelector), mockE164NumberToAddress],
         [select(recipientInfoSelector), mockRecipientInfo],
@@ -225,6 +231,7 @@ describe(watchQrCodeDetections, () => {
       transactionData: mockTransactionData,
     }
     await expectSaga(watchQrCodeDetections)
+      .withState(createMockStore({ app: { multiTokenUseSendFlow: false } }).getState())
       .provide([
         [select(e164NumberToAddressSelector), mockE164NumberToAddress],
         [select(recipientInfoSelector), mockRecipientInfo],
@@ -247,6 +254,7 @@ describe(watchQrCodeDetections, () => {
       transactionData: mockTransactionData,
     }
     await expectSaga(watchQrCodeDetections)
+      .withState(createMockStore({ app: { multiTokenUseSendFlow: false } }).getState())
       .provide([
         [select(e164NumberToAddressSelector), mockE164NumberToAddress],
         [select(recipientInfoSelector), mockRecipientInfo],
@@ -271,6 +279,7 @@ describe(sendPaymentOrInviteSagaLegacy, () => {
       fromModal: false,
     }
     await expectSaga(sendPaymentOrInviteSagaLegacy, sendPaymentOrInviteAction)
+      .withState(createMockStore({ app: { multiTokenUseSendFlow: false } }).getState())
       .provide([
         [call(getConnectedAccount), account],
         [matchers.call.fn(unlockAccount), UnlockResult.CANCELED],
@@ -292,7 +301,7 @@ describe(sendPaymentOrInviteSagaLegacy, () => {
       fromModal: false,
     }
     await expectSaga(sendPaymentOrInviteSagaLegacy, sendPaymentOrInviteAction)
-      .withState(createMockStore({}).getState())
+      .withState(createMockStore({ app: { multiTokenUseSendFlow: false } }).getState())
       .provide([
         [call(getConnectedAccount), account],
         [matchers.call.fn(unlockAccount), UnlockResult.SUCCESS],

--- a/packages/mobile/src/send/utils.test.ts
+++ b/packages/mobile/src/send/utils.test.ts
@@ -3,7 +3,6 @@ import { expectSaga } from 'redux-saga-test-plan'
 import * as matchers from 'redux-saga-test-plan/matchers'
 import { SendOrigin } from 'src/analytics/types'
 import { TokenTransactionType } from 'src/apollo/types'
-import { features } from 'src/flags'
 import { LocalCurrencyCode } from 'src/localCurrency/consts'
 import { fetchExchangeRate } from 'src/localCurrency/saga'
 import { navigate } from 'src/navigator/NavigationService'
@@ -131,15 +130,6 @@ describe('send/utils', () => {
   })
 
   describe('handlePaymentDeeplink', () => {
-    const useTokenSendFlow = features.USE_TOKEN_SEND_FLOW
-    beforeAll(() => {
-      features.USE_TOKEN_SEND_FLOW = true
-    })
-
-    afterAll(() => {
-      features.USE_TOKEN_SEND_FLOW = useTokenSendFlow
-    })
-
     const mockData = {
       address: mockAccount2.toLowerCase(),
       currencyCode: 'USD' as LocalCurrencyCode,
@@ -147,7 +137,7 @@ describe('send/utils', () => {
 
     it('should navigate to SendAmount screen when no amount nor token is sent', async () => {
       await expectSaga(handleSendPaymentData, mockData)
-        .withState(createMockStore({}).getState())
+        .withState(createMockStore({ app: { multiTokenUseSendFlow: true } }).getState())
         .provide([[matchers.call.fn(fetchExchangeRate), mockData.currencyCode]])
         .run()
       expect(navigate).toHaveBeenCalledWith(Screens.SendAmount, {
@@ -160,7 +150,7 @@ describe('send/utils', () => {
 
     it('should navigate to SendAmount screen when no amount is sent but token is', async () => {
       await expectSaga(handleSendPaymentData, { ...mockData, token: 'cEUR' })
-        .withState(createMockStore({}).getState())
+        .withState(createMockStore({ app: { multiTokenUseSendFlow: true } }).getState())
         .provide([[matchers.call.fn(fetchExchangeRate), mockData.currencyCode]])
         .run()
       expect(navigate).toHaveBeenCalledWith(Screens.SendAmount, {
@@ -186,7 +176,7 @@ describe('send/utils', () => {
 
     it('should navigate to SendConfirmation screen when amount and token are sent', async () => {
       await expectSaga(handleSendPaymentData, { ...mockData, amount: 1, token: 'cEUR' })
-        .withState(createMockStore({}).getState())
+        .withState(createMockStore({ app: { multiTokenUseSendFlow: true } }).getState())
         .provide([[matchers.call.fn(fetchExchangeRate), mockData.currencyCode]])
         .run()
       expect(navigate).toHaveBeenCalledWith(Screens.SendConfirmation, {
@@ -202,7 +192,7 @@ describe('send/utils', () => {
 
     it('should navigate to SendConfirmation screen defaulting to cUSD when amount is sent but token isnt', async () => {
       await expectSaga(handleSendPaymentData, { ...mockData, amount: 1 })
-        .withState(createMockStore({}).getState())
+        .withState(createMockStore({ app: { multiTokenUseSendFlow: true } }).getState())
         .provide([[matchers.call.fn(fetchExchangeRate), mockData.currencyCode]])
         .run()
       expect(navigate).toHaveBeenCalledWith(Screens.SendConfirmation, {
@@ -218,15 +208,6 @@ describe('send/utils', () => {
   })
 
   describe('handlePaymentDeeplinkLegacy', () => {
-    const useTokenSendFlow = features.USE_TOKEN_SEND_FLOW
-    beforeAll(() => {
-      features.USE_TOKEN_SEND_FLOW = false
-    })
-
-    afterAll(() => {
-      features.USE_TOKEN_SEND_FLOW = useTokenSendFlow
-    })
-
     const data = {
       address: '0xf7f551752A78Ce650385B58364225e5ec18D96cB',
       displayName: 'Super 8',
@@ -244,6 +225,7 @@ describe('send/utils', () => {
         token: undefined,
       }
       await expectSaga(handlePaymentDeeplink, deeplink)
+        .withState(createMockStore({ app: { multiTokenUseSendFlow: false } }).getState())
         .provide([[matchers.call.fn(handleSendPaymentData), parsed]])
         .run()
     })
@@ -255,6 +237,7 @@ describe('send/utils', () => {
 
       it('should navigate to SendAmount screen when address & currencyCode are given ', async () => {
         await expectSaga(handleSendPaymentData, mockUriData[3])
+          .withState(createMockStore({ app: { multiTokenUseSendFlow: false } }).getState())
           .provide([[matchers.call.fn(fetchExchangeRate), mockUriData[3].currencyCode]])
           .run()
         expect(navigate).toHaveBeenCalledWith(Screens.SendAmountLegacy, {
@@ -274,6 +257,7 @@ describe('send/utils', () => {
         }
 
         await expectSaga(handleSendPaymentData, mockUriData[4])
+          .withState(createMockStore({ app: { multiTokenUseSendFlow: false } }).getState())
           .provide([[matchers.call.fn(fetchExchangeRate), '2']])
           .run()
         expect(navigate).toHaveBeenCalledWith(Screens.SendConfirmationLegacy, {
@@ -293,6 +277,7 @@ describe('send/utils', () => {
         }
 
         await expectSaga(handleSendPaymentData, mockUriData[5])
+          .withState(createMockStore({ app: { multiTokenUseSendFlow: false } }).getState())
           .provide([[matchers.call.fn(fetchExchangeRate), '2']])
           .run()
         expect(navigate).toHaveBeenCalledWith(Screens.SendConfirmationLegacy, {
@@ -310,6 +295,7 @@ describe('send/utils', () => {
 
       it('should navigate to WithdrawCeloReview screen when address, token = CELO, currencyCode, and amount are given ', async () => {
         await expectSaga(handleSendPaymentData, mockUriData[0])
+          .withState(createMockStore({ app: { multiTokenUseSendFlow: false } }).getState())
           .provide([[matchers.call.fn(fetchExchangeRate), mockUriData[0].currencyCode]])
           .run()
         expect(navigate).toHaveBeenCalledWith(Screens.WithdrawCeloReviewScreen, {
@@ -323,6 +309,7 @@ describe('send/utils', () => {
 
       it('should not navigate to WithdrawCeloReview screen when only address & token = CELO are given ', async () => {
         await expectSaga(handleSendPaymentData, mockUriData[1])
+          .withState(createMockStore({ app: { multiTokenUseSendFlow: false } }).getState())
           .provide([[matchers.call.fn(fetchExchangeRate), mockUriData[1].currencyCode]])
           .run()
         expect(navigate).not.toHaveBeenCalled()
@@ -330,6 +317,7 @@ describe('send/utils', () => {
 
       it('should not navigate to any screen when an unsupported token is given ', async () => {
         await expectSaga(handleSendPaymentData, mockUriData[2])
+          .withState(createMockStore({ app: { multiTokenUseSendFlow: false } }).getState())
           .provide([[matchers.call.fn(fetchExchangeRate), mockUriData[2].currencyCode]])
           .run()
         expect(navigate).not.toHaveBeenCalled()

--- a/packages/mobile/src/send/utils.ts
+++ b/packages/mobile/src/send/utils.ts
@@ -7,9 +7,9 @@ import { showError } from 'src/alert/actions'
 import { SendOrigin } from 'src/analytics/types'
 import { TokenTransactionType } from 'src/apollo/types'
 import { ErrorMessages } from 'src/app/ErrorMessages'
+import { multiTokenUseSendFlowSelector } from 'src/app/selectors'
 import { ALERT_BANNER_DURATION } from 'src/config'
 import { FeeType } from 'src/fees/actions'
-import { features } from 'src/flags'
 import { getAddressFromPhoneNumber } from 'src/identity/contactMapping'
 import { E164NumberToAddressType, SecureSendPhoneNumberMapping } from 'src/identity/reducer'
 import { RecipientVerificationStatus } from 'src/identity/types'
@@ -259,7 +259,8 @@ export function* handleSendPaymentData(
     })
   )
 
-  if (!features.USE_TOKEN_SEND_FLOW) {
+  const useTokenSendFlow: boolean = yield select(multiTokenUseSendFlowSelector)
+  if (!useTokenSendFlow) {
     yield call(handleSendPaymentDataLegacy, data, recipient, isOutgoingPaymentRequest, isFromScan)
     return
   }

--- a/packages/mobile/test/schemas.ts
+++ b/packages/mobile/test/schemas.ts
@@ -792,8 +792,16 @@ export const v19Schema = {
     },
     totalBalance: '40',
   },
+}
+
+export const v20Schema = {
+  ...v19Schema,
+  _persist: {
+    ...v19Schema._persist,
+    version: 20,
+  },
   app: {
-    ...v18Schema.app,
+    ...v19Schema.app,
     multiTokenShowHomeBalances: false,
     multiTokenUseSendFlow: false,
     multiTokenUseUpdatedFeed: false,
@@ -801,5 +809,5 @@ export const v19Schema = {
 }
 
 export function getLatestSchema(): Partial<RootState> {
-  return v19Schema as Partial<RootState>
+  return v20Schema as Partial<RootState>
 }

--- a/packages/mobile/test/schemas.ts
+++ b/packages/mobile/test/schemas.ts
@@ -792,6 +792,12 @@ export const v19Schema = {
     },
     totalBalance: '40',
   },
+  app: {
+    ...v18Schema.app,
+    multiTokenShowHomeBalances: false,
+    multiTokenUseSendFlow: false,
+    multiTokenUseUpdatedFeed: false,
+  },
 }
 
 export function getLatestSchema(): Partial<RootState> {


### PR DESCRIPTION
### Description

Added three feature flags to remote config:
- multiTokenShowHomeBalances: If enabled, the total balance will be shown in the home screen, including all supported tokens.
- multiTokenUseSendFlow: If enabled, the send flow will use the new flow that supports multiple tokens except for payment requests
- multiTokenUseUpdatedFeed: If enabled, the feed will use the new feed using the new endpoints.

For now only `multiTokenUseSendFlow` works, `multiTokenShowHomeBalances` needs the changes in #1294 and `multiTokenUseUpdatedFeed` is still a WIP

### Other changes

Changed the firebase remote config fetch time to 0 since we are already waiting an hour to call that function from outside.

### Tested

Manually

### How others should test

No need for QA to test this specifically I think since they don't have access to Firebase but to test you need to change the value of the feature flag on Firebase and see that the new features are seen when they are set to true.

### Related issues

- Fixes #1387

### Backwards compatibility

N/A