### PR TITLE
Fix missing translations in ActionRequest

### DIFF
--- a/packages/mobile/src/walletConnect/constants.ts
+++ b/packages/mobile/src/walletConnect/constants.ts
@@ -1,4 +1,4 @@
-import i18n from 'src/i18n'
+import { TFunction } from 'i18next'
 
 export enum SupportedActions {
   eth_accounts = 'eth_accounts',
@@ -13,47 +13,47 @@ export enum SupportedActions {
 }
 
 const actionDescriptionTranslations: { [action in SupportedActions]: string } = {
-  [SupportedActions.eth_accounts]: i18n.t('description.accounts'),
-  [SupportedActions.eth_signTransaction]: i18n.t('description.signTransaction'),
-  [SupportedActions.eth_sendTransaction]: i18n.t('description.sendTransaction'),
-  [SupportedActions.eth_signTypedData]: i18n.t('description.sign'),
-  [SupportedActions.eth_signTypedData_v4]: i18n.t('description.sign'),
-  [SupportedActions.eth_sign]: i18n.t('description.sign'),
-  [SupportedActions.personal_sign]: i18n.t('description.sign'),
-  [SupportedActions.personal_decrypt]: i18n.t('description.decrypt'),
-  [SupportedActions.computeSharedSecret]: i18n.t('description.computeSharedSecret'),
+  [SupportedActions.eth_accounts]: 'description.accounts',
+  [SupportedActions.eth_signTransaction]: 'description.signTransaction',
+  [SupportedActions.eth_sendTransaction]: 'description.sendTransaction',
+  [SupportedActions.eth_signTypedData]: 'description.sign',
+  [SupportedActions.eth_signTypedData_v4]: 'description.sign',
+  [SupportedActions.eth_sign]: 'description.sign',
+  [SupportedActions.personal_sign]: 'description.sign',
+  [SupportedActions.personal_decrypt]: 'description.decrypt',
+  [SupportedActions.computeSharedSecret]: 'description.computeSharedSecret',
 }
 
 const actionTranslations: { [x in SupportedActions]: string } = {
-  [SupportedActions.eth_accounts]: i18n.t('action.accounts'),
-  [SupportedActions.eth_signTransaction]: i18n.t('action.signTransaction'),
-  [SupportedActions.eth_sendTransaction]: i18n.t('action.sendTransaction'),
-  [SupportedActions.eth_signTypedData]: i18n.t('action.sign'),
-  [SupportedActions.eth_signTypedData_v4]: i18n.t('action.sign'),
-  [SupportedActions.eth_sign]: i18n.t('action.sign'),
-  [SupportedActions.personal_sign]: i18n.t('action.sign'),
-  [SupportedActions.personal_decrypt]: i18n.t('action.decrypt'),
-  [SupportedActions.computeSharedSecret]: i18n.t('action.computeSharedSecret'),
+  [SupportedActions.eth_accounts]: 'action.accounts',
+  [SupportedActions.eth_signTransaction]: 'action.signTransaction',
+  [SupportedActions.eth_sendTransaction]: 'action.sendTransaction',
+  [SupportedActions.eth_signTypedData]: 'action.sign',
+  [SupportedActions.eth_signTypedData_v4]: 'action.sign',
+  [SupportedActions.eth_sign]: 'action.sign',
+  [SupportedActions.personal_sign]: 'action.sign',
+  [SupportedActions.personal_decrypt]: 'action.decrypt',
+  [SupportedActions.computeSharedSecret]: 'action.computeSharedSecret',
 }
 
 export function isSupportedAction(action: string) {
   return action in actionTranslations
 }
 
-export function getTranslationDescriptionFromAction(action: SupportedActions) {
+export function getTranslationDescriptionFromAction(t: TFunction, action: SupportedActions) {
   const translationId = actionDescriptionTranslations[action]
   if (!translationId) {
     return ''
   }
 
-  return translationId
+  return t(translationId)
 }
 
-export function getTranslationFromAction(action: SupportedActions) {
+export function getTranslationFromAction(t: TFunction, action: SupportedActions) {
   const translationId = actionTranslations[action]
   if (!translationId) {
     return ''
   }
 
-  return translationId
+  return t(translationId)
 }

--- a/packages/mobile/src/walletConnect/constants.ts
+++ b/packages/mobile/src/walletConnect/constants.ts
@@ -12,48 +12,48 @@ export enum SupportedActions {
   computeSharedSecret = 'personal_computeSharedSecret',
 }
 
-const actionDescriptionTranslations: { [action in SupportedActions]: string } = {
-  [SupportedActions.eth_accounts]: 'description.accounts',
-  [SupportedActions.eth_signTransaction]: 'description.signTransaction',
-  [SupportedActions.eth_sendTransaction]: 'description.sendTransaction',
-  [SupportedActions.eth_signTypedData]: 'description.sign',
-  [SupportedActions.eth_signTypedData_v4]: 'description.sign',
-  [SupportedActions.eth_sign]: 'description.sign',
-  [SupportedActions.personal_sign]: 'description.sign',
-  [SupportedActions.personal_decrypt]: 'description.decrypt',
-  [SupportedActions.computeSharedSecret]: 'description.computeSharedSecret',
-}
-
-const actionTranslations: { [x in SupportedActions]: string } = {
-  [SupportedActions.eth_accounts]: 'action.accounts',
-  [SupportedActions.eth_signTransaction]: 'action.signTransaction',
-  [SupportedActions.eth_sendTransaction]: 'action.sendTransaction',
-  [SupportedActions.eth_signTypedData]: 'action.sign',
-  [SupportedActions.eth_signTypedData_v4]: 'action.sign',
-  [SupportedActions.eth_sign]: 'action.sign',
-  [SupportedActions.personal_sign]: 'action.sign',
-  [SupportedActions.personal_decrypt]: 'action.decrypt',
-  [SupportedActions.computeSharedSecret]: 'action.computeSharedSecret',
-}
-
 export function isSupportedAction(action: string) {
-  return action in actionTranslations
+  return Object.values(SupportedActions).includes(action as SupportedActions)
 }
 
 export function getTranslationDescriptionFromAction(t: TFunction, action: SupportedActions) {
+  const actionDescriptionTranslations: { [action in SupportedActions]: string } = {
+    [SupportedActions.eth_accounts]: t('description.accounts'),
+    [SupportedActions.eth_signTransaction]: t('description.signTransaction'),
+    [SupportedActions.eth_sendTransaction]: t('description.sendTransaction'),
+    [SupportedActions.eth_signTypedData]: t('description.sign'),
+    [SupportedActions.eth_signTypedData_v4]: t('description.sign'),
+    [SupportedActions.eth_sign]: t('description.sign'),
+    [SupportedActions.personal_sign]: t('description.sign'),
+    [SupportedActions.personal_decrypt]: t('description.decrypt'),
+    [SupportedActions.computeSharedSecret]: t('description.computeSharedSecret'),
+  }
+
   const translationId = actionDescriptionTranslations[action]
   if (!translationId) {
     return ''
   }
 
-  return t(translationId)
+  return translationId
 }
 
 export function getTranslationFromAction(t: TFunction, action: SupportedActions) {
+  const actionTranslations: { [x in SupportedActions]: string } = {
+    [SupportedActions.eth_accounts]: t('action.accounts'),
+    [SupportedActions.eth_signTransaction]: t('action.signTransaction'),
+    [SupportedActions.eth_sendTransaction]: t('action.sendTransaction'),
+    [SupportedActions.eth_signTypedData]: t('action.sign'),
+    [SupportedActions.eth_signTypedData_v4]: t('action.sign'),
+    [SupportedActions.eth_sign]: t('action.sign'),
+    [SupportedActions.personal_sign]: t('action.sign'),
+    [SupportedActions.personal_decrypt]: t('action.decrypt'),
+    [SupportedActions.computeSharedSecret]: t('action.computeSharedSecret'),
+  }
+
   const translationId = actionTranslations[action]
   if (!translationId) {
     return ''
   }
 
-  return t(translationId)
+  return translationId
 }

--- a/packages/mobile/src/walletConnect/screens/ActionRequest.tsx
+++ b/packages/mobile/src/walletConnect/screens/ActionRequest.tsx
@@ -140,7 +140,7 @@ function ActionRequest({ navigation, route: { params: routeParams } }: Props) {
         <View style={styles.sectionDivider}>
           <Text style={styles.sectionHeaderText}>{t('action.operation')}</Text>
           <Text style={styles.bodyText}>
-            {getTranslationFromAction(method as SupportedActions)}
+            {getTranslationFromAction(t, method as SupportedActions)}
           </Text>
 
           {moreInfoString && (

--- a/packages/mobile/src/walletConnect/screens/SessionRequest.tsx
+++ b/packages/mobile/src/walletConnect/screens/SessionRequest.tsx
@@ -67,8 +67,10 @@ function deduplicateArray<T>(array: T[]) {
 }
 
 function ActionList({ actions }: { actions: string[] }) {
+  const { t } = useTranslation()
+
   const descriptions = deduplicateArray(
-    actions.map((a) => getTranslationDescriptionFromAction(a as SupportedActions))
+    actions.map((a) => getTranslationDescriptionFromAction(t, a as SupportedActions))
   )
 
   return (


### PR DESCRIPTION
### Description

Pass the `t` function from components to the static functions used to generate translations, to prevent translated strings from being initialised before the i18n instance is initialised and empty strings being rendered. 

### Other changes

N/A

### Tested

Manually



### Related issues

- Fixes https://github.com/valora-inc/wallet/issues/1557

### Backwards compatibility

N/A