### PR TITLE
remove direct calls to i18n.t when useTranslation hook is available

### DIFF
--- a/packages/mobile/src/account/Profile.tsx
+++ b/packages/mobile/src/account/Profile.tsx
@@ -47,7 +47,7 @@ function Profile({ navigation, route }: Props) {
 
     navigation.setOptions({
       headerRight: () => (
-        <TopBarTextButton title={i18n.t('save')} testID="SaveButton" onPress={onSave} />
+        <TopBarTextButton title={t('save')} testID="SaveButton" onPress={onSave} />
       ),
     })
   }, [navigation, newName, newPictureUri, picturePath])

--- a/packages/mobile/src/account/ShakeForSupport.tsx
+++ b/packages/mobile/src/account/ShakeForSupport.tsx
@@ -5,19 +5,20 @@ import colors from '@celo/react-components/styles/colors'
 import fontStyles from '@celo/react-components/styles/fonts'
 import variables from '@celo/react-components/styles/variables'
 import * as React from 'react'
+import { useTranslation } from 'react-i18next'
 import { StyleSheet, Text } from 'react-native'
 import Modal from 'react-native-modal'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import RNShake from 'react-native-shake'
 import { AppState } from 'src/app/actions'
 import { appStateSelector } from 'src/app/selectors'
-import i18n from 'src/i18n'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import useTypedSelector from 'src/redux/useSelector'
 import Logger from 'src/utils/Logger'
 
 export default function ShakeForSupport() {
+  const { t } = useTranslation()
   const appState = useTypedSelector(appStateSelector)
   const [isVisible, setIsVisible] = React.useState(false)
 
@@ -57,14 +58,14 @@ export default function ShakeForSupport() {
           <Times />
         </Touchable>
         <Text testID="HavingTrouble" style={styles.supportTitle}>
-          {i18n.t('havingTrouble')}
+          {t('havingTrouble')}
         </Text>
         <Text testID="ShakeForSupport" style={styles.supportSubtitle}>
-          {i18n.t('shakeForSupport')}
+          {t('shakeForSupport')}
         </Text>
         <Button
           onPress={onContactSupport}
-          text={i18n.t('contactSupport')}
+          text={t('contactSupport')}
           type={BtnTypes.PRIMARY}
           testID="ContactSupportFromShake"
         />

--- a/packages/mobile/src/components/CommentTextInput.tsx
+++ b/packages/mobile/src/components/CommentTextInput.tsx
@@ -1,9 +1,9 @@
 import colors from '@celo/react-components/styles/colors'
 import fontStyles from '@celo/react-components/styles/fonts'
 import * as React from 'react'
+import { useTranslation } from 'react-i18next'
 import { StyleSheet, TextInput } from 'react-native'
 import { MAX_COMMENT_LENGTH } from 'src/config'
-import i18n from 'src/i18n'
 
 interface Props {
   testID?: string
@@ -13,6 +13,8 @@ interface Props {
 }
 
 export default function CommentTextInput({ testID, onCommentChange, comment, onBlur }: Props) {
+  const { t } = useTranslation()
+
   return (
     <TextInput
       testID={`commentInput/${testID}`}
@@ -23,7 +25,7 @@ export default function CommentTextInput({ testID, onCommentChange, comment, onB
       maxLength={MAX_COMMENT_LENGTH}
       onChangeText={onCommentChange}
       value={comment}
-      placeholder={i18n.t('addDescription')}
+      placeholder={t('addDescription')}
       placeholderTextColor={colors.greenUI}
       returnKeyType={'done'}
       onBlur={onBlur}

--- a/packages/mobile/src/components/OptionsChooser.tsx
+++ b/packages/mobile/src/components/OptionsChooser.tsx
@@ -5,9 +5,9 @@ import colors from '@celo/react-components/styles/colors'
 import fontStyles from '@celo/react-components/styles/fonts'
 import { Spacing } from '@celo/react-components/styles/styles'
 import React, { useEffect } from 'react'
+import { useTranslation } from 'react-i18next'
 import { ActionSheetIOS, Platform, StyleSheet, Text, TouchableOpacity, View } from 'react-native'
 import Modal from 'src/components/Modal'
-import i18n from 'src/i18n'
 
 interface Props {
   isVisible: boolean
@@ -28,7 +28,8 @@ function OptionsChooser({
   onOptionChosen,
   onCancel,
 }: Props) {
-  const fullOptions = includeCancelButton ? [...options, i18n.t('cancel')] : options
+  const { t } = useTranslation()
+  const fullOptions = includeCancelButton ? [...options, t('cancel')] : options
   const cancelButtonIndex = includeCancelButton ? fullOptions.length - 1 : undefined
   const destructiveButtonIndex = isLastOptionDestructive
     ? (cancelButtonIndex || options.length) - 1

--- a/packages/mobile/src/exchange/ExchangeScreenHeader.tsx
+++ b/packages/mobile/src/exchange/ExchangeScreenHeader.tsx
@@ -2,13 +2,13 @@ import Touchable from '@celo/react-components/components/Touchable'
 import DownArrowIcon from '@celo/react-components/icons/DownArrowIcon'
 import colors from '@celo/react-components/styles/colors'
 import React, { useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { Keyboard, StyleSheet, Text, View } from 'react-native'
 import { CeloExchangeEvents } from 'src/analytics/Events'
 import BackButton from 'src/components/BackButton'
 import CustomHeader from 'src/components/header/CustomHeader'
 import TokenBottomSheetLegacy, { TokenPickerOrigin } from 'src/components/TokenBottomSheetLegacy'
 import { STABLE_TRANSACTION_MIN_AMOUNT } from 'src/config'
-import i18n from 'src/i18n'
 import { localCurrencyExchangeRatesSelector } from 'src/localCurrency/selectors'
 import { HeaderTitleWithBalance, styles as headerStyles } from 'src/navigator/Headers'
 import useSelector from 'src/redux/useSelector'
@@ -22,6 +22,7 @@ interface Props {
 }
 
 function ExchangeTradeScreenHeader({ currency, isCeloPurchase, onChangeCurrency }: Props) {
+  const { t } = useTranslation()
   const [showingTokenPicker, setShowTokenPicker] = useState(false)
 
   const onCurrencySelected = (currency: Currency) => {
@@ -44,9 +45,9 @@ function ExchangeTradeScreenHeader({ currency, isCeloPurchase, onChangeCurrency 
     let title
     const tokenPickerEnabled = currenciesWithBalance >= 2 || !isCeloPurchase
     if (!tokenPickerEnabled) {
-      title = i18n.t('buyGold')
+      title = t('buyGold')
     } else {
-      titleText = i18n.t('tokenBalance', { token: currency })
+      titleText = t('tokenBalance', { token: currency })
       title = (
         <View style={styles.titleContainer} testID="HeaderCurrencyPicker">
           <Text style={headerStyles.headerSubTitle}>{titleText}</Text>

--- a/packages/mobile/src/navigator/DrawerNavigator.tsx
+++ b/packages/mobile/src/navigator/DrawerNavigator.tsx
@@ -40,7 +40,6 @@ import { fetchExchangeRate } from 'src/exchange/actions'
 import ExchangeHomeScreen from 'src/exchange/ExchangeHomeScreen'
 import { features } from 'src/flags'
 import WalletHome from 'src/home/WalletHome'
-import i18n from 'src/i18n'
 import { AccountKey } from 'src/icons/navigator/AccountKey'
 import { AddWithdraw } from 'src/icons/navigator/AddWithdraw'
 import { Gold } from 'src/icons/navigator/Gold'
@@ -136,6 +135,7 @@ function CustomDrawerItemList({
 }
 
 function CustomDrawerContent(props: DrawerContentComponentProps<DrawerContentOptions>) {
+  const { t } = useTranslation()
   const displayName = useSelector(nameSelector)
   const e164PhoneNumber = useSelector(e164NumberSelector)
   const defaultCountryCode = useSelector(defaultCountryCodeSelector)
@@ -168,7 +168,7 @@ function CustomDrawerContent(props: DrawerContentComponentProps<DrawerContentOpt
       </View>
       <CustomDrawerItemList {...props} protectedRoutes={[Screens.BackupIntroduction]} />
       <View style={styles.drawerBottom}>
-        <Text style={fontStyles.label}>{i18n.t('address')}</Text>
+        <Text style={fontStyles.label}>{t('address')}</Text>
         <AccountNumber address={account || ''} location={Screens.DrawerNavigator} />
         <Text style={styles.smallLabel}>{`Version ${appVersion}`}</Text>
       </View>

--- a/packages/mobile/src/navigator/NavigatorWrapper.tsx
+++ b/packages/mobile/src/navigator/NavigatorWrapper.tsx
@@ -2,6 +2,7 @@ import colors from '@celo/react-components/styles/colors'
 import AsyncStorage from '@react-native-community/async-storage'
 import { DefaultTheme, NavigationContainer, NavigationState } from '@react-navigation/native'
 import * as React from 'react'
+import { useTranslation } from 'react-i18next'
 import { Share, StyleSheet, View } from 'react-native'
 import DeviceInfo from 'react-native-device-info'
 import { useDispatch, useSelector } from 'react-redux'
@@ -14,7 +15,6 @@ import { getAppLocked } from 'src/app/selectors'
 import UpgradeScreen from 'src/app/UpgradeScreen'
 import { doingBackupFlowSelector, shouldForceBackupSelector } from 'src/backup/selectors'
 import { DEV_RESTORE_NAV_STATE_ON_RELOAD, DYNAMIC_DOWNLOAD_LINK } from 'src/config'
-import i18n from 'src/i18n'
 import InviteFriendModal from 'src/invite/InviteFriendModal'
 import { navigate, navigationRef, navigatorIsReadyRef } from 'src/navigator/NavigationService'
 import Navigator from 'src/navigator/Navigator'
@@ -53,6 +53,7 @@ const AppTheme = {
 }
 
 export const NavigatorWrapper = () => {
+  const { t } = useTranslation()
   const [isReady, setIsReady] = React.useState(RESTORE_STATE ? false : true)
   const [initialState, setInitialState] = React.useState()
   const appLocked = useTypedSelector(getAppLocked)
@@ -155,7 +156,7 @@ export const NavigatorWrapper = () => {
   }
 
   const onInvite = async () => {
-    const message = i18n.t('inviteWithoutPayment', {
+    const message = t('inviteWithoutPayment', {
       link: DYNAMIC_DOWNLOAD_LINK,
     })
     ValoraAnalytics.track(InviteEvents.invite_from_menu)

--- a/packages/mobile/src/notifications/NotificationList.tsx
+++ b/packages/mobile/src/notifications/NotificationList.tsx
@@ -1,9 +1,9 @@
 import fontStyles from '@celo/react-components/styles/fonts'
 import variables from '@celo/react-components/styles/variables'
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 import { ScrollView, StyleSheet, Text, View } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
-import i18n from 'src/i18n'
 import { HeaderTitleWithBalance, headerWithBackButton } from 'src/navigator/Headers'
 import DisconnectBanner from 'src/shared/DisconnectBanner'
 import { Currency } from 'src/utils/currencies'
@@ -19,6 +19,7 @@ interface OwnProps<T> {
 type Props<T> = OwnProps<T>
 
 export function NotificationList<T>(props: Props<T>) {
+  const { t } = useTranslation()
   return (
     <SafeAreaView style={styles.container}>
       <DisconnectBanner />
@@ -27,7 +28,7 @@ export function NotificationList<T>(props: Props<T>) {
           <View style={styles.scrollArea}>{props.items.map(props.listItemRenderer)}</View>
         </ScrollView>
       ) : (
-        <Text style={[fontStyles.regular, styles.empty]}>{i18n.t('emptyList')}</Text>
+        <Text style={[fontStyles.regular, styles.empty]}>{t('emptyList')}</Text>
       )}
     </SafeAreaView>
   )

--- a/packages/mobile/src/onboarding/registration/NameAndPicture.tsx
+++ b/packages/mobile/src/onboarding/registration/NameAndPicture.tsx
@@ -15,7 +15,6 @@ import { OnboardingEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import { ErrorMessages } from 'src/app/ErrorMessages'
 import DevSkipButton from 'src/components/DevSkipButton'
-import i18n from 'src/i18n'
 import { HeaderTitleWithSubtitle, nuxNavigationOptions } from 'src/navigator/Headers'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
@@ -44,8 +43,8 @@ function NameAndPicture({ navigation }: Props) {
     navigation.setOptions({
       headerTitle: () => (
         <HeaderTitleWithSubtitle
-          title={i18n.t(choseToRestoreAccount ? 'restoreAccount' : 'createAccount')}
-          subTitle={i18n.t(choseToRestoreAccount ? 'restoreAccountSteps' : 'createAccountSteps', {
+          title={t(choseToRestoreAccount ? 'restoreAccount' : 'createAccount')}
+          subTitle={t(choseToRestoreAccount ? 'restoreAccountSteps' : 'createAccountSteps', {
             step: '1',
           })}
         />

--- a/packages/mobile/src/pincode/PincodeSet.tsx
+++ b/packages/mobile/src/pincode/PincodeSet.tsx
@@ -181,10 +181,10 @@ export class PincodeSet extends React.Component<Props, State> {
         const updated = await updatePin(this.props.account, this.state.oldPin, pin2)
         if (updated) {
           ValoraAnalytics.track(SettingsEvents.change_pin_new_pin_confirmed)
-          Logger.showMessage(i18n.t('pinChanged'))
+          Logger.showMessage(this.props.t('pinChanged'))
         } else {
           ValoraAnalytics.track(SettingsEvents.change_pin_new_pin_error)
-          Logger.showMessage(i18n.t('pinChangeFailed'))
+          Logger.showMessage(this.props.t('pinChangeFailed'))
         }
       } else {
         setCachedPin(DEFAULT_CACHE_ACCOUNT, pin1)
@@ -206,7 +206,7 @@ export class PincodeSet extends React.Component<Props, State> {
   }
 
   render() {
-    const { route } = this.props
+    const { route, t } = this.props
     const isVerifying = route.params?.isVerifying
     const changingPin = this.isChangingPin()
 
@@ -217,7 +217,7 @@ export class PincodeSet extends React.Component<Props, State> {
         <DevSkipButton onSkip={this.navigateToNextScreen} />
         {isVerifying ? (
           <Pincode
-            title={i18n.t('pincodeSet.verify')}
+            title={t('pincodeSet.verify')}
             errorText={errorText}
             pin={pin2}
             onChangePin={this.onChangePin2}
@@ -225,7 +225,7 @@ export class PincodeSet extends React.Component<Props, State> {
           />
         ) : (
           <Pincode
-            title={changingPin ? i18n.t('pincodeSet.createNew') : ' '}
+            title={changingPin ? t('pincodeSet.createNew') : ' '}
             errorText={errorText}
             pin={pin1}
             onChangePin={this.onChangePin1}

--- a/packages/mobile/src/send/SendAmount/SendAmountHeader.tsx
+++ b/packages/mobile/src/send/SendAmount/SendAmountHeader.tsx
@@ -1,10 +1,10 @@
 import React, { useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { StyleSheet, Text, View } from 'react-native'
 import { RequestEvents, SendEvents } from 'src/analytics/Events'
 import BackButton from 'src/components/BackButton'
 import CustomHeader from 'src/components/header/CustomHeader'
 import TokenBottomSheet, { TokenPickerOrigin } from 'src/components/TokenBottomSheet'
-import i18n from 'src/i18n'
 import { HeaderTitleWithTokenBalance, styles as headerStyles } from 'src/navigator/Headers'
 import useSelector from 'src/redux/useSelector'
 import TokenPickerSelector from 'src/send/SendAmount/TokenPickerSelector'
@@ -24,6 +24,7 @@ function SendAmountHeader({
   onChangeToken,
   disallowCurrencyChange,
 }: Props) {
+  const { t } = useTranslation()
   const [showingCurrencyPicker, setShowCurrencyPicker] = useState(false)
   const tokensWithBalance = useSelector(tokensWithBalanceSelector)
   const tokenInfo = useTokenInfo(tokenAddress)
@@ -48,11 +49,11 @@ function SendAmountHeader({
     let title
     if (!canChangeToken) {
       titleText = isOutgoingPaymentRequest
-        ? i18n.t('request')
-        : i18n.t('sendToken', { token: tokenInfo?.symbol })
+        ? t('request')
+        : t('sendToken', { token: tokenInfo?.symbol })
       title = titleText
     } else {
-      titleText = i18n.t('send')
+      titleText = t('send')
       title = (
         <View style={styles.titleContainer} testID="HeaderCurrencyPicker">
           <Text style={headerStyles.headerTitle}>{titleText}</Text>

--- a/packages/mobile/src/send/SendAmountLegacy/SendAmountHeader.tsx
+++ b/packages/mobile/src/send/SendAmountLegacy/SendAmountHeader.tsx
@@ -2,13 +2,13 @@ import Touchable from '@celo/react-components/components/Touchable'
 import DownArrowIcon from '@celo/react-components/icons/DownArrowIcon'
 import colors from '@celo/react-components/styles/colors'
 import React, { useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { StyleSheet, Text, View } from 'react-native'
 import { RequestEvents, SendEvents } from 'src/analytics/Events'
 import BackButton from 'src/components/BackButton'
 import CustomHeader from 'src/components/header/CustomHeader'
 import TokenBottomSheetLegacy, { TokenPickerOrigin } from 'src/components/TokenBottomSheetLegacy'
 import { STABLE_TRANSACTION_MIN_AMOUNT } from 'src/config'
-import i18n from 'src/i18n'
 import { localCurrencyExchangeRatesSelector } from 'src/localCurrency/selectors'
 import { HeaderTitleWithBalance, styles as headerStyles } from 'src/navigator/Headers'
 import useSelector from 'src/redux/useSelector'
@@ -28,6 +28,7 @@ function SendAmountHeader({
   onChangeCurrency,
   disallowCurrencyChange,
 }: Props) {
+  const { t } = useTranslation()
   const [showingCurrencyPicker, setShowCurrencyPicker] = useState(false)
   const balances = useSelector(balancesSelector)
   const exchangeRates = useSelector(localCurrencyExchangeRatesSelector)
@@ -52,10 +53,10 @@ function SendAmountHeader({
     let titleText
     let title
     if (currenciesWithBalance < 2 || isOutgoingPaymentRequest) {
-      titleText = isOutgoingPaymentRequest ? i18n.t('request') : i18n.t('send')
+      titleText = isOutgoingPaymentRequest ? t('request') : t('send')
       title = titleText
     } else {
-      titleText = i18n.t('sendToken', { token: currency })
+      titleText = t('sendToken', { token: currency })
       title = (
         <View style={styles.titleContainer} testID="HeaderCurrencyPicker">
           <Text style={headerStyles.headerTitle}>{titleText}</Text>

--- a/packages/mobile/src/send/SendConfirmationLegacy.tsx
+++ b/packages/mobile/src/send/SendConfirmationLegacy.tsx
@@ -32,7 +32,6 @@ import CalculateFee, {
 import { FeeType } from 'src/fees/reducer'
 import { FeeInfo } from 'src/fees/saga'
 import { getFeeInTokens } from 'src/fees/selectors'
-import i18n from 'src/i18n'
 import InfoIcon from 'src/icons/InfoIcon'
 import { fetchDataEncryptionKey } from 'src/identity/actions'
 import { getAddressValidationType, getSecureSendAddress } from 'src/identity/secureSend'
@@ -288,7 +287,7 @@ function SendConfirmationLegacy(props: Props) {
     if (type === TokenTransactionType.PayRequest || type === TokenTransactionType.PayPrefill) {
       primaryBtnInfo = {
         action: sendOrInvite,
-        text: i18n.t('pay'),
+        text: t('pay'),
         disabled: isPrimaryButtonDisabled,
       }
     } else {

--- a/packages/mobile/src/send/SendSearchInput.tsx
+++ b/packages/mobile/src/send/SendSearchInput.tsx
@@ -5,7 +5,6 @@ import { isValidAddress } from '@celo/utils/lib/address'
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import { StyleSheet, Text, View } from 'react-native'
-import i18n from 'src/i18n'
 
 const SearchInput = withTextSearchPasteAware(TextInput)
 
@@ -25,7 +24,7 @@ export function SendSearchInput({ input, onChangeText }: SendSearchInputProps) {
         placeholder={t('namePhoneAddress')}
         value={input}
         onChangeText={onChangeText}
-        leftIcon={<Text style={styles.leftIcon}>{i18n.t('to')}</Text>}
+        leftIcon={<Text style={styles.leftIcon}>{t('to')}</Text>}
       />
     </View>
   )

--- a/packages/mobile/src/tokens/TokenBalances.tsx
+++ b/packages/mobile/src/tokens/TokenBalances.tsx
@@ -4,10 +4,10 @@ import variables from '@celo/react-components/styles/variables'
 import { StackScreenProps } from '@react-navigation/stack'
 import BigNumber from 'bignumber.js'
 import React, { useLayoutEffect } from 'react'
+import { useTranslation } from 'react-i18next'
 import { Image, ScrollView, StyleSheet, Text, View } from 'react-native'
 import { useSelector } from 'react-redux'
 import TokenDisplay from 'src/components/TokenDisplay'
-import i18n from 'src/i18n'
 import { getLocalCurrencySymbol } from 'src/localCurrency/selectors'
 import { headerWithBackButton } from 'src/navigator/Headers'
 import { Screens } from 'src/navigator/Screens'
@@ -17,6 +17,7 @@ import { tokensWithBalanceSelector, totalTokenBalanceSelector } from 'src/tokens
 
 type Props = StackScreenProps<StackParamList, Screens.TokenBalances>
 function TokenBalancesScreen({ navigation }: Props) {
+  const { t } = useTranslation()
   const tokens = useSelector(tokensWithBalanceSelector)
   const localCurrencySymbol = useSelector(getLocalCurrencySymbol)
   const totalBalance = useSelector(totalTokenBalanceSelector)
@@ -24,7 +25,7 @@ function TokenBalancesScreen({ navigation }: Props) {
   const header = () => {
     return (
       <View style={styles.header}>
-        <Text style={fontStyles.navigationHeader}>{i18n.t('balances')}</Text>
+        <Text style={fontStyles.navigationHeader}>{t('balances')}</Text>
         <Text style={styles.subtext}>
           {localCurrencySymbol}
           {totalBalance?.toFormat(2)}


### PR DESCRIPTION
### Description

We should avoid calling the `t` function from i18n directly, because the imported `i18n` instance could be uninitialised depending on when it was imported. This causes empty or raw translation keys to be rendered in edge cases (see https://github.com/valora-inc/wallet/issues/1557 and https://github.com/valora-inc/wallet/pull/1561)

This PR makes the easy changes, to use the `t` function from the useTranslation hook when possible. We will need to find some ways of handling places where we do translations in .ts files and static functions (like navigation options) in the future.

### Other changes

N/A

### Tested

Manually tested the affected screens to see translations are still coming through

### How others should test

Same as above

### Related issues

N/A

### Backwards compatibility

N/A
