### PR TITLE
Fix SendConfirmation screen insufficient funds bug

### DIFF
--- a/packages/mobile/src/send/SendConfirmationLegacy.tsx
+++ b/packages/mobile/src/send/SendConfirmationLegacy.tsx
@@ -131,7 +131,8 @@ function SendConfirmationLegacy(props: Props) {
   )
   const account = useSelector(currentAccountSelector)
   const isSending = useSelector(isSendingSelector)
-  const balance = useBalance(currency)
+  // Only load the balance once to prevent race conditions with transactions updating balance
+  const [balance, _] = useState(useBalance(currency))
   const celoBalance = useBalance(Currency.Celo)
   const appConnected = useSelector(isAppConnected)
   const isDekRegistered = useSelector(isDekRegisteredSelector) ?? false

--- a/packages/mobile/src/send/SendConfirmationLegacy.tsx
+++ b/packages/mobile/src/send/SendConfirmationLegacy.tsx
@@ -132,7 +132,7 @@ function SendConfirmationLegacy(props: Props) {
   const account = useSelector(currentAccountSelector)
   const isSending = useSelector(isSendingSelector)
   // Only load the balance once to prevent race conditions with transactions updating balance
-  const [balance, _] = useState(useBalance(currency))
+  const [balance] = useState(useBalance(currency))
   const celoBalance = useBalance(Currency.Celo)
   const appConnected = useSelector(isAppConnected)
   const isDekRegistered = useSelector(isDekRegisteredSelector) ?? false


### PR DESCRIPTION
### Description

Load the balance only once for the SendConfirmationScreen so that it doesn't pick up any balance changes from completed transactions and potentially throw an error.

### Tested

_An explanation of how the changes were tested or an explanation as to why they don't need to be._

I couldn't come up with an easy way to add a unit test for this bug, suggestions welcome! 

Manually test by following the repro steps on https://github.com/valora-inc/wallet/issues/1341 and seeing that the bug no longer repros. 

### How others should test

### Related issues

- Fixes # https://github.com/valora-inc/wallet/issues/1341

### Backwards compatibility

The balance is never refreshed during this flow anyways, so there should be no unintended side effects from only loading it once.