### PR TITLE
feat(bank-accounts): Handle errors from ihl/plaid

### DIFF
--- a/packages/mobile/locales/base/translation.json
+++ b/packages/mobile/locales/base/translation.json
@@ -1094,6 +1094,8 @@
   "supportEmailSubject": "{{appName}} support for {{user}}",
   "personaAccountEndpointFail": "Identity verification is not currently available. Please try again later",
   "plaidCreateLinkTokenFail": "Unable to link bank account. Please try again later",
+  "getBankAccountsFail": "Unable to retrieve your linked bank accounts. Please try again later",
+  "deleteBankAccountFail": "Unable to delete your linked bank account. Please try again later",
   "linkBankAccountScreen": {
     "tryAgain": "Try Again",
     "verifying": {

--- a/packages/mobile/src/account/BankAccounts.test.tsx
+++ b/packages/mobile/src/account/BankAccounts.test.tsx
@@ -7,6 +7,8 @@ import { mockAccount, mockPrivateDEK } from 'test/values'
 import BankAccounts from './BankAccounts'
 import { deleteFinclusiveBankAccount, getFinclusiveBankAccounts } from 'src/in-house-liquidity'
 import openPlaid from 'src/account/openPlaid'
+import { showError } from 'src/alert/actions'
+import { ErrorMessages } from 'src/app/ErrorMessages'
 
 const MOCK_PHONE_NUMBER = '+18487623478'
 const MOCK_BANK_ACCOUNTS = [
@@ -54,6 +56,7 @@ const mockScreenProps = getMockStackScreenProps(Screens.BankAccounts, {
 
 describe('BankAccounts', () => {
   beforeEach(() => {
+    store.dispatch = jest.fn()
     jest.useRealTimers()
     jest.clearAllMocks()
   })
@@ -70,6 +73,35 @@ describe('BankAccounts', () => {
     await fireEvent.press(getByTestId('TripleDot2'))
     await fireEvent.press(getByText('bankAccountsScreen.delete'))
     expect(deleteFinclusiveBankAccount).toHaveBeenCalled()
+  })
+  it('shows an error when delete bank accounts fails', async () => {
+    //@ts-ignore . my IDE complains about this, though jest allows it
+    deleteFinclusiveBankAccount.mockImplementation(() => Promise.reject())
+    const { getByText, getByTestId } = render(
+      <Provider store={store}>
+        <BankAccounts {...mockScreenProps} />
+      </Provider>
+    )
+    await waitFor(() => expect(getFinclusiveBankAccounts).toHaveBeenCalled())
+    expect(getByText('Checking (***8052)'))
+    expect(getByText('Savings (****0992)'))
+    await fireEvent.press(getByTestId('TripleDot2'))
+    await fireEvent.press(getByText('bankAccountsScreen.delete'))
+    expect(deleteFinclusiveBankAccount).toHaveBeenCalled()
+    expect(store.dispatch).toHaveBeenLastCalledWith(
+      showError(ErrorMessages.DELETE_BANK_ACCOUNT_FAIL)
+    )
+  })
+  it('shows an error when get bank accounts fails', async () => {
+    //@ts-ignore . my IDE complains about this, though jest allows it
+    getFinclusiveBankAccounts.mockImplementation(() => Promise.reject())
+    render(
+      <Provider store={store}>
+        <BankAccounts {...mockScreenProps} />
+      </Provider>
+    )
+    await waitFor(() => expect(getFinclusiveBankAccounts).toHaveBeenCalled())
+    expect(store.dispatch).toHaveBeenLastCalledWith(showError(ErrorMessages.GET_BANK_ACCOUNTS_FAIL))
   })
   it('re-fetches bank account info when the newPublicToken navigation prop changes', async () => {
     const { rerender } = render(

--- a/packages/mobile/src/account/BankAccounts.tsx
+++ b/packages/mobile/src/account/BankAccounts.tsx
@@ -6,7 +6,7 @@ import React, { useLayoutEffect, useState } from 'react'
 import { useAsync } from 'react-async-hook'
 import { useTranslation } from 'react-i18next'
 import { ScrollView, StyleSheet, Text, View, Image } from 'react-native'
-import { useSelector } from 'react-redux'
+import { useDispatch, useSelector } from 'react-redux'
 import PlusIcon from 'src/icons/PlusIcon'
 import TripleDotVertical from 'src/icons/TripleDotVertical'
 import {
@@ -24,10 +24,16 @@ import { navigate } from 'src/navigator/NavigationService'
 import openPlaid from './openPlaid'
 import { plaidParamsSelector } from 'src/account/selectors'
 import OptionsChooser from 'src/components/OptionsChooser'
+import Logger from 'src/utils/Logger'
+import { showError } from 'src/alert/actions'
+import { ErrorMessages } from 'src/app/ErrorMessages'
 
 type Props = StackScreenProps<StackParamList, Screens.BankAccounts>
+
+const TAG = 'BankAccounts'
 function BankAccounts({ navigation, route }: Props) {
   const { t } = useTranslation()
+  const dispatch = useDispatch()
   const [isOptionsVisible, setIsOptionsVisible] = useState(false)
   const [selectedBankId, setSelectedBankId] = useState(0)
   const accountMTWAddress = useSelector(mtwAddressSelector)
@@ -55,8 +61,9 @@ function BankAccounts({ navigation, route }: Props) {
         verifyDekAndMTW({ dekPrivate, accountMTWAddress })
       )
       return accounts
-    } catch {
-      // TODO(wallet#1447): handle errors from IHL
+    } catch (error) {
+      Logger.warn(TAG, error)
+      dispatch(showError(ErrorMessages.GET_BANK_ACCOUNTS_FAIL))
       return
     }
   }, [newPublicToken])
@@ -108,8 +115,9 @@ function BankAccounts({ navigation, route }: Props) {
         id: selectedBankId,
       })
       await bankAccounts.execute()
-    } catch {
-      // TODO(wallet#1447): handle errors from IHL
+    } catch (error) {
+      Logger.warn(TAG, error)
+      dispatch(showError(ErrorMessages.DELETE_BANK_ACCOUNT_FAIL))
     }
   }
 
@@ -127,8 +135,12 @@ function BankAccounts({ navigation, route }: Props) {
                   publicToken,
                 })
               },
-              onExit: () => {
-                // TODO(wallet#1447): handle errors from onExit
+              onExit: ({ error }) => {
+                if (error) {
+                  navigate(Screens.LinkBankAccountErrorScreen, {
+                    error,
+                  })
+                }
               },
             })
           }

--- a/packages/mobile/src/app/ErrorMessages.ts
+++ b/packages/mobile/src/app/ErrorMessages.ts
@@ -88,4 +88,6 @@ export enum ErrorMessages {
   WC2_UNSUPPORTED = 'v2Unsupported',
   PERSONA_ACCOUNT_ENDPOINT_FAIL = 'personaAccountEndpointFail',
   PLAID_CREATE_LINK_TOKEN_FAIL = 'plaidCreateLinkTokenFail',
+  GET_BANK_ACCOUNTS_FAIL = 'getBankAccountsFail',
+  DELETE_BANK_ACCOUNT_FAIL = 'deleteBankAccountFail',
 }


### PR DESCRIPTION
### Description

These were missed in [[M2] Handle errors for onExit hooks](https://app.zenhub.com/workspaces/acquisition-squad-sprint-board-6010683afabec1001a090887/issues/valora-inc/wallet/1447) since the BankAccounts component was still in progress when it was done. Better late than never!

### Tested

Manually triggering failed api calls

### How others should test

N/A
