### PR TITLE
Use default genesis block to connect to testnet

### DIFF
--- a/packages/mobile/__mocks__/@celo/network-utils/index.ts
+++ b/packages/mobile/__mocks__/@celo/network-utils/index.ts
@@ -1,7 +1,3 @@
-export const GenesisBlockUtils = jest.fn()
-GenesisBlockUtils.getGenesisBlockAsync = jest.fn()
-GenesisBlockUtils.getChainIdFromGenesis = jest.fn()
-
 export const StaticNodeUtils = jest.fn().mockImplementation()
 StaticNodeUtils.getStaticNodesAsync = jest.fn()
 StaticNodeUtils.getStaticNodeRegion = jest.fn()

--- a/packages/mobile/src/geth/saga.test.ts
+++ b/packages/mobile/src/geth/saga.test.ts
@@ -1,4 +1,4 @@
-import { GenesisBlockUtils, StaticNodeUtils } from '@celo/network-utils'
+import { StaticNodeUtils } from '@celo/network-utils'
 import GethBridge from 'react-native-geth'
 import { expectSaga } from 'redux-saga-test-plan'
 import { delay } from 'redux-saga/effects'
@@ -17,8 +17,6 @@ describe(initGethSaga, () => {
     getStaticNodeRegion.mockReturnValue('')
     const getStaticNodesAsync = StaticNodeUtils.getStaticNodesAsync as jest.Mock
     getStaticNodesAsync.mockReturnValue(Promise.resolve('["enode://foo"]'))
-    const getGenesisBlockAsync = GenesisBlockUtils.getGenesisBlockAsync as jest.Mock
-    getGenesisBlockAsync.mockReturnValue(Promise.resolve({}))
     const MockGethBridge = (GethBridge as unknown) as Record<string, jest.Mock>
     MockGethBridge.startNode.mockClear()
   })
@@ -51,8 +49,6 @@ describe(initGethSaga, () => {
   it('initializes the bridge and starts the node', async () => {
     const getStaticNodeRegion = StaticNodeUtils.getStaticNodeRegion as jest.Mock
     getStaticNodeRegion.mockReturnValue('')
-    const getGenesisBlockAsync = GenesisBlockUtils.getGenesisBlockAsync as jest.Mock
-    getGenesisBlockAsync.mockReturnValue(Promise.resolve({}))
     const MockGethBridge = (GethBridge as unknown) as Record<string, jest.Mock>
     MockGethBridge.startNode.mockClear()
     const getStaticNodesAsync = StaticNodeUtils.getStaticNodesAsync as jest.Mock

--- a/packages/mobile/src/geth/saga.ts
+++ b/packages/mobile/src/geth/saga.ts
@@ -15,12 +15,7 @@ import {
   setInitState,
   SetInitStateAction,
 } from 'src/geth/actions'
-import {
-  FailedToFetchGenesisBlockError,
-  FailedToFetchStaticNodesError,
-  initGeth,
-  stopGethIfInitialized,
-} from 'src/geth/geth'
+import { FailedToFetchStaticNodesError, initGeth, stopGethIfInitialized } from 'src/geth/geth'
 import { InitializationState } from 'src/geth/reducer'
 import {
   chainHeadSelector,
@@ -50,7 +45,6 @@ export enum GethInitOutcomes {
   SUCCESS = 'SUCCESS',
   NETWORK_ERROR_FETCHING_STATIC_NODES = 'NETWORK_ERROR_FETCHING_STATIC_NODES',
   IRRECOVERABLE_FAILURE = 'IRRECOVERABLE_FAILURE',
-  NETWORK_ERROR_FETCHING_GENESIS_BLOCK = 'NETWORK_ERROR_FETCHING_GENESIS_BLOCK',
 }
 
 // react-native-geth on Android returns a non-standard block header encoding from the GethNewHead event.
@@ -194,8 +188,6 @@ function* waitForGethInit() {
     switch (error) {
       case FailedToFetchStaticNodesError:
         return GethInitOutcomes.NETWORK_ERROR_FETCHING_STATIC_NODES
-      case FailedToFetchGenesisBlockError:
-        return GethInitOutcomes.NETWORK_ERROR_FETCHING_GENESIS_BLOCK
       default: {
         Logger.error(TAG, 'Error getting geth instance', error)
         return GethInitOutcomes.IRRECOVERABLE_FAILURE
@@ -241,14 +233,6 @@ export function* initGethSaga() {
   let errorContext: string
 
   switch (failureResult) {
-    case GethInitOutcomes.NETWORK_ERROR_FETCHING_GENESIS_BLOCK: {
-      errorContext =
-        'Could not fetch genesis block from the network. Tell user to check data connection.'
-      Logger.error(TAG, errorContext)
-      yield put(setInitState(InitializationState.DATA_CONNECTION_MISSING_ERROR))
-      restartAppAutomatically = false
-      break
-    }
     case GethInitOutcomes.IRRECOVERABLE_FAILURE: {
       errorContext = 'Could not initialize geth. Will retry.'
       Logger.error(TAG, errorContext)


### PR DESCRIPTION
### Description

Related to https://github.com/celo-org/celo-blockchain/pull/1811, this PR removes the logic to
download and manually set the genesis block when instantiating the blockchain client. When used with
a mobile client that includes the PR linked above, it will use the genesis block for the network
corresponding to the given network ID. This avoids the need to download the genesis block, such that
clients that do not use static nodes (e.g. clients using Forno) will not require downloading any
files before starting their node.

### Other changes

None

### Tested

WIP

### Backwards compatibility

Should be fully backwards compatible, but this should be tested.
