### PR TITLE
add a patch so that when hasStable or hasCelo is undefined, we dont s…

### DIFF
--- a/packages/mobile/src/home/WalletHome.test.tsx
+++ b/packages/mobile/src/home/WalletHome.test.tsx
@@ -31,6 +31,19 @@ const zeroBalances = {
   },
 }
 
+// When fetch balance api fails #1527
+const undefinedBalances = {
+  stableToken: {
+    balances: {
+      [Currency.Dollar]: undefined,
+      [Currency.Euro]: undefined,
+    },
+  },
+  goldToken: {
+    balance: undefined,
+  },
+}
+
 jest.mock('src/exchange/CeloGoldOverview')
 jest.mock('src/transactions/TransactionsList')
 
@@ -143,9 +156,20 @@ describe('WalletHome', () => {
     expect(getByTestId('cashInBtn')).toBeTruthy()
   })
 
-  it('doesnt render cash in bottom sheet when experiment flag is turned on but balances are not zero', async () => {
+  it('Does not render cash in bottom sheet when experiment flag is turned on but balances are not zero', async () => {
     const { queryByTestId } = renderScreen({
       ...balances,
+      app: {
+        cashInButtonExpEnabled: true,
+      },
+    })
+
+    expect(queryByTestId('cashInBtn')).toBeFalsy()
+  })
+
+  it('Does not render cash in bottom sheet when experiment flag is turned on but balances are undefined', async () => {
+    const { queryByTestId } = renderScreen({
+      ...undefinedBalances,
       app: {
         cashInButtonExpEnabled: true,
       },

--- a/packages/mobile/src/home/WalletHome.tsx
+++ b/packages/mobile/src/home/WalletHome.tsx
@@ -102,7 +102,7 @@ function WalletHome() {
       balances[currency]?.isGreaterThan(STABLE_TRANSACTION_MIN_AMOUNT)
     )
     const hasCelo = balances[Currency.Celo]?.isGreaterThan(CELO_TRANSACTION_MIN_AMOUNT)
-    const isAccountBalanceZero = !hasStable && !hasCelo
+    const isAccountBalanceZero = hasStable === false && hasCelo === false
 
     return cashInButtonExpEnabled && isAccountBalanceZero
   }


### PR DESCRIPTION
…how cash in bottom sheet

### Description

We had a support issue when fetch balance api fails, user w/ balances would see the cash in bottom sheet. This PR explicitly checks whether `hasStable` and `hasCelo` is equal to false and we only display the bottom sheet when both value is false. Previously, an undefined value would also display the bottom sheet.

More context -> https://valora-app.slack.com/archives/C018VLA3YAK/p1637704572096200