### PR TITLE
Add clear button to send screen and fix Input for small text

### DIFF
--- a/packages/mobile/locales/en-US/translation.json
+++ b/packages/mobile/locales/en-US/translation.json
@@ -815,6 +815,7 @@
   "reviewPayment": "Review Payment",
   "requestPayment": "Request Payment",
   "max": "MAX",
+  "clear": "CLEAR",
   "inviteSendTo": "Invite & send to",
   "keepMoneySafe": "We'll keep this money safe until your friend creates a {{appName}} account",
   "searchFriends": "Try entering a phone number if you are unable to find who you're looking for",

--- a/packages/mobile/src/send/SendAmount/SendAmountValue.tsx
+++ b/packages/mobile/src/send/SendAmount/SendAmountValue.tsx
@@ -17,8 +17,10 @@ interface Props {
   tokenAmount: BigNumber
   usingLocalAmount: boolean
   tokenAddress: string
+  isOutgoingPaymentRequest: boolean
   onPressMax: () => void
   onSwapInput: () => void
+  onPressClear: () => void
 }
 
 function SendAmountValue({
@@ -26,8 +28,10 @@ function SendAmountValue({
   tokenAmount,
   usingLocalAmount,
   tokenAddress,
+  isOutgoingPaymentRequest,
   onPressMax,
   onSwapInput,
+  onPressClear,
 }: Props) {
   const { t } = useTranslation()
 
@@ -41,9 +45,16 @@ function SendAmountValue({
   return (
     <>
       <View style={styles.container}>
-        <BorderlessButton style={styles.maxButtonContainer} onPress={onPressMax}>
-          <Text style={styles.maxButton}>{t('max')}</Text>
-        </BorderlessButton>
+        {isOutgoingPaymentRequest ? null : (
+          <View style={styles.optionsContainer}>
+            <BorderlessButton style={styles.buttonContainer} onPress={onPressMax}>
+              <Text style={styles.button}>{t('max')}</Text>
+            </BorderlessButton>
+            <BorderlessButton style={styles.buttonContainer} onPress={onPressClear}>
+              <Text style={styles.button}>{t('clear')}</Text>
+            </BorderlessButton>
+          </View>
+        )}
         <View style={styles.valuesContainer}>
           <View style={styles.valueContainer}>
             {usingLocalAmount && (
@@ -101,6 +112,10 @@ const styles = StyleSheet.create({
     flex: 1,
     flexDirection: 'row',
     alignItems: 'center',
+  },
+  optionsContainer: {
+    flexDirection: 'column',
+    justifyContent: 'space-between',
   },
   valuesContainer: {
     flex: 1,

--- a/packages/mobile/src/send/SendAmount/SendAmountValue.tsx
+++ b/packages/mobile/src/send/SendAmount/SendAmountValue.tsx
@@ -65,7 +65,15 @@ function SendAmountValue({
               </View>
             )}
             <View style={styles.amountContainer}>
-              <Text adjustsFontSizeToFit={true} numberOfLines={1} style={styles.mainAmount}>
+              <Text
+                textBreakStrategy={'simple'}
+                adjustsFontSizeToFit={true}
+                numberOfLines={1}
+                minimumFontScale={0.4}
+                selectable={true}
+                ellipsizeMode={'tail'}
+                style={styles.mainAmount}
+              >
                 {inputAmount ? inputAmount : 0}
               </Text>
             </View>
@@ -154,6 +162,7 @@ const styles = StyleSheet.create({
     ...fontStyles.regular,
     fontSize: 64,
     lineHeight: undefined,
+    fontFamily: 'arial',
   },
   secondaryAmount: {
     ...fontStyles.small,

--- a/packages/mobile/src/send/SendAmount/SendAmountValue.tsx
+++ b/packages/mobile/src/send/SendAmount/SendAmountValue.tsx
@@ -131,10 +131,10 @@ const styles = StyleSheet.create({
   symbolContainer: {
     justifyContent: 'center',
   },
-  maxButtonContainer: {
+  buttonContainer: {
     padding: 8,
   },
-  maxButton: {
+  button: {
     color: colors.gray4,
   },
   swapInput: {

--- a/packages/mobile/src/send/SendAmount/index.tsx
+++ b/packages/mobile/src/send/SendAmount/index.tsx
@@ -102,6 +102,9 @@ function SendAmount(props: Props) {
     // TODO: Take into account fee amount if only one fee token has a balance.
     setAmount(usingLocalAmount ? maxInLocalCurrency : tokenInfo.balance.toString())
   }
+  const onPressClear = () => {
+    setAmount('')
+  }
   const onSwapInput = () => setUsingLocalAmount(!usingLocalAmount)
 
   const dispatch = useDispatch()
@@ -175,6 +178,7 @@ function SendAmount(props: Props) {
           tokenAddress={transferTokenAddress}
           onPressMax={onPressMax}
           onSwapInput={onSwapInput}
+          onPressClear={onPressClear}
         />
         <AmountKeypad
           amount={amount}


### PR DESCRIPTION
### Description

Includes a button for clear functionality, tapping back numerous times was tedious.
Included styling to handle large numbers. On iOS values is shown with ellipses while retaining the value. On Android the value is shown in entirely, but in a scrollable view. The value is not impacted by these style changes.

### Other changes

N/A

### Tested

Tested locally on iOS and Android.

### How others should test

- Using the Send Amount component tap max and ensure the value displays without broken numbers or super small text.
- Copy the value and ensure that the whole value is sent.
- Tap 'CLEAR' and ensure the value is cleared. 

### Related issues

N/A

### Backwards compatibility

This change is backwards compatible.

### Screenshot
<div>
  <div>
    <h2>Android Send Amount</h2>
    <img src="https://user-images.githubusercontent.com/26950305/142981740-79db1d57-4bef-4f33-b613-c0b9c395ee8e.png" alt="Android-SendAmount" width="45%" height="auto">
  </div>
  <div>
    <h2>iOS Send Amount</h2>
    <img src="https://user-images.githubusercontent.com/26950305/142982064-3a4102dc-8f51-416f-9e69-16d175d293c9.png" alt="iOS-SendAmount" width="45%" height="auto">
  </div>
</div>

### Notes

- This change doesn't match the mocks, but after using the send amount screen a clear input and larger text was needed.