### PR TITLE
Convert Payment Request Confirmation to Functional Component

### DIFF
--- a/packages/mobile/src/paymentRequest/PaymentRequestConfirmation.tsx
+++ b/packages/mobile/src/paymentRequest/PaymentRequestConfirmation.tsx
@@ -3,12 +3,11 @@ import colors from '@celo/react-components/styles/colors'
 import fontStyles from '@celo/react-components/styles/fonts'
 import { firebase } from '@react-native-firebase/database'
 import { StackScreenProps } from '@react-navigation/stack'
-import * as React from 'react'
-import { WithTranslation } from 'react-i18next'
+import React, { useEffect, useState } from 'react'
+import { useTranslation, WithTranslation } from 'react-i18next'
 import { StyleSheet, Text, View } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
-import { connect } from 'react-redux'
-import { showError } from 'src/alert/actions'
+import { useDispatch } from 'react-redux'
 import { RequestEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import BackButton from 'src/components/BackButton'
@@ -23,86 +22,69 @@ import { StackParamList } from 'src/navigator/types'
 import { writePaymentRequest } from 'src/paymentRequest/actions'
 import { PaymentRequestStatus } from 'src/paymentRequest/types'
 import { getDisplayName } from 'src/recipients/recipient'
-import { RootState } from 'src/redux/reducers'
-import { ConfirmationInput, getConfirmationInput } from 'src/send/utils'
+import useSelector from 'src/redux/useSelector'
+import { getConfirmationInput } from 'src/send/utils'
 import DisconnectBanner from 'src/shared/DisconnectBanner'
 import Logger from 'src/utils/Logger'
-import { currentAccountSelector } from 'src/web3/selectors'
+import { walletAddressSelector } from 'src/web3/selectors'
 
 // @ts-ignore
 const TAG = 'paymentRequest/confirmation'
 
-interface StateProps {
-  e164PhoneNumber: string | null
-  account: string | null
-  confirmationInput: ConfirmationInput
-  addressJustValidated?: boolean
-}
-
-interface DispatchProps {
-  showError: typeof showError
-  writePaymentRequest: typeof writePaymentRequest
-}
-
-const mapDispatchToProps = { showError, writePaymentRequest }
-
-const mapStateToProps = (state: RootState, ownProps: OwnProps): StateProps => {
-  const { route } = ownProps
-  const { transactionData, addressJustValidated } = route.params
-  const { e164NumberToAddress } = state.identity
-  const { secureSendPhoneNumberMapping } = state.identity
-  const confirmationInput = getConfirmationInput(
-    transactionData,
-    e164NumberToAddress,
-    secureSendPhoneNumberMapping
-  )
-  return {
-    confirmationInput,
-    e164PhoneNumber: state.account.e164PhoneNumber,
-    account: currentAccountSelector(state),
-    addressJustValidated,
-  }
-}
-
 type OwnProps = StackScreenProps<StackParamList, Screens.PaymentRequestConfirmation>
 
-type Props = DispatchProps & StateProps & WithTranslation & OwnProps
+type Props = WithTranslation & OwnProps
 
 export const paymentConfirmationScreenNavOptions = () => ({
   ...emptyHeader,
   headerLeft: () => <BackButton eventName={RequestEvents.request_confirm_back} />,
 })
 
-class PaymentRequestConfirmation extends React.Component<Props> {
-  state = {
-    comment: '',
+function PaymentRequestConfirmation({ route }: Props) {
+  const [comment, setComment] = useState('')
+  const [transactionData] = useState(route.params.transactionData)
+  const [addressJustValidated] = useState(route.params.addressJustValidated)
+
+  const e164NumberToAddress = useSelector((state) => state.identity.e164NumberToAddress)
+  const secureSendPhoneNumberMapping = useSelector(
+    (state) => state.identity.secureSendPhoneNumberMapping
+  )
+  const account = useSelector(walletAddressSelector)
+
+  const confirmationInput = getConfirmationInput(
+    transactionData,
+    e164NumberToAddress,
+    secureSendPhoneNumberMapping
+  )
+
+  const amount = {
+    value: confirmationInput.amount,
+    currencyCode: confirmationInput.currency,
   }
 
-  componentDidMount() {
-    const { addressJustValidated, t } = this.props
+  const { t } = useTranslation()
+
+  useEffect(() => {
     if (addressJustValidated) {
       Logger.showMessage(t('addressConfirmed'))
     }
+  }, [])
+
+  const dispatch = useDispatch()
+
+  const onBlur = () => {
+    const trimmedComment = comment.trim()
+    setComment(trimmedComment)
   }
 
-  onCommentChange = (comment: string) => {
-    this.setState({ comment })
-  }
+  const onConfirm = async () => {
+    const { amount, recipient, recipientAddress: requesteeAddress } = confirmationInput
 
-  onBlur = () => {
-    const comment = this.state.comment.trim()
-    this.setState({ comment })
-  }
-
-  onConfirm = async () => {
-    const { amount, recipient, recipientAddress: requesteeAddress } = this.props.confirmationInput
-    const { t } = this.props
     if (!recipient) {
       throw new Error("Can't request without valid recipient")
     }
 
-    const address = this.props.account
-    if (!address) {
+    if (!account) {
       throw new Error("Can't request without a valid account")
     }
 
@@ -112,26 +94,21 @@ class PaymentRequestConfirmation extends React.Component<Props> {
 
     const paymentInfo = {
       amount: amount.toString(),
-      comment: this.state.comment || undefined,
+      comment: comment || undefined,
       createdAt: firebase.database.ServerValue.TIMESTAMP,
-      requesterAddress: address,
-      requesterE164Number: this.props.e164PhoneNumber ?? undefined,
+      requesterAddress: account,
+      requesterE164Number: confirmationInput.recipient.e164PhoneNumber ?? undefined,
       requesteeAddress: requesteeAddress.toLowerCase(),
       status: PaymentRequestStatus.REQUESTED,
       notified: false,
     }
 
     ValoraAnalytics.track(RequestEvents.request_confirm_request, { requesteeAddress })
-    this.props.writePaymentRequest(paymentInfo)
+    dispatch(writePaymentRequest(paymentInfo))
     Logger.showMessage(t('requestSent'))
   }
 
-  renderFooter = () => {
-    const amount = {
-      value: this.props.confirmationInput.amount,
-      currencyCode: this.props.confirmationInput.currency,
-    }
-
+  const renderFooter = () => {
     return (
       <View style={styles.feeContainer}>
         <TotalLineItem amount={amount} showExchangeRate={false} />
@@ -139,45 +116,38 @@ class PaymentRequestConfirmation extends React.Component<Props> {
     )
   }
 
-  render() {
-    const { t, confirmationInput } = this.props
-    const { recipient } = confirmationInput
-    const amount = {
-      value: this.props.confirmationInput.amount,
-      currencyCode: this.props.confirmationInput.currency,
-    }
-
-    return (
-      <SafeAreaView style={styles.container} edges={['bottom']}>
-        <DisconnectBanner />
-        <ReviewFrame
-          FooterComponent={this.renderFooter}
-          confirmButton={{
-            action: this.onConfirm,
-            text: t('request'),
-            disabled: false,
-          }}
-        >
-          <View style={styles.transferContainer}>
-            <View style={styles.headerContainer}>
-              <ContactCircle recipient={recipient} />
-              <View style={styles.recipientInfoContainer}>
-                <Text style={styles.headerText}>{t('requesting')}</Text>
-                <Text style={styles.displayName}>{getDisplayName(recipient, t)}</Text>
-              </View>
+  return (
+    <SafeAreaView style={styles.container} edges={['bottom']}>
+      <DisconnectBanner />
+      <ReviewFrame
+        FooterComponent={renderFooter}
+        confirmButton={{
+          action: onConfirm,
+          text: t('request'),
+          disabled: false,
+        }}
+      >
+        <View style={styles.transferContainer}>
+          <View style={styles.headerContainer}>
+            <ContactCircle recipient={confirmationInput.recipient} />
+            <View style={styles.recipientInfoContainer}>
+              <Text style={styles.headerText}>{t('requesting')}</Text>
+              <Text style={styles.displayName}>
+                {getDisplayName(confirmationInput.recipient, t)}
+              </Text>
             </View>
-            <CurrencyDisplay type={DisplayType.Default} style={styles.amount} amount={amount} />
-            <CommentTextInput
-              testID={'request'}
-              onCommentChange={this.onCommentChange}
-              comment={this.state.comment}
-              onBlur={this.onBlur}
-            />
           </View>
-        </ReviewFrame>
-      </SafeAreaView>
-    )
-  }
+          <CurrencyDisplay type={DisplayType.Default} style={styles.amount} amount={amount} />
+          <CommentTextInput
+            testID={'request'}
+            onCommentChange={setComment}
+            comment={comment}
+            onBlur={onBlur}
+          />
+        </View>
+      </ReviewFrame>
+    </SafeAreaView>
+  )
 }
 
 const styles = StyleSheet.create({
@@ -213,7 +183,4 @@ const styles = StyleSheet.create({
   },
 })
 
-export default connect<StateProps, DispatchProps, OwnProps, RootState>(
-  mapStateToProps,
-  mapDispatchToProps
-)(withTranslation<Props>()(PaymentRequestConfirmation))
+export default withTranslation<Props>()(PaymentRequestConfirmation)

--- a/packages/mobile/src/paymentRequest/PaymentRequestConfirmation.tsx
+++ b/packages/mobile/src/paymentRequest/PaymentRequestConfirmation.tsx
@@ -4,7 +4,7 @@ import fontStyles from '@celo/react-components/styles/fonts'
 import { firebase } from '@react-native-firebase/database'
 import { StackScreenProps } from '@react-navigation/stack'
 import React, { useEffect, useState } from 'react'
-import { useTranslation, WithTranslation } from 'react-i18next'
+import { useTranslation } from 'react-i18next'
 import { StyleSheet, Text, View } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { useDispatch } from 'react-redux'
@@ -16,7 +16,6 @@ import CommentTextInput from 'src/components/CommentTextInput'
 import ContactCircle from 'src/components/ContactCircle'
 import CurrencyDisplay, { DisplayType } from 'src/components/CurrencyDisplay'
 import TotalLineItem from 'src/components/TotalLineItem'
-import { withTranslation } from 'src/i18n'
 import {
   e164NumberToAddressSelector,
   secureSendPhoneNumberMappingSelector,
@@ -36,9 +35,7 @@ import { walletAddressSelector } from 'src/web3/selectors'
 // @ts-ignore
 const TAG = 'paymentRequest/confirmation'
 
-type OwnProps = StackScreenProps<StackParamList, Screens.PaymentRequestConfirmation>
-
-type Props = WithTranslation & OwnProps
+type Props = StackScreenProps<StackParamList, Screens.PaymentRequestConfirmation>
 
 export const paymentConfirmationScreenNavOptions = () => ({
   ...emptyHeader,
@@ -185,4 +182,4 @@ const styles = StyleSheet.create({
   },
 })
 
-export default withTranslation<Props>()(PaymentRequestConfirmation)
+export default PaymentRequestConfirmation


### PR DESCRIPTION
### Description

Changes payment request confirmation from a class based component to a functional component.

### Other changes

N/A

### Tested

Locally tested on iOS and Android and existing unit tests are passing.

### How others should test

Requester: account making the request
Giver: account receiving the request

#### Payment Request Successful

1. From requester send a payment request to the giver - no comment.
2. On requester see that the request is populated in the requests call to action (CTA).
3. From giver see that the request is received.

#### Comments
1. From requester add a comment and send payment request.
2. On requester see that the request is populated in the requests call to action (CTA).
3. From giver see that the request is received.

#### Back
1. From requester go back from the payment request screen
2. Request amount input loads.

### Related issues

Prerequisite for - #1395

### Backwards compatibility

This change is backwards compatible.