### PR TITLE
Throw Error for Low E2E Funds & iOS tests for deep link send

### DIFF
--- a/packages/mobile/e2e/scripts/fund-e2e-accounts.ts
+++ b/packages/mobile/e2e/scripts/fund-e2e-accounts.ts
@@ -14,15 +14,11 @@ const kit = ContractKit.newKitFromWeb3(web3)
 
 // Throw error if balance is low
 const balanceError = async (address = valoraE2ETestWallet, minBalance = 10) => {
-  try {
-    let balanceObject = await getBalance(address)
-    for (const balance in balanceObject) {
-      if (balanceObject[balance] < minBalance) {
-        throw new Error(`Balance of ${address} is below ${minBalance}`)
-      }
+  let balanceObject = await getBalance(address)
+  for (const balance in balanceObject) {
+    if (balanceObject[balance] < minBalance) {
+      throw new Error(`Balance of ${address} is below ${minBalance}`)
     }
-  } catch (err) {
-    console.log(err)
   }
 }
 

--- a/packages/mobile/e2e/src/DeepLinkSend.spec.js
+++ b/packages/mobile/e2e/src/DeepLinkSend.spec.js
@@ -1,6 +1,10 @@
 import HandleDeepLinkSend from './usecases/HandleDeepLinkSend'
+import { quickOnboarding } from './utils/utils'
 
 describe('Deep link without account send', () => {
+  beforeAll(async () => {
+    await quickOnboarding()
+  })
   // The behavior for this case is not really specified yet
   // we kind of know what we want to happen but the code is not there yet
   // added this test case as a reminder to fix that

--- a/packages/mobile/e2e/src/usecases/HandleDeepLinkSend.js
+++ b/packages/mobile/e2e/src/usecases/HandleDeepLinkSend.js
@@ -1,4 +1,4 @@
-import { quote, sleep } from '../utils/utils'
+import { quote, sleep, inputNumberKeypad } from '../utils/utils'
 import { dismissBanners } from '../utils/banners'
 import { reloadReactNative, launchApp } from '../utils/retries'
 
@@ -15,34 +15,37 @@ export default HandleDeepLinkSend = () => {
     await dismissBanners()
     // Arrived at SendAmount screen
     await expect(element(by.id('Review'))).toBeVisible()
+
+    // Enter amount and tap review
+    await inputNumberKeypad('1.5')
+    await element(by.id('Review')).tap()
+
+    // Correct name displayed
+    await expect(element(by.text('Crypto4BlackLives'))).toBeVisible()
   })
 
-  it.skip('Send url while app is in background, back pressed', async () => {
-    // on android there are two ways to "exit" the app
-    // 1. home button
-    // 2. back button
-    // there is a slight but important difference because with the back button
-    // the activity gets destroyed and listeners go away which can cause subtle bugs
+  it(':ios: Send url while app is in background, home pressed', async () => {
     await reloadReactNative()
-    if (device.getPlatform() === 'android') {
-      await device.pressBack()
-    } else {
-      await device.sendToHome()
-    }
-    await launchApp({ url: PAY_URL, newInstance: false })
-    await expect(element(by.id('Review'))).toBeVisible()
-  })
-
-  // skip until we can have a firebase build on ci
-  it.skip('Send url while app is in foreground', async () => {
-    await device.openURL({ url: PAY_URL })
-    await expect(element(by.id('Review'))).toBeVisible()
-  })
-
-  // skip until we can have a firebase build on ci
-  it.skip('Send url while app is in background, process running', async () => {
     await device.sendToHome()
+    await device.launchApp({ url: PAY_URL, newInstance: false })
+  })
+
+  // On Android there are two ways to "exit" the app
+  // 1. home button
+  // 2. back button
+  // there is a slight but important difference because with the back button
+  // the activity gets destroyed and listeners go away which can cause subtle bugs
+  it.skip(':android: Send url while app is in background, back pressed', async () => {
+    await reloadReactNative()
+    await device.pressBack()
     await launchApp({ url: PAY_URL, newInstance: false })
+    await expect(element(by.id('Review'))).toBeVisible()
+  })
+
+  // Skip on Android until we can have a firebase build on ci
+  it(':ios: Send url while app is in foreground', async () => {
+    await reloadReactNative()
+    await device.openURL({ url: PAY_URL })
     await expect(element(by.id('Review'))).toBeVisible()
   })
 }


### PR DESCRIPTION
### Description

- Removes error catch in`fund-e2e-accounts.ts`.
- Enables additional deep link send tests for iOS.

### Other changes

N/A

### Tested

Tested locally and in CI.


### How others should test

This does not need to best tested by QA.

### Related issues

N/A

### Backwards compatibility

Yes