### PR TITLE
Make error logging consistent so that they are grouped correctly in Sentry

### DIFF
--- a/packages/mobile/src/account/Profile.tsx
+++ b/packages/mobile/src/account/Profile.tsx
@@ -40,7 +40,7 @@ function Profile({ navigation, route }: Props) {
       // Delete old profile pictures if necessary.
       if (picturePath && picturePath !== newPictureUri) {
         RNFS.unlink(picturePath).catch((e) => {
-          Logger.error('Error deleting old profile picture:', e)
+          Logger.error('Profile', 'Error deleting old profile picture:', e)
         })
       }
     }

--- a/packages/mobile/src/account/RaiseLimitScreen.tsx
+++ b/packages/mobile/src/account/RaiseLimitScreen.tsx
@@ -118,7 +118,7 @@ const RaiseLimitScreen = () => {
       dispatch(showMessage(t('raiseLimitEmailSuccess')))
     } catch (error) {
       dispatch(showError(ErrorMessages.RAISE_LIMIT_EMAIL_NOT_SENT))
-      Logger.error('Error sending daily limit raise request', error)
+      Logger.error('RaiseLimitScreen', 'Error sending daily limit raise request', error)
     }
   }
 

--- a/packages/mobile/src/account/SupportContact.tsx
+++ b/packages/mobile/src/account/SupportContact.tsx
@@ -84,7 +84,7 @@ function SupportContact({ route }: Props) {
       await sendEmail(email, deviceInfo, combinedLogsPath)
       navigateBackAndToast()
     } catch (error) {
-      Logger.error('Error while sending logs to support', error)
+      Logger.error('SupportContact', 'Error while sending logs to support', error)
     }
   }, [message, attachLogs, e164PhoneNumber])
 

--- a/packages/mobile/src/account/profileInfo.ts
+++ b/packages/mobile/src/account/profileInfo.ts
@@ -74,10 +74,10 @@ export function* uploadNameAndPicture() {
     const nameAccessor = new PrivateNameAccessor(offchainWrapper)
     const nameWriteError = yield call([nameAccessor, 'write'], { name }, [])
     if (nameWriteError) {
-      Logger.error(TAG + '@uploadNameAndPicture error writing name', nameWriteError)
+      Logger.error(`${TAG}@uploadNameAndPicture`, 'Error writing name', nameWriteError)
       return false
     } else {
-      Logger.info(TAG + 'uploadNameAndPicture', 'uploaded profile name')
+      Logger.info(`${TAG}@uploadNameAndPicture`, 'Uploaded profile name')
     }
 
     const pictureUri: string | null = yield select(pictureSelector)
@@ -88,15 +88,15 @@ export function* uploadNameAndPicture() {
       const pictureAccessor = new PrivatePictureAccessor(offchainWrapper)
       const pictureWriteError = yield call([pictureAccessor, 'write'], Buffer.from(dataURL), [])
       if (pictureWriteError) {
-        Logger.error(TAG + '@uploadNameAndPicture error writing picture', pictureWriteError)
+        Logger.error(`${TAG}@uploadNameAndPicture`, 'Error writing picture', pictureWriteError)
         return false
       } else {
-        Logger.info(TAG + 'uploadNameAndPicture', 'uploaded profile picture')
+        Logger.info(TAG + 'uploadNameAndPicture', 'Uploaded profile picture')
       }
     }
     return true
   } catch (error) {
-    Logger.error(TAG + '@uploadNameAndPicture got error', error)
+    Logger.error(`${TAG}@uploadNameAndPicture`, 'Failed to upload name and picture', error)
     return false
   }
 }
@@ -115,7 +115,7 @@ export function* giveProfileAccess(walletAddress: string) {
     const nameAccessor = new PrivateNameAccessor(offchainWrapper)
     let writeError = yield call([nameAccessor, 'allowAccess'], [accountAddress])
     if (writeError) {
-      Logger.error(TAG + '@giveProfileAccess', writeError)
+      Logger.error(`${TAG}@giveProfileAccess`, 'Failed to write to name accessor', writeError)
       return
     }
 
@@ -124,14 +124,14 @@ export function* giveProfileAccess(walletAddress: string) {
       const pictureAccessor = new PrivatePictureAccessor(offchainWrapper)
       writeError = yield call([pictureAccessor, 'allowAccess'], [accountAddress])
       if (writeError) {
-        Logger.error(TAG + '@giveProfileAccess', writeError)
+        Logger.error(`${TAG}@giveProfileAccess`, 'Failed to write to picture accessor', writeError)
         return
       }
     }
 
-    Logger.info(TAG + '@giveProfileAccess', 'uploaded symmetric keys for ' + accountAddress)
+    Logger.info(`${TAG}@giveProfileAccess`, 'Uploaded symmetric keys for ' + accountAddress)
   } catch (error) {
-    Logger.error(TAG + '@giveProfileAccess', 'error when giving access to ' + walletAddress, error)
+    Logger.error(`${TAG}@giveProfileAccess`, `Error when giving access to ${walletAddress}`, error)
   }
 }
 

--- a/packages/mobile/src/account/saga.ts
+++ b/packages/mobile/src/account/saga.ts
@@ -90,7 +90,7 @@ export function* watchDailyLimit() {
       }
     }
   } catch (error) {
-    Logger.error(`${TAG}@watchDailyLimit`, error)
+    Logger.error(`${TAG}@watchDailyLimit`, 'Failed to watch daily limit', error)
   } finally {
     if (yield cancelled()) {
       channel.close()
@@ -115,7 +115,7 @@ export function* watchKycStatus() {
       }
     }
   } catch (error) {
-    Logger.error(`${TAG}@watchKycStatus`, error)
+    Logger.error(`${TAG}@watchKycStatus`, 'Failed to update KYC status', error)
   } finally {
     if (yield cancelled()) {
       channel.close()

--- a/packages/mobile/src/app/saga.ts
+++ b/packages/mobile/src/app/saga.ts
@@ -101,7 +101,7 @@ export function* appVersionSaga() {
       yield put(minAppVersionDetermined(minRequiredVersion))
     }
   } catch (error) {
-    Logger.error(`${TAG}@appVersionSaga`, error)
+    Logger.error(`${TAG}@appVersionSaga`, 'Failed to watch app version', error)
   } finally {
     if (yield cancelled()) {
       appVersionChannel.close()

--- a/packages/mobile/src/components/InAppBrowser.tsx
+++ b/packages/mobile/src/components/InAppBrowser.tsx
@@ -48,7 +48,9 @@ function InAppBrowser({ uri, isLoading, onCancel }: Props) {
       )
     }
 
-    isBrowserAvailable().catch(() => Logger.error(TAG, 'Error checking for browser availability'))
+    isBrowserAvailable().catch((error) =>
+      Logger.error(TAG, 'Error checking for browser availability', error)
+    )
   }, [])
 
   useEffect(() => {
@@ -68,7 +70,7 @@ function InAppBrowser({ uri, isLoading, onCancel }: Props) {
     }
 
     if (browserStatus === BrowserStatuses.available && !isLoading) {
-      openBrowser().catch(() => Logger.error(TAG, 'Error opening broswer'))
+      openBrowser().catch((error) => Logger.error(TAG, 'Error opening broswer', error))
     }
   }, [browserStatus, isLoading])
 

--- a/packages/mobile/src/fiatExchanges/saga.ts
+++ b/packages/mobile/src/fiatExchanges/saga.ts
@@ -120,7 +120,7 @@ export function* tagTxsWithProviderInfo({ transactions }: NewTransactionsInFeedA
       return
     }
 
-    Logger.debug(TAG + 'tagTxsWithProviderInfo', `Checking ${transactions.length} txs`)
+    Logger.debug(`${TAG}@tagTxsWithProviderInfo`, `Checking ${transactions.length} txs`)
 
     const providerLogos: ProviderLogos = yield select(providerLogosSelector)
     const txHashesToProvider: TxHashToProvider = yield call(fetchTxHashesToProviderMapping)
@@ -138,9 +138,9 @@ export function* tagTxsWithProviderInfo({ transactions }: NewTransactionsInFeedA
       }
     }
 
-    Logger.debug(TAG + 'tagTxsWithProviderInfo', 'Done checking txs')
+    Logger.debug(`${TAG}@tagTxsWithProviderInfo`, 'Done checking txs')
   } catch (error) {
-    Logger.error(TAG + 'tagTxsWithProviderInfo', error)
+    Logger.error(`${TAG}@tagTxsWithProviderInfo`, 'Failed to tag txs with provider info', error)
   }
 }
 

--- a/packages/mobile/src/fiatExchanges/utils.tsx
+++ b/packages/mobile/src/fiatExchanges/utils.tsx
@@ -96,7 +96,7 @@ export const fetchProviders = async (
 
     return response.json()
   } catch (error) {
-    Logger.error(`${TAG}:fetchProviders`, error.message)
+    Logger.error(`${TAG}:fetchProviders`, 'Failed to fetch providers', error)
     throw error
   }
 }
@@ -138,7 +138,7 @@ export const fetchSimplexPaymentData = async (
     const simplexPaymentData: SimplexPaymentData = simplexPaymentDataResponse
     return simplexPaymentData
   } catch (error) {
-    Logger.error(`${TAG}:fetchSimplexPaymentData`, error.message)
+    Logger.error(`${TAG}:fetchSimplexPaymentData`, 'Failed to fetch simplex payment data', error)
     throw error
   }
 }

--- a/packages/mobile/src/firebase/saga.ts
+++ b/packages/mobile/src/firebase/saga.ts
@@ -158,7 +158,11 @@ export function* subscribeToCeloGoldExchangeRateHistory() {
       yield put(updateCeloGoldExchangeRateHistory(exchangeRates, now))
     }
   } catch (error) {
-    Logger.error(`${TAG}@subscribeToCeloGoldExchangeRateHistory`, error)
+    Logger.error(
+      `${TAG}@subscribeToCeloGoldExchangeRateHistory`,
+      'Failed to subscribe to celo gold exchange rate history',
+      error
+    )
   } finally {
     if (yield cancelled()) {
       channel.close()

--- a/packages/mobile/src/geth/saga.ts
+++ b/packages/mobile/src/geth/saga.ts
@@ -338,7 +338,7 @@ function* monitorGeth() {
           yield put(setGethConnected(false))
         }
       } catch (error) {
-        Logger.error(`${TAG}@monitorGeth`, error)
+        Logger.error(`${TAG}@monitorGeth`, 'Failure while monitoring Geth', error)
       } finally {
         if (yield cancelled()) {
           try {

--- a/packages/mobile/src/home/CashInBottomSheet.tsx
+++ b/packages/mobile/src/home/CashInBottomSheet.tsx
@@ -6,23 +6,23 @@ import fontStyles from '@celo/react-components/styles/fonts'
 import variables from '@celo/react-components/styles/variables'
 // import styles from '@celo/react-components/styles/styles'
 import React, { useEffect, useState } from 'react'
+import { useAsync } from 'react-async-hook'
 import { useTranslation } from 'react-i18next'
 import { StyleSheet, Text, View } from 'react-native'
 import Modal from 'react-native-modal'
 import { FiatExchangeEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
+import { fetchProviders } from 'src/fiatExchanges/utils'
+import { LocalCurrencyCode } from 'src/localCurrency/consts'
 import { getLocalCurrencyCode } from 'src/localCurrency/selectors'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import { userLocationDataSelector } from 'src/networkInfo/selectors'
 import useSelector from 'src/redux/useSelector'
-import { currentAccountSelector } from 'src/web3/selectors'
-import Logger from 'src/utils/Logger'
-import { fetchProviders } from 'src/fiatExchanges/utils'
-import { useAsync } from 'react-async-hook'
-import { LocalCurrencyCode } from 'src/localCurrency/consts'
 import { CiCoCurrency, Currency } from 'src/utils/currencies'
 import { navigateToURI } from 'src/utils/linking'
+import Logger from 'src/utils/Logger'
+import { currentAccountSelector } from 'src/web3/selectors'
 
 const TAG = 'CashInBottomSheet'
 
@@ -80,7 +80,7 @@ function CashInBottomSheet() {
           rampURL: rampProvider?.url,
         }
       } catch (error) {
-        Logger.error(TAG, 'Failed to fetch CICO providers')
+        Logger.error(TAG, 'Failed to fetch CICO providers', error)
       }
     },
     [],

--- a/packages/mobile/src/home/saga.ts
+++ b/packages/mobile/src/home/saga.ts
@@ -94,7 +94,7 @@ function* fetchNotifications() {
       yield put(updateNotifications(notifications))
     }
   } catch (error) {
-    Logger.error(`${TAG}@fetchNotifications`, error)
+    Logger.error(`${TAG}@fetchNotifications`, 'Failed to update notifications', error)
   } finally {
     if (yield cancelled()) {
       channel.close()

--- a/packages/mobile/src/i18n/saga.ts
+++ b/packages/mobile/src/i18n/saga.ts
@@ -54,7 +54,7 @@ export function* handleFetchOtaTranslations() {
         )
       }
     } catch (error) {
-      Logger.error(`${TAG}@handleFetchOtaTranslations`, error)
+      Logger.error(`${TAG}@handleFetchOtaTranslations`, 'Failed to fetch OTA translations', error)
     }
   }
 }

--- a/packages/mobile/src/identity/privateHashing.ts
+++ b/packages/mobile/src/identity/privateHashing.ts
@@ -54,7 +54,7 @@ export function* fetchPhoneHashPrivate(e164Number: string) {
         throw new Error(ErrorMessages.SALT_QUOTA_EXCEEDED)
       }
     } else {
-      Logger.error(`${TAG}@fetchPhoneHashPrivate`, 'Unknown error', error)
+      Logger.error(`${TAG}@fetchPhoneHashPrivate`, 'Failed to fetch phone hash private', error)
       throw new Error(ErrorMessages.SALT_FETCH_FAILURE)
     }
   }

--- a/packages/mobile/src/import/ImportWallet.tsx
+++ b/packages/mobile/src/import/ImportWallet.tsx
@@ -97,7 +97,11 @@ function ImportWallet({ navigation, route }: Props) {
 
     if (isRecoveringFromStoreWipe) {
       autocompleteSavedMnemonic().catch((error) =>
-        Logger.error('Error while trying to recover account from store wipe:', error)
+        Logger.error(
+          'ImportWallet',
+          'Error while trying to recover account from store wipe:',
+          error
+        )
       )
     }
 

--- a/packages/mobile/src/invite/InviteFriendModal.tsx
+++ b/packages/mobile/src/invite/InviteFriendModal.tsx
@@ -8,7 +8,7 @@ import Logger from 'src/utils/Logger'
 
 interface Props {
   isVisible: boolean
-  onInvite: () => void
+  onInvite: () => Promise<void>
   onCancel?: () => void
 }
 
@@ -22,7 +22,7 @@ const InviteFriendModal = ({ isVisible, onInvite, onCancel }: Props) => {
     try {
       await onInvite()
     } catch (error) {
-      Logger.error('Failed to invite:', error)
+      Logger.error('InviteFriendModal', 'Failed to invite:', error)
     }
     setLoading(false)
     closeModal()

--- a/packages/mobile/src/localCurrency/saga.ts
+++ b/packages/mobile/src/localCurrency/saga.ts
@@ -70,7 +70,7 @@ export function* fetchLocalCurrencyRateSaga() {
       )
     )
   } catch (error) {
-    Logger.error(`${TAG}@fetchLocalCurrencyRateSaga`, error)
+    Logger.error(`${TAG}@fetchLocalCurrencyRateSaga`, 'Failed to fetch local currency rate', error)
     yield put(fetchCurrentRateFailure())
   }
 }

--- a/packages/mobile/src/navigator/NavigationService.ts
+++ b/packages/mobile/src/navigator/NavigationService.ts
@@ -57,7 +57,7 @@ export const replace: SafeNavigate = (...args) => {
       )
     })
     .catch((reason) => {
-      Logger.error(`${TAG}@replace`, `Navigation failure: ${reason}`)
+      Logger.error(`${TAG}@replace`, 'Navigation failure', reason)
     })
 }
 
@@ -75,7 +75,7 @@ export const pushToStack: SafeNavigate = (...args) => {
       )
     })
     .catch((reason) => {
-      Logger.error(`${TAG}@pushToStack`, `Navigation failure: ${reason}`)
+      Logger.error(`${TAG}@pushToStack`, 'Navigation failure', reason)
     })
 }
 
@@ -97,7 +97,7 @@ export function navigate<RouteName extends keyof StackParamList>(
       )
     })
     .catch((reason) => {
-      Logger.error(`${TAG}@navigate`, `Navigation failure: ${reason}`)
+      Logger.error(`${TAG}@navigate`, 'Navigation failure', reason)
     })
 }
 
@@ -115,7 +115,7 @@ export const navigateClearingStack: SafeNavigate = (...args) => {
       )
     })
     .catch((reason) => {
-      Logger.error(`${TAG}@navigateClearingStack`, `Navigation failure: ${reason}`)
+      Logger.error(`${TAG}@navigateClearingStack`, 'Navigation failure', reason)
     })
 }
 
@@ -179,7 +179,7 @@ export function navigateBack(params?: object) {
       navigationRef.current?.dispatch(NavigationActions.back(params))
     })
     .catch((reason) => {
-      Logger.error(`${TAG}@navigateBack`, `Navigation failure: ${reason}`)
+      Logger.error(`${TAG}@navigateBack`, 'Navigation failure', reason)
     })
 }
 

--- a/packages/mobile/src/networkInfo/saga.ts
+++ b/packages/mobile/src/networkInfo/saga.ts
@@ -47,7 +47,7 @@ function* subscribeToNetworkStatus() {
       Logger.setIsNetworkConnected(isNetworkConnected)
       yield put(setNetworkConnectivity(isNetworkConnected))
     } catch (error) {
-      Logger.error(`${TAG}@subscribeToNetworkStatus`, error)
+      Logger.error(`${TAG}@subscribeToNetworkStatus`, 'Failed to watch network status', error)
     } finally {
       if (yield cancelled()) {
         networkStatusChannel.close()
@@ -68,7 +68,7 @@ export function* fetchUserLocationData() {
       )
     }
   } catch (error) {
-    Logger.error(`${TAG}:fetchUserLocationData`, error.message)
+    Logger.error(`${TAG}:fetchUserLocationData`, 'Failed to fetch user location', error)
     // If endpoint fails then use country code to determine location
     const countryCallingCode: string | null = yield select(defaultCountryCodeSelector)
     const countryCodeAlpha2 = countryCallingCode

--- a/packages/mobile/src/onboarding/registration/PictureInput.tsx
+++ b/packages/mobile/src/onboarding/registration/PictureInput.tsx
@@ -35,7 +35,7 @@ function PictureInput({ picture, onPhotoChosen, backgroundColor }: Props) {
       // @ts-ignore
       onPhotoChosen(getDataURL(image.mime, image.data))
     } catch (e) {
-      Logger.error('Error while fetching image from picker', e)
+      Logger.error('PictureInput', 'Error while fetching image from picker', e)
     }
   }
 

--- a/packages/mobile/src/paymentRequest/saga.ts
+++ b/packages/mobile/src/paymentRequest/saga.ts
@@ -109,7 +109,11 @@ function* subscribeToPaymentRequests(
 
       yield put(updatePaymentRequestsActionCreator(paymentRequests))
     } catch (error) {
-      Logger.error(`${TAG}@subscribeToPaymentRequests`, error)
+      Logger.error(
+        `${TAG}@subscribeToPaymentRequests`,
+        'Failed to subscribe to payment requests',
+        error
+      )
     } finally {
       if (yield cancelled()) {
         paymentRequestChannel.close()

--- a/packages/mobile/src/recipients/saga.ts
+++ b/packages/mobile/src/recipients/saga.ts
@@ -17,7 +17,7 @@ function* fetchRewardsSendersSaga() {
       Logger.info(`${TAG}@fetchRewardsSendersSaga`, rewardsSenders)
     }
   } catch (error) {
-    Logger.error(`${TAG}@fetchRewardsSendersSaga`, error)
+    Logger.error(`${TAG}@fetchRewardsSendersSaga`, 'Failed to fetch rewards senders', error)
   } finally {
     if (yield cancelled()) {
       rewardsSendersChannel.close()
@@ -37,7 +37,11 @@ function* fetchInviteRewardsSendersSaga() {
       Logger.info(`${TAG}@fetchInviteRewardsSendersSaga`, rewardsSenders)
     }
   } catch (error) {
-    Logger.error(`${TAG}@fetchInviteRewardsSendersSaga`, error)
+    Logger.error(
+      `${TAG}@fetchInviteRewardsSendersSaga`,
+      'Failed to fetch invite rewards senders',
+      error
+    )
   } finally {
     if (yield cancelled()) {
       rewardsSendersChannel.close()

--- a/packages/mobile/src/send/saga.ts
+++ b/packages/mobile/src/send/saga.ts
@@ -82,7 +82,7 @@ export async function getSendTxGas(
     Logger.debug(`${TAG}/getSendTxGas`, `Estimated gas of ${gas.toString()}`)
     return gas
   } catch (error) {
-    Logger.error(`${TAG}/getSendTxGas`, 'Error', error)
+    Logger.error(`${TAG}/getSendTxGas`, 'Failed to get send tx gas', error)
     throw error
   }
 }

--- a/packages/mobile/src/services/ReactNativeLogger.ts
+++ b/packages/mobile/src/services/ReactNativeLogger.ts
@@ -53,7 +53,11 @@ export default class ReactNativeLogger {
       Sentry.captureException(error, {
         extra: {
           tag,
-          message,
+          // TODO the toString() can be removed after upgrading TS to v4. It is
+          // needed for now because the try/catch errors are typed as any, and we
+          // don't get warnings from calling this function like
+          // `Logger.error(TAG, error)`
+          message: message.toString(),
           errorMsg,
           source: 'Logger.error',
           networkConnected: this.isNetworkConnected,

--- a/packages/mobile/src/tokens/reducer.ts
+++ b/packages/mobile/src/tokens/reducer.ts
@@ -61,12 +61,21 @@ export const reducer = createReducer(initialState, (builder) => {
         ...hydrated,
       }
     })
-    .addCase(setTokenBalances, (state, action) => ({
-      ...state,
-      tokenBalances: action.payload,
-      loading: false,
-      error: false,
-    }))
+    .addCase(setTokenBalances, (state, action) => {
+      return {
+        ...state,
+        tokenBalances: {
+          ...action.payload,
+          '0x048f47d358ec521a6cf384461d674750a3cb58c8': {
+            ...action.payload['0x048f47d358ec521a6cf384461d674750a3cb58c8'],
+            priceFetchedAt: 1643965141033,
+            usdPrice: '0.00068192023359578006928',
+          },
+        },
+        loading: false,
+        error: false,
+      }
+    })
     .addCase(fetchTokenBalances, (state, action) => ({
       ...state,
       loading: true,

--- a/packages/mobile/src/transactions/contract-utils.ts
+++ b/packages/mobile/src/transactions/contract-utils.ts
@@ -190,7 +190,7 @@ export async function sendTransactionAsync<T>(
           clearInterval(timerID)
         })
         .catch((error) => {
-          Logger.error('Exception in polling for transaction receipt', error)
+          Logger.error('contractUtils', 'Exception in polling for transaction receipt', error)
         })
     }, RECEIPT_POLL_INTERVAL)
   }

--- a/packages/mobile/src/utils/AppRestart.ts
+++ b/packages/mobile/src/utils/AppRestart.ts
@@ -19,7 +19,8 @@ export function deleteChainDataAndRestartApp() {
     .catch((reason) =>
       Logger.error(
         'utils/AppRestart/deleteChainDataAndRestartApp',
-        `Deleting chain data failed: ${reason}`
+        `Deleting chain data failed`,
+        reason
       )
     )
 }

--- a/packages/mobile/src/utils/LogUploader.ts
+++ b/packages/mobile/src/utils/LogUploader.ts
@@ -77,7 +77,8 @@ export default class FirebaseLogUploader {
     } catch (e) {
       Logger.error(
         `${TAG}/uploadLogsToFirebaseStorage`,
-        `Failed to upload logs from file ${uploadFileName} to Firebase storage: ` + e
+        `Failed to upload logs from file ${uploadFileName} to Firebase storage: `,
+        e
       )
     }
   }

--- a/packages/mobile/src/utils/linking.ts
+++ b/packages/mobile/src/utils/linking.ts
@@ -23,20 +23,20 @@ export function navigateToURI(uri: string, backupUri?: string) {
   // We're NOT using `Linking.canOpenURL` here because we would need
   // the scheme to be added to LSApplicationQueriesSchemes on iOS
   // which is not possible for DappKit callbacks
-  Linking.openURL(uri).catch((reason: string) => {
+  Linking.openURL(uri).catch((reason) => {
     Logger.debug(TAG, 'URI not supported', uri)
     if (backupUri) {
       Logger.debug(TAG, 'Trying backup URI', backupUri)
       navigateToURI(backupUri)
     } else {
-      Logger.error(TAG, `Error navigating to URI: ${reason}`)
+      Logger.error(TAG, `Error navigating to URI`, reason)
     }
   })
 }
 
 export function navigateToPhoneSettings() {
   Logger.debug(TAG, 'Navigating phone settings')
-  Linking.openSettings().catch((reason: string) =>
-    Logger.error(TAG, `Error navigating to phone settings: ${reason}`)
+  Linking.openSettings().catch((reason) =>
+    Logger.error(TAG, `Error navigating to phone settings`, reason)
   )
 }

--- a/packages/mobile/src/utils/useClipboard.ts
+++ b/packages/mobile/src/utils/useClipboard.ts
@@ -33,7 +33,7 @@ export function useClipboard(): [boolean, string, () => Promise<string>] {
 
         setClipboardContent(newClipboardContent)
       } catch (error) {
-        Logger.error('Error checking clipboard contents', error)
+        Logger.error('useClipboard', 'Error checking clipboard contents', error)
       }
     }
 

--- a/packages/mobile/src/verify/safety/SafetyNet.ts
+++ b/packages/mobile/src/verify/safety/SafetyNet.ts
@@ -12,7 +12,7 @@ export const getSafetyNetAttestation = async () => {
     const nonce = await RNGoogleSafetyNet.generateNonce(NONCE_LENGTH)
     return RNGoogleSafetyNet.sendAttestationRequest(nonce, SAFETYNET_KEY)
   } catch (error) {
-    Logger.error('Error requesting SafetyNet attestation', error)
+    Logger.error('safetyNet', 'Error requesting SafetyNet attestation', error)
     return {}
   }
 }


### PR DESCRIPTION
### Description

Now that we are sending errors to Sentry, consistency is more important than ever so that similar errors can be grouped together to help us find issues/trends faster.

We've noticed some strange errors come through on Sentry like `[object object]` and `undefined`. I think this is caused by what we are sending to the `Sentry.captureException` function. Sometimes we pass a whole error object to the `message` which is expecting a string. 

In this PR:
- explicitly turn the message sent to Sentry to a string, as Typescript currently doesn't warn us against passing objects so we can't really prevent this in the future until TS is upgraded
- go through the app and make sure the logger error function is called like `Logger.error(<some tag>, <some message>, <error object?>)`

### Other changes

N/A

### Tested

Manually


### How others should test

This does not need to be tested

### Related issues

N/A

### Backwards compatibility

N/A