### PR TITLE
feat(CashInBottomSheet): Setup a new experiment linking directly to ramp

### DIFF
--- a/packages/mobile/locales/base/translation.json
+++ b/packages/mobile/locales/base/translation.json
@@ -1065,7 +1065,9 @@
   "cashInBottomSheet": {
     "title": "Add funds to start using Valora!",
     "subtitle": "Your account is currently empty",
-    "addFunds": "Add Funds"
+    "addFunds": "Add Funds",
+    "titleRamp": "Add {{currency}} to start using Valora",
+    "subtitleRamp": "Add funds with zero fees through one of our trusted external providers.",
   },
   "balances": "Balances",
   "totalValue": "Total Balance",

--- a/packages/mobile/src/analytics/Events.tsx
+++ b/packages/mobile/src/analytics/Events.tsx
@@ -364,7 +364,9 @@ export enum FiatExchangeEvents {
   // Add fund flow entered through home screen cash in bottom sheet
   cico_add_funds_bottom_sheet_selected = 'cico_add_funds_bottom_sheet_selected',
   cico_add_funds_bottom_sheet_impression = 'cico_add_funds_bottom_sheet_impression',
-  cico_add_funds_bottom_sheet_ramp = 'cico_add_funds_bottom_sheet_ramp',
+  cico_add_funds_bottom_sheet_ramp_selected = 'cico_add_funds_bottom_sheet_ramp_selected',
+  cico_add_funds_bottom_sheet_ramp_available = 'cico_add_funds_bottom_sheet_ramp_available',
+
   cico_cash_out_selected = 'cico_cash_out_selected',
   cico_spend_selected = 'cico_spend_selected',
   cico_fund_info = 'cico_fund_info',

--- a/packages/mobile/src/analytics/Events.tsx
+++ b/packages/mobile/src/analytics/Events.tsx
@@ -364,6 +364,7 @@ export enum FiatExchangeEvents {
   // Add fund flow entered through home screen cash in bottom sheet
   cico_add_funds_bottom_sheet_selected = 'cico_add_funds_bottom_sheet_selected',
   cico_add_funds_bottom_sheet_impression = 'cico_add_funds_bottom_sheet_impression',
+  cico_add_funds_bottom_sheet_ramp = 'cico_add_funds_bottom_sheet_ramp',
   cico_cash_out_selected = 'cico_cash_out_selected',
   cico_spend_selected = 'cico_spend_selected',
   cico_fund_info = 'cico_fund_info',

--- a/packages/mobile/src/analytics/Properties.tsx
+++ b/packages/mobile/src/analytics/Properties.tsx
@@ -895,7 +895,9 @@ interface FiatExchangeEventsProperties {
     provider: string | undefined
   }
   [FiatExchangeEvents.cico_add_funds_selected]: undefined
-  [FiatExchangeEvents.cico_add_funds_bottom_sheet_selected]: undefined
+  [FiatExchangeEvents.cico_add_funds_bottom_sheet_selected]: {
+    rampAvailable: boolean
+  }
   [FiatExchangeEvents.cico_add_funds_bottom_sheet_impression]: undefined
   [FiatExchangeEvents.cico_add_funds_bottom_sheet_ramp]: undefined
   [FiatExchangeEvents.cico_cash_out_selected]: undefined

--- a/packages/mobile/src/analytics/Properties.tsx
+++ b/packages/mobile/src/analytics/Properties.tsx
@@ -897,6 +897,7 @@ interface FiatExchangeEventsProperties {
   [FiatExchangeEvents.cico_add_funds_selected]: undefined
   [FiatExchangeEvents.cico_add_funds_bottom_sheet_selected]: undefined
   [FiatExchangeEvents.cico_add_funds_bottom_sheet_impression]: undefined
+  [FiatExchangeEvents.cico_add_funds_bottom_sheet_ramp]: undefined
   [FiatExchangeEvents.cico_cash_out_selected]: undefined
   [FiatExchangeEvents.cico_spend_selected]: undefined
   [FiatExchangeEvents.cico_fund_info]: undefined

--- a/packages/mobile/src/analytics/Properties.tsx
+++ b/packages/mobile/src/analytics/Properties.tsx
@@ -899,7 +899,8 @@ interface FiatExchangeEventsProperties {
     rampAvailable: boolean
   }
   [FiatExchangeEvents.cico_add_funds_bottom_sheet_impression]: undefined
-  [FiatExchangeEvents.cico_add_funds_bottom_sheet_ramp]: undefined
+  [FiatExchangeEvents.cico_add_funds_bottom_sheet_ramp_selected]: undefined
+  [FiatExchangeEvents.cico_add_funds_bottom_sheet_ramp_available]: undefined
   [FiatExchangeEvents.cico_cash_out_selected]: undefined
   [FiatExchangeEvents.cico_spend_selected]: undefined
   [FiatExchangeEvents.cico_fund_info]: undefined

--- a/packages/mobile/src/app/reducers.ts
+++ b/packages/mobile/src/app/reducers.ts
@@ -39,6 +39,7 @@ export interface State {
     [lang: string]: string
   }
   cashInButtonExpEnabled: boolean
+  rampCashInButtonExpEnabled: boolean
   multiTokenShowHomeBalances: boolean
   multiTokenUseSendFlow: boolean
   multiTokenUseUpdatedFeed: boolean
@@ -78,6 +79,7 @@ const initialState = {
   pincodeUseExpandedBlocklist: REMOTE_CONFIG_VALUES_DEFAULTS.pincodeUseExpandedBlocklist,
   rewardPillText: JSON.parse(REMOTE_CONFIG_VALUES_DEFAULTS.rewardPillText),
   cashInButtonExpEnabled: REMOTE_CONFIG_VALUES_DEFAULTS.cashInButtonExpEnabled,
+  rampCashInButtonExpEnabled: REMOTE_CONFIG_VALUES_DEFAULTS.rampCashInButtonExpEnabled,
   multiTokenShowHomeBalances: REMOTE_CONFIG_VALUES_DEFAULTS.multiTokenShowHomeBalances,
   multiTokenUseSendFlow: REMOTE_CONFIG_VALUES_DEFAULTS.multiTokenUseSendFlow,
   multiTokenUseUpdatedFeed: REMOTE_CONFIG_VALUES_DEFAULTS.multiTokenUseUpdatedFeed,
@@ -188,6 +190,7 @@ export const appReducer = (
         pincodeUseExpandedBlocklist: action.configValues.pincodeUseExpandedBlocklist,
         rewardPillText: JSON.parse(action.configValues.rewardPillText),
         cashInButtonExpEnabled: action.configValues.cashInButtonExpEnabled,
+        rampCashInButtonExpEnabled: action.configValues.rampCashInButtonExpEnabled,
         multiTokenShowHomeBalances: action.configValues.multiTokenShowHomeBalances,
         multiTokenUseSendFlow: action.configValues.multiTokenUseSendFlow,
         multiTokenUseUpdatedFeed: action.configValues.multiTokenUseUpdatedFeed,

--- a/packages/mobile/src/app/saga.ts
+++ b/packages/mobile/src/app/saga.ts
@@ -163,6 +163,7 @@ export interface RemoteConfigValues {
   pincodeUseExpandedBlocklist: boolean
   rewardPillText: string
   cashInButtonExpEnabled: boolean
+  rampCashInButtonExpEnabled: boolean
   multiTokenShowHomeBalances: boolean
   multiTokenUseSendFlow: boolean
   multiTokenUseUpdatedFeed: boolean

--- a/packages/mobile/src/firebase/firebase.ts
+++ b/packages/mobile/src/firebase/firebase.ts
@@ -263,6 +263,7 @@ export async function fetchRemoteConfigValues(): Promise<RemoteConfigValues | nu
     pincodeUseExpandedBlocklist: flags.pincodeUseExpandedBlocklist.asBoolean(),
     rewardPillText: flags.rewardPillText.asString(),
     cashInButtonExpEnabled: flags.cashInButtonExpEnabled.asBoolean(),
+    rampCashInButtonExpEnabled: flags.rampCashInButtonExpEnabled.asBoolean(),
     logPhoneNumberTypeEnabled: flags.logPhoneNumberTypeEnabled.asBoolean(),
     multiTokenShowHomeBalances: flags.multiTokenShowHomeBalances.asBoolean(),
     multiTokenUseSendFlow: flags.multiTokenUseSendFlow.asBoolean(),

--- a/packages/mobile/src/firebase/remoteConfigValuesDefaults.e2e.ts
+++ b/packages/mobile/src/firebase/remoteConfigValuesDefaults.e2e.ts
@@ -27,6 +27,7 @@ export const REMOTE_CONFIG_VALUES_DEFAULTS: Omit<
   pincodeUseExpandedBlocklist: true,
   rewardPillText: JSON.stringify({ en: 'Earn', pt: 'Ganhar', es: 'Gana' }),
   cashInButtonExpEnabled: false,
+  rampCashInButtonExpEnabled: false,
   logPhoneNumberTypeEnabled: false,
   multiTokenShowHomeBalances: false,
   multiTokenUseSendFlow: false,

--- a/packages/mobile/src/firebase/remoteConfigValuesDefaults.ts
+++ b/packages/mobile/src/firebase/remoteConfigValuesDefaults.ts
@@ -33,6 +33,7 @@ export const REMOTE_CONFIG_VALUES_DEFAULTS: Omit<
     de: 'Belohnungen',
   }),
   cashInButtonExpEnabled: false,
+  rampCashInButtonExpEnabled: false,
   logPhoneNumberTypeEnabled: false,
   multiTokenShowHomeBalances: true,
   multiTokenUseSendFlow: false,

--- a/packages/mobile/src/home/CashInBottomSheet.test.tsx
+++ b/packages/mobile/src/home/CashInBottomSheet.test.tsx
@@ -25,56 +25,19 @@ const mockRampProvider = {
 }
 
 const mockRampProviderUnavailable = {
-  name: 'Ramp',
-  restricted: false,
-  paymentMethods: [PaymentMethod.Card, PaymentMethod.Bank],
-  url: 'www.fakewebsite.com',
-  logo:
-    'https://firebasestorage.googleapis.com/v0/b/celo-mobile-mainnet.appspot.com/o/images%2Framp.png?alt=media',
-  quote: [
-    { paymentMethod: PaymentMethod.Card, digitalAsset: 'cusd', returnedAmount: 100, fiatFee: 0 },
-  ],
-  cashIn: true,
-  cashOut: false,
+  ...mockRampProvider,
   unavailable: true,
 }
 
 const mockRampProviderRestricted = {
-  name: 'Ramp',
+  ...mockRampProvider,
   restricted: true,
-  paymentMethods: [PaymentMethod.Card, PaymentMethod.Bank],
-  url: 'www.fakewebsite.com',
-  logo:
-    'https://firebasestorage.googleapis.com/v0/b/celo-mobile-mainnet.appspot.com/o/images%2Framp.png?alt=media',
-  quote: [
-    { paymentMethod: PaymentMethod.Card, digitalAsset: 'cusd', returnedAmount: 100, fiatFee: 0 },
-  ],
-  cashIn: true,
-  cashOut: false,
-  unavailable: false,
 }
 
 const mockRampProviderNoCashIn = {
-  name: 'Ramp',
-  restricted: false,
-  paymentMethods: [PaymentMethod.Card, PaymentMethod.Bank],
-  url: 'www.fakewebsite.com',
-  logo:
-    'https://firebasestorage.googleapis.com/v0/b/celo-mobile-mainnet.appspot.com/o/images%2Framp.png?alt=media',
-  quote: [
-    { paymentMethod: PaymentMethod.Card, digitalAsset: 'cusd', returnedAmount: 100, fiatFee: 0 },
-  ],
+  ...mockRampProvider,
   cashIn: false,
-  cashOut: false,
-  unavailable: false,
 }
-
-// jest.mock('src/fiatExchanges/utils', () => ({
-//   ...(jest.requireActual('src/fiatExchanges/utils') as any),
-//   fetchProviders: jest.fn(() => [
-//     mockRampProvider
-//   ]),
-// }))
 
 describe('CashInBottomSheet', () => {
   const mockFetch = fetch as FetchMock
@@ -124,7 +87,7 @@ describe('CashInBottomSheet', () => {
     const { getByTestId } = render(
       <Provider
         store={createMockStore({
-          app: { rampCashInButtonExpEnabled: false },
+          app: { rampCashInButtonExpEnabled: true },
         })}
       >
         <CashInBottomSheet />
@@ -137,7 +100,7 @@ describe('CashInBottomSheet', () => {
     const { getByTestId } = render(
       <Provider
         store={createMockStore({
-          app: { rampCashInButtonExpEnabled: false },
+          app: { rampCashInButtonExpEnabled: true },
         })}
       >
         <CashInBottomSheet />
@@ -150,7 +113,7 @@ describe('CashInBottomSheet', () => {
     const { getByTestId } = render(
       <Provider
         store={createMockStore({
-          app: { rampCashInButtonExpEnabled: false },
+          app: { rampCashInButtonExpEnabled: true },
         })}
       >
         <CashInBottomSheet />

--- a/packages/mobile/src/home/CashInBottomSheet.test.tsx
+++ b/packages/mobile/src/home/CashInBottomSheet.test.tsx
@@ -1,12 +1,90 @@
-import { fireEvent, render } from '@testing-library/react-native'
+import { fireEvent, render, waitFor } from '@testing-library/react-native'
+import { FetchMock } from 'jest-fetch-mock/types'
 import * as React from 'react'
 import { Provider } from 'react-redux'
+import { PaymentMethod } from 'src/fiatExchanges/FiatExchangeOptions'
 import CashInBottomSheet from 'src/home/CashInBottomSheet'
 import { navigate } from 'src/navigator/NavigationService'
+import { navigateToURI } from 'src/utils/linking'
 import { Screens } from 'src/navigator/Screens'
 import { createMockStore } from 'test/utils'
 
+const mockRampProvider = {
+  name: 'Ramp',
+  restricted: false,
+  paymentMethods: [PaymentMethod.Card, PaymentMethod.Bank],
+  url: 'www.fakewebsite.com',
+  logo:
+    'https://firebasestorage.googleapis.com/v0/b/celo-mobile-mainnet.appspot.com/o/images%2Framp.png?alt=media',
+  quote: [
+    { paymentMethod: PaymentMethod.Card, digitalAsset: 'cusd', returnedAmount: 100, fiatFee: 0 },
+  ],
+  cashIn: true,
+  cashOut: false,
+  unavailable: false,
+}
+
+const mockRampProviderUnavailable = {
+  name: 'Ramp',
+  restricted: false,
+  paymentMethods: [PaymentMethod.Card, PaymentMethod.Bank],
+  url: 'www.fakewebsite.com',
+  logo:
+    'https://firebasestorage.googleapis.com/v0/b/celo-mobile-mainnet.appspot.com/o/images%2Framp.png?alt=media',
+  quote: [
+    { paymentMethod: PaymentMethod.Card, digitalAsset: 'cusd', returnedAmount: 100, fiatFee: 0 },
+  ],
+  cashIn: true,
+  cashOut: false,
+  unavailable: true,
+}
+
+const mockRampProviderRestricted = {
+  name: 'Ramp',
+  restricted: true,
+  paymentMethods: [PaymentMethod.Card, PaymentMethod.Bank],
+  url: 'www.fakewebsite.com',
+  logo:
+    'https://firebasestorage.googleapis.com/v0/b/celo-mobile-mainnet.appspot.com/o/images%2Framp.png?alt=media',
+  quote: [
+    { paymentMethod: PaymentMethod.Card, digitalAsset: 'cusd', returnedAmount: 100, fiatFee: 0 },
+  ],
+  cashIn: true,
+  cashOut: false,
+  unavailable: false,
+}
+
+const mockRampProviderNoCashIn = {
+  name: 'Ramp',
+  restricted: false,
+  paymentMethods: [PaymentMethod.Card, PaymentMethod.Bank],
+  url: 'www.fakewebsite.com',
+  logo:
+    'https://firebasestorage.googleapis.com/v0/b/celo-mobile-mainnet.appspot.com/o/images%2Framp.png?alt=media',
+  quote: [
+    { paymentMethod: PaymentMethod.Card, digitalAsset: 'cusd', returnedAmount: 100, fiatFee: 0 },
+  ],
+  cashIn: false,
+  cashOut: false,
+  unavailable: false,
+}
+
+// jest.mock('src/fiatExchanges/utils', () => ({
+//   ...(jest.requireActual('src/fiatExchanges/utils') as any),
+//   fetchProviders: jest.fn(() => [
+//     mockRampProvider
+//   ]),
+// }))
+
 describe('CashInBottomSheet', () => {
+  const mockFetch = fetch as FetchMock
+
+  beforeEach(() => {
+    jest.useRealTimers()
+    jest.clearAllMocks()
+    mockFetch.resetMocks()
+  })
+
   it('renders correctly', () => {
     const tree = render(
       <Provider store={createMockStore({})}>
@@ -16,7 +94,7 @@ describe('CashInBottomSheet', () => {
     expect(tree).toMatchSnapshot()
   })
 
-  it('navigates to the add funds page when the add funds button is clicked', () => {
+  it('navigates to the add funds page when the add funds button is clicked', async () => {
     const { getByTestId } = render(
       <Provider store={createMockStore({})}>
         <CashInBottomSheet />
@@ -27,5 +105,72 @@ describe('CashInBottomSheet', () => {
     expect(navigate).toHaveBeenCalledWith(Screens.FiatExchangeOptions, {
       isCashIn: true,
     })
+  })
+  it('Regular Version is visible when experiment is disabled even if ramp is available', async () => {
+    mockFetch.mockResponse(JSON.stringify([mockRampProvider]))
+    const { getByTestId } = render(
+      <Provider
+        store={createMockStore({
+          app: { rampCashInButtonExpEnabled: false },
+        })}
+      >
+        <CashInBottomSheet />
+      </Provider>
+    )
+    await waitFor(() => expect(getByTestId('cashInBtn')))
+  })
+  it('Regular Version is visible when ramp is unavailable', async () => {
+    mockFetch.mockResponse(JSON.stringify([mockRampProviderUnavailable]))
+    const { getByTestId } = render(
+      <Provider
+        store={createMockStore({
+          app: { rampCashInButtonExpEnabled: false },
+        })}
+      >
+        <CashInBottomSheet />
+      </Provider>
+    )
+    await waitFor(() => expect(getByTestId('cashInBtn')))
+  })
+  it('Regular Version is visible when ramp is restricted', async () => {
+    mockFetch.mockResponse(JSON.stringify([mockRampProviderRestricted]))
+    const { getByTestId } = render(
+      <Provider
+        store={createMockStore({
+          app: { rampCashInButtonExpEnabled: false },
+        })}
+      >
+        <CashInBottomSheet />
+      </Provider>
+    )
+    await waitFor(() => expect(getByTestId('cashInBtn')))
+  })
+  it('Regular Version is visible when ramp does not have cash in', async () => {
+    mockFetch.mockResponse(JSON.stringify([mockRampProviderNoCashIn]))
+    const { getByTestId } = render(
+      <Provider
+        store={createMockStore({
+          app: { rampCashInButtonExpEnabled: false },
+        })}
+      >
+        <CashInBottomSheet />
+      </Provider>
+    )
+    await waitFor(() => expect(getByTestId('cashInBtn')))
+  })
+  it('Ramp Version: navigates to ramp when add funds button is clicked', async () => {
+    mockFetch.mockResponse(JSON.stringify([mockRampProvider]))
+    const { getByTestId } = render(
+      <Provider
+        store={createMockStore({
+          app: { rampCashInButtonExpEnabled: true },
+        })}
+      >
+        <CashInBottomSheet />
+      </Provider>
+    )
+    await waitFor(() => expect(getByTestId('cashInBtnRamp')))
+    fireEvent.press(getByTestId('cashInBtnRamp'))
+    expect(navigateToURI).toHaveBeenCalledWith(mockRampProvider.url)
   })
 })

--- a/packages/mobile/src/home/CashInBottomSheet.tsx
+++ b/packages/mobile/src/home/CashInBottomSheet.tsx
@@ -11,12 +11,29 @@ import { StyleSheet, Text, View } from 'react-native'
 import Modal from 'react-native-modal'
 import { FiatExchangeEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
+import { getLocalCurrencyCode } from 'src/localCurrency/selectors'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
+import { userLocationDataSelector } from 'src/networkInfo/selectors'
+import useSelector from 'src/redux/useSelector'
+import { currentAccountSelector } from 'src/web3/selectors'
+import Logger from 'src/utils/Logger'
+import { fetchProviders } from 'src/fiatExchanges/utils'
+import { useAsync } from 'react-async-hook'
+import { LocalCurrencyCode } from 'src/localCurrency/consts'
+import { CiCoCurrency } from 'src/utils/currencies'
+import { navigateToURI } from 'src/utils/linking'
+
+const TAG = 'CashInBottomSheet'
 
 function CashInBottomSheet() {
   const { t } = useTranslation()
-  const [isModalVisible, setModalVisible] = useState(true)
+  const [isModalVisible, setModalVisible] = useState(false)
+
+  const userLocation = useSelector(userLocationDataSelector)
+  const account = useSelector(currentAccountSelector)
+  const localCurrency = useSelector(getLocalCurrencyCode)
+  const rampCashInButtonExpEnabled = useSelector((state) => state.app.rampCashInButtonExpEnabled)
 
   useEffect(() => {
     ValoraAnalytics.track(FiatExchangeEvents.cico_add_funds_bottom_sheet_impression)
@@ -35,6 +52,49 @@ function CashInBottomSheet() {
     ValoraAnalytics.track(FiatExchangeEvents.cico_add_funds_bottom_sheet_selected)
   }
 
+  const asyncProviders = useAsync(async () => {
+    if (!account) {
+      Logger.error(TAG, 'No account set')
+      setModalVisible(true)
+      return
+    }
+    // Use cEUR if that is their local currency, otherwise default to cUSD
+    const currencyToBuy =
+      localCurrency === LocalCurrencyCode.EUR ? CiCoCurrency.CEUR : CiCoCurrency.CUSD
+
+    try {
+      const providers = await fetchProviders({
+        userLocation,
+        walletAddress: account,
+        fiatCurrency: localCurrency,
+        digitalAsset: currencyToBuy,
+        fiatAmount: 20,
+        digitalAssetAmount: 20,
+        txType: 'buy',
+      })
+      setModalVisible(true)
+      return providers
+    } catch (error) {
+      setModalVisible(true)
+      console.debug('FAILED', error)
+    }
+  }, [])
+
+  const rampProvider = asyncProviders.result?.find((provider) => provider.name === 'Ramp')
+  const rampAvailable =
+    rampProvider &&
+    rampProvider?.cashIn &&
+    !rampProvider.restricted &&
+    rampProvider.url &&
+    !rampProvider.unavailable
+
+  const goToRamp = () => {
+    onDismissBottomSheet()
+
+    rampAvailable && rampProvider?.url && navigateToURI(rampProvider.url)
+    ValoraAnalytics.track(FiatExchangeEvents.cico_add_funds_bottom_sheet_ramp)
+  }
+  console.debug(rampProvider, rampAvailable)
   return (
     <Modal
       animationIn="slideInUp"
@@ -54,15 +114,33 @@ function CashInBottomSheet() {
         >
           <Times />
         </Touchable>
-        <Text style={styles.title}>{t('cashInBottomSheet.title')}</Text>
-        <Text style={styles.subtitle}>{t('cashInBottomSheet.subtitle')}</Text>
-        <Button
-          text={t('cashInBottomSheet.addFunds')}
-          size={BtnSizes.FULL}
-          onPress={goToAddFunds}
-          style={styles.addFundBtn}
-          testID={'cashInBtn'}
-        />
+        {rampAvailable && rampCashInButtonExpEnabled ? (
+          <View>
+            <Text style={styles.title}>{'Add [cUSD] to start using Valora'}</Text>
+            <Text style={styles.subtitle}>
+              {'Add funds with zero fees through one of our trusted external providers.'}
+            </Text>
+            <Button
+              text={t('cashInBottomSheet.addFunds')}
+              size={BtnSizes.FULL}
+              onPress={goToRamp}
+              style={styles.addFundBtn}
+              testID={'cashInBtn'}
+            />
+          </View>
+        ) : (
+          <View>
+            <Text style={styles.title}>{t('cashInBottomSheet.title')}</Text>
+            <Text style={styles.subtitle}>{t('cashInBottomSheet.subtitle')}</Text>
+            <Button
+              text={t('cashInBottomSheet.addFunds')}
+              size={BtnSizes.FULL}
+              onPress={goToAddFunds}
+              style={styles.addFundBtn}
+              testID={'cashInBtn'}
+            />
+          </View>
+        )}
       </View>
     </Modal>
   )

--- a/packages/mobile/src/home/CashInBottomSheet.tsx
+++ b/packages/mobile/src/home/CashInBottomSheet.tsx
@@ -43,43 +43,47 @@ function CashInBottomSheet() {
     setModalVisible(false)
   }
 
-  const asyncRampInfo = useAsync(async () => {
-    if (!account) {
-      Logger.error(TAG, 'No account set')
-      setModalVisible(true)
-      return
-    }
-    // Use cEUR if that is their local currency, otherwise default to cUSD
-    const currencyToBuy =
-      localCurrency === LocalCurrencyCode.EUR ? CiCoCurrency.CEUR : CiCoCurrency.CUSD
-
-    try {
-      const providers = await fetchProviders({
-        userLocation,
-        walletAddress: account,
-        fiatCurrency: localCurrency,
-        digitalAsset: currencyToBuy,
-        fiatAmount: 20,
-        digitalAssetAmount: 20,
-        txType: 'buy',
-      })
-      setModalVisible(true)
-      const rampProvider = providers?.find((provider) => provider.name === 'Ramp')
-      const rampAvailable = !!(
-        rampProvider &&
-        rampProvider?.cashIn &&
-        !rampProvider.restricted &&
-        !rampProvider.unavailable
-      )
-      return {
-        rampAvailable,
-        rampURL: rampProvider?.url,
+  const asyncRampInfo = useAsync(
+    async () => {
+      if (!account) {
+        Logger.error(TAG, 'No account set')
+        return
       }
-    } catch (error) {
-      Logger.error(TAG, 'Failed to fetch CICO providers')
-      setModalVisible(true)
+      // Use cEUR if that is their local currency, otherwise default to cUSD
+      const currencyToBuy =
+        localCurrency === LocalCurrencyCode.EUR ? CiCoCurrency.CEUR : CiCoCurrency.CUSD
+
+      try {
+        const providers = await fetchProviders({
+          userLocation,
+          walletAddress: account,
+          fiatCurrency: localCurrency,
+          digitalAsset: currencyToBuy,
+          fiatAmount: 20,
+          digitalAssetAmount: 20,
+          txType: 'buy',
+        })
+        const rampProvider = providers?.find((provider) => provider.name === 'Ramp')
+        const rampAvailable = !!(
+          rampProvider &&
+          rampProvider?.cashIn &&
+          !rampProvider.restricted &&
+          !rampProvider.unavailable
+        )
+        return {
+          rampAvailable,
+          rampURL: rampProvider?.url,
+        }
+      } catch (error) {
+        Logger.error(TAG, 'Failed to fetch CICO providers')
+      }
+    },
+    [],
+    {
+      onSuccess: () => setModalVisible(true),
+      onError: () => setModalVisible(true),
     }
-  }, [])
+  )
 
   const { result: { rampAvailable = false, rampURL = '' } = {} } = asyncRampInfo
 

--- a/packages/mobile/src/home/CashInBottomSheet.tsx
+++ b/packages/mobile/src/home/CashInBottomSheet.tsx
@@ -70,6 +70,11 @@ function CashInBottomSheet() {
           !rampProvider.restricted &&
           !rampProvider.unavailable
         )
+        if (rampAvailable) {
+          // This event can be used as an activation event to limit the experiment
+          // analysis to users that have ramp available to them
+          ValoraAnalytics.track(FiatExchangeEvents.cico_add_funds_bottom_sheet_ramp_available)
+        }
         return {
           rampAvailable,
           rampURL: rampProvider?.url,
@@ -91,7 +96,7 @@ function CashInBottomSheet() {
     onDismissBottomSheet()
 
     navigateToURI(rampURL)
-    ValoraAnalytics.track(FiatExchangeEvents.cico_add_funds_bottom_sheet_ramp)
+    ValoraAnalytics.track(FiatExchangeEvents.cico_add_funds_bottom_sheet_ramp_selected)
   }
 
   const goToAddFunds = () => {

--- a/packages/mobile/src/home/WalletHome.tsx
+++ b/packages/mobile/src/home/WalletHome.tsx
@@ -159,7 +159,7 @@ function WalletHome() {
         keyExtractor={keyExtractor}
       />
       <SendOrRequestBar />
-      {<CashInBottomSheet />}
+      {shouldShowCashInBottomSheet() && <CashInBottomSheet />}
     </SafeAreaView>
   )
 }

--- a/packages/mobile/src/home/WalletHome.tsx
+++ b/packages/mobile/src/home/WalletHome.tsx
@@ -159,7 +159,7 @@ function WalletHome() {
         keyExtractor={keyExtractor}
       />
       <SendOrRequestBar />
-      {shouldShowCashInBottomSheet() && <CashInBottomSheet />}
+      {<CashInBottomSheet />}
     </SafeAreaView>
   )
 }

--- a/packages/mobile/src/home/__snapshots__/CashInBottomSheet.test.tsx.snap
+++ b/packages/mobile/src/home/__snapshots__/CashInBottomSheet.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`CashInBottomSheet renders correctly 1`] = `
   swipeDirection="down"
   swipeThreshold={100}
   transparent={true}
-  visible={true}
+  visible={false}
 >
   <View
     accessible={true}
@@ -83,7 +83,7 @@ exports[`CashInBottomSheet renders correctly 1`] = `
         "top": 0,
         "transform": Array [
           Object {
-            "translateY": 1334,
+            "translateY": 0,
           },
         ],
       }
@@ -167,103 +167,106 @@ exports[`CashInBottomSheet renders correctly 1`] = `
           />
         </svg>
       </View>
-      <Text
-        style={
-          Object {
-            "color": "#2E3338",
-            "fontFamily": "Jost-Medium",
-            "fontSize": 22,
-            "lineHeight": 28,
-            "marginBottom": 16,
-            "paddingHorizontal": 36,
-            "textAlign": "center",
-          }
-        }
-      >
-        cashInBottomSheet.title
-      </Text>
-      <Text
-        style={
-          Object {
-            "color": "#81868B",
-            "fontFamily": "Inter-Regular",
-            "fontSize": 16,
-            "lineHeight": 22,
-            "textAlign": "center",
-          }
-        }
-      >
-        cashInBottomSheet.subtitle
-      </Text>
-      <View
-        style={
-          Array [
+      <View>
+        <Text
+          style={
             Object {
-              "flexDirection": "column",
-            },
+              "color": "#2E3338",
+              "fontFamily": "Jost-Medium",
+              "fontSize": 22,
+              "lineHeight": 28,
+              "marginBottom": 16,
+              "paddingHorizontal": 36,
+              "textAlign": "center",
+            }
+          }
+        >
+          cashInBottomSheet.title
+        </Text>
+        <Text
+          style={
             Object {
-              "marginHorizontal": 16,
-              "marginVertical": 28,
-            },
-          ]
-        }
-      >
+              "color": "#81868B",
+              "fontFamily": "Inter-Regular",
+              "fontSize": 16,
+              "lineHeight": 22,
+              "paddingHorizontal": 36,
+              "textAlign": "center",
+            }
+          }
+        >
+          cashInBottomSheet.subtitle
+        </Text>
         <View
           style={
             Array [
               Object {
-                "overflow": "hidden",
+                "flexDirection": "column",
               },
               Object {
-                "borderRadius": 100,
+                "marginHorizontal": 16,
+                "marginVertical": 28,
               },
             ]
           }
         >
           <View
-            accessible={true}
-            focusable={true}
-            nativeBackgroundAndroid={
-              Object {
-                "attribute": "selectableItemBackground",
-                "rippleRadius": undefined,
-                "type": "ThemeAttrAndroid",
-              }
-            }
-            onClick={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
             style={
-              Object {
-                "alignItems": "center",
-                "backgroundColor": "#1AB775",
-                "flexGrow": 1,
-                "height": 48,
-                "justifyContent": "center",
-                "opacity": undefined,
-                "paddingHorizontal": 24,
-                "paddingVertical": 5,
-              }
-            }
-            testID="cashInBtn"
-          >
-            <Text
-              maxFontSizeMultiplier={1}
-              style={
+              Array [
                 Object {
-                  "color": "#FFFFFF",
-                  "fontFamily": "Inter-SemiBold",
-                  "fontSize": 16,
-                  "lineHeight": 22,
+                  "overflow": "hidden",
+                },
+                Object {
+                  "borderRadius": 100,
+                },
+              ]
+            }
+          >
+            <View
+              accessible={true}
+              focusable={true}
+              nativeBackgroundAndroid={
+                Object {
+                  "attribute": "selectableItemBackground",
+                  "rippleRadius": undefined,
+                  "type": "ThemeAttrAndroid",
                 }
               }
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                Object {
+                  "alignItems": "center",
+                  "backgroundColor": "#1AB775",
+                  "flexGrow": 1,
+                  "height": 48,
+                  "justifyContent": "center",
+                  "opacity": undefined,
+                  "paddingHorizontal": 24,
+                  "paddingVertical": 5,
+                }
+              }
+              testID="cashInBtn"
             >
-              cashInBottomSheet.addFunds
-            </Text>
+              <Text
+                maxFontSizeMultiplier={1}
+                style={
+                  Object {
+                    "color": "#FFFFFF",
+                    "fontFamily": "Inter-SemiBold",
+                    "fontSize": 16,
+                    "lineHeight": 22,
+                  }
+                }
+              >
+                cashInBottomSheet.addFunds
+              </Text>
+            </View>
           </View>
         </View>
       </View>

--- a/packages/mobile/src/redux/migrations.ts
+++ b/packages/mobile/src/redux/migrations.ts
@@ -355,4 +355,11 @@ export const migrations = {
       sentryTracesSampleRate: DEFAULT_SENTRY_TRACES_SAMPLE_RATE,
     },
   }),
+  26: (state: any) => ({
+    ...state,
+    app: {
+      ...state.app,
+      rampCashInButtonExpEnabled: false,
+    },
+  }),
 }

--- a/packages/mobile/src/redux/store.ts
+++ b/packages/mobile/src/redux/store.ts
@@ -20,7 +20,7 @@ let lastEventTime = Date.now()
 
 const persistConfig: PersistConfig<RootState> = {
   key: 'root',
-  version: 25, // default is -1, increment as we make migrations
+  version: 26, // default is -1, increment as we make migrations
   keyPrefix: `reduxStore-`, // the redux-persist default is `persist:` which doesn't work with some file systems.
   storage: FSStorage(),
   blacklist: ['geth', 'networkInfo', 'alert', 'imports'],

--- a/packages/mobile/test/schemas.ts
+++ b/packages/mobile/test/schemas.ts
@@ -857,6 +857,18 @@ export const v25Schema = {
   },
 }
 
+export const v26Schema = {
+  ...v25Schema,
+  _persist: {
+    ...v25Schema._persist,
+    version: 26,
+  },
+  app: {
+    ...v25Schema.app,
+    rampCashInButtonExpEnabled: false,
+  },
+}
+
 export function getLatestSchema(): Partial<RootState> {
-  return v25Schema as Partial<RootState>
+  return v26Schema as Partial<RootState>
 }


### PR DESCRIPTION
### Description

**Still needs Tests**

The experiment compares the existing Cash In Bottom sheet which goes through typical CICO flow to a new one that links directly to Ramp. The goal is to drive up Cash In engagement.

[Zenhub](https://app.zenhub.com/workspaces/acquisition-squad-sprint-board-6010683afabec1001a090887/issues/valora-inc/wallet/1687)
[Experiment Design
](https://www.notion.so/Experiment-2-Change-CTA-to-Add-cUSD-cEUR-10-cbb3e82e2c2c4687a3bc7c42defe5cd9)

<img width="398" alt="Screen Shot 2022-01-07 at 4 57 12 PM" src="https://user-images.githubusercontent.com/8432644/148625034-fbda5cd3-caf0-4ccc-95f6-e952982ab7e3.png">
<img width="398" alt="Screen Shot 2022-01-07 at 4 57 27 PM" src="https://user-images.githubusercontent.com/8432644/148625036-bd0debb9-2c1c-4ba0-8ff5-5da4cc501fe9.png">


### Other changes

_Describe any minor or "drive-by" changes here._

### Tested

_An explanation of how the changes were tested or an explanation as to why they don't need to be._


### How others should test

_Does this need to be tested by QA in the next release cycle? If so please give a brief explanation of how to test these changes._

### Related issues

- Fixes #[issue number here]

### Backwards compatibility

_Brief explanation of why these changes are/are not backwards compatible._