### PR TITLE
Enable multiple devices for android e2e test runs

### DIFF
--- a/.github/workflows/e2e-android.yml
+++ b/.github/workflows/e2e-android.yml
@@ -65,7 +65,7 @@ jobs:
           export PATH=$ANDROID_SDK_ROOT/platform-tools:$PATH
           export PATH=$ANDROID_SDK_ROOT/emulator:$PATH
           cd packages/mobile
-          yarn run test:e2e:android -w 1
+          yarn run test:e2e:android -w 4
         timeout-minutes: 90
       # Publish Test Results
       - name: Publish Android JUnit Report

--- a/packages/mobile/scripts/run_e2e.sh
+++ b/packages/mobile/scripts/run_e2e.sh
@@ -46,12 +46,6 @@ done
 [ -z "$PLATFORM" ] && echo "Need to set the PLATFORM via the -p flag" && exit 1;
 echo "Network delay: $NET_DELAY"
 
-# Android can't handle multiple instances
-if [ "$PLATFORM" == "android" ]; then
-  WORKERS=1
-fi
-
-
 # Start the packager and wait until ready
 startPackager() {
     if [ "$RELEASE" = true ]; then
@@ -166,20 +160,29 @@ if [ $PLATFORM = "android" ]; then
       exit 1
     fi
 
-    echo "Starting the emulator"
-    $ANDROID_SDK_ROOT/emulator/emulator \
-      -avd $VD_NAME \
-      -no-boot-anim \
-      -noaudio \
-      -no-snapshot \
-      -netdelay $NET_DELAY \
-      ${CI:+-gpu swiftshader_indirect -no-window} \
-      &
-
-    echo "Waiting for device to connect to Wifi, this is a good proxy the device is ready"
-    until [ `adb shell dumpsys wifi | grep "mNetworkInfo" | grep "state: CONNECTED" | wc -l` -gt 0 ]
+    for ((i=1; i<=$WORKERS; i=i+1))
     do
-      sleep 3
+      echo "Starting the emulator"
+      $ANDROID_SDK_ROOT/emulator/emulator \
+        -avd $VD_NAME \
+        -no-boot-anim \
+        -noaudio \
+        -no-snapshot \
+        -read-only \
+        -netdelay $NET_DELAY \
+        ${CI:+-gpu swiftshader_indirect -no-window} \
+        &
+    done
+
+    # Give a few second for emulators to launch
+    sleep 3
+    echo `adb devices`
+    for DEVICE in `adb devices| grep emulator| cut -f1`; do
+      echo "Waiting for ${DEVICE} to connect to Wifi, this is a good proxy the device is ready"
+      until [ `adb -s ${DEVICE} shell dumpsys wifi | grep "mNetworkInfo" | grep "state: CONNECTED" | wc -l` -gt 0 ]
+      do
+        sleep 3
+      done
     done
   fi
 


### PR DESCRIPTION
### Description

Enabled multiple devices for Android test runs.

### Other changes

N/A

### Tested

Tested locally on Android.

### How others should test

Does not need to be tested by QA. Reviewers should view the test runs for Android related to this PR.

### Related issues

N/A

### Backwards compatibility

Yes