### PR TITLE
fix incorrect translation key name in consumer incentives screen

### DIFF
--- a/packages/mobile/locales/de/translation.json
+++ b/packages/mobile/locales/de/translation.json
@@ -160,8 +160,8 @@
       "text": "Jeder mit deiner Phrase hat Zugriff auf dein Konto und alle Guthaben. Teile es nicht mit anderen."
     }
   ],
-  "customerIncentivesTitle": "Erhöhe deine Belohnungen",
-  "customerIncentivesSummary": "Supercharge ist da! Erhalte {{percent}}% jährliche Belohnungen auf dein {{currency}} Saldo. Nur für kurze Zeit, also starte deine Einzahlung!",
+  "consumerIncentivesTitle": "Erhöhe deine Belohnungen",
+  "consumerIncentivesSummary": "Supercharge ist da! Erhalte {{percent}}% jährliche Belohnungen auf dein {{currency}} Saldo. Nur für kurze Zeit, also starte deine Einzahlung!",
   "earnWeekly": {
     "header": "Wöchentliche Auszahlung",
     "text": "Sende und gib aus wie gewohnt und erhalte Belohnungen auf den verbleibenden Saldo."

--- a/packages/mobile/locales/en-US/translation.json
+++ b/packages/mobile/locales/en-US/translation.json
@@ -160,8 +160,8 @@
       "text": "Anyone with your Phrase will have access to your account and all of its funds. Don’t share it with others."
     }
   ],
-  "customerIncentivesTitle": "Boost your Rewards",
-  "customerIncentivesSummary": "Supercharge is here! Get {{percent}}% annual rewards on your {{currency}} balance. Available for a limited time so start cashing in!",
+  "consumerIncentivesTitle": "Boost your Rewards",
+  "consumerIncentivesSummary": "Supercharge is here! Get {{percent}}% annual rewards on your {{currency}} balance. Available for a limited time so start cashing in!",
   "earnWeekly": {
     "header": "Weekly payout",
     "text": "Send and spend as usual, you’ll get rewarded on the remaining balance."

--- a/packages/mobile/locales/es-419/translation.json
+++ b/packages/mobile/locales/es-419/translation.json
@@ -160,8 +160,8 @@
       "text": "Cualquier persona que acceda a tu frase tendrá acceso a tu cuenta y a todos tus fondos. No la compartas con nadie."
     }
   ],
-  "customerIncentivesTitle": "Aumenta tus recompensas",
-  "customerIncentivesSummary": "¡Supercharge está aquí! Obtén un {{percent}}% de recompensas anuales sobre tu saldo en {{currency}}. Disponible por tiempo limitado, ¡empieza a agregar fondos!",
+  "consumerIncentivesTitle": "Aumenta tus recompensas",
+  "consumerIncentivesSummary": "¡Supercharge está aquí! Obtén un {{percent}}% de recompensas anuales sobre tu saldo en {{currency}}. Disponible por tiempo limitado, ¡empieza a agregar fondos!",
   "earnWeekly": {
     "header": "Pago semanal",
     "text": "Envía y gasta como siempre, obtendrás recompensas en el saldo restante."

--- a/packages/mobile/locales/pt-BR/translation.json
+++ b/packages/mobile/locales/pt-BR/translation.json
@@ -160,8 +160,8 @@
       "text": "Qualquer pessoa com sua frase terá acesso à sua conta e a todos os seus fundos. Não compartilhe com outras pessoas."
     }
   ],
-  "customerIncentivesTitle": "Aumente suas recompensas",
-  "customerIncentivesSummary": "O Supercharge chegou! Ganhe {{percent}}% em recompensas anuais no seu saldo de {{currency}}. Quer começar a adicionar fundos? Então corra, porque é por tempo limitado!",
+  "consumerIncentivesTitle": "Aumente suas recompensas",
+  "consumerIncentivesSummary": "O Supercharge chegou! Ganhe {{percent}}% em recompensas anuais no seu saldo de {{currency}}. Quer começar a adicionar fundos? Então corra, porque é por tempo limitado!",
   "earnWeekly": {
     "header": "Pagamento semanal",
     "text": "Envie e gaste como de costume. Você receberá recompensas sobre o saldo restante."


### PR DESCRIPTION
I found that I had mistyped the translation key for the customer incentives screen title and summary 🥲