### PR TITLE
Replace user address in dapp URLs

### DIFF
--- a/packages/mobile/src/dappsExplorer/DAppsExplorerScreen.tsx
+++ b/packages/mobile/src/dappsExplorer/DAppsExplorerScreen.tsx
@@ -21,7 +21,6 @@ import { SafeAreaView } from 'react-native-safe-area-context'
 import { useDispatch, useSelector } from 'react-redux'
 import { openUrl } from 'src/app/actions'
 import { dappsListApiUrlSelector } from 'src/app/selectors'
-import { accountAddressSelector } from 'src/web3/selectors'
 import BackButton from 'src/components/BackButton'
 import BottomSheet from 'src/components/BottomSheet'
 import Dialog from 'src/components/Dialog'
@@ -91,16 +90,13 @@ export function DAppsExplorerScreen() {
         throw new Error('Dapps list url is not defined')
       }
 
-      const response = await fetch(
-        `${dappsListUrl}?language=${shortLanguage}&address=${address}`,
-        {
-          method: 'GET',
-          headers: {
-            'Content-Type': 'application/json',
-            Accept: 'application/json',
-          },
-        }
-      )
+      const response = await fetch(`${dappsListUrl}?language=${shortLanguage}&address=${address}`, {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+        },
+      })
 
       const result = await response.json()
       try {

--- a/packages/mobile/src/dappsExplorer/DAppsExplorerScreen.tsx
+++ b/packages/mobile/src/dappsExplorer/DAppsExplorerScreen.tsx
@@ -32,6 +32,7 @@ import QuitIcon from 'src/icons/QuitIcon'
 import { TopBarIconButton } from 'src/navigator/TopBarButton'
 import { isDeepLink } from 'src/utils/linking'
 import Logger from 'src/utils/Logger'
+import { walletAddressSelector } from 'src/web3/selectors'
 
 const TAG = 'DAppExplorerScreen'
 
@@ -67,6 +68,7 @@ interface SectionData {
 export function DAppsExplorerScreen() {
   const { t, i18n } = useTranslation()
   const dappsListUrl = useSelector(dappsListApiUrlSelector)
+  const address = useSelector(walletAddressSelector)
   const [isHelpDialogVisible, setHelpDialogVisible] = useState(false)
   const [isBottomSheetVisible, setBottomSheetVisible] = useState(false)
   const [dappSelected, setDappSelected] = useState<Dapp>()
@@ -115,7 +117,7 @@ export function DAppsExplorerScreen() {
             name: app.name,
             iconUrl: app.logoUrl,
             description: app.description,
-            dappUrl: app.url,
+            dappUrl: app.url.replace('{{address}}', address ?? ''),
           })
         })
 


### PR DESCRIPTION
### Description

This will allow some dApps to open with the user already 'connected'. The motivating example is CeloTracker, where you can put the address in the URL like `https://celotracker.com/?address={{address}}` and it will show that address's balance.

### Other changes

N/A

### Tested

Manually


### How others should test

No way for QA to test this at this time, but whenever Celo Tracker shows up in the Dapps screen then it should open with the user's account already set when opened

### Related issues

- Fixes #1821

### Backwards compatibility

N/A