### PR TITLE
Add some delay for biometry authentication to allow native verification animation to run fully

### DIFF
--- a/packages/mobile/src/pincode/authentication.test.ts
+++ b/packages/mobile/src/pincode/authentication.test.ts
@@ -100,6 +100,7 @@ describe(getPasswordSaga, () => {
 describe(getPincode, () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    jest.useRealTimers()
     mockedNavigate.mockReset()
     clearPasswordCaches()
   })
@@ -131,6 +132,7 @@ describe(getPincode, () => {
       storage: 'storage',
     })
     const pin = await getPincode()
+    jest.runAllTimers()
 
     expect(pin).toEqual(mockPin)
     expect(mockedKeychain.getGenericPassword).toHaveBeenCalledTimes(1)
@@ -192,6 +194,7 @@ describe(getPincode, () => {
 
 describe(getPincodeWithBiometry, () => {
   it('returns the correct pin and populates the cache', async () => {
+    jest.useRealTimers()
     clearPasswordCaches()
     mockedKeychain.getGenericPassword.mockResolvedValue({
       password: mockPin,
@@ -200,6 +203,7 @@ describe(getPincodeWithBiometry, () => {
       storage: 'storage',
     })
     const retrievedPin = await getPincodeWithBiometry()
+    jest.runAllTimers()
 
     expect(retrievedPin).toEqual(mockPin)
     expect(getCachedPin(DEFAULT_CACHE_ACCOUNT)).toEqual(mockPin)
@@ -216,6 +220,7 @@ describe(getPincodeWithBiometry, () => {
 
 describe(setPincodeWithBiometry, () => {
   beforeEach(() => {
+    jest.useRealTimers()
     jest.clearAllMocks()
     clearPasswordCaches()
     mockedNavigate.mockReset()
@@ -231,6 +236,7 @@ describe(setPincodeWithBiometry, () => {
     })
 
     await setPincodeWithBiometry()
+    jest.runAllTimers()
 
     expect(mockedKeychain.setGenericPassword).toHaveBeenCalledTimes(1)
     expect(mockedKeychain.setGenericPassword).toHaveBeenCalledWith(
@@ -256,6 +262,7 @@ describe(setPincodeWithBiometry, () => {
     })
 
     await setPincodeWithBiometry()
+    jest.runAllTimers()
 
     expectPincodeEntered()
     expect(mockedKeychain.setGenericPassword).toHaveBeenCalledTimes(1)

--- a/packages/mobile/src/pincode/authentication.test.ts
+++ b/packages/mobile/src/pincode/authentication.test.ts
@@ -36,6 +36,9 @@ jest.mock('react-native-securerandom', () => ({
   ...(jest.requireActual('react-native-securerandom') as any),
   generateSecureRandom: jest.fn(() => new Uint8Array(16).fill(1)),
 }))
+jest.mock('@celo/utils/lib/async', () => ({
+  sleep: jest.fn().mockResolvedValue(true),
+}))
 
 const loggerErrorSpy = jest.spyOn(Logger, 'error')
 const mockPepper = {
@@ -100,7 +103,6 @@ describe(getPasswordSaga, () => {
 describe(getPincode, () => {
   beforeEach(() => {
     jest.clearAllMocks()
-    jest.useRealTimers()
     mockedNavigate.mockReset()
     clearPasswordCaches()
   })
@@ -131,8 +133,8 @@ describe(getPincode, () => {
       service: 'service',
       storage: 'storage',
     })
+
     const pin = await getPincode()
-    jest.runAllTimers()
 
     expect(pin).toEqual(mockPin)
     expect(mockedKeychain.getGenericPassword).toHaveBeenCalledTimes(1)
@@ -194,7 +196,6 @@ describe(getPincode, () => {
 
 describe(getPincodeWithBiometry, () => {
   it('returns the correct pin and populates the cache', async () => {
-    jest.useRealTimers()
     clearPasswordCaches()
     mockedKeychain.getGenericPassword.mockResolvedValue({
       password: mockPin,
@@ -203,7 +204,6 @@ describe(getPincodeWithBiometry, () => {
       storage: 'storage',
     })
     const retrievedPin = await getPincodeWithBiometry()
-    jest.runAllTimers()
 
     expect(retrievedPin).toEqual(mockPin)
     expect(getCachedPin(DEFAULT_CACHE_ACCOUNT)).toEqual(mockPin)
@@ -220,7 +220,6 @@ describe(getPincodeWithBiometry, () => {
 
 describe(setPincodeWithBiometry, () => {
   beforeEach(() => {
-    jest.useRealTimers()
     jest.clearAllMocks()
     clearPasswordCaches()
     mockedNavigate.mockReset()
@@ -236,7 +235,6 @@ describe(setPincodeWithBiometry, () => {
     })
 
     await setPincodeWithBiometry()
-    jest.runAllTimers()
 
     expect(mockedKeychain.setGenericPassword).toHaveBeenCalledTimes(1)
     expect(mockedKeychain.setGenericPassword).toHaveBeenCalledWith(
@@ -262,7 +260,6 @@ describe(setPincodeWithBiometry, () => {
     })
 
     await setPincodeWithBiometry()
-    jest.runAllTimers()
 
     expectPincodeEntered()
     expect(mockedKeychain.setGenericPassword).toHaveBeenCalledTimes(1)

--- a/packages/mobile/src/pincode/authentication.ts
+++ b/packages/mobile/src/pincode/authentication.ts
@@ -60,6 +60,7 @@ export const PIN_LENGTH = 6
 export const DEFAULT_CACHE_ACCOUNT = 'default'
 export const DEK = 'DEK'
 export const CANCELLED_PIN_INPUT = 'CANCELLED_PIN_INPUT'
+export const BIOMETRY_VERIFICATION_DELAY = 800
 
 /**
  * Pin blocklist that loads from the bundle resources a pre-configured list and allows it to be
@@ -276,6 +277,12 @@ export function* getPasswordSaga(account: string, withVerification?: boolean, st
 
 type PinCallback = (pin: string) => void
 
+async function addBiometryVerificationDelay() {
+  // insert artificial delay so that the native biometry verification
+  // animation can run the full course
+  return new Promise((resolve) => setTimeout(resolve, BIOMETRY_VERIFICATION_DELAY))
+}
+
 export async function setPincodeWithBiometry() {
   let pin = getCachedPin(DEFAULT_CACHE_ACCOUNT)
   if (!pin) {
@@ -287,6 +294,7 @@ export async function setPincodeWithBiometry() {
     // from previous app installs/failed save attempts will be overwritten
     // safely here
     await storePinWithBiometry(pin)
+    await addBiometryVerificationDelay()
   } catch (error) {
     Logger.warn(TAG, 'Failed to save pin with biometry', error)
     throw error
@@ -298,6 +306,7 @@ export async function getPincodeWithBiometry() {
     const retrievedPin = await retrieveStoredItem(STORAGE_KEYS.PIN)
     if (retrievedPin) {
       setCachedPin(DEFAULT_CACHE_ACCOUNT, retrievedPin)
+      await addBiometryVerificationDelay()
       return retrievedPin
     }
     throw new Error('Failed to retrieve pin with biometry, recieved null value')


### PR DESCRIPTION
### Description

Add delay in biometry get/set functions so that the native animations can run fully before moving the user on. Without the delay, the animation can be running while the app is navigating to the next screen already.

With a 800ms delay, the animation runs like this:

https://user-images.githubusercontent.com/20150449/152314145-9f21302e-1f6f-4123-823b-889b1930b645.MP4


### Other changes

N/A

### Tested

Unit tests and manually


### How others should test

In the onboarding flow when enabling biometrics, and in flows where you need biometry to get the pin (recovery phrase screen, send flow, change pin, etc.) see that the biometric verification animation run to the end before the app moves on.

### Related issues

N/A

### Backwards compatibility

N/A