### PR TITLE
feat(plaid): Add onExit implementation for Plaid

### DIFF
--- a/packages/mobile/locales/base/translation.json
+++ b/packages/mobile/locales/base/translation.json
@@ -1120,6 +1120,11 @@
       "title": "Link a bank account",
       "description": "You're almost done! You can connect your bank acount to Valora now via Plaid.",
       "cta": "Coming Soon!"
+    },
+    "error": {
+      "title": "Unable to link bank account.",
+      "description": "Please try to link your bank account again, or contact support.",
+      "contactSupportPrefill": "I was unable to link my bank account to Valora"
     }
   },
   "linkBankAccountSettingsTitle": "Link Bank Accounts",

--- a/packages/mobile/src/account/LinkBankAccountErrorScreen.tsx
+++ b/packages/mobile/src/account/LinkBankAccountErrorScreen.tsx
@@ -1,0 +1,69 @@
+import BorderlessButton from '@celo/react-components/components/BorderlessButton'
+import Button, { BtnSizes, BtnTypes } from '@celo/react-components/components/Button'
+import * as React from 'react'
+import fontStyles from '@celo/react-components/styles/fonts'
+import { SafeAreaView } from 'react-native-safe-area-context'
+import { ScrollView, StyleSheet, Text, View } from 'react-native'
+import { StackScreenProps } from '@react-navigation/stack'
+import { Screens } from 'src/navigator/Screens'
+import { useTranslation } from 'react-i18next'
+import { navigate, navigateBack } from 'src/navigator/NavigationService'
+
+type Props = StackScreenProps<StackParamList, Screens.LinkBankAccountErrorScreen>
+
+function LinkBankAccountErrorScreen({ route }: Props) {
+  const { t } = useTranslation()
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>{t('linkBankAccountScreen.error.title')}</Text>
+      <Text style={styles.description}>{t('linkBankAccountScreen.error.description')}</Text>
+      <Button
+        style={styles.button}
+        onPress={() => navigateBack()}
+        text={t('linkBankAccountScreen.tryAgain')}
+        type={BtnTypes.SECONDARY}
+        size={BtnSizes.MEDIUM}
+      />
+      <View style={styles.contactSupportButton}>
+        <BorderlessButton
+          onPress={() => {
+            navigate(Screens.SupportContact, {
+              prefilledText: t('linkBankAccountScreen.error.contactSupportPrefill'),
+            })
+          }}
+        >
+          <Text style={styles.contactSupport}>{t('contactSupport')}</Text>
+        </BorderlessButton>
+      </View>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  title: {
+    ...fontStyles.h2,
+  },
+  description: {
+    ...fontStyles.regular,
+    textAlign: 'center',
+    marginTop: 12,
+    paddingHorizontal: 48,
+  },
+  button: {
+    marginTop: 13,
+  },
+  contactSupport: {
+    ...fontStyles.regular600,
+  },
+  contactSupportButton: {
+    marginTop: 26,
+  },
+})
+
+export default LinkBankAccountErrorScreen

--- a/packages/mobile/src/account/LinkBankAccountScreen.tsx
+++ b/packages/mobile/src/account/LinkBankAccountScreen.tsx
@@ -217,8 +217,12 @@ export function StepTwo({ disabled }: { disabled: boolean }) {
                 publicToken,
               })
             },
-            onExit: () => {
-              // TODO(wallet#1447): handle errors from onExit
+            onExit: ({ error }) => {
+              if (error) {
+                navigate(Screens.LinkBankAccountErrorScreen, {
+                  error,
+                })
+              }
             },
           })
         }

--- a/packages/mobile/src/navigator/Navigator.tsx
+++ b/packages/mobile/src/navigator/Navigator.tsx
@@ -8,6 +8,7 @@ import ConnectPhoneNumberScreen from 'src/account/ConnectPhoneNumberScreen'
 import GoldEducation from 'src/account/GoldEducation'
 import Licenses from 'src/account/Licenses'
 import LinkBankAccountScreen from 'src/account/LinkBankAccountScreen'
+import LinkBankAccountErrorScreen from 'src/account/LinkBankAccountErrorScreen'
 import SyncBankAccountScreen from 'src/account/SyncBankAccountScreen'
 import Profile from 'src/account/Profile'
 import RaiseLimitScreen from 'src/account/RaiseLimitScreen'
@@ -457,6 +458,11 @@ const settingsScreens = (Navigator: typeof Stack) => (
       name={Screens.LinkBankAccountScreen}
       component={LinkBankAccountScreen}
       options={headerWithBackButton}
+    />
+    <Navigator.Screen
+      name={Screens.LinkBankAccountErrorScreen}
+      component={LinkBankAccountErrorScreen}
+      options={headerWithCloseButton}
     />
     <Navigator.Screen
       name={Screens.SyncBankAccountScreen}

--- a/packages/mobile/src/navigator/Screens.tsx
+++ b/packages/mobile/src/navigator/Screens.tsx
@@ -33,6 +33,7 @@ export enum Screens {
   LanguageModal = 'LanguageModal',
   Licenses = 'Licenses',
   LinkBankAccountScreen = 'LinkBankAccountScreen',
+  LinkBankAccountErrorScreen = 'LinkBankAccountErrorScreen',
   Main = 'Main',
   MoonPayScreen = 'MoonPayScreen',
   XanpoolScreen = 'XanpoolScreen',

--- a/packages/mobile/src/navigator/types.tsx
+++ b/packages/mobile/src/navigator/types.tsx
@@ -18,6 +18,7 @@ import { TransferConfirmationCardProps } from 'src/transactions/TransferConfirma
 import { TokenTransaction } from 'src/transactions/types'
 import { CiCoCurrency, Currency } from 'src/utils/currencies'
 import { PendingAction, PendingSession } from 'src/walletConnect/types'
+import { LinkError } from 'react-native-plaid-link-sdk'
 
 // Typed nested navigator params
 type NestedNavigatorParams<ParamList> = {
@@ -292,6 +293,7 @@ export type StackParamList = {
         choseToRestoreAccount?: boolean
       }
     | undefined
+  [Screens.LinkBankAccountErrorScreen]: { error: LinkError }
   [Screens.LinkBankAccountScreen]: { kycStatus: KycStatus | undefined }
   [Screens.ConnectPhoneNumberScreen]: undefined
   [Screens.VerificationInputScreen]:


### PR DESCRIPTION
### Description

This PR implements a handler for the `onExit` handler for the Plaid Link flow. Plaid returns a user-friendly string with the error text, which we pass to the error screen, but we currently don't display.

#### Screenshots

![2022-01-27-172034_946x1681_scrot](https://user-images.githubusercontent.com/569401/151455910-c783c18a-a60b-44d7-9515-bb9b5470e922.png)

![2022-01-27-172113_947x1683_scrot](https://user-images.githubusercontent.com/569401/151455916-0386e0f7-b590-43eb-ae5a-20c27911660f.png)


### Tested

_An explanation of how the changes were tested or an explanation as to why they don't need to be._


### How others should test

_Does this need to be tested by QA in the next release cycle? If so please give a brief explanation of how to test these changes._

### Related issues

- Fixes #1447