### PR TITLE
Make sure totalBalanceUsd is not NaN

### DIFF
--- a/packages/mobile/src/analytics/selectors.ts
+++ b/packages/mobile/src/analytics/selectors.ts
@@ -45,7 +45,9 @@ export const getCurrentUserTraits = createSelector(
     let totalBalanceUsd = new BigNumber(0)
     for (const token of tokensByUsdBalance) {
       const tokenBalanceUsd = token.balance.multipliedBy(token.usdPrice)
-      totalBalanceUsd = totalBalanceUsd.plus(tokenBalanceUsd)
+      if (!tokenBalanceUsd.isNaN()) {
+        totalBalanceUsd = totalBalanceUsd.plus(tokenBalanceUsd)
+      }
     }
 
     // Don't rename these unless you have a really good reason!

--- a/packages/mobile/src/tokens/selectors.ts
+++ b/packages/mobile/src/tokens/selectors.ts
@@ -15,10 +15,11 @@ export const tokensByAddressSelector = createSelector(
       if (!storedState || storedState.balance === null) {
         continue
       }
+      const usdPrice = new BigNumber(storedState.usdPrice)
       tokenBalances[tokenAddress] = {
         ...storedState,
         balance: new BigNumber(storedState.balance),
-        usdPrice: new BigNumber(storedState.usdPrice),
+        usdPrice: usdPrice.isNaN() ? new BigNumber(0) : usdPrice,
       }
     }
     return tokenBalances


### PR DESCRIPTION
### Description

We had a bad token in Firebase which caused the total balance to return `NaN`. This should avoid it from crashing the app.

### Other changes

N/A

### Tested

Locally

### How others should test

Open the app, make sure it doesn't crash.

### Related issues

- Fixes #1671

### Backwards compatibility

N/A