### PR TITLE
Adding phone number not verified UI for link bank account page

### DIFF
--- a/packages/mobile/locales/base/translation.json
+++ b/packages/mobile/locales/base/translation.json
@@ -1108,5 +1108,10 @@
     }
   },
   "linkBankAccountSettingsTitle": "Link Bank Accounts",
-  "linkBankAccountSettingsValue": "Get Access"
+  "linkBankAccountSettingsValue": "Get Access",
+  "connectPhoneNumber": {
+    "title": "Connect phone number to continue",
+    "body": "Your phone number needs to be connected to verify your identity and link your bank account.",
+    "buttonText": "Connect"
+  }
 }

--- a/packages/mobile/src/account/ConnectPhoneNumberScreen.tsx
+++ b/packages/mobile/src/account/ConnectPhoneNumberScreen.tsx
@@ -4,8 +4,7 @@ import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import { Image, StyleSheet, Text, View } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
-// todo: change the image here
-import { celoEducation1 } from 'src/images/Images'
+import { getVerified } from 'src/images/Images'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 
@@ -22,7 +21,7 @@ export default function ConnectPhoneNumberScreen() {
     <SafeAreaView>
       <View style={styles.container}>
         <View>
-          <Image source={celoEducation1} style={styles.bodyImage} resizeMode="contain" />
+          <Image source={getVerified} style={styles.bodyImage} resizeMode="contain" />
 
           <Text style={styles.heading}>{t('connectPhoneNumber.title')}</Text>
           <Text style={styles.bodyText}>{t('connectPhoneNumber.body')}</Text>

--- a/packages/mobile/src/account/ConnectPhoneNumberScreen.tsx
+++ b/packages/mobile/src/account/ConnectPhoneNumberScreen.tsx
@@ -10,7 +10,6 @@ import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 
 function onPressConnectButton() {
-  console.log('connect button pressed lisa')
   navigate(Screens.VerificationEducationScreen, {
     hideOnboardingStep: true,
   })

--- a/packages/mobile/src/account/ConnectPhoneNumberScreen.tsx
+++ b/packages/mobile/src/account/ConnectPhoneNumberScreen.tsx
@@ -1,0 +1,63 @@
+import TextButton from '@celo/react-components/components/TextButton'
+import fontStyles from '@celo/react-components/styles/fonts'
+import * as React from 'react'
+import { useTranslation } from 'react-i18next'
+import { Image, StyleSheet, Text, View } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
+// todo: change the image here
+import { celoEducation1 } from 'src/images/Images'
+import { navigate } from 'src/navigator/NavigationService'
+import { Screens } from 'src/navigator/Screens'
+
+function onPressConnectButton() {
+  console.log('connect button pressed lisa')
+  navigate(Screens.VerificationEducationScreen, {
+    hideOnboardingStep: true,
+  })
+}
+
+export default function ConnectPhoneNumberScreen() {
+  const { t } = useTranslation()
+
+  return (
+    <SafeAreaView>
+      <View style={styles.container}>
+        <View>
+          <Image source={celoEducation1} style={styles.bodyImage} resizeMode="contain" />
+
+          <Text style={styles.heading}>{t('connectPhoneNumber.title')}</Text>
+          <Text style={styles.bodyText}>{t('connectPhoneNumber.body')}</Text>
+        </View>
+        <TextButton style={styles.connectButton} onPress={onPressConnectButton}>
+          {t('connectPhoneNumber.buttonText')}
+        </TextButton>
+      </View>
+    </SafeAreaView>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    marginHorizontal: 24,
+  },
+
+  heading: {
+    marginTop: 24,
+    ...fontStyles.h2,
+    textAlign: 'center',
+  },
+  bodyText: {
+    ...fontStyles.regular,
+    textAlign: 'center',
+    paddingTop: 16,
+    marginBottom: 24,
+  },
+  bodyImage: {
+    alignSelf: 'center',
+    marginBottom: 24,
+  },
+  connectButton: {
+    alignSelf: 'center',
+    justifyContent: 'center',
+  },
+})

--- a/packages/mobile/src/account/Settings.test.tsx
+++ b/packages/mobile/src/account/Settings.test.tsx
@@ -127,6 +127,24 @@ describe('Account', () => {
     expect(navigate).not.toHaveBeenCalled()
   })
 
+  it('navigate to connect phone number screen if phone number is not verified', async () => {
+    const tree = render(
+      <Provider
+        store={createMockStore({
+          app: {
+            linkBankAccountEnabled: true,
+            numberVerified: false,
+          },
+        })}
+      >
+        <Settings {...getMockStackScreenProps(Screens.Settings)} />
+      </Provider>
+    )
+
+    fireEvent.press(tree.getByTestId('linkBankAccountSettings'))
+    expect(navigate).toHaveBeenCalledWith(Screens.ConnectPhoneNumberScreen)
+  })
+
   it('navigate to LinkBankAccount screen with kycStatus', async () => {
     const tree = render(
       <Provider
@@ -144,6 +162,7 @@ describe('Account', () => {
             status: {},
           },
           app: {
+            numberVerified: true,
             linkBankAccountEnabled: true,
           },
         })}
@@ -153,6 +172,8 @@ describe('Account', () => {
     )
 
     fireEvent.press(tree.getByTestId('linkBankAccountSettings'))
-    expect(navigate).toHaveBeenCalled()
+    expect(navigate).toHaveBeenCalledWith(Screens.LinkBankAccountScreen, {
+      kycStatus: KycStatus.Completed,
+    })
   })
 })

--- a/packages/mobile/src/account/Settings.test.tsx
+++ b/packages/mobile/src/account/Settings.test.tsx
@@ -9,7 +9,7 @@ import { Screens } from 'src/navigator/Screens'
 import { Currency } from 'src/utils/currencies'
 import { KomenciAvailable } from 'src/verify/reducer'
 import { createMockStore, flushMicrotasksQueue, getMockStackScreenProps } from 'test/utils'
-import { mockE164Number, mockE164NumberPepper } from 'test/values'
+import { mockAccount, mockE164Number, mockE164NumberPepper } from 'test/values'
 
 const mockedEnsurePincode = ensurePincode as jest.Mock
 
@@ -127,13 +127,12 @@ describe('Account', () => {
     expect(navigate).not.toHaveBeenCalled()
   })
 
-  it('navigate to connect phone number screen if phone number is not verified', async () => {
+  it('navigate to connect phone number screen if mtwAddress is not present', async () => {
     const tree = render(
       <Provider
         store={createMockStore({
           app: {
             linkBankAccountEnabled: true,
-            numberVerified: false,
           },
         })}
       >
@@ -162,8 +161,10 @@ describe('Account', () => {
             status: {},
           },
           app: {
-            numberVerified: true,
             linkBankAccountEnabled: true,
+          },
+          web3: {
+            mtwAddress: mockAccount,
           },
         })}
       >

--- a/packages/mobile/src/account/Settings.tsx
+++ b/packages/mobile/src/account/Settings.tsx
@@ -87,6 +87,7 @@ interface StateProps {
   walletConnectEnabled: boolean
   linkBankAccountEnabled: boolean
   kycStatus: KycStatus | undefined
+  mtwAddress: string | null
 }
 
 type OwnProps = StackScreenProps<StackParamList, Screens.Settings>
@@ -114,6 +115,7 @@ const mapStateToProps = (state: RootState): StateProps => {
     walletConnectEnabled: v1 || v2,
     linkBankAccountEnabled: state.app.linkBankAccountEnabled,
     kycStatus: state.account.kycStatus,
+    mtwAddress: state.web3.mtwAddress,
   }
 }
 
@@ -378,7 +380,14 @@ export class Account extends React.Component<Props, State> {
   }
 
   render() {
-    const { t, i18n, numberVerified, verificationPossible, linkBankAccountEnabled } = this.props
+    const {
+      t,
+      i18n,
+      numberVerified,
+      verificationPossible,
+      linkBankAccountEnabled,
+      mtwAddress,
+    } = this.props
     const promptFornoModal = this.props.route.params?.promptFornoModal ?? false
     const promptConfirmRemovalModal = this.props.route.params?.promptConfirmRemovalModal ?? false
     const currentLanguage = locales[i18n.language]
@@ -404,9 +413,7 @@ export class Account extends React.Component<Props, State> {
             {linkBankAccountEnabled && (
               <SettingsItemTextValue
                 title={t('linkBankAccountSettingsTitle')}
-                onPress={
-                  numberVerified ? this.goToLinkBankAccount : this.goToNumberNotConnectScreen
-                }
+                onPress={mtwAddress ? this.goToLinkBankAccount : this.goToNumberNotConnectScreen}
                 value={t('linkBankAccountSettingsValue')}
                 isValueActionable={true}
                 testID="linkBankAccountSettings"

--- a/packages/mobile/src/account/Settings.tsx
+++ b/packages/mobile/src/account/Settings.tsx
@@ -161,6 +161,10 @@ export class Account extends React.Component<Props, State> {
     })
   }
 
+  goToNumberNotConnectScreen = () => {
+    navigate(Screens.ConnectPhoneNumberScreen)
+  }
+
   goToLanguageSetting = () => {
     this.props.navigation.navigate(Screens.Language, { nextScreen: this.props.route.name })
   }
@@ -400,7 +404,9 @@ export class Account extends React.Component<Props, State> {
             {linkBankAccountEnabled && (
               <SettingsItemTextValue
                 title={t('linkBankAccountSettingsTitle')}
-                onPress={this.goToLinkBankAccount}
+                onPress={
+                  numberVerified ? this.goToLinkBankAccount : this.goToNumberNotConnectScreen
+                }
                 value={t('linkBankAccountSettingsValue')}
                 isValueActionable={true}
                 testID="linkBankAccountSettings"

--- a/packages/mobile/src/navigator/Navigator.tsx
+++ b/packages/mobile/src/navigator/Navigator.tsx
@@ -4,6 +4,7 @@ import * as React from 'react'
 import { PixelRatio, Platform } from 'react-native'
 import SplashScreen from 'react-native-splash-screen'
 import AccountKeyEducation from 'src/account/AccountKeyEducation'
+import ConnectPhoneNumberScreen from 'src/account/ConnectPhoneNumberScreen'
 import GoldEducation from 'src/account/GoldEducation'
 import Licenses from 'src/account/Licenses'
 import LinkBankAccountScreen from 'src/account/LinkBankAccountScreen'
@@ -59,6 +60,7 @@ import {
   HeaderTitleWithBalance,
   headerWithBackButton,
   headerWithBackEditButtons,
+  headerWithCloseButton,
   noHeader,
   noHeaderGestureDisabled,
 } from 'src/navigator/Headers'
@@ -441,6 +443,11 @@ const settingsScreens = (Navigator: typeof Stack) => (
       name={Screens.LinkBankAccountScreen}
       component={LinkBankAccountScreen}
       options={headerWithBackButton}
+    />
+    <Navigator.Screen
+      name={Screens.ConnectPhoneNumberScreen}
+      component={ConnectPhoneNumberScreen}
+      options={headerWithCloseButton}
     />
     <Navigator.Screen
       name={Screens.WalletConnectSessions}

--- a/packages/mobile/src/navigator/Screens.tsx
+++ b/packages/mobile/src/navigator/Screens.tsx
@@ -8,6 +8,7 @@ export enum Screens {
   BackupQuiz = 'BackupQuiz',
   BidaliScreen = 'BidaliScreen',
   CashInSuccess = 'CashInSuccess',
+  ConnectPhoneNumberScreen = 'ConnectPhoneNumberScreen',
   ConsumerIncentivesHomeScreen = 'ConsumerIncentivesHomeScreen',
   DappKitAccountAuth = 'DappKitAccountAuth',
   DappKitSignTxScreen = 'DappKitSignTxScreen',

--- a/packages/mobile/src/navigator/types.tsx
+++ b/packages/mobile/src/navigator/types.tsx
@@ -287,6 +287,7 @@ export type StackParamList = {
       }
     | undefined
   [Screens.LinkBankAccountScreen]: { kycStatus: KycStatus | undefined }
+  [Screens.ConnectPhoneNumberScreen]: undefined
   [Screens.VerificationInputScreen]:
     | { showHelpDialog?: boolean; choseToRestoreAccount?: boolean }
     | undefined


### PR DESCRIPTION
### Description
Design: https://www.figma.com/file/DAcpLsmPdeHT9Gt4eXhtWe/Finclusive-(US)?node-id=952%3A18424
Adding a UI screen for link bank account page when phone number is not verified.

### Tested

unit tested

### Related issues

- Fixes #1553


![263537482_588928148859517_8726079532472956389_n](https://user-images.githubusercontent.com/3597818/144979981-65f3e5d3-0f9a-44a9-988d-f5447c10009f.jpeg)
 
