### PR TITLE
add app version to firebase registrations node

### DIFF
--- a/packages/mobile/src/firebase/db-rules.json
+++ b/packages/mobile/src/firebase/db-rules.json
@@ -26,6 +26,9 @@
         "language": {
           ".write": "auth.uid != null && $address === root.child('users').child(auth.uid).child('address').val()"
         },
+        "appVersion": {
+          ".write": "auth.uid != null && $address === root.child('users').child(auth.uid).child('address').val()"
+        },
         "dailyLimitCusd": {
           ".write": false,
           ".validate": "newData.isNumber() && newData.val() >= 500"


### PR DESCRIPTION
### Description

Add app version as a new property in the registrations node so that we can capture the app version in the Firebase RTDB and manage backwards compatibility with our BE services.

The immediate use case for this is push notifications for all supported tokens - as the push notifications allow a deep link into the app, we want to prevent incompatible notifications from being sent to the app. In the future this will be useful for feature support for various app versions.

This PR only adds the new db property, as this needs to be deployed before we can test writing to it.

