### PR TITLE
Check that sentry is enabled before making calls

### DIFF
--- a/packages/mobile/src/app/ErrorBoundary.tsx
+++ b/packages/mobile/src/app/ErrorBoundary.tsx
@@ -5,6 +5,7 @@ import { WithTranslation } from 'react-i18next'
 import { AppEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import ErrorScreen from 'src/app/ErrorScreen'
+import { SENTRY_ENABLED } from 'src/config'
 import { withTranslation } from 'src/i18n'
 
 interface State {
@@ -25,7 +26,9 @@ class ErrorBoundary extends React.Component<Props, State> {
   componentDidCatch(error: Error, info: any) {
     this.setState({ childError: error })
     ValoraAnalytics.track(AppEvents.error_displayed, { error: error.message })
-    Sentry.captureException(error)
+    if (SENTRY_ENABLED) {
+      Sentry.captureException(error)
+    }
   }
 
   render() {

--- a/packages/mobile/src/services/ReactNativeLogger.ts
+++ b/packages/mobile/src/services/ReactNativeLogger.ts
@@ -2,7 +2,6 @@
 import * as Sentry from '@sentry/react-native'
 import * as RNFS from 'react-native-fs'
 import Toast from 'react-native-simple-toast'
-import { SENTRY_ENABLED } from 'src/config'
 
 export default class ReactNativeLogger {
   /**
@@ -35,9 +34,7 @@ export default class ReactNativeLogger {
     const sanitizedError =
       error && shouldSanitizeError ? this.sanitizeError(error, valueToPurge) : error
     const errorMsg = this.getErrorMessage(sanitizedError)
-    if (SENTRY_ENABLED) {
-      Sentry.captureException(error, { extra: { tag, message, errorMsg, source: 'Logger.error' } })
-    }
+    Sentry.captureException(error, { extra: { tag, message, errorMsg, source: 'Logger.error' } })
     console.info(`${tag} :: ${message} :: ${errorMsg}`)
     if (__DEV__) {
       console.info(console.trace())

--- a/packages/mobile/src/services/ReactNativeLogger.ts
+++ b/packages/mobile/src/services/ReactNativeLogger.ts
@@ -2,6 +2,7 @@
 import * as Sentry from '@sentry/react-native'
 import * as RNFS from 'react-native-fs'
 import Toast from 'react-native-simple-toast'
+import { SENTRY_ENABLED } from 'src/config'
 
 export default class ReactNativeLogger {
   /**
@@ -34,7 +35,9 @@ export default class ReactNativeLogger {
     const sanitizedError =
       error && shouldSanitizeError ? this.sanitizeError(error, valueToPurge) : error
     const errorMsg = this.getErrorMessage(sanitizedError)
-    Sentry.captureException(error, { extra: { tag, message, errorMsg, source: 'Logger.error' } })
+    if (SENTRY_ENABLED) {
+      Sentry.captureException(error, { extra: { tag, message, errorMsg, source: 'Logger.error' } })
+    }
     console.info(`${tag} :: ${message} :: ${errorMsg}`)
     if (__DEV__) {
       console.info(console.trace())

--- a/packages/mobile/src/transactions/feed/TransactionFeed.tsx
+++ b/packages/mobile/src/transactions/feed/TransactionFeed.tsx
@@ -4,6 +4,7 @@ import React, { useMemo, useState } from 'react'
 import { useAsync } from 'react-async-hook'
 import { SectionList } from 'react-native'
 import { useDispatch } from 'react-redux'
+import { SENTRY_ENABLED } from 'src/config'
 import config from 'src/geth/networkConfig'
 import useInterval from 'src/hooks/useInterval'
 import { getLocalCurrencyCode } from 'src/localCurrency/selectors'
@@ -76,7 +77,9 @@ function useQueryTransactionFeed() {
           dispatch(updateTransactions(result.data.tokenTransactionsV2.transactions))
         }
         if (result?.errors) {
-          Sentry.captureException(result.errors)
+          if (SENTRY_ENABLED) {
+            Sentry.captureException(result.errors)
+          }
           Logger.warn(
             TAG,
             `Found errors when querying the transaction feed: ${JSON.stringify(result.errors)}`


### PR DESCRIPTION
### Description

Sentry calls were being made when they shouldn't be e.g. e2e tests. This resulted in a large amount of sentry errors. This PR uses the SENTRY_ENABLED flag to check if we should be making the call prior to making the sentry call.

Slack Thread: https://valora-app.slack.com/archives/C02N3AR2P2S/p1642875669024700

### Tested

Tested in CI & sentry errors observed to be reduced (WIP).

[Issue 1](https://sentry.io/share/issue/3c309012982f42159758d39b91f4eb91)
[Issue 2](https://sentry.io/share/issue/d24cfb5430c0498eb173a92f162c7893)


### How others should test

No need for QA to test. Reviewers please check that the number of errors from Sentry is decreasing.

### Related issues

N/A

### Backwards compatibility

Yes