### PR TITLE
Remove strict mode from mergify configuration

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -12,7 +12,6 @@ pull_request_rules:
     actions:
       merge:
         method: squash 
-        strict: true
         commit_message: title+body
       delete_head_branch:
         force: False


### PR DESCRIPTION
### Description

strict mode is being deprecated and today (December 6th) there is a global brownout of the configuration, so none of our builds will pass today unless we fix this :) 

https://blog.mergify.com/strict-mode-deprecation/