### PR TITLE
minor UI update to ensure content at bottom of Dapps explorer is not clipped

### DIFF
--- a/packages/mobile/src/dappsExplorer/DAppsExplorerScreen.tsx
+++ b/packages/mobile/src/dappsExplorer/DAppsExplorerScreen.tsx
@@ -275,7 +275,7 @@ export function DAppsExplorerScreen() {
                 )}
               </>
             }
-            style={styles.sectionList}
+            contentContainerStyle={styles.sectionList}
             sections={parseResultIntoSections(result.categories)}
             renderItem={({ item: dapp }) => <Dapp dapp={dapp} onPressDapp={onPressDapp} />}
             keyExtractor={(dapp: Dapp) => `${dapp.categoryId}-${dapp.id}`}
@@ -464,7 +464,6 @@ const styles = StyleSheet.create({
     marginVertical: Spacing.Regular16,
   },
   sectionList: {
-    flex: 1,
     padding: Spacing.Regular16,
   },
   sectionTitle: {


### PR DESCRIPTION


### Description

Currently the content is clipped at the bottom, this PR fixes that

![Image from iOS (3)](https://user-images.githubusercontent.com/20150449/152979521-15993e5f-d4f8-44b9-a3ae-a7558fd9f101.png)

### Other changes

N/A

### Tested

Manually

### How others should test

Check that no content on the dapps explorer screen is clipped

### Related issues

N/A

### Backwards compatibility

N/A