### PR TITLE
Replace default recipient wallet address with e2e test faucet address

### DIFF
--- a/packages/mobile/e2e/src/utils/consts.js
+++ b/packages/mobile/e2e/src/utils/consts.js
@@ -1,4 +1,4 @@
-export const DEFAULT_RECIPIENT_ADDRESS = '0x22c8a9178841ba95a944afd1a1faae517d3f5daa'
+export const DEFAULT_RECIPIENT_ADDRESS = '0xe5F5363e31351C38ac82DBAdeaD91Fd5a7B08846'
 export const SAMPLE_BACKUP_KEY =
   'general debate dial flock want basket local machine effort monitor stomach purity attend brand extend salon obscure soul open floor useful like cause exhaust'
 export const DEFAULT_PIN = '323122'


### PR DESCRIPTION
### Description

Changed the `DEFAULT_RECIPIENT_ADDRESS` to the e2e test faucet address. This should help e2e tests from running low on funds.

### Other changes

N/A

### Tested

Tested with CI.

### How others should test

N/A - only impacts e2e tests no need for QA to test.

### Related issues

N/A

### Backwards compatibility

These changes only impact e2e tests and are backwards compatible.