### PR TITLE
Fire analytics event when selecting Supercharge in the side menu

### DIFF
--- a/packages/mobile/src/consumerIncentives/analyticsEventsTracker.ts
+++ b/packages/mobile/src/consumerIncentives/analyticsEventsTracker.ts
@@ -7,6 +7,7 @@ export enum RewardsScreenOrigin {
   NotificationBox = 'NotificationBox',
   PaymentDetail = 'PaymentDetail',
   PushNotification = 'PushNotification',
+  SideMenu = 'SideMenu',
 }
 
 export enum RewardsScreenCta {

--- a/packages/mobile/src/navigator/DrawerNavigator.tsx
+++ b/packages/mobile/src/navigator/DrawerNavigator.tsx
@@ -29,7 +29,7 @@ import GoldEducation from 'src/account/GoldEducation'
 import { defaultCountryCodeSelector, e164NumberSelector, nameSelector } from 'src/account/selectors'
 import SettingsScreen from 'src/account/Settings'
 import Support from 'src/account/Support'
-import { HomeEvents } from 'src/analytics/Events'
+import { HomeEvents, RewardsEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import { toggleInviteModal } from 'src/app/actions'
 import {
@@ -42,6 +42,7 @@ import { SuperchargeButtonType } from 'src/app/types'
 import BackupIntroduction from 'src/backup/BackupIntroduction'
 import AccountNumber from 'src/components/AccountNumber'
 import ContactCircleSelf from 'src/components/ContactCircleSelf'
+import { RewardsScreenOrigin } from 'src/consumerIncentives/analyticsEventsTracker'
 import ConsumerIncentivesHomeScreen from 'src/consumerIncentives/ConsumerIncentivesHomeScreen'
 import DAppsExplorerScreen from 'src/dappsExplorer/DAppsExplorerScreen'
 import { fetchExchangeRate } from 'src/exchange/actions'
@@ -100,6 +101,11 @@ function CustomDrawerItemList({
     const focused = i === state.index
     const { title, drawerLabel, drawerIcon } = descriptors[route.key].options
     const navigateToItem = () => {
+      if (route.name === Screens.ConsumerIncentivesHomeScreen) {
+        ValoraAnalytics.track(RewardsEvents.rewards_screen_opened, {
+          origin: RewardsScreenOrigin.SideMenu,
+        })
+      }
       ValoraAnalytics.track(HomeEvents.drawer_navigation, {
         navigateTo: route.name,
       })


### PR DESCRIPTION
### Description

I realized when setting up the experiment that if the user opens the Supercharge screen from an option in the side menu then we were not firing the `rewards_screen_opened` event. Added the event for that as well.

### Other changes

N/A

### Tested

Manually

### How others should test

No need for QA to test.

### Related issues

- Fixes #1686

### Backwards compatibility

N/A