### PR TITLE
Fix fee calculation for non cUSD tokens

### DIFF
--- a/packages/mobile/src/fees/hooks.ts
+++ b/packages/mobile/src/fees/hooks.ts
@@ -10,17 +10,12 @@ import { calculateFee, FeeInfo, fetchFeeCurrency } from 'src/fees/saga'
 import { WEI_DECIMALS } from 'src/geth/consts'
 import useSelector from 'src/redux/useSelector'
 import { STATIC_SEND_TOKEN_GAS_ESTIMATE } from 'src/send/saga'
-import {
-  tokensByCurrencySelector,
-  tokensByUsdBalanceSelector,
-  tokensListSelector,
-} from 'src/tokens/selectors'
-import { Fee } from 'src/transactions/types'
+import { tokensByCurrencySelector, tokensByUsdBalanceSelector } from 'src/tokens/selectors'
+import { Fee, FeeType as TransactionFeeType } from 'src/transactions/types'
 import { Currency } from 'src/utils/currencies'
 import Logger from 'src/utils/Logger'
 import { getRegisterDekTxGas } from 'src/web3/dataEncryptionKey'
 import { walletAddressSelector } from 'src/web3/selectors'
-import { FeeType as TransactionFeeType } from 'src/transactions/types'
 
 async function getSendGasFeeEstimate(
   address: string,

--- a/packages/mobile/src/fees/hooks.ts
+++ b/packages/mobile/src/fees/hooks.ts
@@ -10,7 +10,11 @@ import { calculateFee, FeeInfo, fetchFeeCurrency } from 'src/fees/saga'
 import { WEI_DECIMALS } from 'src/geth/consts'
 import useSelector from 'src/redux/useSelector'
 import { STATIC_SEND_TOKEN_GAS_ESTIMATE } from 'src/send/saga'
-import { tokensByCurrencySelector, tokensListSelector } from 'src/tokens/selectors'
+import {
+  tokensByCurrencySelector,
+  tokensByUsdBalanceSelector,
+  tokensListSelector,
+} from 'src/tokens/selectors'
 import { Fee } from 'src/transactions/types'
 import { Currency } from 'src/utils/currencies'
 import Logger from 'src/utils/Logger'
@@ -91,7 +95,7 @@ export function useEstimateGasFee(
 }
 
 export function useFeeCurrency(): Currency {
-  const tokens = useSelector(tokensListSelector)
+  const tokens = useSelector(tokensByUsdBalanceSelector)
   return fetchFeeCurrency(tokens)
 }
 

--- a/packages/mobile/src/fees/saga.test.ts
+++ b/packages/mobile/src/fees/saga.test.ts
@@ -13,13 +13,34 @@ import { Currency } from 'src/utils/currencies'
 import { getContractKit, getContractKitAsync } from 'src/web3/contracts'
 import { estimateGas } from 'src/web3/utils'
 import { createMockStore } from 'test/utils'
-import { mockContract, mockCusdAddress } from 'test/values'
+import { mockCeurAddress, mockContract, mockCusdAddress } from 'test/values'
 
 const GAS_AMOUNT = 500000
 
 jest.mock('@celo/connect')
 
 const mockTxo = jest.fn()
+
+const store = createMockStore({
+  tokens: {
+    tokenBalances: {
+      [mockCusdAddress]: {
+        address: mockCusdAddress,
+        symbol: 'cUSD',
+        usdPrice: '1',
+        balance: '100',
+        isCoreToken: true,
+      },
+      [mockCeurAddress]: {
+        address: mockCeurAddress,
+        symbol: 'cEUR',
+        usdPrice: '1.2',
+        balance: '20',
+        isCoreToken: true,
+      },
+    },
+  },
+})
 
 describe(estimateFeeSaga, () => {
   beforeAll(() => {
@@ -47,7 +68,7 @@ describe(estimateFeeSaga, () => {
     await expectSaga(estimateFeeSaga, {
       payload: { feeType: FeeType.INVITE, tokenAddress: mockCusdAddress },
     })
-      .withState(createMockStore({}).getState())
+      .withState(store.getState())
       .provide([
         [call(getContractKit), contractKit],
         [call(getERC20TokenContract, mockCusdAddress), mockContract],
@@ -72,7 +93,7 @@ describe(estimateFeeSaga, () => {
     await expectSaga(estimateFeeSaga, {
       payload: { feeType: FeeType.SEND, tokenAddress: mockCusdAddress },
     })
-      .withState(createMockStore({}).getState())
+      .withState(store.getState())
       .provide([
         [matchers.call.fn(buildSendTx), jest.fn(() => ({ txo: mockTxo }))],
         [matchers.call.fn(estimateGas), new BigNumber(GAS_AMOUNT)],
@@ -99,7 +120,7 @@ describe(estimateFeeSaga, () => {
         paymentID: 'paymentID',
       },
     })
-      .withState(createMockStore({}).getState())
+      .withState(store.getState())
       .provide([
         [call(createReclaimTransaction, 'paymentID'), mockTxo],
         [matchers.call.fn(estimateGas), new BigNumber(GAS_AMOUNT)],
@@ -124,7 +145,7 @@ describe(estimateFeeSaga, () => {
     await expectSaga(estimateFeeSaga, {
       payload: { feeType: FeeType.REGISTER_DEK, tokenAddress: mockCusdAddress },
     })
-      .withState(createMockStore({}).getState())
+      .withState(store.getState())
       .provide([
         [call(getContractKit), kit],
         [call([kit.contracts, kit.contracts.getAccounts]), mockAccountsWrapper],
@@ -148,7 +169,7 @@ describe(estimateFeeSaga, () => {
     await expectSaga(estimateFeeSaga, {
       payload: { feeType: FeeType.RECLAIM_ESCROW, tokenAddress: mockCusdAddress },
     })
-      .withState(createMockStore({}).getState())
+      .withState(store.getState())
       .provide([
         [call(createReclaimTransaction, 'paymentID'), mockTxo],
         [matchers.call.fn(estimateGas), new BigNumber(GAS_AMOUNT)],
@@ -176,7 +197,7 @@ describe(estimateFeeSaga, () => {
     await expectSaga(estimateFeeSaga, {
       payload: { feeType: FeeType.SEND, tokenAddress: mockCusdAddress },
     })
-      .withState(createMockStore({}).getState())
+      .withState(store.getState())
       .provide([
         [matchers.call.fn(buildSendTx), jest.fn(() => ({ txo: mockTxo }))],
         [matchers.call.fn(estimateGas), new BigNumber(GAS_AMOUNT)],
@@ -204,7 +225,7 @@ describe(estimateFeeSaga, () => {
     await expectSaga(estimateFeeSaga, {
       payload: { feeType: FeeType.SEND, tokenAddress: 'randomAddress' },
     })
-      .withState(createMockStore({}).getState())
+      .withState(store.getState())
       .provide([
         [matchers.call.fn(buildSendTx), jest.fn(() => ({ txo: mockTxo }))],
         [matchers.call.fn(estimateGas), new BigNumber(GAS_AMOUNT)],

--- a/packages/mobile/src/fees/saga.ts
+++ b/packages/mobile/src/fees/saga.ts
@@ -20,6 +20,7 @@ import {
 import {
   tokensByAddressSelector,
   tokensByCurrencySelector,
+  tokensByUsdBalanceSelector,
   tokensListSelector,
 } from 'src/tokens/selectors'
 import { Currency } from 'src/utils/currencies'
@@ -225,7 +226,7 @@ export async function calculateFee(gas: BigNumber, currency: Currency): Promise<
 }
 
 function* fetchFeeCurrencySaga() {
-  const tokens: TokenBalance[] = yield select(tokensListSelector)
+  const tokens: TokenBalance[] = yield select(tokensByUsdBalanceSelector)
   return fetchFeeCurrency(tokens)
 }
 

--- a/packages/mobile/src/fees/saga.ts
+++ b/packages/mobile/src/fees/saga.ts
@@ -21,7 +21,6 @@ import {
   tokensByAddressSelector,
   tokensByCurrencySelector,
   tokensByUsdBalanceSelector,
-  tokensListSelector,
 } from 'src/tokens/selectors'
 import { Currency } from 'src/utils/currencies'
 import Logger from 'src/utils/Logger'

--- a/packages/mobile/src/send/SendConfirmation.test.tsx
+++ b/packages/mobile/src/send/SendConfirmation.test.tsx
@@ -188,7 +188,7 @@ describe('SendConfirmation', () => {
     const feeComponent = getByTestId('feeDrawer/SendConfirmation/totalFee/value')
     expect(getElementText(feeComponent)).toEqual('₱0.0266')
 
-    // Subtotal is $1.33, which is added the fee amount.
+    // Subtotal is $1.33, which is added to the fee amount.
     const totalComponent = getByTestId('TotalLineItem/Total')
     expect(getElementText(totalComponent)).toEqual('₱1.36')
   })

--- a/packages/mobile/src/send/SendConfirmation.test.tsx
+++ b/packages/mobile/src/send/SendConfirmation.test.tsx
@@ -60,6 +60,26 @@ type ScreenProps = StackScreenProps<
   Screens.SendConfirmation | Screens.SendConfirmationModal
 >
 
+const mockFeeEstimates = {
+  [FeeType.SEND]: {
+    usdFee: '0.02',
+    lastUpdated: 500,
+    loading: false,
+    error: false,
+    feeInfo: mockFeeInfo,
+  },
+  [FeeType.INVITE]: {
+    usdFee: '0.04',
+    lastUpdated: 500,
+    loading: false,
+    error: false,
+    feeInfo: mockFeeInfo,
+  },
+  [FeeType.EXCHANGE]: undefined,
+  [FeeType.RECLAIM_ESCROW]: undefined,
+  [FeeType.REGISTER_DEK]: undefined,
+}
+
 describe('SendConfirmation', () => {
   beforeEach(() => {
     jest.clearAllMocks()
@@ -97,25 +117,8 @@ describe('SendConfirmation', () => {
       },
       fees: {
         estimates: {
-          [mockCusdAddress]: {
-            [FeeType.SEND]: {
-              usdFee: '0.02',
-              lastUpdated: 500,
-              loading: false,
-              error: false,
-              feeInfo: mockFeeInfo,
-            },
-            [FeeType.INVITE]: {
-              usdFee: '0.04',
-              lastUpdated: 500,
-              loading: false,
-              error: false,
-              feeInfo: mockFeeInfo,
-            },
-            [FeeType.EXCHANGE]: undefined,
-            [FeeType.RECLAIM_ESCROW]: undefined,
-            [FeeType.REGISTER_DEK]: undefined,
-          },
+          [mockCusdAddress]: mockFeeEstimates,
+          [mockCeurAddress]: mockFeeEstimates,
         },
       },
       ...storeOverrides,
@@ -138,8 +141,44 @@ describe('SendConfirmation', () => {
     expect(tree).toMatchSnapshot()
   })
 
-  it('renders correctly for send payment confirmation with CELO fees', async () => {
+  it('renders correctly for send payment confirmation with cUSD fees', async () => {
     const { getByText, getByTestId } = renderScreen()
+
+    fireEvent.press(getByText('feeEstimate'))
+
+    jest.runAllTimers()
+    await flushMicrotasksQueue()
+
+    const feeComponent = getByTestId('feeDrawer/SendConfirmation/totalFee/value')
+    expect(getElementText(feeComponent)).toEqual('₱0.0266')
+
+    // Subtotal is $1.33, which is added the fee amount.
+    const totalComponent = getByTestId('TotalLineItem/Total')
+    expect(getElementText(totalComponent)).toEqual('₱1.36')
+  })
+
+  it('renders correctly for send payment confirmation with cEUR fees', async () => {
+    // Note: Higher balance is picked to pay for fees.
+    const { getByText, getByTestId } = renderScreen({
+      tokens: {
+        tokenBalances: {
+          [mockCusdAddress]: {
+            address: mockCusdAddress,
+            symbol: 'cUSD',
+            balance: '2',
+            usdPrice: '1',
+            isCoreToken: true,
+          },
+          [mockCeurAddress]: {
+            address: mockCeurAddress,
+            symbol: 'cEUR',
+            balance: '100',
+            usdPrice: '1.2',
+            isCoreToken: true,
+          },
+        },
+      },
+    })
 
     fireEvent.press(getByText('feeEstimate'))
 


### PR DESCRIPTION
### Description

There were a couple of issues.
First, the token to use as fee currency was being chosen at random. Not a huge deal I guess, but switched back to using the token with highest balance for consistency.
The more important issue is that we were sending to the `FeeDrawer` the `totalFee` in USD but also sending the fee currency and the exchange rate, so in the end we were transforming the value and ended up showing something inaccurate. Since we're already calculating the fee in USD, we are not just passing the currency as `Currency.Dollar` and letting the `FeeDrawer` component transform it into the local currency normally (`CurrencyDisplay` ends up doing that).

### Other changes

N/A

### Tested

I did a TDD approach here, if you run the new test with the old code it fails, but after the changes it works.

### How others should test

Try to send using different fee currencies (decided by the highest balance, so try while having more cUSD than cEUR/CELO and then by having more cEUR than cUSD/CELO) and see that the fee currency has an expected value. Not sure how to decide what "expected value" is though 🤔 

### Related issues

- Fixes #1727

### Backwards compatibility

N/A