### PR TITLE
Tweak Dapps page layout

### DIFF
--- a/packages/mobile/src/dappsExplorer/DAppsExplorerScreen.tsx
+++ b/packages/mobile/src/dappsExplorer/DAppsExplorerScreen.tsx
@@ -17,7 +17,7 @@ import {
   Text,
   View,
 } from 'react-native'
-import { SafeAreaView } from 'react-native-safe-area-context'
+import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useDispatch, useSelector } from 'react-redux'
 import { DappExplorerEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
@@ -88,6 +88,7 @@ export function DAppsExplorerScreen() {
   const [isBottomSheetVisible, setBottomSheetVisible] = useState(false)
   const [dappSelected, setDappSelected] = useState<Dapp>()
   const dispatch = useDispatch()
+  const insets = useSafeAreaInsets()
 
   const shortLanguage = i18n.language.split('-')[0]
 
@@ -203,7 +204,7 @@ export function DAppsExplorerScreen() {
   }
 
   return (
-    <SafeAreaView style={styles.safeAreaContainer}>
+    <SafeAreaView style={styles.safeAreaContainer} edges={['top']}>
       <CustomHeader
         left={<BackButton />}
         title={t('dappsScreen.title')}
@@ -276,7 +277,13 @@ export function DAppsExplorerScreen() {
               </>
             }
             style={styles.sectionList}
-            sections={parseResultIntoSections(result.categories)}
+            contentContainerStyle={{
+              padding: Spacing.Regular16,
+              paddingBottom: Math.max(insets.bottom, Spacing.Regular16),
+            }}
+            // Workaround iOS setting an incorrect automatic inset at the top
+            scrollIndicatorInsets={{ top: 0.01 }}
+            sections={parseResultIntoSections(result.categories.filter((c) => c.dapps.length > 0))}
             renderItem={({ item: dapp }) => <Dapp dapp={dapp} onPressDapp={onPressDapp} />}
             keyExtractor={(dapp: Dapp) => `${dapp.categoryId}-${dapp.id}`}
             stickySectionHeadersEnabled={false}
@@ -465,7 +472,6 @@ const styles = StyleSheet.create({
   },
   sectionList: {
     flex: 1,
-    padding: Spacing.Regular16,
   },
   sectionTitle: {
     ...fontStyles.label,

--- a/packages/mobile/src/dappsExplorer/DAppsExplorerScreen.tsx
+++ b/packages/mobile/src/dappsExplorer/DAppsExplorerScreen.tsx
@@ -4,7 +4,6 @@ import Touchable from '@celo/react-components/components/Touchable'
 import colors, { Colors } from '@celo/react-components/styles/colors'
 import fontStyles from '@celo/react-components/styles/fonts'
 import { Shadow, Spacing } from '@celo/react-components/styles/styles'
-import variables from '@celo/react-components/styles/variables'
 import React, { useRef, useState } from 'react'
 import { useAsync } from 'react-async-hook'
 import { useTranslation } from 'react-i18next'
@@ -13,6 +12,7 @@ import {
   Image,
   SectionList,
   SectionListData,
+  SectionListProps,
   StyleSheet,
   Text,
   View,
@@ -37,7 +37,10 @@ import { isDeepLink } from 'src/utils/linking'
 import Logger from 'src/utils/Logger'
 import { walletAddressSelector } from 'src/web3/selectors'
 
-const AnimatedSectionList = Animated.createAnimatedComponent(SectionList)
+// @ts-ignore
+const AnimatedSectionList = Animated.createAnimatedComponent<SectionListProps<ItemT, SectionT>>(
+  SectionList
+)
 
 const TAG = 'DAppExplorerScreen'
 
@@ -388,9 +391,6 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     flex: 1,
     marginHorizontal: Spacing.Smallest8,
-  },
-  helpIconContainer: {
-    padding: variables.contentPadding,
   },
   loadingIcon: {
     marginVertical: Spacing.Thick24,

--- a/packages/mobile/src/dappsExplorer/DAppsExplorerScreen.tsx
+++ b/packages/mobile/src/dappsExplorer/DAppsExplorerScreen.tsx
@@ -23,14 +23,14 @@ import { DappExplorerEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import { openUrl } from 'src/app/actions'
 import { dappsListApiUrlSelector } from 'src/app/selectors'
-import BackButton from 'src/components/BackButton'
 import BottomSheet from 'src/components/BottomSheet'
 import Dialog from 'src/components/Dialog'
-import CustomHeader from 'src/components/header/CustomHeader'
 import LinkArrow from 'src/icons/LinkArrow'
 import Help from 'src/icons/navigator/Help'
 import QuitIcon from 'src/icons/QuitIcon'
 import { dappListLogo } from 'src/images/Images'
+import DrawerTopBar from 'src/navigator/DrawerTopBar'
+import { styles as headerStyles } from 'src/navigator/Headers'
 import { TopBarIconButton } from 'src/navigator/TopBarButton'
 import { isDeepLink } from 'src/utils/linking'
 import Logger from 'src/utils/Logger'
@@ -205,16 +205,9 @@ export function DAppsExplorerScreen() {
 
   return (
     <SafeAreaView style={styles.safeAreaContainer} edges={['top']}>
-      <CustomHeader
-        left={<BackButton />}
-        title={t('dappsScreen.title')}
-        right={
-          <TopBarIconButton
-            icon={<Help />}
-            onPress={onPressHelp}
-            style={styles.helpIconContainer}
-          />
-        }
+      <DrawerTopBar
+        middleElement={<Text style={headerStyles.headerTitle}>{t('dappsScreen.title')}</Text>}
+        rightElement={<TopBarIconButton icon={<Help />} onPress={onPressHelp} />}
       />
       <BottomSheet isVisible={isBottomSheetVisible} onBackgroundPress={onCloseBottomSheet}>
         <View>

--- a/packages/mobile/src/dappsExplorer/DAppsExplorerScreen.tsx
+++ b/packages/mobile/src/dappsExplorer/DAppsExplorerScreen.tsx
@@ -284,7 +284,7 @@ export function DAppsExplorerScreen() {
             scrollIndicatorInsets={{ top: 0.01 }}
             scrollEventThrottle={16}
             onScroll={onScroll}
-            sections={parseResultIntoSections(result.categories.filter((c) => c.dapps.length > 0))}
+            sections={parseResultIntoSections(result.categories)}
             renderItem={({ item: dapp }) => <Dapp dapp={dapp} onPressDapp={onPressDapp} />}
             keyExtractor={(dapp: Dapp) => `${dapp.categoryId}-${dapp.id}`}
             stickySectionHeadersEnabled={false}


### PR DESCRIPTION
### Description

- Use the hamburger icon since this page is navigated from the drawer menu.
  - Line separating the navigation header from the scrolling content is animated (same as on the WalletHome).
- Prevent clipping at the bottom. 
  - Full layout at the bottom. Nicer on devices with a home bar. 
  - Make sure the last item can be interacted with fully on devices with a home bar.

### Tested

**before/after (iOS)**
<img src="https://user-images.githubusercontent.com/57791/152986545-506a39da-e31f-44f1-80a9-d61a3744656e.png" width="50%" /><img src="https://user-images.githubusercontent.com/57791/152986586-98af4869-e77a-4db5-b5cf-a7df9188564c.png" width="50%" />

**before/after (Android)**
<img src="https://user-images.githubusercontent.com/57791/152986648-8f890e15-cde8-4bb1-837a-c0872d5de7fd.png" width="50%" /><img src="https://user-images.githubusercontent.com/57791/152986691-ad94ac83-dca1-454d-9a20-0b3dc7551612.png" width="50%" />

### How others should test

See screenshots

### Related issues

Discussed on [Slack](https://valora-app.slack.com/archives/C029Z1QMD7B/p1643640224807469).

### Backwards compatibility

Yes