### PR TITLE
merge bundled translations with cached OTA translations on app load

### DIFF
--- a/packages/mobile/README.md
+++ b/packages/mobile/README.md
@@ -1,40 +1,42 @@
 # Mobile (Valora)
 
-  - [Overview](#overview)
-  - [Architecture](#architecture)
-  - [Setup](#setup)
-    - [iOS](#ios)
-      - [Enroll in the Apple Developer Program](#enroll-in-the-apple-developer-program)
-      - [Install Xcode](#install-xcode)
-      - [Install Cocopods, Bundler, and download project dependencies](#install-cocopods-bundler-and-download-project-dependencies)
-    - [Android](#android)
-      - [Install Java](#install-java)
-      - [Install Android Dev Tools](#install-android-dev-tools)
-      - [Optional: Install an Android emulator](#optional-install-an-android-emulator)
-  - [Running the mobile wallet](#running-the-mobile-wallet)
-    - [iOS](#ios-1)
-    - [Android](#android-1)
-    - [Running in forno (data saver) mode](<#running-in-forno-(data-saver)-mode>)
-  - [Debugging & App Profiling](#debugging--app-profiling)
-    - [Debugging](#debugging)
-      - [Optional: Install React Native Debugger](#optional-install-react-native-debugger)
-    - [App Profiling](#app-profiling)
-  - [Testing](#testing)
-    - [Snapshot testing](#snapshot-testing)
-    - [React component unit testing](#react-component-unit-testing)
-    - [Saga testing](#saga-testing)
-    - [End-to-End testing](#end-to-end-testing)
-  - [Building APKs / Bundles](#building-apks--bundles)
-    - [Creating a fake keystore](#creating-a-fake-keystore)
-    - [Building an APK or Bundle](#building-an-apk-or-bundle)
-  - [Other](#other)
-    - [Localization (l10n) / translation process](#localization-l10n--translation-process)
-    - [Configuring the SMS Retriever](#configuring-the-sms-retriever)
-    - [Generating GraphQL Types](#generating-graphql-types)
-    - [How we handle Geth crashes in wallet app on Android](#how-we-handle-geth-crashes-in-wallet-app-on-android)
-    - [Why do we use http(s) provider?](#why-do-we-use-https-provider)
-    - [Troubleshooting](#troubleshooting)
-      - [`Activity class {org.celo.mobile.staging/org.celo.mobile.MainActivity} does not exist.`](#activity-class-orgcelomobilestagingorgcelomobilemainactivity-does-not-exist)
+- [Overview](#overview)
+- [Architecture](#architecture)
+- [Setup](#setup)
+  - [iOS](#ios)
+    - [Enroll in the Apple Developer Program](#enroll-in-the-apple-developer-program)
+    - [Install Xcode](#install-xcode)
+    - [Install Cocopods, Bundler, and download project dependencies](#install-cocopods-bundler-and-download-project-dependencies)
+  - [Android](#android)
+    - [Install Java](#install-java)
+    - [Install Android Dev Tools](#install-android-dev-tools)
+    - [Optional: Install an Android emulator](#optional-install-an-android-emulator)
+- [Running the mobile wallet](#running-the-mobile-wallet)
+  - [iOS](#ios-1)
+  - [Android](#android-1)
+  - [Running in forno (data saver) mode](<#running-in-forno-(data-saver)-mode>)
+- [Debugging & App Profiling](#debugging--app-profiling)
+  - [Debugging](#debugging)
+    - [Optional: Install React Native Debugger](#optional-install-react-native-debugger)
+  - [App Profiling](#app-profiling)
+- [Testing](#testing)
+  - [Snapshot testing](#snapshot-testing)
+  - [React component unit testing](#react-component-unit-testing)
+  - [Saga testing](#saga-testing)
+  - [End-to-End testing](#end-to-end-testing)
+- [Building APKs / Bundles](#building-apks--bundles)
+  - [Creating a fake keystore](#creating-a-fake-keystore)
+  - [Building an APK or Bundle](#building-an-apk-or-bundle)
+- [Other](#other)
+  - [Localization (l10n) / translation process](#localization-l10n--translation-process)
+  - [Configuring the SMS Retriever](#configuring-the-sms-retriever)
+  - [Generating GraphQL Types](#generating-graphql-types)
+  - [How we handle Geth crashes in wallet app on Android](#how-we-handle-geth-crashes-in-wallet-app-on-android)
+  - [Why do we use http(s) provider?](#why-do-we-use-https-provider)
+  - [Attaching to the geth instance](#attaching-to-the-geth-instance)
+  - [Helpful hints for development](#helpful-hints-for-development)
+  - [Troubleshooting](#troubleshooting)
+    - [`Activity class {org.celo.mobile.staging/org.celo.mobile.MainActivity} does not exist.`](#activity-class-orgcelomobilestagingorgcelomobilemainactivity-does-not-exist)
 
 ## Overview
 
@@ -282,7 +284,8 @@ The below steps should help you successfully run the mobile wallet on either a U
 6. From the `packages/mobile` directory run `yarn run dev:android`.
 
 ### Running on Mainnet
-By default, the mobile wallet app runs on celo's testnet `alfajores`. To run the app on `mainnet`, supply an env flag, eg. `yarn run dev:ios -e mainnet`. The command will then run the app with the env file `.env.mainnet`. 
+
+By default, the mobile wallet app runs on celo's testnet `alfajores`. To run the app on `mainnet`, supply an env flag, eg. `yarn run dev:ios -e mainnet`. The command will then run the app with the env file `.env.mainnet`.
 
 ### Running in forno (data saver) mode
 
@@ -353,7 +356,7 @@ react components. It allows for deep rendering and interaction with the rendered
 tree to assert proper reactions to user interaction and input. See an example at
 [`src/send/SendAmount.test.tsx`] or read more about the [docs][rntl-docs].
 
-To run a single component test file: `yarn test Send.test.tsx` 
+To run a single component test file: `yarn test Send.test.tsx`
 
 ### Saga testing
 
@@ -478,6 +481,13 @@ To attach:
 
 1. Start geth's HTTP RPC server by setting the config variable `GETH_START_HTTP_RPC_SERVER` to true. This is meant for development purposes only and can be a serious vulnerability if used in production.
 2. Using a geth binary on your computer, run `geth attach http://<DEVICE_IP_ADDRESS>:8545`
+
+### Helpful hints for development
+
+We try to minimise the differences between running Valora in different modes and environments, however there are a few helpful things to know when developing the app.
+
+- Valora uses Crowdin Over-The-Air (OTA) content delivery to enable dynamic translation updates. The OTA translations are cached and used on subsequent app loads instead of the strings in the translation files of the app bundle. This means that during development, the app will not respond to manual changes of the translation.json files.
+- In development mode, analytics are disabled.
 
 ### Troubleshooting
 

--- a/packages/mobile/src/i18n/i18n.test.ts
+++ b/packages/mobile/src/i18n/i18n.test.ts
@@ -21,7 +21,7 @@ const handleSetupTests = () => {
 
   jest.mock('../../locales/en-US/translation.json', () => {
     enLoaded = true
-    return { someKey: 'Hi!' }
+    return { someKey: 'Hi!', someExtraKey: 'someExtraValue' }
   })
 
   jest.mock('../../locales/es-419/translation.json', () => {
@@ -80,7 +80,7 @@ describe('i18n', () => {
 
     it('displays the cached translation for default language (en-US)', () => {
       expect(i18n.t('someKey')).toEqual('Hello!')
-      expect(enLoaded).toBe(false)
+      expect(enLoaded).toBe(true)
       expect(esLoaded).toBe(false)
       expect(ptLoaded).toBe(false)
     })
@@ -91,6 +91,12 @@ describe('i18n', () => {
       expect(enLoaded).toBe(false)
       expect(esLoaded).toBe(false)
       expect(ptLoaded).toBe(true)
+    })
+
+    it('displays bundled translation values if they are missing from cached translations', () => {
+      // Note that this is a valid scenario for development
+      expect(i18n.t('someKey')).toEqual('Hello!')
+      expect(i18n.t('someExtraKey')).toEqual('someExtraValue')
     })
   })
 })

--- a/packages/mobile/src/i18n/index.ts
+++ b/packages/mobile/src/i18n/index.ts
@@ -1,6 +1,7 @@
 import locales from '@celo/mobile/locales'
 import hoistStatics from 'hoist-non-react-statics'
 import i18n, { Resource } from 'i18next'
+import _ from 'lodash'
 import {
   initReactI18next,
   WithTranslation,
@@ -17,7 +18,7 @@ async function getAvailableResources(cachedTranslations: Resource) {
   for (const [language, value] of Object.entries(locales)) {
     Object.defineProperty(resources, language, {
       get: () => ({
-        translation: cachedTranslations[language] || value!.strings.translation,
+        translation: _.merge(value!.strings.translation, cachedTranslations[language]),
       }),
       enumerable: true,
     })


### PR DESCRIPTION
### Description

During development you may need to add a new translation key as part of your new feature. While this feature/new translation key is not merged to main, it will not be registered in Crowdin and will therefore not come through as part of the OTA translations. As a result you'll see raw translation keys during development which doesn't give confidence that the feature is working correctly.

In this PR, when loading the resources, use the bundled translations as the base and merge cached OTA translations on top so that we can pick up the OTA changes but also have new translation keys that were added in the app.

Note that this means we always load the bundled resource for the selected language (as opposed to before when we could save this resource load if there are cached translations)

### Other changes

N/A

### Tested

Manually add a new key to the translation.json in feature branch and verify that it is displayed correctly in the app

### How others should test

Same as above

### Related issues

N/A

### Backwards compatibility

N/A