### PR TITLE
Add segment analytics to Dapps screen to allow us to measure engagement

### DIFF
--- a/packages/mobile/src/analytics/Events.tsx
+++ b/packages/mobile/src/analytics/Events.tsx
@@ -537,6 +537,10 @@ export enum CICOEvents {
 export enum DappExplorerEvents {
   dapp_impression = 'dapp_impression', // when a dapp shows up in the featured section of the app
   dapp_open = 'dapp_open', // when a dapp is opened
+  dapp_screen_open = 'dapp_screen_open',
+  dapp_select = 'dapp_select',
+  dapp_bottom_sheet_open = 'dapp_bottom_sheet_open',
+  dapp_bottom_sheet_dismiss = 'dapp_bottom_sheet_dismiss',
 }
 
 export type AnalyticsEventType =

--- a/packages/mobile/src/analytics/Properties.tsx
+++ b/packages/mobile/src/analytics/Properties.tsx
@@ -1168,19 +1168,24 @@ interface CICOEventsProperties {
   [CICOEvents.connect_phone_cancel]: undefined
 }
 
+interface DappEventProperties {
+  categoryId: string
+  dappId: string
+  dappName: string
+}
+
+interface DappSelectEventProperties extends DappEventProperties {
+  section: string
+  horizontalPosition: number
+}
+
 interface DappExplorerEventsProperties {
-  [DappExplorerEvents.dapp_impression]: {
-    categoryId: string
-    dappId: string
-    dappName: string
-  }
-  [DappExplorerEvents.dapp_open]: {
-    categoryId: string
-    dappId: string
-    dappName: string
-    section: string
-    horizontalPosition: number
-  }
+  [DappExplorerEvents.dapp_impression]: DappEventProperties
+  [DappExplorerEvents.dapp_open]: DappSelectEventProperties
+  [DappExplorerEvents.dapp_screen_open]: undefined
+  [DappExplorerEvents.dapp_select]: DappSelectEventProperties
+  [DappExplorerEvents.dapp_bottom_sheet_open]: DappSelectEventProperties
+  [DappExplorerEvents.dapp_bottom_sheet_dismiss]: DappSelectEventProperties
 }
 
 export type AnalyticsPropertiesList = AppEventsProperties &

--- a/packages/mobile/src/dappsExplorer/DAppsExplorerScreen.tsx
+++ b/packages/mobile/src/dappsExplorer/DAppsExplorerScreen.tsx
@@ -4,7 +4,7 @@ import Touchable from '@celo/react-components/components/Touchable'
 import colors, { Colors } from '@celo/react-components/styles/colors'
 import fontStyles from '@celo/react-components/styles/fonts'
 import { Shadow, Spacing } from '@celo/react-components/styles/styles'
-import React, { useRef, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { useAsync } from 'react-async-hook'
 import { useTranslation } from 'react-i18next'
 import {
@@ -100,6 +100,10 @@ export function DAppsExplorerScreen() {
 
   const shortLanguage = i18n.language.split('-')[0]
 
+  useEffect(() => {
+    ValoraAnalytics.track(DappExplorerEvents.dapp_screen_open)
+  }, [])
+
   const {
     loading,
     error,
@@ -175,6 +179,15 @@ export function DAppsExplorerScreen() {
 
   const onCloseBottomSheet = () => {
     setBottomSheetVisible(false)
+    if (dappSelected) {
+      ValoraAnalytics.track(DappExplorerEvents.dapp_bottom_sheet_dismiss, {
+        categoryId: dappSelected.categoryId,
+        dappId: dappSelected.id,
+        dappName: dappSelected.name,
+        horizontalPosition: 0,
+        section: dappSelected.isFeatured ? 'featured' : 'all',
+      })
+    }
   }
 
   const onPressHelp = () => {
@@ -203,9 +216,19 @@ export function DAppsExplorerScreen() {
   }
 
   const onPressDapp = (dapp: Dapp) => {
+    const dappEventProps = {
+      categoryId: dapp.categoryId,
+      dappId: dapp.id,
+      dappName: dapp.name,
+      horizontalPosition: 0,
+      section: dapp.isFeatured ? 'featured' : 'all',
+    }
+    ValoraAnalytics.track(DappExplorerEvents.dapp_select, dappEventProps)
+
     if (!isDeepLink(dapp.dappUrl)) {
       setDappSelected(dapp)
       setBottomSheetVisible(true)
+      ValoraAnalytics.track(DappExplorerEvents.dapp_bottom_sheet_open, dappEventProps)
     } else {
       openDapp(dapp)
     }


### PR DESCRIPTION
### Description

Add events for screen open/dapp selected/bottom sheet open and close

### Other changes

N/A

### Tested

Manually

### How others should test

No testing necessary

### Related issues

- Fixes #1918 

### Backwards compatibility

Yes