### PR TITLE
trigger i18n refresh after resource bundle is added

### DIFF
--- a/packages/mobile/src/i18n/index.ts
+++ b/packages/mobile/src/i18n/index.ts
@@ -50,6 +50,9 @@ export async function initI18n(
       escapeValue: false,
       defaultVariables: { appName: APP_NAME, tosLink: TOS_LINK_DISPLAY },
     },
+    react: {
+      bindI18nStore: 'added',
+    },
   })
 }
 


### PR DESCRIPTION
### Description

When OTA translations have been fetched, we call `i18n.addResourceBundle` to refresh the i18n instance with the updated translations. This does not trigger an instant refresh, and the updated translation will need a re-render event to be displayed. 

I initially thought this was the best user experience anyway, to not have text change before your eyes. However it is unpredictable when re-renders will occur for each component, and for some components they do not happen for a long time (e.g. I couldn't get the settings page to refresh until i changed the app language)

Adding this `bindI18nStore` property to the i18n instance refreshes the text after a resource bundle has been added. The text is refreshed in front of your eyes but I think this is still the most correct behaviour

https://user-images.githubusercontent.com/20150449/144053413-42772a12-7dcb-4fdd-91df-c45425dcfc70.mov


### Other changes

N/A

### Tested

Manually:
- change some text in translation.json
- load the app, with OTA translations remote config false
- verify you see the text in translation.json
- reload the app with OTA translations remote config true
- see the OTA translations are loaded in the app after a few seconds


### How others should test

Same as above

### Related issues

N/A


### Backwards compatibility

N/A