### PR TITLE
Don't try to fetch user balances if there's no address in the store

### DIFF
--- a/packages/mobile/src/tokens/saga.test.ts
+++ b/packages/mobile/src/tokens/saga.test.ts
@@ -77,6 +77,18 @@ describe(fetchTokenBalancesSaga, () => {
       .run()
   })
 
+  it("nothing happens if there's no address in the store", async () => {
+    await expectSaga(fetchTokenBalancesSaga)
+      .provide([
+        [select(walletAddressSelector), null],
+        [call(readOnceFromFirebase, 'tokensInfo'), firebaseTokenInfo],
+        [call(fetchTokenBalancesForAddress, mockAccount), fetchBalancesResponse],
+      ])
+      .not.call(readOnceFromFirebase, 'tokensInfo')
+      .not.put(setTokenBalances(mockTokenBalances))
+      .run()
+  })
+
   it("fires an event if there's an error", async () => {
     await expectSaga(fetchTokenBalancesSaga)
       .provide([

--- a/packages/mobile/src/tokens/saga.ts
+++ b/packages/mobile/src/tokens/saga.ts
@@ -307,11 +307,15 @@ export async function fetchTokenBalancesForAddress(
 
 export function* fetchTokenBalancesSaga() {
   try {
+    const address: string | null = yield select(walletAddressSelector)
+    if (!address) {
+      Logger.debug(TAG, 'Skipping fetching tokens since no address was found')
+      return
+    }
     // In e2e environment we use a static token list since we can't access Firebase.
     const tokens: StoredTokenBalances = isE2EEnv
       ? e2eTokens()
       : yield call(readOnceFromFirebase, 'tokensInfo')
-    const address: string = yield select(walletAddressSelector)
     const tokenBalances: FetchedTokenBalance[] = yield call(fetchTokenBalancesForAddress, address)
     for (const token of Object.values(tokens) as StoredTokenBalance[]) {
       const tokenBalance = tokenBalances.find(


### PR DESCRIPTION
### Description

We're querying for user balances even if there's no address in the store (address === null). This is causing errors in `blockchain-api` since you can't query the endpoint with a `null` address.

### Other changes

N/A

### Tested

unit test

### How others should test

No need to test this specifically

### Related issues

- Fixes #1424

### Backwards compatibility

N/A