### PR TITLE
Avoid capturing an exception when the state is undefined

### DIFF
--- a/packages/mobile/src/utils/accountChecker.test.ts
+++ b/packages/mobile/src/utils/accountChecker.test.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/react-native'
 import * as Keychain from 'react-native-keychain'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import { deleteNodeData } from 'src/geth/geth'
@@ -22,6 +23,7 @@ describe('resetStateOnInvalidStoredAccount', () => {
 
     expect(result === state).toEqual(true)
     expect(deleteNodeData).toHaveBeenCalledTimes(0)
+    expect(Sentry.captureException).toHaveBeenCalledTimes(0)
   })
 
   it('returns the same state when given an invalid state', async () => {
@@ -30,6 +32,16 @@ describe('resetStateOnInvalidStoredAccount', () => {
 
     expect(result === invalidState).toEqual(true)
     expect(deleteNodeData).toHaveBeenCalledTimes(0)
+    expect(Sentry.captureException).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns the same state when given an undefined state', async () => {
+    const result = await resetStateOnInvalidStoredAccount(undefined)
+
+    expect(result === undefined).toEqual(true)
+    expect(deleteNodeData).toHaveBeenCalledTimes(0)
+    // This is normal flow, we don't epect an exception
+    expect(Sentry.captureException).toHaveBeenCalledTimes(0)
   })
 
   it("returns the same state when there's an account and a matching password hash in the keychain", async () => {
@@ -46,6 +58,7 @@ describe('resetStateOnInvalidStoredAccount', () => {
 
     expect(result === state).toEqual(true)
     expect(deleteNodeData).toHaveBeenCalledTimes(0)
+    expect(Sentry.captureException).toHaveBeenCalledTimes(0)
   })
 
   it("returns an undefined state when there's an account and no matching password hash in the keychain", async () => {
@@ -56,6 +69,7 @@ describe('resetStateOnInvalidStoredAccount', () => {
 
     expect(result === undefined).toEqual(true)
     expect(deleteNodeData).toHaveBeenCalledTimes(1)
+    expect(Sentry.captureException).toHaveBeenCalledTimes(0)
     expect(ValoraAnalytics.track).toHaveBeenCalledWith('redux_no_matching_keychain_account', {
       walletAddress: '0x0000000000000000000000000000000000007e57',
     })

--- a/packages/mobile/src/utils/accountChecker.test.ts
+++ b/packages/mobile/src/utils/accountChecker.test.ts
@@ -40,7 +40,7 @@ describe('resetStateOnInvalidStoredAccount', () => {
 
     expect(result === undefined).toEqual(true)
     expect(deleteNodeData).toHaveBeenCalledTimes(0)
-    // This is normal flow, we don't epect an exception
+    // This is normal flow, we don't expect an exception
     expect(Sentry.captureException).toHaveBeenCalledTimes(0)
   })
 

--- a/packages/mobile/src/utils/accountChecker.ts
+++ b/packages/mobile/src/utils/accountChecker.ts
@@ -46,9 +46,9 @@ export function* checkAccountExistenceSaga() {
 // Note: this function is meant to be used before the redux state has been rehydrated.
 // With the way the app init is currently done, this was the less disruptive place.
 // I tried adding this to checkAccountExistenceSaga above, but it was causing issues because of sagas initializing in parallel.
-export async function resetStateOnInvalidStoredAccount(state: RootState) {
+export async function resetStateOnInvalidStoredAccount(state: RootState | undefined) {
   try {
-    const walletAddress = walletAddressSelector(state)
+    const walletAddress = state && walletAddressSelector(state)
     Logger.info(TAG, `Stored wallet address: ${walletAddress}`)
     if (walletAddress) {
       let passwordHash


### PR DESCRIPTION
### Description

Follow up to #1539, I missed the case where the state is undefined on the first app launch.
This would have caused seeing a lot of false positive Sentry exceptions around this.

### Tested

Updated unit tests.

### How others should test

N/A

### Related issues

- #729

### Backwards compatibility

Yes