### PR TITLE
Misc E2E: Test ID's and update to fund-e2e-accounts.sh

### DIFF
--- a/packages/mobile/e2e/scripts/fund-e2e-accounts.ts
+++ b/packages/mobile/e2e/scripts/fund-e2e-accounts.ts
@@ -12,6 +12,20 @@ const valoraTestFaucetSecret = process.env.TEST_FAUCET_SECRET
 const web3 = new Web3('https://alfajores-forno.celo-testnet.org')
 const kit = ContractKit.newKitFromWeb3(web3)
 
+// Throw error if balance is low
+const balanceError = async (address = valoraE2ETestWallet, minBalance = 10) => {
+  try {
+    let balanceObject = await getBalance(address)
+    for (const balance in balanceObject) {
+      if (balanceObject[balance] < minBalance) {
+        throw new Error(`Balance of ${address} is below ${minBalance}`)
+      }
+    }
+  } catch (err) {
+    console.log(err)
+  }
+}
+
 // Default e2e address to lookup
 const getBalance = async (address = valoraE2ETestWallet) => {
   try {
@@ -85,4 +99,5 @@ const getBalance = async (address = valoraE2ETestWallet) => {
   console.table(await getBalance())
   console.log('Valora Test Facuet')
   console.table(await getBalance(valoraTestFaucet))
+  await balanceError()
 })()

--- a/packages/mobile/e2e/src/usecases/NewAccountPhoneVerification.js
+++ b/packages/mobile/e2e/src/usecases/NewAccountPhoneVerification.js
@@ -64,7 +64,7 @@ export default NewAccountPhoneVerification = () => {
 
   // Check that Twilio SID, Auth Token and Verification Phone Number are defined
   if (TWILIO_ACCOUNT_SID && TWILIO_AUTH_TOKEN && VERIFICATION_PHONE_NUMBER) {
-    // Conditionally skipping jest tests with an async request is currently possible
+    // Conditionally skipping jest tests with an async request is currently not possible
     // https://github.com/facebook/jest/issues/7245
     // https://github.com/facebook/jest/issues/11489
     // Either fix or move to nightly tests when present
@@ -167,6 +167,7 @@ export default NewAccountPhoneVerification = () => {
     })
   }
 
+  // TODO(tomm): use translations file instead of hardcoded strings
   // Assert correct content is visible on the phone verification screen
   jest.retryTimes(1)
   it('Then should have correct phone verification screen', async () => {
@@ -182,28 +183,35 @@ export default NewAccountPhoneVerification = () => {
     await element(by.text('Do I need to confirm?')).tap()
 
     // Assert modal content is visible
-    await expect(element(by.text('Phone Numbers and Valora'))).toBeVisible()
-    await expect(
-      element(
-        by.text(
-          'Confirming makes it easy to connect with your friends by allowing you to send and receive funds to your phone number.\n\nCan I do this later?\n\nYes, but unconfirmed accounts can only send payments with QR codes or Account Addresses.\n\nSecure and Private\n\nValora uses state of the art cryptography to keep your phone number private.'
-        )
-      )
-    ).toBeVisible()
+    await waitFor(element(by.id('VerificationLearnMoreDialog')))
+      .toBeVisible()
+      .withTimeout(10 * 1000)
+    // TODO(tomm): use translations file to grab expected text
+    // await expect(element(by.text('Phone Numbers and Valora'))).toBeVisible()
+    // await expect(
+    //   element(
+    //     by.text(
+    //       'Confirming makes it easy to connect with your friends by allowing you to send and receive funds to your phone number.\n\nCan I do this later?\n\nYes, but unconfirmed accounts can only send payments with QR codes or Account Addresses.\n\nSecure and Private\n\nValora uses state of the art cryptography to keep your phone number private.'
+    //     )
+    //   )
+    // ).toBeVisible()
 
     // Assert able to dismiss modal and skip
     await element(by.text('Dismiss')).tap()
     await element(by.text('Skip')).tap()
 
-    // Assert modal contents of 'Are you Sure?' modal are visible
-    await expect(element(by.text('Are you sure?'))).toBeVisible()
-    await expect(
-      element(
-        by.text(
-          'Confirming allows you to send and receive funds easily to your phone number.\n\nUnconfirmed accounts can only send payments using Celo addresses or QR codes.'
-        )
-      )
-    ).toBeVisible()
+    // Assert VerificationSkipDialog modal visible
+    await waitFor(element(by.id('VerificationSkipDialog')))
+      .toBeVisible()
+      .withTimeout(10 * 1000)
+    // await expect(element(by.text('Are you sure?'))).toBeVisible()
+    // await expect(
+    //   element(
+    //     by.text(
+    //       'Confirming allows you to send and receive funds easily to your phone number.\n\nUnconfirmed accounts can only send payments using Celo addresses or QR codes.'
+    //     )
+    //   )
+    // ).toBeVisible()
 
     // Assert Back button is enabled
     let goBackButtonAttributes = await element(by.text('Go Back')).getAttributes()

--- a/packages/mobile/e2e/src/usecases/OffRamps.js
+++ b/packages/mobile/e2e/src/usecases/OffRamps.js
@@ -37,9 +37,9 @@ export default offRamps = () => {
         // Got To Exchanges
         await element(by.id('FiatExchangeNextButton')).tap()
         // Check Page Elements
-        await expect(element(by.id('noProviders'))).toHaveText(
-          'There are no providers available for cUSD in your region.'
-        )
+        await waitFor(element(by.id('noProviders')))
+          .toBeVisible()
+          .withTimeout(10 * 1000)
         await expect(element(by.id('ContactSupport'))).toBeVisible()
 
         // Check Screenshot

--- a/packages/mobile/src/verify/VerificationLearnMoreDialog.tsx
+++ b/packages/mobile/src/verify/VerificationLearnMoreDialog.tsx
@@ -13,6 +13,7 @@ export default function VerificationLearnMoreDialog({ isVisible, onPressDismiss 
   const { t } = useTranslation()
   return (
     <Dialog
+      testID="VerificationLearnMoreDialog"
       title={t('verificationLearnMoreDialog.title')}
       isVisible={isVisible}
       actionText={t('verificationLearnMoreDialog.dismiss')}

--- a/packages/mobile/src/verify/__snapshots__/VerificationEducationScreen.test.tsx.snap
+++ b/packages/mobile/src/verify/__snapshots__/VerificationEducationScreen.test.tsx.snap
@@ -1107,6 +1107,7 @@ exports[`VerificationEducationScreen shows the \`continue\` button when the user
       ]
     }
     swipeThreshold={100}
+    testID="VerificationLearnMoreDialog"
     transparent={true}
     visible={false}
   >
@@ -1166,6 +1167,7 @@ exports[`VerificationEducationScreen shows the \`continue\` button when the user
         ]
       }
       swipeThreshold={100}
+      testID="VerificationLearnMoreDialog"
     >
       <RNCSafeAreaView>
         <View
@@ -1283,6 +1285,7 @@ exports[`VerificationEducationScreen shows the \`continue\` button when the user
               onResponderTerminate={[Function]}
               onResponderTerminationRequest={[Function]}
               onStartShouldSetResponder={[Function]}
+              testID="VerificationLearnMoreDialog/PrimaryAction"
             >
               <Text
                 style={
@@ -2155,6 +2158,7 @@ exports[`VerificationEducationScreen shows the \`continue\` button when the user
       ]
     }
     swipeThreshold={100}
+    testID="VerificationLearnMoreDialog"
     transparent={true}
     visible={false}
   >
@@ -2214,6 +2218,7 @@ exports[`VerificationEducationScreen shows the \`continue\` button when the user
         ]
       }
       swipeThreshold={100}
+      testID="VerificationLearnMoreDialog"
     >
       <RNCSafeAreaView>
         <View
@@ -2331,6 +2336,7 @@ exports[`VerificationEducationScreen shows the \`continue\` button when the user
               onResponderTerminate={[Function]}
               onResponderTerminationRequest={[Function]}
               onStartShouldSetResponder={[Function]}
+              testID="VerificationLearnMoreDialog/PrimaryAction"
             >
               <Text
                 style={
@@ -3203,6 +3209,7 @@ exports[`VerificationEducationScreen shows the \`skip\` button when already veri
       ]
     }
     swipeThreshold={100}
+    testID="VerificationLearnMoreDialog"
     transparent={true}
     visible={false}
   >
@@ -3262,6 +3269,7 @@ exports[`VerificationEducationScreen shows the \`skip\` button when already veri
         ]
       }
       swipeThreshold={100}
+      testID="VerificationLearnMoreDialog"
     >
       <RNCSafeAreaView>
         <View
@@ -3379,6 +3387,7 @@ exports[`VerificationEducationScreen shows the \`skip\` button when already veri
               onResponderTerminate={[Function]}
               onResponderTerminationRequest={[Function]}
               onStartShouldSetResponder={[Function]}
+              testID="VerificationLearnMoreDialog/PrimaryAction"
             >
               <Text
                 style={
@@ -4251,6 +4260,7 @@ exports[`VerificationEducationScreen shows the \`skip\` button when user is not 
       ]
     }
     swipeThreshold={100}
+    testID="VerificationLearnMoreDialog"
     transparent={true}
     visible={false}
   >
@@ -4310,6 +4320,7 @@ exports[`VerificationEducationScreen shows the \`skip\` button when user is not 
         ]
       }
       swipeThreshold={100}
+      testID="VerificationLearnMoreDialog"
     >
       <RNCSafeAreaView>
         <View
@@ -4427,6 +4438,7 @@ exports[`VerificationEducationScreen shows the \`skip\` button when user is not 
               onResponderTerminate={[Function]}
               onResponderTerminationRequest={[Function]}
               onStartShouldSetResponder={[Function]}
+              testID="VerificationLearnMoreDialog/PrimaryAction"
             >
               <Text
                 style={


### PR DESCRIPTION
### Description

Add a testID to the verification learn more model and assert based on testID presence or absence instead of displayed text which can change in Crowdin.

### Other changes

- Updated snapshots.
- E2E tests will now fail prior to running if balance of the e2e test wallet is below 10 for any currency prior to running the e2e tests. This should allow e2e test runs to fail prior to running Detox.

### Tested

E2E Tests and unit tests run locally.

### How others should test

This does not need to be tested by QA.

### Related issues

N/A

### Backwards compatibility

Yes