### PR TITLE
Fix some network errors still incorrectly being sent to Sentry

### DIFF
--- a/packages/mobile/src/services/ReactNativeLogger.ts
+++ b/packages/mobile/src/services/ReactNativeLogger.ts
@@ -42,8 +42,10 @@ export default class ReactNativeLogger {
     const sanitizedError =
       error && shouldSanitizeError ? this.sanitizeError(error, valueToPurge) : error
     const errorMsg = this.getErrorMessage(sanitizedError)
-    const isNetworkError = this.networkErrors.some((networkError) =>
-      errorMsg.toLowerCase().includes(networkError)
+    const isNetworkError = this.networkErrors.some(
+      (networkError) =>
+        message.toString().toLowerCase().includes(networkError) ||
+        errorMsg.toLowerCase().includes(networkError)
     )
 
     // prevent genuine network errors from being sent to Sentry


### PR DESCRIPTION
### Description

Previously we were checking only the `error` argument of the logger error function for network errors, we should also check the `message` argument. As a consequence, some network errors were still being sent to Sentry.

The `message` argument of `Logger.error` is supposed to be a string but it sometimes receives an object. Typescript does not complain about calling `try {...} catch (error) { Logger.error(TAG, error) }` because `error` has type `any`. So I've added a `.toString()` before checking the value for network errors.

### Other changes

N/A

### Tested

Manually

### How others should test

No testing needed by QA

### Related issues

N/A

### Backwards compatibility

Yes