### PR TITLE
Cancel in progress runs of workflows to avoid building outdated code

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,6 +8,12 @@ on:
   # ..and any pull request.
   pull_request:
 
+# Cancel any in progress run of the workflow for a given PR
+# This avoids building outdated code
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   vulnerability:
     name: Vulnerabilities

--- a/.github/workflows/e2e-android.yml
+++ b/.github/workflows/e2e-android.yml
@@ -9,14 +9,20 @@ on:
   workflow_dispatch:
     inputs:
       logLevel:
-        description: 'Log level'     
+        description: 'Log level'
         required: true
         default: 'warning'
       tags:
         description: 'End-to-end Tests'
   # Cron job to run e2e tests @ 8:30 pm daily on the latest commit on the default branch - main
   schedule:
-    - cron: "30 20 * * *"
+    - cron: '30 20 * * *'
+
+# Cancel any in progress run of the workflow for a given PR
+# This avoids building outdated code
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
 
 jobs:
   android:
@@ -40,14 +46,14 @@ jobs:
           TWILIO_AUTH_TOKEN: ${{ secrets.TWILIO_AUTH_TOKEN }}
           TWILIO_ACCOUNT_SID: ${{ secrets.TWILIO_ACCOUNT_SID }}
           VERIFICATION_PHONE_NUMBER: ${{ secrets.VERIFICATION_PHONE_NUMBER }}
-        run : |
+        run: |
           cd packages/mobile/e2e
           echo TEST_FAUCET_SECRET=$TEST_FAUCET_SECRET >> .env
           echo TWILIO_AUTH_TOKEN=$TWILIO_AUTH_TOKEN >> .env
           echo TWILIO_ACCOUNT_SID=$TWILIO_ACCOUNT_SID >> .env
           echo VERIFICATION_PHONE_NUMBER=$VERIFICATION_PHONE_NUMBER >> .env
       - name: Fund E2E accounts
-        run : |
+        run: |
           cd packages/mobile/e2e/scripts
           node ./fund-e2e-accounts.ts
       - name: Run E2E tests
@@ -65,7 +71,7 @@ jobs:
         if: always()
         uses: mikepenz/action-junit-report@v2
         with:
-          check_name: Android e2e Test Report 
+          check_name: Android e2e Test Report
           report_paths: 'packages/mobile/e2e/test-results/junit.xml'
       # Upload Artifacts
       - name: 'Upload Android E2E Artifacts'

--- a/.github/workflows/e2e-ios.yml
+++ b/.github/workflows/e2e-ios.yml
@@ -9,14 +9,20 @@ on:
   workflow_dispatch:
     inputs:
       logLevel:
-        description: 'Log level'     
+        description: 'Log level'
         required: true
         default: 'warning'
       tags:
         description: 'End-to-end Tests'
   # Cron job to run e2e tests @ 8:30 pm daily on the latest commit on the default branch - main
   schedule:
-    - cron: "30 20 * * *"
+    - cron: '30 20 * * *'
+
+# Cancel any in progress run of the workflow for a given PR
+# There's no need building outdated code
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
 
 jobs:
   ios:
@@ -46,14 +52,14 @@ jobs:
           TWILIO_AUTH_TOKEN: ${{ secrets.TWILIO_AUTH_TOKEN }}
           TWILIO_ACCOUNT_SID: ${{ secrets.TWILIO_ACCOUNT_SID }}
           VERIFICATION_PHONE_NUMBER: ${{ secrets.VERIFICATION_PHONE_NUMBER }}
-        run : |
+        run: |
           cd packages/mobile/e2e
           echo TEST_FAUCET_SECRET=$TEST_FAUCET_SECRET >> .env
           echo TWILIO_AUTH_TOKEN=$TWILIO_AUTH_TOKEN >> .env
           echo TWILIO_ACCOUNT_SID=$TWILIO_ACCOUNT_SID >> .env
           echo VERIFICATION_PHONE_NUMBER=$VERIFICATION_PHONE_NUMBER >> .env
       - name: Fund E2E accounts
-        run : |
+        run: |
           cd packages/mobile/e2e/scripts
           node ./fund-e2e-accounts.ts
       - name: Run E2E tests
@@ -66,7 +72,7 @@ jobs:
         if: always()
         uses: mikepenz/action-junit-report@v2
         with:
-          check_name: iOS e2e Test Report 
+          check_name: iOS e2e Test Report
           report_paths: 'packages/mobile/e2e/test-results/junit.xml'
       # Upload Artifacts
       - name: 'Upload iOS E2E Artifacts'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,12 @@ on:
   # ..and any pull request.
   pull_request:
 
+# Cancel any in progress run of the workflow for a given PR
+# This avoids building outdated code
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   general:
     name: General
@@ -40,7 +46,7 @@ jobs:
         uses: codecov/codecov-action@v2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-    
+
   mobile:
     name: Mobile
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Description

Cancel in progress runs of workflows to avoid building outdated code.
This should help speed up CI runs a little when commits are pushed before the last run finished.

See https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#concurrency

Note: also formatted the yaml files with prettier.
