### PR TITLE
Count only tokens with balance in analytics

### DIFF
--- a/packages/mobile/src/analytics/ValoraAnalytics.test.ts
+++ b/packages/mobile/src/analytics/ValoraAnalytics.test.ts
@@ -3,6 +3,12 @@ import { HomeEvents } from 'src/analytics/Events'
 import ValoraAnalyticsModule from 'src/analytics/ValoraAnalytics'
 import { store } from 'src/redux/store'
 import { getMockStoreData } from 'test/utils'
+import {
+  mockCeloAddress,
+  mockCeurAddress,
+  mockCusdAddress,
+  mockTestTokenAddress,
+} from 'test/values'
 import { mocked } from 'ts-jest/utils'
 
 jest.mock('@segment/analytics-react-native', () => ({
@@ -29,7 +35,53 @@ Date.now = jest.fn(() => 1482363367071)
 const mockedAnalytics = mocked(Analytics)
 
 const mockStore = mocked(store)
-const state = getMockStoreData()
+const state = getMockStoreData({
+  tokens: {
+    tokenBalances: {
+      [mockCusdAddress]: {
+        address: mockCusdAddress,
+        symbol: 'cUSD',
+        usdPrice: '1',
+        balance: '10',
+        priceFetchedAt: Date.now(),
+      },
+      [mockCeurAddress]: {
+        address: mockCeurAddress,
+        symbol: 'cEUR',
+        usdPrice: '1.2',
+        balance: '20',
+        priceFetchedAt: Date.now(),
+      },
+      [mockCeloAddress]: {
+        address: mockCeloAddress,
+        symbol: 'CELO',
+        usdPrice: '5',
+        balance: '0',
+        priceFetchedAt: Date.now(),
+      },
+      [mockTestTokenAddress]: {
+        address: mockTestTokenAddress,
+        symbol: 'TT',
+        balance: '10',
+        priceFetchedAt: Date.now(),
+      },
+      '0xMOO': {
+        address: '0xMOO',
+        symbol: 'MOO',
+        usdPrice: '4',
+        balance: '0',
+        priceFetchedAt: Date.now(),
+      },
+      '0xUBE': {
+        address: '0xUBE',
+        symbol: 'UBE',
+        usdPrice: '2',
+        balance: '1',
+        priceFetchedAt: Date.now(),
+      },
+    },
+  },
+})
 mockStore.getState.mockImplementation(() => state)
 
 // Disable __DEV__ so analytics is enabled
@@ -86,12 +138,12 @@ describe('ValoraAnalytics', () => {
       sHasVerifiedNumber: false,
       sLanguage: 'es-419',
       sLocalCurrencyCode: 'PHP',
-      sOtherTenTokens: 'TT:0,MOO:0',
+      sOtherTenTokens: 'UBE:1,TT:10',
       sPhoneCountryCallingCode: '+1',
       sPhoneCountryCodeAlpha2: 'US',
       sPrevScreenId: undefined,
-      sTokenCount: 5,
-      sTotalBalanceUsd: 34,
+      sTokenCount: 4,
+      sTotalBalanceUsd: 36,
       sWalletAddress: '0x0000000000000000000000000000000000007e57',
       sessionId: expectedSessionId,
       timestamp: 1482363367071,
@@ -120,12 +172,12 @@ describe('ValoraAnalytics', () => {
       sHasVerifiedNumber: false,
       sLanguage: 'es-419',
       sLocalCurrencyCode: 'PHP',
-      sOtherTenTokens: 'TT:0,MOO:0',
+      sOtherTenTokens: 'UBE:1,TT:10',
       sPhoneCountryCallingCode: '+1',
       sPhoneCountryCodeAlpha2: 'US',
       sPrevScreenId: undefined,
-      sTokenCount: 5,
-      sTotalBalanceUsd: 34,
+      sTokenCount: 4,
+      sTotalBalanceUsd: 36,
       sWalletAddress: '0x0000000000000000000000000000000000007e57',
       sessionId: expectedSessionId,
       timestamp: 1482363367071,
@@ -157,12 +209,12 @@ describe('ValoraAnalytics', () => {
       sHasVerifiedNumber: false,
       sLanguage: 'es-419',
       sLocalCurrencyCode: 'PHP',
-      sOtherTenTokens: 'TT:0,MOO:0',
+      sOtherTenTokens: 'UBE:1,TT:10',
       sPhoneCountryCallingCode: '+1',
       sPhoneCountryCodeAlpha2: 'US',
       sPrevScreenId: undefined,
-      sTokenCount: 5,
-      sTotalBalanceUsd: 34,
+      sTokenCount: 4,
+      sTotalBalanceUsd: 36,
       sWalletAddress: '0x0000000000000000000000000000000000007e57',
       sessionId: expectedSessionId,
       someProp: 'testValue',
@@ -191,12 +243,12 @@ describe('ValoraAnalytics', () => {
       sHasVerifiedNumber: false,
       sLanguage: 'es-419',
       sLocalCurrencyCode: 'PHP',
-      sOtherTenTokens: 'TT:0,MOO:0',
+      sOtherTenTokens: 'UBE:1,TT:10',
       sPhoneCountryCallingCode: '+1',
       sPhoneCountryCodeAlpha2: 'US',
       sPrevScreenId: 'Some Page',
-      sTokenCount: 5,
-      sTotalBalanceUsd: 34,
+      sTokenCount: 4,
+      sTotalBalanceUsd: 36,
       sWalletAddress: '0x0000000000000000000000000000000000007e57',
       sessionId: expectedSessionId,
       someProp: 'testValue2',
@@ -227,12 +279,12 @@ describe('ValoraAnalytics', () => {
       sHasVerifiedNumber: false,
       sLanguage: 'es-419',
       sLocalCurrencyCode: 'PHP',
-      sOtherTenTokens: 'TT:0,MOO:0',
+      sOtherTenTokens: 'UBE:1,TT:10',
       sPhoneCountryCallingCode: '+1',
       sPhoneCountryCodeAlpha2: 'US',
       sPrevScreenId: undefined,
-      sTokenCount: 5,
-      sTotalBalanceUsd: 34,
+      sTokenCount: 4,
+      sTotalBalanceUsd: 36,
       sWalletAddress: '0x0000000000000000000000000000000000007e57',
       sessionId: expectedSessionId,
       timestamp: 1482363367071,
@@ -261,12 +313,12 @@ describe('ValoraAnalytics', () => {
       sHasVerifiedNumber: false,
       sLanguage: 'es-419',
       sLocalCurrencyCode: 'PHP',
-      sOtherTenTokens: 'TT:0,MOO:0',
+      sOtherTenTokens: 'UBE:1,TT:10',
       sPhoneCountryCallingCode: '+1',
       sPhoneCountryCodeAlpha2: 'US',
       sPrevScreenId: undefined,
-      sTokenCount: 5,
-      sTotalBalanceUsd: 34,
+      sTokenCount: 4,
+      sTotalBalanceUsd: 36,
       sWalletAddress: '0x0000000000000000000000000000000000007e57',
       sessionId: expectedSessionId,
       someProp: 'someValue',

--- a/packages/mobile/src/analytics/selectors.test.ts
+++ b/packages/mobile/src/analytics/selectors.test.ts
@@ -171,7 +171,7 @@ describe('getCurrentUserTraits', () => {
       otherTenTokens: 'I:1000,K:80,0xi:11.003,G:10,H:9.12345,E:7,F:6,B:3,C:2,A:1',
       phoneCountryCallingCode: '+33',
       phoneCountryCodeAlpha2: 'FR',
-      tokenCount: 14,
+      tokenCount: 13,
       totalBalanceUsd: 5679.682283945,
       walletAddress: '0x0000000000000000000000000000000000007e57',
     })

--- a/packages/mobile/src/analytics/selectors.ts
+++ b/packages/mobile/src/analytics/selectors.ts
@@ -9,7 +9,8 @@ import { backupCompletedSelector } from 'src/backup/selectors'
 import { currentLanguageSelector } from 'src/i18n/selectors'
 import { getLocalCurrencyCode } from 'src/localCurrency/selectors'
 import { userLocationDataSelector } from 'src/networkInfo/selectors'
-import { tokensByCurrencySelector, tokensByUsdBalanceSelector } from 'src/tokens/selectors'
+import { tokensByCurrencySelector, tokensWithTokenBalanceSelector } from 'src/tokens/selectors'
+import { sortByUsdBalance } from 'src/tokens/utils'
 import { Currency } from 'src/utils/currencies'
 import { accountAddressSelector, walletAddressSelector } from 'src/web3/selectors'
 
@@ -20,7 +21,7 @@ export const getCurrentUserTraits = createSelector(
     defaultCountryCodeSelector,
     userLocationDataSelector,
     currentLanguageSelector,
-    tokensByUsdBalanceSelector,
+    tokensWithTokenBalanceSelector,
     tokensByCurrencySelector,
     getLocalCurrencyCode,
     numberVerifiedSelector,
@@ -32,7 +33,7 @@ export const getCurrentUserTraits = createSelector(
     phoneCountryCallingCode,
     { countryCodeAlpha2 },
     language,
-    tokensByUsdBalance,
+    tokens,
     tokensByCurrency,
     localCurrencyCode,
     hasVerifiedNumber,
@@ -41,6 +42,7 @@ export const getCurrentUserTraits = createSelector(
     const currencyAddresses = new Set(
       Object.values(tokensByCurrency).map((token) => token?.address)
     )
+    const tokensByUsdBalance = tokens.sort(sortByUsdBalance)
 
     let totalBalanceUsd = new BigNumber(0)
     for (const token of tokensByUsdBalance) {


### PR DESCRIPTION
### Description

The totalCount property was counting tokens with 0 balance, which is not what we wanted. Now it counts the tokens that do actually have a balance.

See this thread for details: https://valora-app.slack.com/archives/C02N2BJ03QA/p1643232123019100

### Other changes

N/A

### Tested

With unit tests


### How others should test

Don't

### Related issues

- Fixes #1868

### Backwards compatibility

N/A