### PR TITLE
Dynamic total steps number on registration flow screen headers

### DIFF
--- a/packages/mobile/locales/base/translation.json
+++ b/packages/mobile/locales/base/translation.json
@@ -679,8 +679,8 @@
   },
   "createAccount": "Create Account",
   "restoreAccount": "Restore My Account",
-  "createAccountSteps": "Step {{step}} of 3",
-  "restoreAccountSteps": "Step {{step}} of 4",
+  "createAccountSteps": "Step {{step}} of {{totalSteps}}",
+  "restoreAccountSteps": "Step {{step}} of {{totalSteps}}",
   "selectCountryCode": "Select Country Code",
   "pincodeSet": {
     "create": "Create a PIN",
@@ -1067,7 +1067,7 @@
     "subtitle": "Your account is currently empty",
     "addFunds": "Add Funds",
     "titleRamp": "Add {{currency}} to start using Valora",
-    "subtitleRamp": "Add funds with zero fees through one of our trusted external providers.",
+    "subtitleRamp": "Add funds with zero fees through one of our trusted external providers."
   },
   "balances": "Balances",
   "totalValue": "Total Balance",

--- a/packages/mobile/src/account/selectors.ts
+++ b/packages/mobile/src/account/selectors.ts
@@ -44,3 +44,13 @@ export const accountToRecoverSelector = (state: RootState) =>
   state.account.accountToRecoverFromStoreWipe
 export const kycStatusSelector = (state: RootState) => state.account.kycStatus
 export const backupCompletedSelector = (state: RootState) => state.account.backupCompleted
+
+export const choseToRestoreAccountSelector = (state: RootState) =>
+  state.account.choseToRestoreAccount
+
+export const totalRegistrationStepsSelector = createSelector(
+  choseToRestoreAccountSelector,
+  (chooseRestoreAccount) => {
+    return chooseRestoreAccount ? 4 : 3
+  }
+)

--- a/packages/mobile/src/import/ImportWallet.tsx
+++ b/packages/mobile/src/import/ImportWallet.tsx
@@ -5,7 +5,7 @@ import colors from '@celo/react-components/styles/colors'
 import fontStyles from '@celo/react-components/styles/fonts'
 import { HeaderHeightContext, StackScreenProps } from '@react-navigation/stack'
 import BigNumber from 'bignumber.js'
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useLayoutEffect, useState } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import { Dimensions, Keyboard, StyleSheet, Text, View } from 'react-native'
 import { SafeAreaInsetsContext } from 'react-native-safe-area-context'
@@ -24,12 +24,12 @@ import {
 import CodeInput, { CodeInputStatus } from 'src/components/CodeInput'
 import CurrencyDisplay from 'src/components/CurrencyDisplay'
 import Dialog from 'src/components/Dialog'
-import i18n from 'src/i18n'
 import { importBackupPhrase } from 'src/import/actions'
 import { HeaderTitleWithSubtitle, nuxNavigationOptions } from 'src/navigator/Headers'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import { StackParamList } from 'src/navigator/types'
+import useRegistrationStep from 'src/onboarding/registration/useRegistrationStep'
 import TopBarTextButtonOnboarding from 'src/onboarding/TopBarTextButtonOnboarding'
 import UseBackToWelcomeScreen from 'src/onboarding/UseBackToWelcomeScreen'
 import { isAppConnected } from 'src/redux/selectors'
@@ -59,6 +59,7 @@ function ImportWallet({ navigation, route }: Props) {
 
   const dispatch = useDispatch()
   const { t } = useTranslation()
+  const registrationStep = useRegistrationStep(3)
 
   async function autocompleteSavedMnemonic() {
     if (!accountToRecoverFromStoreWipe) {
@@ -70,6 +71,22 @@ function ImportWallet({ navigation, route }: Props) {
       onPressRestore()
     }
   }
+
+  useLayoutEffect(() => {
+    navigation.setOptions({
+      ...nuxNavigationOptions,
+      headerLeft: () => (
+        <TopBarTextButtonOnboarding
+          title={t('cancel')}
+          // Note: redux state reset is handled by UseBackToWelcomeScreen
+          onPress={() => navigate(Screens.Welcome)}
+        />
+      ),
+      headerTitle: () => (
+        <HeaderTitleWithSubtitle title={t('importIt')} subTitle={registrationStep} />
+      ),
+    })
+  }, [navigation, registrationStep, route.params])
 
   useEffect(() => {
     ValoraAnalytics.track(OnboardingEvents.wallet_import_start)
@@ -217,23 +234,6 @@ function ImportWallet({ navigation, route }: Props) {
       )}
     </HeaderHeightContext.Consumer>
   )
-}
-
-ImportWallet.navigationOptions = {
-  ...nuxNavigationOptions,
-  headerLeft: () => (
-    <TopBarTextButtonOnboarding
-      title={i18n.t('cancel')}
-      // Note: redux state reset is handled by UseBackToWelcomeScreen
-      onPress={() => navigate(Screens.Welcome)}
-    />
-  ),
-  headerTitle: () => (
-    <HeaderTitleWithSubtitle
-      title={i18n.t('importIt')}
-      subTitle={i18n.t('restoreAccountSteps', { step: '3' })}
-    />
-  ),
 }
 
 const styles = StyleSheet.create({

--- a/packages/mobile/src/navigator/types.tsx
+++ b/packages/mobile/src/navigator/types.tsx
@@ -188,6 +188,7 @@ export type StackParamList = {
         changePin?: boolean
         komenciAvailable?: boolean
         choseToRestoreAccount?: boolean
+        totalRegistrationSteps?: number
       }
     | undefined
   [Screens.PhoneNumberLookupQuota]: {
@@ -289,7 +290,7 @@ export type StackParamList = {
   [Screens.LinkBankAccountScreen]: { kycStatus: KycStatus | undefined }
   [Screens.ConnectPhoneNumberScreen]: undefined
   [Screens.VerificationInputScreen]:
-    | { showHelpDialog?: boolean; choseToRestoreAccount?: boolean }
+    | { showHelpDialog?: boolean; choseToRestoreAccount?: boolean; totalRegistrationSteps?: number }
     | undefined
   [Screens.VerificationLoadingScreen]: { withoutRevealing: boolean }
   [Screens.OnboardingEducationScreen]: undefined

--- a/packages/mobile/src/onboarding/registration/NameAndPicture.tsx
+++ b/packages/mobile/src/onboarding/registration/NameAndPicture.tsx
@@ -20,6 +20,7 @@ import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import { StackParamList } from 'src/navigator/types'
 import PictureInput from 'src/onboarding/registration/PictureInput'
+import useRegistrationStep from 'src/onboarding/registration/useRegistrationStep'
 import useTypedSelector from 'src/redux/useSelector'
 import { saveProfilePicture } from 'src/utils/image'
 import { useAsyncKomenciReadiness } from 'src/verify/hooks'
@@ -35,6 +36,7 @@ function NameAndPicture({ navigation }: Props) {
   const dispatch = useDispatch()
 
   const { t } = useTranslation()
+  const registrationStep = useRegistrationStep(1)
 
   // CB TEMPORARY HOTFIX: Pinging Komenci endpoint to ensure availability
   const asyncKomenciReadiness = useAsyncKomenciReadiness()
@@ -44,13 +46,11 @@ function NameAndPicture({ navigation }: Props) {
       headerTitle: () => (
         <HeaderTitleWithSubtitle
           title={t(choseToRestoreAccount ? 'restoreAccount' : 'createAccount')}
-          subTitle={t(choseToRestoreAccount ? 'restoreAccountSteps' : 'createAccountSteps', {
-            step: '1',
-          })}
+          subTitle={registrationStep}
         />
       ),
     })
-  }, [navigation, choseToRestoreAccount])
+  }, [navigation, choseToRestoreAccount, registrationStep])
 
   const goToNextScreen = () => {
     if (recoveringFromStoreWipe) {

--- a/packages/mobile/src/onboarding/registration/useRegistrationStep.ts
+++ b/packages/mobile/src/onboarding/registration/useRegistrationStep.ts
@@ -1,0 +1,17 @@
+import { useTranslation } from 'react-i18next'
+import { useSelector } from 'react-redux'
+import {
+  choseToRestoreAccountSelector,
+  totalRegistrationStepsSelector,
+} from 'src/account/selectors'
+
+export default function useRegistrationStep(step: number) {
+  const { t } = useTranslation()
+  const choseToRestoreAccount = useSelector(choseToRestoreAccountSelector)
+  const totalSteps = useSelector(totalRegistrationStepsSelector)
+
+  return t(choseToRestoreAccount ? 'restoreAccountSteps' : 'createAccountSteps', {
+    step,
+    totalSteps,
+  })
+}

--- a/packages/mobile/src/pincode/PincodeSet.tsx
+++ b/packages/mobile/src/pincode/PincodeSet.tsx
@@ -10,6 +10,7 @@ import { SafeAreaView } from 'react-native-safe-area-context'
 import { connect } from 'react-redux'
 import { initializeAccount, setPincode } from 'src/account/actions'
 import { PincodeType } from 'src/account/reducer'
+import { totalRegistrationStepsSelector } from 'src/account/selectors'
 import { OnboardingEvents, SettingsEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import DevSkipButton from 'src/components/DevSkipButton'
@@ -35,6 +36,7 @@ interface StateProps {
   hideVerification: boolean
   useExpandedBlocklist: boolean
   account: string
+  totalRegistrationSteps: number
 }
 
 interface DispatchProps {
@@ -57,6 +59,7 @@ type Props = ScreenProps & StateProps & DispatchProps & WithTranslation
 function mapStateToProps(state: RootState): StateProps {
   return {
     choseToRestoreAccount: state.account.choseToRestoreAccount,
+    totalRegistrationSteps: totalRegistrationStepsSelector(state),
     hideVerification: state.app.hideVerification,
     useExpandedBlocklist: state.app.pincodeUseExpandedBlocklist,
     account: currentAccountSelector(state) ?? '',
@@ -85,7 +88,7 @@ export class PincodeSet extends React.Component<Props, State> {
                   route.params?.choseToRestoreAccount
                     ? 'restoreAccountSteps'
                     : 'createAccountSteps',
-                  { step: '2' }
+                  { step: '2', totalSteps: route.params?.totalRegistrationSteps }
                 )
           }
         />
@@ -114,7 +117,10 @@ export class PincodeSet extends React.Component<Props, State> {
     }
 
     // Setting choseToRestoreAccount on route param for navigationOptions
-    this.props.navigation.setParams({ choseToRestoreAccount: this.props.choseToRestoreAccount })
+    this.props.navigation.setParams({
+      choseToRestoreAccount: this.props.choseToRestoreAccount,
+      totalRegistrationSteps: this.props.totalRegistrationSteps,
+    })
   }
 
   isChangingPin() {

--- a/packages/mobile/src/verify/VerificationEducationScreen.tsx
+++ b/packages/mobile/src/verify/VerificationEducationScreen.tsx
@@ -7,7 +7,7 @@ import { Spacing } from '@celo/react-components/styles/styles'
 import { Countries } from '@celo/utils/lib/countries'
 import { useFocusEffect } from '@react-navigation/native'
 import { StackScreenProps, useHeaderHeight } from '@react-navigation/stack'
-import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useState } from 'react'
 import { useAsync } from 'react-async-hook'
 import { useTranslation } from 'react-i18next'
 import { ActivityIndicator, ScrollView, StyleSheet, Text, View } from 'react-native'
@@ -16,7 +16,7 @@ import Modal from 'react-native-modal'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useDispatch, useSelector } from 'react-redux'
 import { initializeAccount, setPhoneNumber } from 'src/account/actions'
-import { defaultCountryCodeSelector } from 'src/account/selectors'
+import { choseToRestoreAccountSelector, defaultCountryCodeSelector } from 'src/account/selectors'
 import { showError } from 'src/alert/actions'
 import { OnboardingEvents, VerificationEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
@@ -32,6 +32,7 @@ import { navigate, navigateHome } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import { TopBarTextButton } from 'src/navigator/TopBarButton'
 import { StackParamList } from 'src/navigator/types'
+import useRegistrationStep from 'src/onboarding/registration/useRegistrationStep'
 import { waitUntilSagasFinishLoading } from 'src/redux/sagas'
 import useTypedSelector from 'src/redux/useSelector'
 import { getCountryFeatures } from 'src/utils/countryFeatures'
@@ -87,7 +88,8 @@ function VerificationEducationScreen({ route, navigation }: Props) {
   const currentState = useSelector(currentStateSelector)
   const shouldUseKomenci = useSelector(shouldUseKomenciSelector)
   const verificationStatus = useSelector(verificationStatusSelector)
-  const choseToRestoreAccount = useTypedSelector((state) => state.account.choseToRestoreAccount)
+  const choseToRestoreAccount = useSelector(choseToRestoreAccountSelector)
+  const registrationStep = useRegistrationStep(route.params?.choseToRestoreAccount ? 4 : 3)
 
   const onPressStart = async () => {
     if (!canUsePhoneNumber()) {
@@ -136,6 +138,32 @@ function VerificationEducationScreen({ route, navigation }: Props) {
     dispatch(stop())
     ValoraAnalytics.track(VerificationEvents.verification_recaptcha_canceled)
   }
+
+  useLayoutEffect(() => {
+    const title = route.params?.hideOnboardingStep
+      ? t('verificationEducation.title')
+      : () => (
+          <HeaderTitleWithSubtitle
+            title={t('verificationEducation.title')}
+            subTitle={registrationStep}
+          />
+        )
+
+    navigation.setOptions({
+      ...nuxNavigationOptions,
+      headerTitle: title,
+      headerRight: () =>
+        !route.params?.hideOnboardingStep && (
+          <TopBarTextButton
+            title={t('skip')}
+            testID="VerificationEducationSkipHeader"
+            onPress={() => navigation.setParams({ showSkipDialog: true })}
+            titleStyle={{ color: colors.goldDark }}
+          />
+        ),
+      headerLeft: () => route.params?.hideOnboardingStep && <BackButton />,
+    })
+  }, [navigation, registrationStep, route.params])
 
   useEffect(() => {
     const newCountryAlpha2 = route.params?.selectedCountryCodeAlpha2
@@ -381,34 +409,6 @@ function VerificationEducationScreen({ route, navigation }: Props) {
       />
     </View>
   )
-}
-
-VerificationEducationScreen.navigationOptions = ({ navigation, route }: ScreenProps) => {
-  const title = route.params?.hideOnboardingStep
-    ? i18n.t('verificationEducation.title')
-    : () => (
-        <HeaderTitleWithSubtitle
-          title={i18n.t('verificationEducation.title')}
-          subTitle={i18n.t(
-            route.params?.choseToRestoreAccount ? 'restoreAccountSteps' : 'createAccountSteps',
-            { step: route.params?.choseToRestoreAccount ? '4' : '3' }
-          )}
-        />
-      )
-  return {
-    ...nuxNavigationOptions,
-    headerTitle: title,
-    headerRight: () =>
-      !route.params?.hideOnboardingStep && (
-        <TopBarTextButton
-          title={i18n.t('skip')}
-          testID="VerificationEducationSkipHeader"
-          onPress={() => navigation.setParams({ showSkipDialog: true })}
-          titleStyle={{ color: colors.goldDark }}
-        />
-      ),
-    headerLeft: () => route.params?.hideOnboardingStep && <BackButton />,
-  }
 }
 
 const styles = StyleSheet.create({

--- a/packages/mobile/src/verify/VerificationInputScreen.tsx
+++ b/packages/mobile/src/verify/VerificationInputScreen.tsx
@@ -16,6 +16,7 @@ import { WithTranslation } from 'react-i18next'
 import { Platform, StyleSheet, Text, View } from 'react-native'
 import { SafeAreaInsetsContext } from 'react-native-safe-area-context'
 import { connect, useDispatch } from 'react-redux'
+import { totalRegistrationStepsSelector } from 'src/account/selectors'
 import { hideAlert, showError, showMessage } from 'src/alert/actions'
 import { errorSelector } from 'src/alert/reducer'
 import { ErrorMessages } from 'src/app/ErrorMessages'
@@ -57,6 +58,7 @@ interface StateProps {
   underlyingError: ErrorMessages | null | undefined
   lastRevealAttempt: number | null
   choseToRestoreAccount: boolean | undefined
+  totalRegistrationSteps: number
 }
 
 interface DispatchProps {
@@ -99,6 +101,7 @@ const mapStateToProps = (state: RootState): StateProps => {
     underlyingError: errorSelector(state),
     lastRevealAttempt,
     choseToRestoreAccount: state.account.choseToRestoreAccount,
+    totalRegistrationSteps: totalRegistrationStepsSelector(state),
   }
 }
 
@@ -125,7 +128,10 @@ class VerificationInputScreen extends React.Component<Props, State> {
         title={i18n.t('verificationInput.title')}
         subTitle={i18n.t(
           route.params?.choseToRestoreAccount ? 'restoreAccountSteps' : 'createAccountSteps',
-          { step: route.params?.choseToRestoreAccount ? '4' : '3' }
+          {
+            step: route.params?.choseToRestoreAccount ? '4' : '3',
+            totalSteps: route.params?.totalRegistrationSteps,
+          }
         )}
       />
     ),
@@ -156,7 +162,10 @@ class VerificationInputScreen extends React.Component<Props, State> {
     }, 1000)
 
     // Setting choseToRestoreAccount on route param for navigationOptions
-    this.props.navigation.setParams({ choseToRestoreAccount: this.props.choseToRestoreAccount })
+    this.props.navigation.setParams({
+      choseToRestoreAccount: this.props.choseToRestoreAccount,
+      totalRegistrationSteps: this.props.totalRegistrationSteps,
+    })
   }
 
   componentDidUpdate(prevProps: Props) {


### PR DESCRIPTION
### Description

In the onboarding registration flow, the screen headers are hard coded to say something like `step {{step}} of 3`. For the biometrics experiment, we need to allow for an extra registration step so we need to make this dynamic.

Rather than going through each screen and adding an extra condition, i've opted to extract this simple logic in a reusable hook. Unfortunately 2 of our onboarding screens are class components so I couldn't use them there.

### Other changes

N/A

### Tested

Manually

### How others should test

The onboarding flow (create account/restore account) should work as expected and the step numbers should work as expected.

<img width="414" alt="Screenshot 2022-01-12 at 11 47 23" src="https://user-images.githubusercontent.com/20150449/149126263-5ff1010b-eaf2-47e8-acbd-314728703b53.png">


### Related issues

- Relates to #1683 

### Backwards compatibility

Yes