### PR TITLE
Filter Out Empty Dapp Categories

### DIFF
--- a/packages/mobile/src/dappsExplorer/DAppsExplorerScreen.tsx
+++ b/packages/mobile/src/dappsExplorer/DAppsExplorerScreen.tsx
@@ -291,7 +291,8 @@ export function DAppsExplorerScreen() {
 }
 
 function parseResultIntoSections(categoriesWithDapps: CategoryWithDapps[]): SectionData[] {
-  return categoriesWithDapps.map((category) => ({
+  let filtered = categoriesWithDapps.filter((category) => category.dapps.length)
+  return filtered.map((category) => ({
     data: category.dapps,
     category: category,
   }))

--- a/packages/mobile/src/dappsExplorer/DAppsExplorerScreen.tsx
+++ b/packages/mobile/src/dappsExplorer/DAppsExplorerScreen.tsx
@@ -291,7 +291,7 @@ export function DAppsExplorerScreen() {
 }
 
 function parseResultIntoSections(categoriesWithDapps: CategoryWithDapps[]): SectionData[] {
-  let filtered = categoriesWithDapps.filter((category) => category.dapps.length)
+  const filtered = categoriesWithDapps.filter((category) => category.dapps.length)
   return filtered.map((category) => ({
     data: category.dapps,
     category: category,


### PR DESCRIPTION
### Description

Filter out empty Dapp categories.

### Other changes

N/A

### Tested

Tested locally on iOS.

### How others should test

1. Open the Dapp Explorer
2. Ensure no empty Dapp Categories are seen.

### Related issues

N/A

### Backwards compatibility

Yes