### PR TITLE
Bump pathval from 1.1.0 to 1.1.1

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -17421,9 +17421,9 @@ path-type@^4.0.0:
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
 pathval@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.0.tgz#b942e6d4bde653005ef6b71361def8727d0645e0"
-  integrity sha1-uULm1L3mUwBe9rcTYd74cn0GReA=
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.1.tgz#8534e77a77ce7ac5a2512ea21e0fdb8fcf6c3d8d"
+  integrity sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==
 
 pbkdf2@3.0.8:
   version "3.0.8"


### PR DESCRIPTION
### Description

`pathval` needed to be upgraded because of a vulnerability.
See example CI run which failed: https://github.com/valora-inc/wallet/runs/5149764789?check_suite_focus=true

There's no direct impact to the wallet security.
`pathval` is being transitively included: `@celo/utils>bls12377js>chai>pathval`
And is actually a `devDependency` that was incorrectly set as a runtime dependency.
This was fixed in https://github.com/celo-org/bls12377js/pull/15
But we haven't upgraded the Celo SDK yet which should reference the updated version.

### Tested

Vulnerability check passes.

### How others should test

N/A

### Related issues

N/A

### Backwards compatibility

Yes