### PR TITLE
Update react-native-email-link

### DIFF
--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -116,7 +116,7 @@
     "react-native-config": "https://github.com/luggit/react-native-config#2f68b94",
     "react-native-contacts": "https://github.com/celo-org/react-native-contacts#e473717",
     "react-native-device-info": "^8.3.1",
-    "react-native-email-link": "^1.9.1",
+    "react-native-email-link": "^1.12.2",
     "react-native-exit-app": "^1.1.0",
     "react-native-fast-crypto": "^2.0.0",
     "react-native-flag-secure-android": "git://github.com/kristiansorens/react-native-flag-secure-android#e234251",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17251,10 +17251,10 @@ react-native-dotenv@^3.2.0:
   dependencies:
     dotenv "^10.0.0"
 
-react-native-email-link@^1.9.1:
-  version "1.9.2"
-  resolved "https://registry.yarnpkg.com/react-native-email-link/-/react-native-email-link-1.9.2.tgz#cbacf7eec9ab8c80f01b0daf50e14edeb466d9cf"
-  integrity sha512-w9VbKWcbqO138QcuiUyNUGoLcwZPhUY/jl+y3oiyuCzBwZGvoFeo138TOxoI8FecpHd+IMtsVn9QZVIB8PFXpQ==
+react-native-email-link@^1.12.2:
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/react-native-email-link/-/react-native-email-link-1.12.2.tgz#61e8718dca98b362b3a847d7d05aa2b930ad7206"
+  integrity sha512-tr/Md3J0YuR7RO7R7c/N6bmM5r/44ZEUnbeJVO69/X4kTfvTUbCaAwNChqSRLnr2nXAtdTbaap0lBnHu2uyy8w==
 
 react-native-exit-app@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
### Description

Updates [react-native-email-link](https://www.npmjs.com/package/react-native-email-link) to `1.12.2`.

### Other changes

N/A

### Tested

Tested locally on iOS and Android.

### How others should test

Attempt to contact support in App on Android devices and ensure the email bodies are not encoded.

### Related issues

- Fixes https://github.com/valora-inc/support-issues/issues/70

### Backwards compatibility

Yes