### PR TITLE
refactor: Removing extra feature flag for dapps screen

### DIFF
--- a/packages/mobile/src/app/reducers.ts
+++ b/packages/mobile/src/app/reducers.ts
@@ -18,7 +18,6 @@ export interface State {
   celoEducationUri: string | null
   celoEuroEnabled: boolean
   dappListApiUrl: string | null
-  dappsExplorerEnabled: boolean
   inviteModalVisible: boolean
   activeScreen: Screens
   hideVerification: boolean
@@ -64,7 +63,6 @@ const initialState = {
   celoEducationUri: null,
   celoEuroEnabled: REMOTE_CONFIG_VALUES_DEFAULTS.celoEuroEnabled,
   dappListApiUrl: null,
-  dappsExplorerEnabled: REMOTE_CONFIG_VALUES_DEFAULTS.dappsExplorerEnabled,
   inviteModalVisible: false,
   activeScreen: Screens.Main,
   hideVerification: REMOTE_CONFIG_VALUES_DEFAULTS.hideVerification,
@@ -184,7 +182,6 @@ export const appReducer = (
         celoEducationUri: action.configValues.celoEducationUri,
         celoEuroEnabled: action.configValues.celoEuroEnabled,
         dappListApiUrl: action.configValues.dappListApiUrl,
-        dappsExplorerEnabled: action.configValues.dappsExplorerEnabled,
         walletConnectV1Enabled: action.configValues.walletConnectV1Enabled,
         walletConnectV2Enabled: action.configValues.walletConnectV2Enabled,
         rewardsPercent: action.configValues.rewardsPercent,

--- a/packages/mobile/src/app/saga.ts
+++ b/packages/mobile/src/app/saga.ts
@@ -146,7 +146,6 @@ export interface RemoteConfigValues {
   celoEducationUri: string | null
   celoEuroEnabled: boolean
   dappListApiUrl: string | null
-  dappsExplorerEnabled: boolean
   inviteRewardCusd: number
   inviteRewardWeeklyLimit: number
   inviteRewardsEnabled: boolean

--- a/packages/mobile/src/firebase/firebase.ts
+++ b/packages/mobile/src/firebase/firebase.ts
@@ -249,7 +249,6 @@ export async function fetchRemoteConfigValues(): Promise<RemoteConfigValues | nu
     celoEducationUri: flags.celoEducationUri?.asString() ?? null,
     celoEuroEnabled: flags.celoEuroEnabled.asBoolean(),
     dappListApiUrl: flags.dappListApiUrl?.asString() ?? null,
-    dappsExplorerEnabled: flags.dappsExplorerEnabled.asBoolean(),
     inviteRewardsEnabled: flags.inviteRewardsEnabled.asBoolean(),
     inviteRewardCusd: flags.inviteRewardCusd.asNumber(),
     inviteRewardWeeklyLimit: flags.inviteRewardWeeklyLimit.asNumber(),

--- a/packages/mobile/src/firebase/remoteConfigValuesDefaults.e2e.ts
+++ b/packages/mobile/src/firebase/remoteConfigValuesDefaults.e2e.ts
@@ -38,6 +38,5 @@ export const REMOTE_CONFIG_VALUES_DEFAULTS: Omit<
   sentryTracesSampleRate: 0.2,
   dappListApiUrl:
     'https://raw.githubusercontent.com/valora-inc/dapp-list/main/translations/valora-dapp-list-base.json',
-  dappsExplorerEnabled: true,
   superchargeButtonType: SuperchargeButtonType.PillRewards,
 }

--- a/packages/mobile/src/firebase/remoteConfigValuesDefaults.ts
+++ b/packages/mobile/src/firebase/remoteConfigValuesDefaults.ts
@@ -13,7 +13,6 @@ export const REMOTE_CONFIG_VALUES_DEFAULTS: Omit<
   // same here
   // celoEducationUri: null,
   // dappListApiUrl: null,
-  dappsExplorerEnabled: false,
   celoEuroEnabled: true,
   inviteRewardsEnabled: false,
   inviteRewardCusd: 5,

--- a/packages/mobile/src/navigator/DrawerNavigator.tsx
+++ b/packages/mobile/src/navigator/DrawerNavigator.tsx
@@ -196,7 +196,6 @@ function CustomDrawerContent(props: DrawerContentComponentProps<DrawerContentOpt
 export default function DrawerNavigator() {
   const { t } = useTranslation()
   const isCeloEducationComplete = useSelector((state) => state.goldToken.educationCompleted)
-  const isDappsExplorerEnabled = useSelector((state) => state.app.dappsExplorerEnabled)
   const dappsListUrl = useSelector(dappsListApiUrlSelector)
 
   const rewardsEnabled = useSelector(rewardsEnabledSelector)
@@ -239,7 +238,7 @@ export default function DrawerNavigator() {
           }}
         />
       )}
-      {isDappsExplorerEnabled && dappsListUrl && (
+      {dappsListUrl && (
         <Drawer.Screen
           name={Screens.DAppsExplorerScreen}
           component={DAppsExplorerScreen}

--- a/packages/mobile/src/redux/migrations.ts
+++ b/packages/mobile/src/redux/migrations.ts
@@ -375,7 +375,6 @@ export const migrations = {
     app: {
       ...state.app,
       dappListApiUrl: null,
-      dappsExplorerEnabled: false,
     },
   }),
 }

--- a/packages/mobile/test/schemas.ts
+++ b/packages/mobile/test/schemas.ts
@@ -891,7 +891,6 @@ export const v28Schema = {
   app: {
     ...v27Schema.app,
     dappListApiUrl: null,
-    dappsExplorerEnabled: false,
   },
 }
 


### PR DESCRIPTION
### Description

`dappsExplorerEnabled` is removed, now we check if `dappListApiUrl` is defined to show the Dapps Screen. (see: https://github.com/valora-inc/wallet/pull/1784#discussion_r789935054)

### Tested

Locally in the emulator.
