### PR TITLE
upgrade follow-redirects to latest version

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -10932,9 +10932,9 @@ flush-write-stream@^1.0.0:
     readable-stream "^2.3.6"
 
 follow-redirects@^1.14.0:
-  version "1.14.4"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.4.tgz#838fdf48a8bbdd79e52ee51fb1c94e3ed98b9379"
-  integrity sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g==
+  version "1.14.7"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.7.tgz#2004c02eb9436eee9a21446a6477debf17e81685"
+  integrity sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==
 
 for-in@^0.1.3:
   version "0.1.8"


### PR DESCRIPTION
### Description
follow-redirects pages has security vulnerabilities and is used as a subdependency of `crowdin/ota-client`
The latest patch fixes the vulnerabilities. 

As a result, our ci_check_vulnerabilities script has been failing and thus blocking new commits, eg this execution => https://github.com/valora-inc/wallet/runs/4797782357?check_suite_focus=true

This PR upgrades follow-redirects  to latests version


### Tested
ci_check_vulnerabilities passes now

