### PR TITLE
Fix bidali modal not triggered

### DIFF
--- a/packages/mobile/src/navigator/Navigator.tsx
+++ b/packages/mobile/src/navigator/Navigator.tsx
@@ -625,6 +625,11 @@ const modalAnimatedScreens = (Navigator: typeof Stack) => (
       component={SendConfirmation}
       options={sendConfirmationScreenNavOptions}
     />
+    <Navigator.Screen
+      name={Screens.SendConfirmationLegacyModal}
+      component={SendConfirmationLegacy}
+      options={sendConfirmationLegacyScreenNavOptions}
+    />
   </>
 )
 


### PR DESCRIPTION
### Description

The SendConfirmation was refactored into `SendConfirmation` (multi token) and `SendConfirmationLegacy` (previous impl).
However `SendConfirmationModalLegacy` was not added back. This fixes it.

### Tested

Manually.

### How others should test

Bidali payment modal is displayed.

### Related issues

- Fixes #1521

### Backwards compatibility

Yes