### PR TITLE
Add i18next json type to crowdin config to enable multiple pluralisation

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,5 +1,6 @@
 files:
   - source: /packages/mobile/locales/base/*.json
     translation: /packages/mobile/locales/%locale%/%original_file_name%
+    type: i18next_json
   - source: /packages/mobile/ios/celo/Base.lproj/InfoPlist.strings
     translation: /packages/mobile/ios/celo/%osx_code%/%original_file_name%


### PR DESCRIPTION
### Description

Update i18n config to include type i18next_json to enable multiple pluralisation

### Other changes

N/A

### Tested

None


### How others should test

None

### Related issues

N/A

### Backwards compatibility
N/A