### PR TITLE
prevent whole firebase registrations registry from being loaded into memory

### DIFF
--- a/packages/notification-service/src/firebase.ts
+++ b/packages/notification-service/src/firebase.ts
@@ -107,13 +107,17 @@ export function initializeDb() {
     firebaseFetchError('Rewards senders')
   )
 
-  database.ref('/inviteRewardAddresses').on('value', (snapshot) => {
-    const addresses = snapshot?.val() ?? []
-    console.debug(`inviteRewardAddresses fetched: ${addresses}`)
-    if (addresses.length) {
-      inviteRewardsSenders = addresses
-    }
-  })
+  database.ref('/inviteRewardAddresses').on(
+    'value',
+    (snapshot) => {
+      const addresses = snapshot?.val() ?? []
+      console.debug(`inviteRewardAddresses fetched: ${addresses}`)
+      if (addresses.length) {
+        inviteRewardsSenders = addresses
+      }
+    },
+    firebaseFetchError('Invite rewards addresses')
+  )
 
   knownAddressesCache = new KnownAddressesCache()
   knownAddressesCache.startListening(database)

--- a/packages/notification-service/src/firebase.ts
+++ b/packages/notification-service/src/firebase.ts
@@ -55,6 +55,12 @@ export function _setKnownAddressesCache(testKnownAddressesCache: KnownAddressesC
   knownAddressesCache = testKnownAddressesCache
 }
 
+function firebaseFetchError(nodeKey: string) {
+  return (errorObject: any) => {
+    console.error(`${nodeKey} data read failed:`, errorObject.code)
+  }
+}
+
 export function initializeDb() {
   database = admin.database()
   registrationsRef = database.ref('/registrations')
@@ -79,9 +85,7 @@ export function initializeDb() {
       }
       metrics.setLastBlockNotified(lastBlockNotified)
     },
-    (errorObject: any) => {
-      console.error('Latest block data read failed:', errorObject.code)
-    }
+    firebaseFetchError('Latest block')
   )
 
   lastInviteBlockRef.on(
@@ -91,9 +95,7 @@ export function initializeDb() {
       console.debug('Latest invite block updated: ', lastBlock)
       lastInviteBlockNotified = lastBlock
     },
-    (errorObject: any) => {
-      console.error('Latest invite block read failed:', errorObject.code)
-    }
+    firebaseFetchError('Latest invite block')
   )
 
   database.ref('/rewardsSenders').on(
@@ -102,9 +104,7 @@ export function initializeDb() {
       rewardsSenders = snapshot?.val() ?? []
       console.debug('Rewards senders updated: ', rewardsSenders)
     },
-    (errorObject: any) => {
-      console.error('Rewards senders data read failed:', errorObject.code)
-    }
+    firebaseFetchError('Rewards senders')
   )
 
   database.ref('/inviteRewardAddresses').on('value', (snapshot) => {
@@ -126,9 +126,7 @@ export async function getRegistration(address: string) {
     (snapshot) => {
       registration = (snapshot?.val() || {})[address]
     },
-    (errorObject: any) => {
-      console.error('Get registration for address failed failed:', errorObject.code)
-    }
+    firebaseFetchError('Registration')
   )
   return registration
 }

--- a/packages/notification-service/test/firebase.test.ts
+++ b/packages/notification-service/test/firebase.test.ts
@@ -4,8 +4,8 @@ import {
   sendPaymentNotification,
   _setInviteRewardsSenders,
   _setKnownAddressesCache,
+  _setRegistrationsRef,
   _setRewardsSenders,
-  _setTestRegistrations,
 } from '../src/firebase'
 
 const SENDER_ADDRESS = '0x123456'
@@ -33,8 +33,17 @@ const mockedKnownAddressesCache = {
   },
 }
 
+const mockedRegistrationsRef = {
+  on: jest.fn((event, callback) =>
+    // @ts-ignore: Only mocking the `val` property
+    callback({ val: () => ({ '0xabc': { fcmToken: 'TEST_FCM_TOKEN' } }) })
+  ),
+}
+
 describe('sendPaymentNotification', () => {
   beforeEach(() => {
+    // @ts-ignore: Only mocking the `on` property
+    _setRegistrationsRef(mockedRegistrationsRef)
     //@ts-ignore: Only mocking getDisplayInfo
     _setKnownAddressesCache(mockedKnownAddressesCache)
     mockedMessagingSend.mockClear()
@@ -43,7 +52,6 @@ describe('sendPaymentNotification', () => {
   it('should send a payment notification for cUSD', async () => {
     expect.hasAssertions()
 
-    _setTestRegistrations({ '0xabc': { fcmToken: 'TEST_FCM_TOKEN' } })
     _setRewardsSenders([])
 
     await sendPaymentNotification(SENDER_ADDRESS, '0xabc', '10', Currencies.DOLLAR, 150, {})
@@ -77,7 +85,6 @@ describe('sendPaymentNotification', () => {
   })
 
   it('should send a deposit received notification for CELO', async () => {
-    _setTestRegistrations({ '0xabc': { fcmToken: 'TEST_FCM_TOKEN' } })
     _setRewardsSenders([])
 
     await sendPaymentNotification(SENDER_ADDRESS, '0xabc', '10', Currencies.GOLD, 150, {})
@@ -90,7 +97,6 @@ describe('sendPaymentNotification', () => {
   })
 
   it('should send a reward received notification', async () => {
-    _setTestRegistrations({ '0xabc': { fcmToken: 'TEST_FCM_TOKEN' } })
     _setRewardsSenders([SENDER_ADDRESS])
 
     await sendPaymentNotification(SENDER_ADDRESS, '0xabc', '10', Currencies.EURO, 150, {})
@@ -105,7 +111,6 @@ describe('sendPaymentNotification', () => {
   })
 
   it('should send an invite reward received notification', async () => {
-    _setTestRegistrations({ '0xabc': { fcmToken: 'TEST_FCM_TOKEN' } })
     _setRewardsSenders([])
     _setInviteRewardsSenders([SENDER_ADDRESS])
 

--- a/packages/notification-service/test/firebase.test.ts
+++ b/packages/notification-service/test/firebase.test.ts
@@ -34,7 +34,7 @@ const mockedKnownAddressesCache = {
 }
 
 const mockedRegistrationsRef = {
-  on: jest.fn((event, callback) =>
+  once: jest.fn((event, callback) =>
     // @ts-ignore: Only mocking the `val` property
     callback({ val: () => ({ '0xabc': { fcmToken: 'TEST_FCM_TOKEN' } }) })
   ),


### PR DESCRIPTION
### Description

Instead of loading the whole firebase registrations db into memory, query the db for the relevant registration on demand when a push event needs it

### Other changes

N/A

### Tested

Running the notifications service locally, log the output of `getRegistration` on push event and validating that it is matching what is in firebase rtdb

### How others should test

Same as above

### Related issues

- Fixes #1381 
### Backwards compatibility

N/A