### PR TITLE
Enable mergify's merge queue

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -12,7 +12,6 @@ pull_request_rules:
     actions:
       merge:
         method: squash 
-        strict: true
         commit_message: title+body
       delete_head_branch:
         force: False

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,17 +1,39 @@
+queue_rules:
+  - name: default
+    # With `speculative_check: 1` and `batch_size: 3`, if there are 3 PRs in the queue,
+    # Mergify will test #1 + #2 + #3 (combined). If it passes, Mergify assumes #1 and #1 + #2 works too
+    # and merges all of those pull requests at the same time.
+    # Note: it's possible but unlikely that one composing pull requests would fail if tested individually
+    # but we're willing to make this trade-off
+    # See https://blog.mergify.com/a-merge-queue-on-steroids/ for more details
+    speculative_checks: 1
+    batch_size: 3
+    conditions:
+      # List of all the tests that should pass.
+      # Keep this in sync with the github branch protection settings
+      - check-success=Lint
+      - check-success=Vulnerabilities
+      - check-success=General
+      - check-success=Mobile
+      - check-success=iOS
+      - check-success=Android
+
 pull_request_rules:
   - name: Automatically merge on CI success and code review
     conditions:
-      # Add this label when you are ready to automerge the pull request.       
-      - "label=automerge"
+      # Add this label when you are ready to automerge the pull request.
+      - 'label=automerge'
       # Exclude drafts
-      - "-draft"
+      - '-draft'
       # At least one approval required
-      - "#approved-reviews-by>=1"
+      - '#approved-reviews-by>=1'
       # Only enable this when the pull request is being merged into main
-      - "base=main"
+      - 'base=main'
     actions:
-      merge:
-        method: squash 
-        commit_message: title+body
+      queue:
+        # Updates with latest from main, then merges once CI passes
+        name: default
+        method: squash
+        commit_message_template: "{{ title }} ({{ number }})\n\n{{ body }}"
       delete_head_branch:
         force: False


### PR DESCRIPTION
### Description

Based on #1578, and enables the merge queue with `batch_size: 3`.

This should speed up merging PRs when multiple PRs are ready. 
For instance, when there are 3 PRs in the queue, we'll only need to wait for ~30mins (e2e checks) instead of 1h30mins 
See details in the config.

One important detail though with this:
> With speculative checks, pull requests are tested against the base branch within another temporary pull request. This requires the branch protection settings `Require branches to be up to date before merging` to be disabled.
See https://docs.mergify.com/actions/queue/#speculative-checks

I assume this applies to `batch_size` too given how it works. I haven't yet made this config change on the repo. 
I'll observe this to confirm it's needed. 
In that case I'll probably make it a requirement to merge PRs using the `automerge` tag to prevent manual merges which could fail once in the `main` branch.

### Tested

- Waiting for checks to pass and seeing it works when multiple PRs are ready.

### How others should test

N/A

### Related issues

- Discussed on [Slack](https://valora-app.slack.com/archives/CL7BVQPHB/p1641889703016600?thread_ts=1638820711.238300&cid=CL7BVQPHB)

### Backwards compatibility

Yes