### PR TITLE
prevent translations resource merging for every translation key

### DIFF
--- a/packages/mobile/src/i18n/index.ts
+++ b/packages/mobile/src/i18n/index.ts
@@ -13,40 +13,22 @@ import { getOtaTranslations } from 'src/i18n/otaTranslations'
 
 const TOS_LINK_DISPLAY = TOS_LINK.replace(/^https?:\/\//i, '')
 
-// used to prevent translations for all languages from being loaded upfront
-const translationResource: Resource = {}
-
-const mergeTranslationResources = (
-  res1: ResourceLanguage,
-  res2: ResourceLanguage,
-  language: string
-) => {
-  if (!translationResource[language]) {
-    translationResource[language] = _.merge(res1, res2)
-  }
-
-  return translationResource[language]
-}
-
 function getAvailableResources(cachedTranslations: Resource) {
   const resources: Resource = {}
   for (const [language, value] of Object.entries(locales)) {
+    let translation: ResourceLanguage
     Object.defineProperty(resources, language, {
       get: () => {
-        return {
-          translation: mergeTranslationResources(
-            value!.strings.translation,
-            cachedTranslations[language],
-            language
-          ),
+        if (!translation) {
+          translation = _.merge(value!.strings.translation, cachedTranslations[language])
         }
+        return { translation }
       },
       enumerable: true,
     })
   }
   return resources
 }
-
 export async function initI18n(
   language: string,
   allowOtaTranslations: boolean,


### PR DESCRIPTION
### Description

When loading the translations on app start, we try to prevent resources for all languages from loading upfront. This is to ensure only the language that is needed is loaded into memory.

When introducing the OTA translations, we wanted to ensure that developers can still add new translations during development. Therefore, when loading the resources, we do a `merge` of the OTA translations and bundled translations for the given language. This is done via the `get` function for each resource language.

Unfortunately the `get` function is called each time a key is translated, and therefore the `merge`. This introduced a noticeable lag for physical Android devices (not noticed during testing on simulators, physical iOS devices, Android emulators). For more context, refer https://valora-app.slack.com/archives/C018VLA3YAK/p1640035112135000

In this PR:
- prevent the `merge` from unnecessarily executing by keeping the merged translations in memory.

### Other changes

N/A

### Tested

Manually, on physical android device:
- make sure the `allowOTATranslations` feature flag is enabled
- load the app on a physical Android device - not an emulator (and preferably use with an account that has some transaction history)
- force close the app, and reload
- in the 1.23.0 release candidate, the app performs very poorly on this second load. Either the UI is extremely laggy and unresponsive to touch, or the app will crash.
- after this change, the lag is less and the app does not crash on this second load. 


### How others should test

Same as above

### Related issues

- Fixes #[issue number here]

