### PR TITLE
Fix crash when no local amount is returned by the blockchain-api

### DIFF
--- a/packages/mobile/src/exchange/ExchangeConfirmationCard.test.tsx
+++ b/packages/mobile/src/exchange/ExchangeConfirmationCard.test.tsx
@@ -3,25 +3,33 @@ import * as React from 'react'
 import 'react-native'
 import { Provider } from 'react-redux'
 import ExchangeConfirmationCard from 'src/exchange/ExchangeConfirmationCard'
-import { createMockStore } from 'test/utils'
+import { createMockStore, getElementText } from 'test/utils'
 
 const localAmount = {
   value: '1.23',
   exchangeRate: '0.555',
   currencyCode: 'EUR',
 }
-const makerAmount = { value: '20', currencyCode: 'cGLD', localAmount }
-const takerAmount = { value: '1.99', currencyCode: 'cUSD', localAmount }
 
 const store = createMockStore({})
 
-it('renders correctly with no exchange rate', () => {
+it('renders correctly', () => {
   const tree = render(
     <Provider store={store}>
-      <ExchangeConfirmationCard makerAmount={makerAmount} takerAmount={takerAmount} />
+      <ExchangeConfirmationCard
+        makerAmount={{ value: '20', currencyCode: 'cGLD', localAmount }}
+        takerAmount={{ value: '1.99', currencyCode: 'cUSD', localAmount }}
+      />
     </Provider>
   )
   expect(tree).toMatchSnapshot()
+
+  expect(getElementText(tree.getByTestId('CeloAmount/value'))).toEqual('20.000')
+  expect(getElementText(tree.getByTestId('CeloExchangeRate/value'))).toEqual('€0.55')
+
+  expect(getElementText(tree.getByTestId('TotalLineItem/Total/value'))).toEqual('$2.64')
+  expect(getElementText(tree.getByTestId('TotalLineItem/ExchangeRate/value'))).toEqual('$0.75')
+  expect(getElementText(tree.getByTestId('TotalLineItem/Subtotal/value'))).toEqual('$1.99')
 })
 
 it('renders correctly with giant numbers', () => {
@@ -34,4 +42,51 @@ it('renders correctly with giant numbers', () => {
     </Provider>
   )
   expect(tree).toMatchSnapshot()
+
+  expect(getElementText(tree.getByTestId('CeloAmount/value'))).toEqual('18,000,000,000.000')
+  expect(getElementText(tree.getByTestId('CeloExchangeRate/value'))).toEqual('€0.55')
+
+  expect(getElementText(tree.getByTestId('TotalLineItem/Total/value'))).toEqual('$31,920,000.00')
+  expect(getElementText(tree.getByTestId('TotalLineItem/ExchangeRate/value'))).toEqual('$0.75')
+  expect(getElementText(tree.getByTestId('TotalLineItem/Subtotal/value'))).toEqual('$24,000,000.00')
+})
+
+it('renders correctly when local amount is null', () => {
+  const tree = render(
+    <Provider store={store}>
+      <ExchangeConfirmationCard
+        makerAmount={{ value: '20', currencyCode: 'cGLD', localAmount: null }}
+        takerAmount={{ value: '1.99', currencyCode: 'cUSD', localAmount: null }}
+      />
+    </Provider>
+  )
+  expect(tree).toMatchSnapshot()
+
+  // This is a degraded mode, when we can't get the exchange rate from the blockchain-api, better than nothing
+  expect(getElementText(tree.getByTestId('CeloAmount/value'))).toEqual('20.000')
+  expect(getElementText(tree.getByTestId('CeloExchangeRate/value'))).toEqual('-')
+
+  expect(getElementText(tree.getByTestId('TotalLineItem/Total/value'))).toEqual('$2.64')
+  expect(getElementText(tree.getByTestId('TotalLineItem/ExchangeRate/value'))).toEqual('$0.75')
+  expect(getElementText(tree.getByTestId('TotalLineItem/Subtotal/value'))).toEqual('$1.99')
+})
+
+it('renders correctly when local amount is null and no local exchange rate is set', () => {
+  const tree = render(
+    <Provider store={createMockStore({ localCurrency: { exchangeRates: {} } })}>
+      <ExchangeConfirmationCard
+        makerAmount={{ value: '20', currencyCode: 'cGLD', localAmount: null }}
+        takerAmount={{ value: '1.99', currencyCode: 'cUSD', localAmount: null }}
+      />
+    </Provider>
+  )
+  expect(tree).toMatchSnapshot()
+
+  // This is an even more degraded mode, when we can't get the exchange rate from the blockchain-api, better than nothing
+  expect(getElementText(tree.getByTestId('CeloAmount/value'))).toEqual('20.000')
+  expect(getElementText(tree.getByTestId('CeloExchangeRate/value'))).toEqual('-')
+
+  expect(getElementText(tree.getByTestId('TotalLineItem/Total/value'))).toEqual('-')
+  expect(tree.queryByTestId('TotalLineItem/ExchangeRate/value')).toBeNull()
+  expect(tree.queryByTestId('TotalLineItem/Subtotal/value')).toBeNull()
 })

--- a/packages/mobile/src/exchange/ExchangeConfirmationCard.test.tsx
+++ b/packages/mobile/src/exchange/ExchangeConfirmationCard.test.tsx
@@ -27,6 +27,8 @@ it('renders correctly', () => {
   expect(getElementText(tree.getByTestId('CeloAmount/value'))).toEqual('20.000')
   expect(getElementText(tree.getByTestId('CeloExchangeRate/value'))).toEqual('€0.55')
 
+  // The values here are a bit confusing because of the the local currency is MXN and has the same $ symbol
+  // TODO: fixme ;)
   expect(getElementText(tree.getByTestId('TotalLineItem/Total/value'))).toEqual('$2.64')
   expect(getElementText(tree.getByTestId('TotalLineItem/ExchangeRate/value'))).toEqual('$0.75')
   expect(getElementText(tree.getByTestId('TotalLineItem/Subtotal/value'))).toEqual('$1.99')
@@ -46,6 +48,8 @@ it('renders correctly with giant numbers', () => {
   expect(getElementText(tree.getByTestId('CeloAmount/value'))).toEqual('18,000,000,000.000')
   expect(getElementText(tree.getByTestId('CeloExchangeRate/value'))).toEqual('€0.55')
 
+  // The values here are a bit confusing because of the the local currency is MXN and has the same $ symbol
+  // TODO: fixme ;)
   expect(getElementText(tree.getByTestId('TotalLineItem/Total/value'))).toEqual('$31,920,000.00')
   expect(getElementText(tree.getByTestId('TotalLineItem/ExchangeRate/value'))).toEqual('$0.75')
   expect(getElementText(tree.getByTestId('TotalLineItem/Subtotal/value'))).toEqual('$24,000,000.00')
@@ -66,6 +70,8 @@ it('renders correctly when local amount is null', () => {
   expect(getElementText(tree.getByTestId('CeloAmount/value'))).toEqual('20.000')
   expect(getElementText(tree.getByTestId('CeloExchangeRate/value'))).toEqual('-')
 
+  // The values here are a bit confusing because of the the local currency is MXN and has the same $ symbol
+  // TODO: fixme ;)
   expect(getElementText(tree.getByTestId('TotalLineItem/Total/value'))).toEqual('$2.64')
   expect(getElementText(tree.getByTestId('TotalLineItem/ExchangeRate/value'))).toEqual('$0.75')
   expect(getElementText(tree.getByTestId('TotalLineItem/Subtotal/value'))).toEqual('$1.99')

--- a/packages/mobile/src/exchange/ExchangeConfirmationCard.test.tsx
+++ b/packages/mobile/src/exchange/ExchangeConfirmationCard.test.tsx
@@ -82,7 +82,7 @@ it('renders correctly when local amount is null and no local exchange rate is se
   )
   expect(tree).toMatchSnapshot()
 
-  // This is an even more degraded mode, when we can't get the exchange rate from the blockchain-api, better than nothing
+  // This is an even more degraded mode, when we can't get the exchange rate from the blockchain-api or locally, better than nothing
   expect(getElementText(tree.getByTestId('CeloAmount/value'))).toEqual('20.000')
   expect(getElementText(tree.getByTestId('CeloExchangeRate/value'))).toEqual('-')
 

--- a/packages/mobile/src/exchange/ExchangeConfirmationCard.test.tsx
+++ b/packages/mobile/src/exchange/ExchangeConfirmationCard.test.tsx
@@ -27,7 +27,7 @@ it('renders correctly', () => {
   expect(getElementText(tree.getByTestId('CeloAmount/value'))).toEqual('20.000')
   expect(getElementText(tree.getByTestId('CeloExchangeRate/value'))).toEqual('€0.55')
 
-  // The values here are a bit confusing because of the the local currency is MXN and has the same $ symbol
+  // The values here are a bit confusing because the local currency is MXN and has the same $ symbol
   // TODO: fixme ;)
   expect(getElementText(tree.getByTestId('TotalLineItem/Total/value'))).toEqual('$2.64')
   expect(getElementText(tree.getByTestId('TotalLineItem/ExchangeRate/value'))).toEqual('$0.75')
@@ -48,7 +48,7 @@ it('renders correctly with giant numbers', () => {
   expect(getElementText(tree.getByTestId('CeloAmount/value'))).toEqual('18,000,000,000.000')
   expect(getElementText(tree.getByTestId('CeloExchangeRate/value'))).toEqual('€0.55')
 
-  // The values here are a bit confusing because of the the local currency is MXN and has the same $ symbol
+  // The values here are a bit confusing because the local currency is MXN and has the same $ symbol
   // TODO: fixme ;)
   expect(getElementText(tree.getByTestId('TotalLineItem/Total/value'))).toEqual('$31,920,000.00')
   expect(getElementText(tree.getByTestId('TotalLineItem/ExchangeRate/value'))).toEqual('$0.75')
@@ -70,7 +70,7 @@ it('renders correctly when local amount is null', () => {
   expect(getElementText(tree.getByTestId('CeloAmount/value'))).toEqual('20.000')
   expect(getElementText(tree.getByTestId('CeloExchangeRate/value'))).toEqual('-')
 
-  // The values here are a bit confusing because of the the local currency is MXN and has the same $ symbol
+  // The values here are a bit confusing because the local currency is MXN and has the same $ symbol
   // TODO: fixme ;)
   expect(getElementText(tree.getByTestId('TotalLineItem/Total/value'))).toEqual('$2.64')
   expect(getElementText(tree.getByTestId('TotalLineItem/ExchangeRate/value'))).toEqual('$0.75')

--- a/packages/mobile/src/exchange/ExchangeConfirmationCard.tsx
+++ b/packages/mobile/src/exchange/ExchangeConfirmationCard.tsx
@@ -37,7 +37,7 @@ export default function ExchangeConfirmationCard(props: Props) {
   const localAmount = (isSellGoldTx ? makerAmount : takerAmount).localAmount
   // TODO: find a way on how to show local exchangeRate without this hack
   const exchangeRateAmount = {
-    value: localAmount?.exchangeRate,
+    value: localAmount?.exchangeRate || '',
     currencyCode: Currency.Dollar,
     localAmount: localAmount
       ? {

--- a/packages/mobile/src/exchange/ExchangeConfirmationCard.tsx
+++ b/packages/mobile/src/exchange/ExchangeConfirmationCard.tsx
@@ -34,16 +34,18 @@ export default function ExchangeConfirmationCard(props: Props) {
   const totalFee = new BigNumber(tobinTax).plus(fee)
   const feeCurrency = Currency.Dollar
 
-  const localAmount = (isSellGoldTx ? makerAmount : takerAmount).localAmount!
+  const localAmount = (isSellGoldTx ? makerAmount : takerAmount).localAmount
   // TODO: find a way on how to show local exchangeRate without this hack
   const exchangeRateAmount = {
-    value: localAmount.exchangeRate,
+    value: localAmount?.exchangeRate,
     currencyCode: Currency.Dollar,
-    localAmount: {
-      value: localAmount.exchangeRate,
-      exchangeRate: localAmount.exchangeRate,
-      currencyCode: localAmount.currencyCode,
-    },
+    localAmount: localAmount
+      ? {
+          value: localAmount.exchangeRate,
+          exchangeRate: localAmount.exchangeRate,
+          currencyCode: localAmount.currencyCode,
+        }
+      : null,
   }
 
   const goldAmount = {
@@ -68,13 +70,22 @@ export default function ExchangeConfirmationCard(props: Props) {
           <View style={styles.flexStart}>
             <View style={styles.amountRow}>
               <Text style={styles.exchangeBodyText}>{t('goldAmount')}</Text>
-              <CurrencyDisplay style={styles.currencyAmountText} amount={goldAmount} />
+              <CurrencyDisplay
+                style={styles.currencyAmountText}
+                amount={goldAmount}
+                testID="CeloAmount"
+              />
             </View>
             <HorizontalLine />
             <LineItemRow
               title={
                 <Trans i18nKey="subtotalAmount">
-                  Subtotal @ <CurrencyDisplay amount={exchangeRateAmount} showLocalAmount={true} />
+                  Subtotal @{' '}
+                  <CurrencyDisplay
+                    amount={exchangeRateAmount}
+                    showLocalAmount={true}
+                    testID="CeloExchangeRate"
+                  />
                 </Trans>
               }
               amount={<CurrencyDisplay amount={subtotalAmount} />}

--- a/packages/mobile/src/exchange/__snapshots__/ExchangeConfirmationCard.test.tsx.snap
+++ b/packages/mobile/src/exchange/__snapshots__/ExchangeConfirmationCard.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders correctly with giant numbers 1`] = `
+exports[`renders correctly 1`] = `
 <RCTScrollView>
   <View>
     <RNCSafeAreaView
@@ -62,540 +62,7 @@ exports[`renders correctly with giant numbers 1`] = `
                   },
                 ]
               }
-              testID="undefined/value"
-            >
-              
-              
-              18,000,000,000.000
-            </Text>
-          </View>
-          <View
-            style={
-              Object {
-                "borderStyle": "solid",
-                "borderTopColor": "#F8F9F9",
-                "borderTopWidth": 1,
-                "marginBottom": 15,
-                "marginTop": 10,
-                "width": "100%",
-              }
-            }
-          />
-          <View
-            style={
-              Array [
-                Object {
-                  "flexDirection": "row",
-                  "flexWrap": "wrap",
-                  "justifyContent": "space-between",
-                  "marginVertical": 5,
-                },
-                undefined,
-              ]
-            }
-          >
-            <View
-              style={
-                Object {
-                  "alignItems": "center",
-                  "flexDirection": "row",
-                  "marginRight": 5,
-                }
-              }
-            >
-              <Text
-                style={
-                  Array [
-                    Object {
-                      "color": "#2E3338",
-                      "fontFamily": "Inter-Regular",
-                      "fontSize": 16,
-                      "lineHeight": 22,
-                    },
-                    undefined,
-                  ]
-                }
-              >
-                Subtotal @ 
-                <Text
-                  style={
-                    Array [
-                      undefined,
-                      Object {
-                        "color": undefined,
-                      },
-                    ]
-                  }
-                  testID="undefined/value"
-                >
-                  
-                  €
-                  0.55
-                </Text>
-              </Text>
-            </View>
-            <Text
-              style={
-                Array [
-                  Object {
-                    "color": "#2E3338",
-                    "fontFamily": "Inter-Regular",
-                    "fontSize": 16,
-                    "lineHeight": 22,
-                  },
-                  undefined,
-                ]
-              }
-            >
-              <Text
-                style={
-                  Array [
-                    undefined,
-                    Object {
-                      "color": undefined,
-                    },
-                  ]
-                }
-                testID="undefined/value"
-              >
-                
-                $
-                31,920,000.00
-              </Text>
-            </Text>
-          </View>
-          <View>
-            <View
-              accessible={true}
-              focusable={true}
-              nativeBackgroundAndroid={
-                Object {
-                  "attribute": "selectableItemBackground",
-                  "rippleRadius": undefined,
-                  "type": "ThemeAttrAndroid",
-                }
-              }
-              onClick={[Function]}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
-              testID="feeDrawer/ExchangeConfirmationCard"
-            >
-              <View
-                style={
-                  Object {
-                    "flexDirection": "row",
-                    "justifyContent": "space-between",
-                  }
-                }
-              >
-                <View
-                  style={
-                    Array [
-                      Object {
-                        "alignItems": "center",
-                        "flexDirection": "row",
-                        "flexWrap": "wrap",
-                      },
-                      undefined,
-                    ]
-                  }
-                >
-                  <Text
-                    style={
-                      Object {
-                        "color": "#2E3338",
-                        "fontFamily": "Inter-Regular",
-                        "fontSize": 16,
-                        "lineHeight": 22,
-                      }
-                    }
-                  >
-                    feeActual
-                  </Text>
-                  <View
-                    style={
-                      Object {
-                        "marginLeft": 7,
-                        "transform": Array [
-                          Object {
-                            "rotate": "0deg",
-                          },
-                        ],
-                      }
-                    }
-                  >
-                    <svg
-                      fill="none"
-                      height={16}
-                      viewBox="0 0 16 16"
-                      width={16}
-                    >
-                      <path
-                        d="M3 6l5 5 5-5"
-                        stroke="#B4B9BD"
-                      />
-                    </svg>
-                  </View>
-                </View>
-                <View
-                  style={
-                    Array [
-                      Object {
-                        "flexDirection": "row",
-                        "flexWrap": "wrap",
-                        "justifyContent": "space-between",
-                        "marginVertical": 5,
-                      },
-                      undefined,
-                    ]
-                  }
-                >
-                  <View
-                    style={
-                      Object {
-                        "alignItems": "center",
-                        "flexDirection": "row",
-                        "marginRight": 5,
-                      }
-                    }
-                  >
-                    <Text
-                      style={
-                        Array [
-                          Object {
-                            "color": "#2E3338",
-                            "fontFamily": "Inter-Regular",
-                            "fontSize": 16,
-                            "lineHeight": 22,
-                          },
-                          undefined,
-                        ]
-                      }
-                    >
-                      
-                    </Text>
-                  </View>
-                  <Text
-                    style={
-                      Array [
-                        Object {
-                          "color": "#2E3338",
-                          "fontFamily": "Inter-Regular",
-                          "fontSize": 16,
-                          "lineHeight": 22,
-                        },
-                        undefined,
-                      ]
-                    }
-                  >
-                    <Text
-                      style={
-                        Array [
-                          undefined,
-                          Object {
-                            "color": undefined,
-                          },
-                        ]
-                      }
-                      testID="feeDrawer/ExchangeConfirmationCard/totalFee/value"
-                    >
-                      
-                      $
-                      0
-                    </Text>
-                  </Text>
-                </View>
-              </View>
-            </View>
-          </View>
-          <View
-            style={
-              Object {
-                "borderStyle": "solid",
-                "borderTopColor": "#F8F9F9",
-                "borderTopWidth": 1,
-                "marginBottom": 15,
-                "marginTop": 10,
-                "width": "100%",
-              }
-            }
-          />
-          <View
-            style={
-              Array [
-                Object {
-                  "flexDirection": "row",
-                  "flexWrap": "wrap",
-                  "justifyContent": "space-between",
-                  "marginVertical": 5,
-                },
-                undefined,
-              ]
-            }
-          >
-            <View
-              style={
-                Object {
-                  "alignItems": "center",
-                  "flexDirection": "row",
-                  "marginRight": 5,
-                }
-              }
-            >
-              <Text
-                style={
-                  Array [
-                    Object {
-                      "color": "#2E3338",
-                      "fontFamily": "Inter-Regular",
-                      "fontSize": 16,
-                      "lineHeight": 22,
-                    },
-                    Object {
-                      "color": "#2E3338",
-                      "fontFamily": "Inter-SemiBold",
-                      "fontSize": 16,
-                      "lineHeight": 22,
-                    },
-                  ]
-                }
-              >
-                total
-              </Text>
-            </View>
-            <Text
-              style={
-                Array [
-                  Object {
-                    "color": "#2E3338",
-                    "fontFamily": "Inter-Regular",
-                    "fontSize": 16,
-                    "lineHeight": 22,
-                  },
-                  Object {
-                    "color": "#2E3338",
-                    "fontFamily": "Inter-SemiBold",
-                    "fontSize": 16,
-                    "lineHeight": 22,
-                  },
-                ]
-              }
-            >
-              <Text
-                style={
-                  Array [
-                    undefined,
-                    Object {
-                      "color": undefined,
-                    },
-                  ]
-                }
-                testID="TotalLineItem/Total/value"
-              >
-                
-                $
-                31,920,000.00
-              </Text>
-            </Text>
-          </View>
-          <View
-            style={
-              Array [
-                Object {
-                  "flexDirection": "row",
-                  "flexWrap": "wrap",
-                  "justifyContent": "space-between",
-                  "marginVertical": 5,
-                },
-                Object {
-                  "marginVertical": 0,
-                },
-              ]
-            }
-          >
-            <View
-              style={
-                Object {
-                  "alignItems": "center",
-                  "flexDirection": "row",
-                  "marginRight": 5,
-                }
-              }
-            >
-              <Text
-                style={
-                  Array [
-                    Object {
-                      "color": "#2E3338",
-                      "fontFamily": "Inter-Regular",
-                      "fontSize": 16,
-                      "lineHeight": 22,
-                    },
-                    Object {
-                      "color": "#9CA4A9",
-                      "fontFamily": "Inter-Regular",
-                      "fontSize": 14,
-                      "lineHeight": 18,
-                    },
-                  ]
-                }
-              >
-                <View
-                  accessible={true}
-                  focusable={false}
-                  nativeBackgroundAndroid={
-                    Object {
-                      "attribute": "selectableItemBackground",
-                      "rippleRadius": undefined,
-                      "type": "ThemeAttrAndroid",
-                    }
-                  }
-                  onClick={[Function]}
-                  onResponderGrant={[Function]}
-                  onResponderMove={[Function]}
-                  onResponderRelease={[Function]}
-                  onResponderTerminate={[Function]}
-                  onResponderTerminationRequest={[Function]}
-                  onStartShouldSetResponder={[Function]}
-                >
-                  <Text
-                    style={
-                      Object {
-                        "color": "#9CA4A9",
-                        "fontFamily": "Inter-Regular",
-                        "fontSize": 14,
-                        "lineHeight": 18,
-                      }
-                    }
-                  >
-                    <Text
-                      style={
-                        Array [
-                          undefined,
-                          Object {
-                            "color": undefined,
-                          },
-                        ]
-                      }
-                      testID="TotalLineItem/ExchangeRate/value"
-                    >
-                      
-                      $
-                      0.75
-                    </Text>
-                  </Text>
-                </View>
-              </Text>
-            </View>
-            <Text
-              style={
-                Array [
-                  Object {
-                    "color": "#2E3338",
-                    "fontFamily": "Inter-Regular",
-                    "fontSize": 16,
-                    "lineHeight": 22,
-                  },
-                  Object {
-                    "color": "#9CA4A9",
-                    "fontFamily": "Inter-Regular",
-                    "fontSize": 14,
-                    "lineHeight": 18,
-                  },
-                ]
-              }
-            >
-              <Text
-                style={
-                  Array [
-                    undefined,
-                    Object {
-                      "color": undefined,
-                    },
-                  ]
-                }
-                testID="TotalLineItem/Subtotal/value"
-              >
-                
-                $
-                24,000,000.00
-              </Text>
-            </Text>
-          </View>
-        </View>
-      </View>
-    </RNCSafeAreaView>
-  </View>
-</RCTScrollView>
-`;
-
-exports[`renders correctly with no exchange rate 1`] = `
-<RCTScrollView>
-  <View>
-    <RNCSafeAreaView
-      style={
-        Object {
-          "flex": 1,
-          "justifyContent": "space-between",
-        }
-      }
-    >
-      <View
-        style={
-          Object {
-            "flex": 1,
-            "paddingHorizontal": 16,
-          }
-        }
-      >
-        <View
-          style={
-            Object {
-              "justifyContent": "flex-start",
-            }
-          }
-        >
-          <View
-            style={
-              Object {
-                "alignItems": "center",
-                "flexDirection": "row",
-                "justifyContent": "space-between",
-                "marginTop": 30,
-              }
-            }
-          >
-            <Text
-              style={
-                Object {
-                  "color": "#2E3338",
-                  "fontFamily": "Inter-SemiBold",
-                  "fontSize": 16,
-                  "lineHeight": 22,
-                }
-              }
-            >
-              goldAmount
-            </Text>
-            <Text
-              style={
-                Array [
-                  Object {
-                    "color": "#2E3338",
-                    "fontFamily": "Inter-SemiBold",
-                    "fontSize": 16,
-                    "lineHeight": 22,
-                  },
-                  Object {
-                    "color": "#2E3338",
-                  },
-                ]
-              }
-              testID="undefined/value"
+              testID="CeloAmount/value"
             >
               
               
@@ -649,7 +116,8 @@ exports[`renders correctly with no exchange rate 1`] = `
                   ]
                 }
               >
-                Subtotal @ 
+                Subtotal @
+                 
                 <Text
                   style={
                     Array [
@@ -659,7 +127,7 @@ exports[`renders correctly with no exchange rate 1`] = `
                       },
                     ]
                   }
-                  testID="undefined/value"
+                  testID="CeloExchangeRate/value"
                 >
                   
                   €
@@ -1056,6 +524,1479 @@ exports[`renders correctly with no exchange rate 1`] = `
                 
                 $
                 1.99
+              </Text>
+            </Text>
+          </View>
+        </View>
+      </View>
+    </RNCSafeAreaView>
+  </View>
+</RCTScrollView>
+`;
+
+exports[`renders correctly when local amount is null 1`] = `
+<RCTScrollView>
+  <View>
+    <RNCSafeAreaView
+      style={
+        Object {
+          "flex": 1,
+          "justifyContent": "space-between",
+        }
+      }
+    >
+      <View
+        style={
+          Object {
+            "flex": 1,
+            "paddingHorizontal": 16,
+          }
+        }
+      >
+        <View
+          style={
+            Object {
+              "justifyContent": "flex-start",
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "justifyContent": "space-between",
+                "marginTop": 30,
+              }
+            }
+          >
+            <Text
+              style={
+                Object {
+                  "color": "#2E3338",
+                  "fontFamily": "Inter-SemiBold",
+                  "fontSize": 16,
+                  "lineHeight": 22,
+                }
+              }
+            >
+              goldAmount
+            </Text>
+            <Text
+              style={
+                Array [
+                  Object {
+                    "color": "#2E3338",
+                    "fontFamily": "Inter-SemiBold",
+                    "fontSize": 16,
+                    "lineHeight": 22,
+                  },
+                  Object {
+                    "color": "#2E3338",
+                  },
+                ]
+              }
+              testID="CeloAmount/value"
+            >
+              
+              
+              20.000
+            </Text>
+          </View>
+          <View
+            style={
+              Object {
+                "borderStyle": "solid",
+                "borderTopColor": "#F8F9F9",
+                "borderTopWidth": 1,
+                "marginBottom": 15,
+                "marginTop": 10,
+                "width": "100%",
+              }
+            }
+          />
+          <View
+            style={
+              Array [
+                Object {
+                  "flexDirection": "row",
+                  "flexWrap": "wrap",
+                  "justifyContent": "space-between",
+                  "marginVertical": 5,
+                },
+                undefined,
+              ]
+            }
+          >
+            <View
+              style={
+                Object {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "marginRight": 5,
+                }
+              }
+            >
+              <Text
+                style={
+                  Array [
+                    Object {
+                      "color": "#2E3338",
+                      "fontFamily": "Inter-Regular",
+                      "fontSize": 16,
+                      "lineHeight": 22,
+                    },
+                    undefined,
+                  ]
+                }
+              >
+                Subtotal @
+                 
+                <Text
+                  style={
+                    Array [
+                      undefined,
+                      Object {
+                        "color": undefined,
+                      },
+                    ]
+                  }
+                  testID="CeloExchangeRate/value"
+                >
+                  
+                  -
+                </Text>
+              </Text>
+            </View>
+            <Text
+              style={
+                Array [
+                  Object {
+                    "color": "#2E3338",
+                    "fontFamily": "Inter-Regular",
+                    "fontSize": 16,
+                    "lineHeight": 22,
+                  },
+                  undefined,
+                ]
+              }
+            >
+              <Text
+                style={
+                  Array [
+                    undefined,
+                    Object {
+                      "color": undefined,
+                    },
+                  ]
+                }
+                testID="undefined/value"
+              >
+                
+                $
+                2.64
+              </Text>
+            </Text>
+          </View>
+          <View>
+            <View
+              accessible={true}
+              focusable={true}
+              nativeBackgroundAndroid={
+                Object {
+                  "attribute": "selectableItemBackground",
+                  "rippleRadius": undefined,
+                  "type": "ThemeAttrAndroid",
+                }
+              }
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              testID="feeDrawer/ExchangeConfirmationCard"
+            >
+              <View
+                style={
+                  Object {
+                    "flexDirection": "row",
+                    "justifyContent": "space-between",
+                  }
+                }
+              >
+                <View
+                  style={
+                    Array [
+                      Object {
+                        "alignItems": "center",
+                        "flexDirection": "row",
+                        "flexWrap": "wrap",
+                      },
+                      undefined,
+                    ]
+                  }
+                >
+                  <Text
+                    style={
+                      Object {
+                        "color": "#2E3338",
+                        "fontFamily": "Inter-Regular",
+                        "fontSize": 16,
+                        "lineHeight": 22,
+                      }
+                    }
+                  >
+                    feeActual
+                  </Text>
+                  <View
+                    style={
+                      Object {
+                        "marginLeft": 7,
+                        "transform": Array [
+                          Object {
+                            "rotate": "0deg",
+                          },
+                        ],
+                      }
+                    }
+                  >
+                    <svg
+                      fill="none"
+                      height={16}
+                      viewBox="0 0 16 16"
+                      width={16}
+                    >
+                      <path
+                        d="M3 6l5 5 5-5"
+                        stroke="#B4B9BD"
+                      />
+                    </svg>
+                  </View>
+                </View>
+                <View
+                  style={
+                    Array [
+                      Object {
+                        "flexDirection": "row",
+                        "flexWrap": "wrap",
+                        "justifyContent": "space-between",
+                        "marginVertical": 5,
+                      },
+                      undefined,
+                    ]
+                  }
+                >
+                  <View
+                    style={
+                      Object {
+                        "alignItems": "center",
+                        "flexDirection": "row",
+                        "marginRight": 5,
+                      }
+                    }
+                  >
+                    <Text
+                      style={
+                        Array [
+                          Object {
+                            "color": "#2E3338",
+                            "fontFamily": "Inter-Regular",
+                            "fontSize": 16,
+                            "lineHeight": 22,
+                          },
+                          undefined,
+                        ]
+                      }
+                    >
+                      
+                    </Text>
+                  </View>
+                  <Text
+                    style={
+                      Array [
+                        Object {
+                          "color": "#2E3338",
+                          "fontFamily": "Inter-Regular",
+                          "fontSize": 16,
+                          "lineHeight": 22,
+                        },
+                        undefined,
+                      ]
+                    }
+                  >
+                    <Text
+                      style={
+                        Array [
+                          undefined,
+                          Object {
+                            "color": undefined,
+                          },
+                        ]
+                      }
+                      testID="feeDrawer/ExchangeConfirmationCard/totalFee/value"
+                    >
+                      
+                      $
+                      0
+                    </Text>
+                  </Text>
+                </View>
+              </View>
+            </View>
+          </View>
+          <View
+            style={
+              Object {
+                "borderStyle": "solid",
+                "borderTopColor": "#F8F9F9",
+                "borderTopWidth": 1,
+                "marginBottom": 15,
+                "marginTop": 10,
+                "width": "100%",
+              }
+            }
+          />
+          <View
+            style={
+              Array [
+                Object {
+                  "flexDirection": "row",
+                  "flexWrap": "wrap",
+                  "justifyContent": "space-between",
+                  "marginVertical": 5,
+                },
+                undefined,
+              ]
+            }
+          >
+            <View
+              style={
+                Object {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "marginRight": 5,
+                }
+              }
+            >
+              <Text
+                style={
+                  Array [
+                    Object {
+                      "color": "#2E3338",
+                      "fontFamily": "Inter-Regular",
+                      "fontSize": 16,
+                      "lineHeight": 22,
+                    },
+                    Object {
+                      "color": "#2E3338",
+                      "fontFamily": "Inter-SemiBold",
+                      "fontSize": 16,
+                      "lineHeight": 22,
+                    },
+                  ]
+                }
+              >
+                total
+              </Text>
+            </View>
+            <Text
+              style={
+                Array [
+                  Object {
+                    "color": "#2E3338",
+                    "fontFamily": "Inter-Regular",
+                    "fontSize": 16,
+                    "lineHeight": 22,
+                  },
+                  Object {
+                    "color": "#2E3338",
+                    "fontFamily": "Inter-SemiBold",
+                    "fontSize": 16,
+                    "lineHeight": 22,
+                  },
+                ]
+              }
+            >
+              <Text
+                style={
+                  Array [
+                    undefined,
+                    Object {
+                      "color": undefined,
+                    },
+                  ]
+                }
+                testID="TotalLineItem/Total/value"
+              >
+                
+                $
+                2.64
+              </Text>
+            </Text>
+          </View>
+          <View
+            style={
+              Array [
+                Object {
+                  "flexDirection": "row",
+                  "flexWrap": "wrap",
+                  "justifyContent": "space-between",
+                  "marginVertical": 5,
+                },
+                Object {
+                  "marginVertical": 0,
+                },
+              ]
+            }
+          >
+            <View
+              style={
+                Object {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "marginRight": 5,
+                }
+              }
+            >
+              <Text
+                style={
+                  Array [
+                    Object {
+                      "color": "#2E3338",
+                      "fontFamily": "Inter-Regular",
+                      "fontSize": 16,
+                      "lineHeight": 22,
+                    },
+                    Object {
+                      "color": "#9CA4A9",
+                      "fontFamily": "Inter-Regular",
+                      "fontSize": 14,
+                      "lineHeight": 18,
+                    },
+                  ]
+                }
+              >
+                <View
+                  accessible={true}
+                  focusable={false}
+                  nativeBackgroundAndroid={
+                    Object {
+                      "attribute": "selectableItemBackground",
+                      "rippleRadius": undefined,
+                      "type": "ThemeAttrAndroid",
+                    }
+                  }
+                  onClick={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                >
+                  <Text
+                    style={
+                      Object {
+                        "color": "#9CA4A9",
+                        "fontFamily": "Inter-Regular",
+                        "fontSize": 14,
+                        "lineHeight": 18,
+                      }
+                    }
+                  >
+                    <Text
+                      style={
+                        Array [
+                          undefined,
+                          Object {
+                            "color": undefined,
+                          },
+                        ]
+                      }
+                      testID="TotalLineItem/ExchangeRate/value"
+                    >
+                      
+                      $
+                      0.75
+                    </Text>
+                  </Text>
+                </View>
+              </Text>
+            </View>
+            <Text
+              style={
+                Array [
+                  Object {
+                    "color": "#2E3338",
+                    "fontFamily": "Inter-Regular",
+                    "fontSize": 16,
+                    "lineHeight": 22,
+                  },
+                  Object {
+                    "color": "#9CA4A9",
+                    "fontFamily": "Inter-Regular",
+                    "fontSize": 14,
+                    "lineHeight": 18,
+                  },
+                ]
+              }
+            >
+              <Text
+                style={
+                  Array [
+                    undefined,
+                    Object {
+                      "color": undefined,
+                    },
+                  ]
+                }
+                testID="TotalLineItem/Subtotal/value"
+              >
+                
+                $
+                1.99
+              </Text>
+            </Text>
+          </View>
+        </View>
+      </View>
+    </RNCSafeAreaView>
+  </View>
+</RCTScrollView>
+`;
+
+exports[`renders correctly when local amount is null and no local exchange rate is set 1`] = `
+<RCTScrollView>
+  <View>
+    <RNCSafeAreaView
+      style={
+        Object {
+          "flex": 1,
+          "justifyContent": "space-between",
+        }
+      }
+    >
+      <View
+        style={
+          Object {
+            "flex": 1,
+            "paddingHorizontal": 16,
+          }
+        }
+      >
+        <View
+          style={
+            Object {
+              "justifyContent": "flex-start",
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "justifyContent": "space-between",
+                "marginTop": 30,
+              }
+            }
+          >
+            <Text
+              style={
+                Object {
+                  "color": "#2E3338",
+                  "fontFamily": "Inter-SemiBold",
+                  "fontSize": 16,
+                  "lineHeight": 22,
+                }
+              }
+            >
+              goldAmount
+            </Text>
+            <Text
+              style={
+                Array [
+                  Object {
+                    "color": "#2E3338",
+                    "fontFamily": "Inter-SemiBold",
+                    "fontSize": 16,
+                    "lineHeight": 22,
+                  },
+                  Object {
+                    "color": "#2E3338",
+                  },
+                ]
+              }
+              testID="CeloAmount/value"
+            >
+              
+              
+              20.000
+            </Text>
+          </View>
+          <View
+            style={
+              Object {
+                "borderStyle": "solid",
+                "borderTopColor": "#F8F9F9",
+                "borderTopWidth": 1,
+                "marginBottom": 15,
+                "marginTop": 10,
+                "width": "100%",
+              }
+            }
+          />
+          <View
+            style={
+              Array [
+                Object {
+                  "flexDirection": "row",
+                  "flexWrap": "wrap",
+                  "justifyContent": "space-between",
+                  "marginVertical": 5,
+                },
+                undefined,
+              ]
+            }
+          >
+            <View
+              style={
+                Object {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "marginRight": 5,
+                }
+              }
+            >
+              <Text
+                style={
+                  Array [
+                    Object {
+                      "color": "#2E3338",
+                      "fontFamily": "Inter-Regular",
+                      "fontSize": 16,
+                      "lineHeight": 22,
+                    },
+                    undefined,
+                  ]
+                }
+              >
+                Subtotal @
+                 
+                <Text
+                  style={
+                    Array [
+                      undefined,
+                      Object {
+                        "color": undefined,
+                      },
+                    ]
+                  }
+                  testID="CeloExchangeRate/value"
+                >
+                  
+                  -
+                </Text>
+              </Text>
+            </View>
+            <Text
+              style={
+                Array [
+                  Object {
+                    "color": "#2E3338",
+                    "fontFamily": "Inter-Regular",
+                    "fontSize": 16,
+                    "lineHeight": 22,
+                  },
+                  undefined,
+                ]
+              }
+            >
+              <Text
+                style={
+                  Array [
+                    undefined,
+                    Object {
+                      "color": undefined,
+                    },
+                  ]
+                }
+                testID="undefined/value"
+              >
+                
+                -
+              </Text>
+            </Text>
+          </View>
+          <View>
+            <View
+              accessible={true}
+              focusable={true}
+              nativeBackgroundAndroid={
+                Object {
+                  "attribute": "selectableItemBackground",
+                  "rippleRadius": undefined,
+                  "type": "ThemeAttrAndroid",
+                }
+              }
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              testID="feeDrawer/ExchangeConfirmationCard"
+            >
+              <View
+                style={
+                  Object {
+                    "flexDirection": "row",
+                    "justifyContent": "space-between",
+                  }
+                }
+              >
+                <View
+                  style={
+                    Array [
+                      Object {
+                        "alignItems": "center",
+                        "flexDirection": "row",
+                        "flexWrap": "wrap",
+                      },
+                      undefined,
+                    ]
+                  }
+                >
+                  <Text
+                    style={
+                      Object {
+                        "color": "#2E3338",
+                        "fontFamily": "Inter-Regular",
+                        "fontSize": 16,
+                        "lineHeight": 22,
+                      }
+                    }
+                  >
+                    feeActual
+                  </Text>
+                  <View
+                    style={
+                      Object {
+                        "marginLeft": 7,
+                        "transform": Array [
+                          Object {
+                            "rotate": "0deg",
+                          },
+                        ],
+                      }
+                    }
+                  >
+                    <svg
+                      fill="none"
+                      height={16}
+                      viewBox="0 0 16 16"
+                      width={16}
+                    >
+                      <path
+                        d="M3 6l5 5 5-5"
+                        stroke="#B4B9BD"
+                      />
+                    </svg>
+                  </View>
+                </View>
+                <View
+                  style={
+                    Array [
+                      Object {
+                        "flexDirection": "row",
+                        "flexWrap": "wrap",
+                        "justifyContent": "space-between",
+                        "marginVertical": 5,
+                      },
+                      undefined,
+                    ]
+                  }
+                >
+                  <View
+                    style={
+                      Object {
+                        "alignItems": "center",
+                        "flexDirection": "row",
+                        "marginRight": 5,
+                      }
+                    }
+                  >
+                    <Text
+                      style={
+                        Array [
+                          Object {
+                            "color": "#2E3338",
+                            "fontFamily": "Inter-Regular",
+                            "fontSize": 16,
+                            "lineHeight": 22,
+                          },
+                          undefined,
+                        ]
+                      }
+                    >
+                      
+                    </Text>
+                  </View>
+                  <Text
+                    style={
+                      Array [
+                        Object {
+                          "color": "#2E3338",
+                          "fontFamily": "Inter-Regular",
+                          "fontSize": 16,
+                          "lineHeight": 22,
+                        },
+                        undefined,
+                      ]
+                    }
+                  >
+                    <Text
+                      style={
+                        Array [
+                          undefined,
+                          Object {
+                            "color": undefined,
+                          },
+                        ]
+                      }
+                      testID="feeDrawer/ExchangeConfirmationCard/totalFee/value"
+                    >
+                      
+                      -
+                    </Text>
+                  </Text>
+                </View>
+              </View>
+            </View>
+          </View>
+          <View
+            style={
+              Object {
+                "borderStyle": "solid",
+                "borderTopColor": "#F8F9F9",
+                "borderTopWidth": 1,
+                "marginBottom": 15,
+                "marginTop": 10,
+                "width": "100%",
+              }
+            }
+          />
+          <View
+            style={
+              Array [
+                Object {
+                  "flexDirection": "row",
+                  "flexWrap": "wrap",
+                  "justifyContent": "space-between",
+                  "marginVertical": 5,
+                },
+                undefined,
+              ]
+            }
+          >
+            <View
+              style={
+                Object {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "marginRight": 5,
+                }
+              }
+            >
+              <Text
+                style={
+                  Array [
+                    Object {
+                      "color": "#2E3338",
+                      "fontFamily": "Inter-Regular",
+                      "fontSize": 16,
+                      "lineHeight": 22,
+                    },
+                    Object {
+                      "color": "#2E3338",
+                      "fontFamily": "Inter-SemiBold",
+                      "fontSize": 16,
+                      "lineHeight": 22,
+                    },
+                  ]
+                }
+              >
+                total
+              </Text>
+            </View>
+            <Text
+              style={
+                Array [
+                  Object {
+                    "color": "#2E3338",
+                    "fontFamily": "Inter-Regular",
+                    "fontSize": 16,
+                    "lineHeight": 22,
+                  },
+                  Object {
+                    "color": "#2E3338",
+                    "fontFamily": "Inter-SemiBold",
+                    "fontSize": 16,
+                    "lineHeight": 22,
+                  },
+                ]
+              }
+            >
+              <Text
+                style={
+                  Array [
+                    undefined,
+                    Object {
+                      "color": undefined,
+                    },
+                  ]
+                }
+                testID="TotalLineItem/Total/value"
+              >
+                
+                -
+              </Text>
+            </Text>
+          </View>
+        </View>
+      </View>
+    </RNCSafeAreaView>
+  </View>
+</RCTScrollView>
+`;
+
+exports[`renders correctly with giant numbers 1`] = `
+<RCTScrollView>
+  <View>
+    <RNCSafeAreaView
+      style={
+        Object {
+          "flex": 1,
+          "justifyContent": "space-between",
+        }
+      }
+    >
+      <View
+        style={
+          Object {
+            "flex": 1,
+            "paddingHorizontal": 16,
+          }
+        }
+      >
+        <View
+          style={
+            Object {
+              "justifyContent": "flex-start",
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "justifyContent": "space-between",
+                "marginTop": 30,
+              }
+            }
+          >
+            <Text
+              style={
+                Object {
+                  "color": "#2E3338",
+                  "fontFamily": "Inter-SemiBold",
+                  "fontSize": 16,
+                  "lineHeight": 22,
+                }
+              }
+            >
+              goldAmount
+            </Text>
+            <Text
+              style={
+                Array [
+                  Object {
+                    "color": "#2E3338",
+                    "fontFamily": "Inter-SemiBold",
+                    "fontSize": 16,
+                    "lineHeight": 22,
+                  },
+                  Object {
+                    "color": "#2E3338",
+                  },
+                ]
+              }
+              testID="CeloAmount/value"
+            >
+              
+              
+              18,000,000,000.000
+            </Text>
+          </View>
+          <View
+            style={
+              Object {
+                "borderStyle": "solid",
+                "borderTopColor": "#F8F9F9",
+                "borderTopWidth": 1,
+                "marginBottom": 15,
+                "marginTop": 10,
+                "width": "100%",
+              }
+            }
+          />
+          <View
+            style={
+              Array [
+                Object {
+                  "flexDirection": "row",
+                  "flexWrap": "wrap",
+                  "justifyContent": "space-between",
+                  "marginVertical": 5,
+                },
+                undefined,
+              ]
+            }
+          >
+            <View
+              style={
+                Object {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "marginRight": 5,
+                }
+              }
+            >
+              <Text
+                style={
+                  Array [
+                    Object {
+                      "color": "#2E3338",
+                      "fontFamily": "Inter-Regular",
+                      "fontSize": 16,
+                      "lineHeight": 22,
+                    },
+                    undefined,
+                  ]
+                }
+              >
+                Subtotal @
+                 
+                <Text
+                  style={
+                    Array [
+                      undefined,
+                      Object {
+                        "color": undefined,
+                      },
+                    ]
+                  }
+                  testID="CeloExchangeRate/value"
+                >
+                  
+                  €
+                  0.55
+                </Text>
+              </Text>
+            </View>
+            <Text
+              style={
+                Array [
+                  Object {
+                    "color": "#2E3338",
+                    "fontFamily": "Inter-Regular",
+                    "fontSize": 16,
+                    "lineHeight": 22,
+                  },
+                  undefined,
+                ]
+              }
+            >
+              <Text
+                style={
+                  Array [
+                    undefined,
+                    Object {
+                      "color": undefined,
+                    },
+                  ]
+                }
+                testID="undefined/value"
+              >
+                
+                $
+                31,920,000.00
+              </Text>
+            </Text>
+          </View>
+          <View>
+            <View
+              accessible={true}
+              focusable={true}
+              nativeBackgroundAndroid={
+                Object {
+                  "attribute": "selectableItemBackground",
+                  "rippleRadius": undefined,
+                  "type": "ThemeAttrAndroid",
+                }
+              }
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              testID="feeDrawer/ExchangeConfirmationCard"
+            >
+              <View
+                style={
+                  Object {
+                    "flexDirection": "row",
+                    "justifyContent": "space-between",
+                  }
+                }
+              >
+                <View
+                  style={
+                    Array [
+                      Object {
+                        "alignItems": "center",
+                        "flexDirection": "row",
+                        "flexWrap": "wrap",
+                      },
+                      undefined,
+                    ]
+                  }
+                >
+                  <Text
+                    style={
+                      Object {
+                        "color": "#2E3338",
+                        "fontFamily": "Inter-Regular",
+                        "fontSize": 16,
+                        "lineHeight": 22,
+                      }
+                    }
+                  >
+                    feeActual
+                  </Text>
+                  <View
+                    style={
+                      Object {
+                        "marginLeft": 7,
+                        "transform": Array [
+                          Object {
+                            "rotate": "0deg",
+                          },
+                        ],
+                      }
+                    }
+                  >
+                    <svg
+                      fill="none"
+                      height={16}
+                      viewBox="0 0 16 16"
+                      width={16}
+                    >
+                      <path
+                        d="M3 6l5 5 5-5"
+                        stroke="#B4B9BD"
+                      />
+                    </svg>
+                  </View>
+                </View>
+                <View
+                  style={
+                    Array [
+                      Object {
+                        "flexDirection": "row",
+                        "flexWrap": "wrap",
+                        "justifyContent": "space-between",
+                        "marginVertical": 5,
+                      },
+                      undefined,
+                    ]
+                  }
+                >
+                  <View
+                    style={
+                      Object {
+                        "alignItems": "center",
+                        "flexDirection": "row",
+                        "marginRight": 5,
+                      }
+                    }
+                  >
+                    <Text
+                      style={
+                        Array [
+                          Object {
+                            "color": "#2E3338",
+                            "fontFamily": "Inter-Regular",
+                            "fontSize": 16,
+                            "lineHeight": 22,
+                          },
+                          undefined,
+                        ]
+                      }
+                    >
+                      
+                    </Text>
+                  </View>
+                  <Text
+                    style={
+                      Array [
+                        Object {
+                          "color": "#2E3338",
+                          "fontFamily": "Inter-Regular",
+                          "fontSize": 16,
+                          "lineHeight": 22,
+                        },
+                        undefined,
+                      ]
+                    }
+                  >
+                    <Text
+                      style={
+                        Array [
+                          undefined,
+                          Object {
+                            "color": undefined,
+                          },
+                        ]
+                      }
+                      testID="feeDrawer/ExchangeConfirmationCard/totalFee/value"
+                    >
+                      
+                      $
+                      0
+                    </Text>
+                  </Text>
+                </View>
+              </View>
+            </View>
+          </View>
+          <View
+            style={
+              Object {
+                "borderStyle": "solid",
+                "borderTopColor": "#F8F9F9",
+                "borderTopWidth": 1,
+                "marginBottom": 15,
+                "marginTop": 10,
+                "width": "100%",
+              }
+            }
+          />
+          <View
+            style={
+              Array [
+                Object {
+                  "flexDirection": "row",
+                  "flexWrap": "wrap",
+                  "justifyContent": "space-between",
+                  "marginVertical": 5,
+                },
+                undefined,
+              ]
+            }
+          >
+            <View
+              style={
+                Object {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "marginRight": 5,
+                }
+              }
+            >
+              <Text
+                style={
+                  Array [
+                    Object {
+                      "color": "#2E3338",
+                      "fontFamily": "Inter-Regular",
+                      "fontSize": 16,
+                      "lineHeight": 22,
+                    },
+                    Object {
+                      "color": "#2E3338",
+                      "fontFamily": "Inter-SemiBold",
+                      "fontSize": 16,
+                      "lineHeight": 22,
+                    },
+                  ]
+                }
+              >
+                total
+              </Text>
+            </View>
+            <Text
+              style={
+                Array [
+                  Object {
+                    "color": "#2E3338",
+                    "fontFamily": "Inter-Regular",
+                    "fontSize": 16,
+                    "lineHeight": 22,
+                  },
+                  Object {
+                    "color": "#2E3338",
+                    "fontFamily": "Inter-SemiBold",
+                    "fontSize": 16,
+                    "lineHeight": 22,
+                  },
+                ]
+              }
+            >
+              <Text
+                style={
+                  Array [
+                    undefined,
+                    Object {
+                      "color": undefined,
+                    },
+                  ]
+                }
+                testID="TotalLineItem/Total/value"
+              >
+                
+                $
+                31,920,000.00
+              </Text>
+            </Text>
+          </View>
+          <View
+            style={
+              Array [
+                Object {
+                  "flexDirection": "row",
+                  "flexWrap": "wrap",
+                  "justifyContent": "space-between",
+                  "marginVertical": 5,
+                },
+                Object {
+                  "marginVertical": 0,
+                },
+              ]
+            }
+          >
+            <View
+              style={
+                Object {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "marginRight": 5,
+                }
+              }
+            >
+              <Text
+                style={
+                  Array [
+                    Object {
+                      "color": "#2E3338",
+                      "fontFamily": "Inter-Regular",
+                      "fontSize": 16,
+                      "lineHeight": 22,
+                    },
+                    Object {
+                      "color": "#9CA4A9",
+                      "fontFamily": "Inter-Regular",
+                      "fontSize": 14,
+                      "lineHeight": 18,
+                    },
+                  ]
+                }
+              >
+                <View
+                  accessible={true}
+                  focusable={false}
+                  nativeBackgroundAndroid={
+                    Object {
+                      "attribute": "selectableItemBackground",
+                      "rippleRadius": undefined,
+                      "type": "ThemeAttrAndroid",
+                    }
+                  }
+                  onClick={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                >
+                  <Text
+                    style={
+                      Object {
+                        "color": "#9CA4A9",
+                        "fontFamily": "Inter-Regular",
+                        "fontSize": 14,
+                        "lineHeight": 18,
+                      }
+                    }
+                  >
+                    <Text
+                      style={
+                        Array [
+                          undefined,
+                          Object {
+                            "color": undefined,
+                          },
+                        ]
+                      }
+                      testID="TotalLineItem/ExchangeRate/value"
+                    >
+                      
+                      $
+                      0.75
+                    </Text>
+                  </Text>
+                </View>
+              </Text>
+            </View>
+            <Text
+              style={
+                Array [
+                  Object {
+                    "color": "#2E3338",
+                    "fontFamily": "Inter-Regular",
+                    "fontSize": 16,
+                    "lineHeight": 22,
+                  },
+                  Object {
+                    "color": "#9CA4A9",
+                    "fontFamily": "Inter-Regular",
+                    "fontSize": 14,
+                    "lineHeight": 18,
+                  },
+                ]
+              }
+            >
+              <Text
+                style={
+                  Array [
+                    undefined,
+                    Object {
+                      "color": undefined,
+                    },
+                  ]
+                }
+                testID="TotalLineItem/Subtotal/value"
+              >
+                
+                $
+                24,000,000.00
               </Text>
             </Text>
           </View>

--- a/packages/mobile/src/transactions/GoldTransactionFeedItem.test.tsx
+++ b/packages/mobile/src/transactions/GoldTransactionFeedItem.test.tsx
@@ -7,7 +7,7 @@ import { Provider } from 'react-redux'
 import { TokenTransactionType } from 'src/apollo/types'
 import GoldTransactionFeedItem from 'src/transactions/GoldTransactionFeedItem'
 import { TransactionStatus } from 'src/transactions/types'
-import { createMockStore, getMockI18nProps } from 'test/utils'
+import { createMockStore, getElementText, getMockI18nProps } from 'test/utils'
 
 expect.extend({ toBeDisabled })
 
@@ -49,6 +49,57 @@ describe('GoldTransactionFeedItem', () => {
       </Provider>
     )
     expect(tree).toMatchSnapshot()
+
+    expect(getElementText(tree.getByTestId('GoldTransactionFeedItemRate/value'))).toEqual('€0.55')
+    expect(getElementText(tree.getByTestId('GoldTransactionFeedItemAmount/value'))).toEqual('€1.23')
+  })
+
+  it('renders correctly when local amount is null', () => {
+    const tree = render(
+      <Provider store={createMockStore({})}>
+        <GoldTransactionFeedItem
+          status={TransactionStatus.Complete}
+          __typename="TokenExchange"
+          type={TokenTransactionType.Exchange}
+          hash={'0x'}
+          amount={{ value: '-1', currencyCode: 'cUSD', localAmount: null }}
+          makerAmount={{ value: '1', currencyCode: 'cUSD', localAmount: null }}
+          takerAmount={{ value: '10', currencyCode: 'cGLD', localAmount: null }}
+          timestamp={1}
+          {...getMockI18nProps()}
+        />
+      </Provider>
+    )
+    expect(tree).toMatchSnapshot()
+
+    // This is a degraded mode, when we can't get the exchange rate from the blockchain-api, better than nothing
+    expect(getElementText(tree.getByTestId('GoldTransactionFeedItemRate/value'))).toEqual('-')
+    expect(getElementText(tree.getByTestId('GoldTransactionFeedItemAmount/value'))).toEqual(
+      '-$1.33'
+    )
+  })
+
+  it('renders correctly when local amount is null and no local exchange rate was set', () => {
+    const tree = render(
+      <Provider store={createMockStore({ localCurrency: { exchangeRates: {} } })}>
+        <GoldTransactionFeedItem
+          status={TransactionStatus.Complete}
+          __typename="TokenExchange"
+          type={TokenTransactionType.Exchange}
+          hash={'0x'}
+          amount={{ value: '-1', currencyCode: 'cUSD', localAmount: null }}
+          makerAmount={{ value: '1', currencyCode: 'cUSD', localAmount: null }}
+          takerAmount={{ value: '10', currencyCode: 'cGLD', localAmount: null }}
+          timestamp={1}
+          {...getMockI18nProps()}
+        />
+      </Provider>
+    )
+    expect(tree).toMatchSnapshot()
+
+    // This is a degraded mode, when we can't get the exchange rate from the blockchain-api, better than nothing
+    expect(getElementText(tree.getByTestId('GoldTransactionFeedItemRate/value'))).toEqual('-')
+    expect(getElementText(tree.getByTestId('GoldTransactionFeedItemAmount/value'))).toEqual('-')
   })
 
   it('tap disabled while pending', () => {

--- a/packages/mobile/src/transactions/GoldTransactionFeedItem.test.tsx
+++ b/packages/mobile/src/transactions/GoldTransactionFeedItem.test.tsx
@@ -97,7 +97,7 @@ describe('GoldTransactionFeedItem', () => {
     )
     expect(tree).toMatchSnapshot()
 
-    // This is an even more degraded mode, when we can't get the exchange rate from the blockchain-api, better than nothing
+    // This is an even more degraded mode, when we can't get the exchange rate from the blockchain-api or locally, better than nothing
     expect(getElementText(tree.getByTestId('GoldTransactionFeedItemRate/value'))).toEqual('-')
     expect(getElementText(tree.getByTestId('GoldTransactionFeedItemAmount/value'))).toEqual('-')
   })

--- a/packages/mobile/src/transactions/GoldTransactionFeedItem.test.tsx
+++ b/packages/mobile/src/transactions/GoldTransactionFeedItem.test.tsx
@@ -79,7 +79,7 @@ describe('GoldTransactionFeedItem', () => {
     )
   })
 
-  it('renders correctly when local amount is null and no local exchange rate was set', () => {
+  it('renders correctly when local amount is null and no local exchange rate is set', () => {
     const tree = render(
       <Provider store={createMockStore({ localCurrency: { exchangeRates: {} } })}>
         <GoldTransactionFeedItem
@@ -97,7 +97,7 @@ describe('GoldTransactionFeedItem', () => {
     )
     expect(tree).toMatchSnapshot()
 
-    // This is a degraded mode, when we can't get the exchange rate from the blockchain-api, better than nothing
+    // This is an even more degraded mode, when we can't get the exchange rate from the blockchain-api, better than nothing
     expect(getElementText(tree.getByTestId('GoldTransactionFeedItemRate/value'))).toEqual('-')
     expect(getElementText(tree.getByTestId('GoldTransactionFeedItemAmount/value'))).toEqual('-')
   })

--- a/packages/mobile/src/transactions/GoldTransactionFeedItem.tsx
+++ b/packages/mobile/src/transactions/GoldTransactionFeedItem.tsx
@@ -38,7 +38,7 @@ export function ExchangeFeedItem(props: Props) {
   const localAmount = (isSellGoldTx ? makerAmount : takerAmount).localAmount
   // TODO: find a way on how to show local exchangeRate without this hack
   const exchangeRateAmount = {
-    value: localAmount?.exchangeRate,
+    value: localAmount?.exchangeRate || '',
     currencyCode: Currency.Dollar,
     localAmount: localAmount
       ? {

--- a/packages/mobile/src/transactions/GoldTransactionFeedItem.tsx
+++ b/packages/mobile/src/transactions/GoldTransactionFeedItem.tsx
@@ -35,16 +35,18 @@ export function ExchangeFeedItem(props: Props) {
   const isPending = status === TransactionStatus.Pending
   // We always show Local Currency to cGLD exchage rate
   // independent of transaction type
-  const localAmount = (isSellGoldTx ? makerAmount : takerAmount).localAmount!
+  const localAmount = (isSellGoldTx ? makerAmount : takerAmount).localAmount
   // TODO: find a way on how to show local exchangeRate without this hack
   const exchangeRateAmount = {
-    value: localAmount.exchangeRate,
+    value: localAmount?.exchangeRate,
     currencyCode: Currency.Dollar,
-    localAmount: {
-      value: localAmount.exchangeRate,
-      exchangeRate: localAmount.exchangeRate,
-      currencyCode: localAmount.currencyCode,
-    },
+    localAmount: localAmount
+      ? {
+          value: localAmount.exchangeRate,
+          exchangeRate: localAmount.exchangeRate,
+          currencyCode: localAmount.currencyCode,
+        }
+      : null,
   }
 
   return (
@@ -62,10 +64,15 @@ export function ExchangeFeedItem(props: Props) {
               hideCode={true}
               showLocalAmount={true}
               style={styles.exchangeRate}
+              testID="GoldTransactionFeedItemRate"
             />
           </View>
           <View>
-            <CurrencyDisplay amount={amount} style={styles.amount} />
+            <CurrencyDisplay
+              amount={amount}
+              style={styles.amount}
+              testID="GoldTransactionFeedItemAmount"
+            />
           </View>
         </View>
         <View style={styles.secondRow}>

--- a/packages/mobile/src/transactions/__snapshots__/GoldTransactionFeedItem.test.tsx.snap
+++ b/packages/mobile/src/transactions/__snapshots__/GoldTransactionFeedItem.test.tsx.snap
@@ -87,7 +87,7 @@ exports[`GoldTransactionFeedItem renders correctly 1`] = `
               },
             ]
           }
-          testID="undefined/value"
+          testID="GoldTransactionFeedItemRate/value"
         >
           
           €
@@ -109,11 +109,282 @@ exports[`GoldTransactionFeedItem renders correctly 1`] = `
               },
             ]
           }
-          testID="undefined/value"
+          testID="GoldTransactionFeedItemAmount/value"
         >
           
           €
           1.23
+        </Text>
+      </View>
+    </View>
+    <View
+      style={Object {}}
+    >
+      <Text
+        style={
+          Object {
+            "color": "#9CA4A9",
+            "fontFamily": "Inter-Regular",
+            "fontSize": 14,
+            "lineHeight": 18,
+          }
+        }
+      >
+        Dec 31 at 5:00 PM
+      </Text>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`GoldTransactionFeedItem renders correctly when local amount is null 1`] = `
+<View
+  accessible={true}
+  focusable={true}
+  nativeBackgroundAndroid={
+    Object {
+      "attribute": "selectableItemBackground",
+      "rippleRadius": undefined,
+      "type": "ThemeAttrAndroid",
+    }
+  }
+  onClick={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  testID="GoldTransactionFeedItem"
+>
+  <View
+    style={
+      Object {
+        "flex": 1,
+        "justifyContent": "space-between",
+        "padding": 16,
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "flex": 1,
+          "flexDirection": "row",
+          "flexWrap": "wrap",
+          "justifyContent": "space-between",
+          "paddingBottom": 2,
+        }
+      }
+    >
+      <View
+        style={
+          Object {
+            "flexDirection": "row",
+          }
+        }
+      >
+        <Text
+          style={
+            Object {
+              "color": "#2E3338",
+              "fontFamily": "Inter-Medium",
+              "fontSize": 16,
+              "lineHeight": 22,
+            }
+          }
+        >
+          feedItemGoldPurchased
+        </Text>
+        <Text
+          style={
+            Object {
+              "color": "#2E3338",
+              "flexWrap": "wrap",
+              "fontFamily": "Inter-Medium",
+              "fontSize": 16,
+              "lineHeight": 22,
+            }
+          }
+        >
+           @ 
+        </Text>
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "#2E3338",
+                "flexWrap": "wrap",
+                "fontFamily": "Inter-Medium",
+                "fontSize": 16,
+                "lineHeight": 22,
+              },
+              Object {
+                "color": "#2E3338",
+              },
+            ]
+          }
+          testID="GoldTransactionFeedItemRate/value"
+        >
+          
+          -
+        </Text>
+      </View>
+      <View>
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "#2E3338",
+                "fontFamily": "Inter-Medium",
+                "fontSize": 16,
+                "lineHeight": 22,
+              },
+              Object {
+                "color": "#2E3338",
+              },
+            ]
+          }
+          testID="GoldTransactionFeedItemAmount/value"
+        >
+          -
+          $
+          1.33
+        </Text>
+      </View>
+    </View>
+    <View
+      style={Object {}}
+    >
+      <Text
+        style={
+          Object {
+            "color": "#9CA4A9",
+            "fontFamily": "Inter-Regular",
+            "fontSize": 14,
+            "lineHeight": 18,
+          }
+        }
+      >
+        Dec 31 at 5:00 PM
+      </Text>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`GoldTransactionFeedItem renders correctly when local amount is null and no local exchange rate was set 1`] = `
+<View
+  accessible={true}
+  focusable={true}
+  nativeBackgroundAndroid={
+    Object {
+      "attribute": "selectableItemBackground",
+      "rippleRadius": undefined,
+      "type": "ThemeAttrAndroid",
+    }
+  }
+  onClick={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  testID="GoldTransactionFeedItem"
+>
+  <View
+    style={
+      Object {
+        "flex": 1,
+        "justifyContent": "space-between",
+        "padding": 16,
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "flex": 1,
+          "flexDirection": "row",
+          "flexWrap": "wrap",
+          "justifyContent": "space-between",
+          "paddingBottom": 2,
+        }
+      }
+    >
+      <View
+        style={
+          Object {
+            "flexDirection": "row",
+          }
+        }
+      >
+        <Text
+          style={
+            Object {
+              "color": "#2E3338",
+              "fontFamily": "Inter-Medium",
+              "fontSize": 16,
+              "lineHeight": 22,
+            }
+          }
+        >
+          feedItemGoldPurchased
+        </Text>
+        <Text
+          style={
+            Object {
+              "color": "#2E3338",
+              "flexWrap": "wrap",
+              "fontFamily": "Inter-Medium",
+              "fontSize": 16,
+              "lineHeight": 22,
+            }
+          }
+        >
+           @ 
+        </Text>
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "#2E3338",
+                "flexWrap": "wrap",
+                "fontFamily": "Inter-Medium",
+                "fontSize": 16,
+                "lineHeight": 22,
+              },
+              Object {
+                "color": "#2E3338",
+              },
+            ]
+          }
+          testID="GoldTransactionFeedItemRate/value"
+        >
+          
+          -
+        </Text>
+      </View>
+      <View>
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "#2E3338",
+                "fontFamily": "Inter-Medium",
+                "fontSize": 16,
+                "lineHeight": 22,
+              },
+              Object {
+                "color": "#2E3338",
+              },
+            ]
+          }
+          testID="GoldTransactionFeedItemAmount/value"
+        >
+          
+          -
         </Text>
       </View>
     </View>

--- a/packages/mobile/src/transactions/__snapshots__/GoldTransactionFeedItem.test.tsx.snap
+++ b/packages/mobile/src/transactions/__snapshots__/GoldTransactionFeedItem.test.tsx.snap
@@ -273,7 +273,7 @@ exports[`GoldTransactionFeedItem renders correctly when local amount is null 1`]
 </View>
 `;
 
-exports[`GoldTransactionFeedItem renders correctly when local amount is null and no local exchange rate was set 1`] = `
+exports[`GoldTransactionFeedItem renders correctly when local amount is null and no local exchange rate is set 1`] = `
 <View
   accessible={true}
   focusable={true}


### PR DESCRIPTION
### Description

This improves our resilience to currencylayer API outages / or missing exchange rate data preventing currency conversion to happen in blockchain-api.

Now Valora gracefully degrades and tries to do currency conversions locally using the cached rate of the day.
And if there's no cached rate, it just displays `-` or nothing at all, which is not great but at least it doesn't crash.

This should be improved even more with the switch to the new transaction feed with multiple tokens where the actual underlying token would always be displayed.

### Tested

Added new unit tests.

### How others should test

This is hard to test manually because it needs a local test instance of the blockchain-api which wouldn't return the local amount.
Or an actual outage from currencylayer.

### Related issues

- See [discussion on Slack](https://valora-app.slack.com/archives/C02N3AR2P2S/p1637725955019100).
- This also addresses the following incident item from [the previous incident](https://www.notion.so/valora-inc/Valora-Transaction-Feed-Not-Loading-b34d9470388d4827a41ee49ecc7f27f8):
  - When currency conversions fail, the whole feed doesn't load at all. The UI should degrade gracefully instead.

### Backwards compatibility

Yes