### PR TITLE
Fix WalletConnect sign/send now failing with Espresso hardfork nodes

### DIFF
--- a/packages/mobile/src/walletConnect/request.test.ts
+++ b/packages/mobile/src/walletConnect/request.test.ts
@@ -94,7 +94,7 @@ describe(handleRequest, () => {
             feeCurrency: undefined, // undefined to pay with CELO, since the balance is non zero
             gas: 1000000,
             gasPrice: 3,
-            chainId: 44787,
+            chainId: '0xaef3', // 44787 as a hex string
             nonce: 7,
           })
           .run()
@@ -134,7 +134,7 @@ describe(handleRequest, () => {
             feeCurrency: '0xStableToken',
             gas: '50001', // 1 + STATIC_GAS_PADDING
             gasPrice: 3,
-            chainId: 44787,
+            chainId: '0xaef3', // 44787 as a hex string
             nonce: 3,
           })
           .run()
@@ -155,7 +155,7 @@ describe(handleRequest, () => {
             feeCurrency: undefined, // undefined to pay with CELO, since the balance is non zero
             gas: 1,
             gasPrice: 3,
-            chainId: 44787,
+            chainId: '0xaef3', // 44787 as a hex string
             nonce: 3,
           })
           .run()
@@ -178,7 +178,15 @@ describe(handleRequest, () => {
           .provide([[call(getWallet), mockWallet]])
           .withState(state)
           .call(unlockAccount, '0xwallet')
-          .call([mockWallet, 'signTransaction'], txParams)
+          .call([mockWallet, 'signTransaction'], {
+            from: '0xTEST',
+            data: '0xABC',
+            chainId: '0xafc8', // 45000 as a hex string
+            feeCurrency: '0xSomeCurrency',
+            gas: 1,
+            gasPrice: 2,
+            nonce: 3,
+          })
           .run()
       })
 
@@ -202,7 +210,7 @@ describe(handleRequest, () => {
             feeCurrency: '0xStableTokenEUR',
             gas: 1000000,
             gasPrice: 3,
-            chainId: 44787,
+            chainId: '0xaef3', // 44787 as a hex string
             nonce: 7,
           })
           .run()


### PR DESCRIPTION
### Description

Fix WalletConnect sign/send now failing with Espresso hardfork nodes when it needs to call `estimateGas` when gas is not provided.

This fixes our E2E tests failing in the WalletConnect suite.

Note: I still need to asses whether existing Valora versions will actually be impacted by forno switching to version [1.5.0 of Geth](https://github.com/celo-org/celo-blockchain/releases/tag/v1.5.0). Initial thought is most dapps already set `gas` so this shouldn't be a real problem.

### Tested

- Updated unit tests
- E2E test works again

### How others should test

Dapps using WalletConnect can still sign/send transactions.

### Related issues

- Discussed on [Slack](https://valora-app.slack.com/archives/CL7BVQPHB/p1642105337052600)

### Backwards compatibility

Yes.