### PR TITLE
feat: tracking event for when no cico options are shown

### DIFF
--- a/packages/mobile/src/analytics/Events.tsx
+++ b/packages/mobile/src/analytics/Events.tsx
@@ -353,6 +353,7 @@ export enum FiatExchangeEvents {
   external_exchange_link = 'external_exchange_link',
   spend_merchant_link = 'spend_merchant_link',
 
+  cico_no_provider_options = 'cico_no_provider_options',
   cico_option_chosen = 'cico_option_chosen',
   provider_chosen = 'provider_chosen',
   cash_in_success = 'cash_in_success',

--- a/packages/mobile/src/analytics/Events.tsx
+++ b/packages/mobile/src/analytics/Events.tsx
@@ -353,7 +353,7 @@ export enum FiatExchangeEvents {
   external_exchange_link = 'external_exchange_link',
   spend_merchant_link = 'spend_merchant_link',
 
-  cico_no_provider_options = 'cico_no_provider_options',
+  cico_num_provider_options = 'cico_num_provider_options',
   cico_option_chosen = 'cico_option_chosen',
   provider_chosen = 'provider_chosen',
   cash_in_success = 'cash_in_success',

--- a/packages/mobile/src/analytics/Properties.tsx
+++ b/packages/mobile/src/analytics/Properties.tsx
@@ -878,10 +878,12 @@ interface FiatExchangeEventsProperties {
     name: string
     link: string
   }
-  [FiatExchangeEvents.cico_no_provider_options]: {
+  [FiatExchangeEvents.cico_num_provider_options]: {
     isCashIn: boolean
+    numProviderOptions: number
     paymentMethod: PaymentMethod
-    currency: Currency
+    cryptoCurrency: Currency
+    fiatCurrency: LocalCurrencyCode
     fiatAmount: number
     country: string | null
     region: string | null

--- a/packages/mobile/src/analytics/Properties.tsx
+++ b/packages/mobile/src/analytics/Properties.tsx
@@ -878,6 +878,14 @@ interface FiatExchangeEventsProperties {
     name: string
     link: string
   }
+  [FiatExchangeEvents.cico_no_provider_options]: {
+    isCashIn: boolean
+    paymentMethod: PaymentMethod
+    currency: Currency
+    fiatAmount: number
+    country: string | null
+    region: string | null
+  }
   [FiatExchangeEvents.cico_option_chosen]: {
     isCashIn: boolean
     paymentMethod: PaymentMethod

--- a/packages/mobile/src/fiatExchanges/ProviderOptionsScreen.test.tsx
+++ b/packages/mobile/src/fiatExchanges/ProviderOptionsScreen.test.tsx
@@ -1,3 +1,9 @@
+const mockTrack = jest.fn()
+jest.mock('../analytics/ValoraAnalytics.ts', () => {
+  return jest.fn().mockImplementation(() => ({
+    track: mockTrack,
+  }))
+})
 import { fireEvent, render, waitFor } from '@testing-library/react-native'
 import { FetchMock } from 'jest-fetch-mock/types'
 import * as React from 'react'
@@ -413,5 +419,19 @@ describe('ProviderOptionsScreen', () => {
 
     const freeElement = tree.queryByText('free')
     expect(freeElement).toBeTruthy()
+  })
+
+  it(`Logs analytics event for how many providers are available`, async () => {
+    mockFetch.mockResponse(MOCK_PROVIDER_FETCH)
+
+    const tree = render(
+      <Provider store={mockStore}>
+        <ProviderOptionsScreen {...mockScreenProps(true, PaymentMethod.Card, Currency.Dollar)} />
+      </Provider>
+    )
+
+    await waitFor(() => tree.getByText('Simplex'))
+
+    expect(mockTrack).toHaveBeenCalled() // fixme this hasn't been called, maybe because we haven't waited long enough...
   })
 })

--- a/packages/mobile/src/fiatExchanges/ProviderOptionsScreen.tsx
+++ b/packages/mobile/src/fiatExchanges/ProviderOptionsScreen.tsx
@@ -130,16 +130,20 @@ function ProviderOptionsScreen({ route, navigation }: Props) {
         digitalAssetAmount: route.params.amount.crypto,
         txType: isCashIn ? 'buy' : 'sell',
       })
-      if (!providers?.length) {
-        ValoraAnalytics.track(FiatExchangeEvents.cico_no_provider_options, {
-          isCashIn,
-          paymentMethod,
-          currency: route.params.selectedCrypto,
-          fiatAmount: route.params.amount.fiat,
-          country: userLocation.countryCodeAlpha2,
-          region: userLocation.region,
-        })
-      }
+      const numProviderOptions =
+        providers?.filter(
+          (provider) => !!provider && (isCashIn ? provider.cashIn : provider.cashOut)
+        )?.length ?? 0
+      ValoraAnalytics.track(FiatExchangeEvents.cico_num_provider_options, {
+        isCashIn,
+        numProviderOptions,
+        paymentMethod,
+        cryptoCurrency: route.params.selectedCrypto,
+        fiatCurrency: localCurrency,
+        fiatAmount: route.params.amount.fiat,
+        country: userLocation.countryCodeAlpha2,
+        region: userLocation.region,
+      })
       return providers
     } catch (error) {
       dispatch(showError(ErrorMessages.PROVIDER_FETCH_FAILED))
@@ -184,7 +188,7 @@ function ProviderOptionsScreen({ route, navigation }: Props) {
       if (provider.quote && userLocation?.ipAddress && isSimplexQuote(providerQuote)) {
         navigate(Screens.Simplex, {
           simplexQuote: providerQuote,
-          userIpAddress: userLocation.ipAddress,
+          userIpAddress: userLocation.ipAddress, // todo figure out if this is how Simplex infers user location (and if so, if we can provide it some other way)
         })
       }
       return

--- a/packages/mobile/src/fiatExchanges/ProviderOptionsScreen.tsx
+++ b/packages/mobile/src/fiatExchanges/ProviderOptionsScreen.tsx
@@ -188,7 +188,7 @@ function ProviderOptionsScreen({ route, navigation }: Props) {
       if (provider.quote && userLocation?.ipAddress && isSimplexQuote(providerQuote)) {
         navigate(Screens.Simplex, {
           simplexQuote: providerQuote,
-          userIpAddress: userLocation.ipAddress, // todo figure out if this is how Simplex infers user location (and if so, if we can provide it some other way)
+          userIpAddress: userLocation.ipAddress,
         })
       }
       return

--- a/packages/mobile/src/fiatExchanges/ProviderOptionsScreen.tsx
+++ b/packages/mobile/src/fiatExchanges/ProviderOptionsScreen.tsx
@@ -130,6 +130,16 @@ function ProviderOptionsScreen({ route, navigation }: Props) {
         digitalAssetAmount: route.params.amount.crypto,
         txType: isCashIn ? 'buy' : 'sell',
       })
+      if (!providers?.length) {
+        ValoraAnalytics.track(FiatExchangeEvents.cico_no_provider_options, {
+          isCashIn,
+          paymentMethod,
+          currency: route.params.selectedCrypto,
+          fiatAmount: route.params.amount.fiat,
+          country: userLocation.countryCodeAlpha2,
+          region: userLocation.region,
+        })
+      }
       return providers
     } catch (error) {
       dispatch(showError(ErrorMessages.PROVIDER_FETCH_FAILED))


### PR DESCRIPTION
### Description

The motivating use case for this is to find a coarse upper bound for how often a user sees no CICO options shown for their area, even though they are supposed to be covered. With this tracking event, we'll at least know how often a user sees no CICO options (perhaps because their state isn't covered, or perhaps because they're not in the state we think they are in).

The event will also help us gather data on how often people are trying to cash in from states that are not covered. 

### Other changes

n/a

### Tested

_An explanation of how the changes were tested or an explanation as to why they don't need to be._


### How others should test

_Does this need to be tested by QA in the next release cycle? If so please give a brief explanation of how to test these changes._

### Related issues

cc #1589 

### Backwards compatibility

🆗 