### PR TITLE
Kathy/recent dapps

### DIFF
--- a/packages/mobile/locales/base/translation.json
+++ b/packages/mobile/locales/base/translation.json
@@ -1171,6 +1171,8 @@
     "message": "You are about to open an application not operated by Valora.\n\nValora makes no representations about this application. Use at your own risk.",
     "button": "Go to {{dappName}}"
   },
+  "recentlyUsedDapps": "Recently Used Dapps",
+  "allDapps": "All Dapps",
   "rewards": "Rewards",
   "supercharge": "Supercharge",
   "others": "Others",

--- a/packages/mobile/src/app/actions.ts
+++ b/packages/mobile/src/app/actions.ts
@@ -1,5 +1,6 @@
 import { BIOMETRY_TYPE } from 'react-native-keychain'
 import { RemoteConfigValues } from 'src/app/saga'
+import { Dapp } from 'src/app/types'
 import { Screens } from 'src/navigator/Screens'
 
 // https://facebook.github.io/react-native/docs/appstate
@@ -32,6 +33,7 @@ export enum Actions {
   APP_UNMOUNTED = 'APP/APP_UNMOUNTED',
   VERIFICATION_MIGRATION_RAN = 'APP/VERIFICATION_MIGRATION_RAN',
   ANDROID_MOBILE_SERVICES_AVAILABILITY_CHECKED = 'APP/ANDROID_MOBILE_SERVICES_AVAILABILITY_CHECKED',
+  RECENT_DAPP_SELECTED = 'APP/RECENT_DAPP_SELECTED',
 }
 
 export interface SetAppState {
@@ -135,6 +137,11 @@ export interface AndroidMobileServicesAvailabilityChecked {
   huaweiIsAvailable: boolean | undefined
 }
 
+export interface RecentDappSelected {
+  type: Actions.RECENT_DAPP_SELECTED
+  dapp: Dapp
+}
+
 export type ActionTypes =
   | SetAppState
   | SetLoggedIn
@@ -156,6 +163,7 @@ export type ActionTypes =
   | AppUnmounted
   | VerificationMigrationRanAction
   | AndroidMobileServicesAvailabilityChecked
+  | RecentDappSelected
 
 export const setAppState = (state: string) => ({
   type: Actions.SET_APP_STATE,
@@ -272,4 +280,9 @@ export const androidMobileServicesAvailabilityChecked = (
   type: Actions.ANDROID_MOBILE_SERVICES_AVAILABILITY_CHECKED,
   googleIsAvailable,
   huaweiIsAvailable,
+})
+
+export const recentDappSelected = (dapp: Dapp) => ({
+  type: Actions.RECENT_DAPP_SELECTED,
+  dapp,
 })

--- a/packages/mobile/src/app/reducers.ts
+++ b/packages/mobile/src/app/reducers.ts
@@ -52,6 +52,7 @@ export interface State {
   supportedBiometryType: BIOMETRY_TYPE | null
   biometryEnabled: boolean
   superchargeButtonType: SuperchargeButtonType
+  recentDappsEnabled: boolean
 }
 
 const initialState = {
@@ -97,6 +98,7 @@ const initialState = {
   supportedBiometryType: null,
   biometryEnabled: REMOTE_CONFIG_VALUES_DEFAULTS.biometryEnabled,
   superchargeButtonType: REMOTE_CONFIG_VALUES_DEFAULTS.superchargeButtonType,
+  recentDappsEnabled: REMOTE_CONFIG_VALUES_DEFAULTS.recentDappsEnabled,
 }
 
 export const appReducer = (
@@ -212,6 +214,7 @@ export const appReducer = (
         sentryNetworkErrors: action.configValues.sentryNetworkErrors,
         biometryEnabled: action.configValues.biometryEnabled && Platform.OS === 'ios',
         superchargeButtonType: action.configValues.superchargeButtonType,
+        recentDappsEnabled: action.configValues.recentDappsEnabled,
       }
     case Actions.TOGGLE_INVITE_MODAL:
       return {

--- a/packages/mobile/src/app/reducers.ts
+++ b/packages/mobile/src/app/reducers.ts
@@ -249,7 +249,7 @@ export const appReducer = (
     case Actions.RECENT_DAPP_SELECTED:
       return {
         ...state,
-        recentDapps: [action.dapp, ...state.recentDapps].slice(0, NUM_RECENT_DAPPS),
+        recentDapps: [...new Set([action.dapp, ...state.recentDapps])].slice(0, NUM_RECENT_DAPPS),
       }
     default:
       return state

--- a/packages/mobile/src/app/reducers.ts
+++ b/packages/mobile/src/app/reducers.ts
@@ -1,7 +1,8 @@
 import { Platform } from 'react-native'
 import { BIOMETRY_TYPE } from 'react-native-keychain'
 import { Actions, ActionTypes, AppState } from 'src/app/actions'
-import { SuperchargeButtonType } from 'src/app/types'
+import { Dapp, SuperchargeButtonType } from 'src/app/types'
+import { NUM_RECENT_DAPPS } from 'src/config'
 import { REMOTE_CONFIG_VALUES_DEFAULTS } from 'src/firebase/remoteConfigValuesDefaults'
 import { Screens } from 'src/navigator/Screens'
 import { getRehydratePayload, REHYDRATE, RehydrateAction } from 'src/redux/persist-helper'
@@ -53,6 +54,7 @@ export interface State {
   biometryEnabled: boolean
   superchargeButtonType: SuperchargeButtonType
   recentDappsEnabled: boolean
+  recentDapps: Dapp[]
 }
 
 const initialState = {
@@ -99,6 +101,7 @@ const initialState = {
   biometryEnabled: REMOTE_CONFIG_VALUES_DEFAULTS.biometryEnabled,
   superchargeButtonType: REMOTE_CONFIG_VALUES_DEFAULTS.superchargeButtonType,
   recentDappsEnabled: REMOTE_CONFIG_VALUES_DEFAULTS.recentDappsEnabled,
+  recentDapps: [],
 }
 
 export const appReducer = (
@@ -242,6 +245,11 @@ export const appReducer = (
       return {
         ...state,
         supportedBiometryType: action.supportedBiometryType,
+      }
+    case Actions.RECENT_DAPP_SELECTED:
+      return {
+        ...state,
+        recentDapps: [action.dapp, ...state.recentDapps].slice(0, NUM_RECENT_DAPPS),
       }
     default:
       return state

--- a/packages/mobile/src/app/reducers.ts
+++ b/packages/mobile/src/app/reducers.ts
@@ -249,7 +249,10 @@ export const appReducer = (
     case Actions.RECENT_DAPP_SELECTED:
       return {
         ...state,
-        recentDapps: [...new Set([action.dapp, ...state.recentDapps])].slice(0, NUM_RECENT_DAPPS),
+        recentDapps: [
+          action.dapp,
+          ...state.recentDapps.filter((recentDapp) => recentDapp.id !== action.dapp.id),
+        ].slice(0, NUM_RECENT_DAPPS),
       }
     default:
       return state

--- a/packages/mobile/src/app/saga.ts
+++ b/packages/mobile/src/app/saga.ts
@@ -185,6 +185,7 @@ export interface RemoteConfigValues {
   sentryNetworkErrors: string[]
   biometryEnabled: boolean
   superchargeButtonType: SuperchargeButtonType
+  recentDappsEnabled: boolean
 }
 
 export function* appRemoteFeatureFlagSaga() {

--- a/packages/mobile/src/app/selectors.ts
+++ b/packages/mobile/src/app/selectors.ts
@@ -127,6 +127,8 @@ export const activeScreenSelector = (state: RootState) => state.app.activeScreen
 
 export const dappsListApiUrlSelector = (state: RootState) => state.app.dappListApiUrl
 
+export const recentDappsEnabledSelector = (state: RootState) => state.app.recentDappsEnabled
+
 export const superchargeButtonTypeSelector = (state: RootState) => state.app.superchargeButtonType
 
 type StoreWipeRecoveryScreens = Extract<

--- a/packages/mobile/src/app/selectors.ts
+++ b/packages/mobile/src/app/selectors.ts
@@ -129,6 +129,8 @@ export const dappsListApiUrlSelector = (state: RootState) => state.app.dappListA
 
 export const recentDappsEnabledSelector = (state: RootState) => state.app.recentDappsEnabled
 
+export const recentDappsSelector = (state: RootState) => state.app.recentDapps
+
 export const superchargeButtonTypeSelector = (state: RootState) => state.app.superchargeButtonType
 
 type StoreWipeRecoveryScreens = Extract<

--- a/packages/mobile/src/app/types.ts
+++ b/packages/mobile/src/app/types.ts
@@ -4,3 +4,13 @@ export enum SuperchargeButtonType {
   MenuRewards = 'MENU_REWARDS',
   MenuSupercharge = 'MENU_SUPERCHARGE',
 }
+
+export interface Dapp {
+  id: string
+  categoryId: string
+  iconUrl: string
+  name: string
+  description: string
+  dappUrl: string
+  isFeatured: boolean
+}

--- a/packages/mobile/src/config.ts
+++ b/packages/mobile/src/config.ts
@@ -172,4 +172,4 @@ export const DEFAULT_APP_LANGUAGE = 'en-US'
 export const DEFAULT_SENTRY_TRACES_SAMPLE_RATE = 0.2
 export const DEFAULT_SENTRY_NETWORK_ERRORS = ['network request failed']
 
-export const NUM_RECENT_DAPPS = 3
+export const NUM_RECENT_DAPPS = 4

--- a/packages/mobile/src/config.ts
+++ b/packages/mobile/src/config.ts
@@ -171,3 +171,5 @@ export const DEFAULT_APP_LANGUAGE = 'en-US'
 
 export const DEFAULT_SENTRY_TRACES_SAMPLE_RATE = 0.2
 export const DEFAULT_SENTRY_NETWORK_ERRORS = ['network request failed']
+
+export const NUM_RECENT_DAPPS = 3

--- a/packages/mobile/src/dappsExplorer/DAppsBottomSheet.tsx
+++ b/packages/mobile/src/dappsExplorer/DAppsBottomSheet.tsx
@@ -1,0 +1,71 @@
+import Button from '@celo/react-components/components/Button'
+import fontStyles from '@celo/react-components/styles/fonts'
+import { Spacing } from '@celo/react-components/styles/styles'
+import React from 'react'
+import { useTranslation } from 'react-i18next'
+import { StyleSheet, Text, View } from 'react-native'
+import { Dapp } from 'src/app/types'
+import BottomSheet from 'src/components/BottomSheet'
+import QuitIcon from 'src/icons/QuitIcon'
+import { TopBarIconButton } from 'src/navigator/TopBarButton'
+
+interface Props {
+  selectedDapp: Dapp | null
+  isVisible: boolean
+  onClose(): void
+  onConfirmOpenDapp(): void
+}
+
+export function DAppsBottomSheet({ selectedDapp, isVisible, onClose, onConfirmOpenDapp }: Props) {
+  const { t } = useTranslation()
+
+  return (
+    <BottomSheet isVisible={isVisible} onBackgroundPress={onClose}>
+      <View>
+        <TopBarIconButton
+          icon={<QuitIcon />}
+          style={styles.bottomSheetCloseButton}
+          onPress={onClose}
+        />
+        <View style={styles.centerContainer}>
+          <Text style={styles.bottomSheetTitleText}>
+            {t('dappsScreenBottomSheet.title', { dappName: selectedDapp?.name })}
+          </Text>
+          <Text style={styles.bottomSheetMessageText}>{t('dappsScreenBottomSheet.message')}</Text>
+          <Button
+            style={styles.bottomSheetButton}
+            onPress={onConfirmOpenDapp}
+            text={t('dappsScreenBottomSheet.button', { dappName: selectedDapp?.name })}
+            testID="ConfirmDappButton"
+          />
+        </View>
+      </View>
+    </BottomSheet>
+  )
+}
+
+const styles = StyleSheet.create({
+  centerContainer: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    flex: 1,
+  },
+  bottomSheetTitleText: {
+    ...fontStyles.h2,
+    textAlign: 'center',
+    paddingVertical: Spacing.Regular16,
+  },
+  bottomSheetMessageText: {
+    ...fontStyles.regular,
+    textAlign: 'center',
+    flex: 1,
+  },
+  bottomSheetCloseButton: {
+    alignSelf: 'flex-end',
+  },
+  bottomSheetButton: {
+    marginVertical: Spacing.Regular16,
+  },
+})
+
+export default DAppsBottomSheet

--- a/packages/mobile/src/dappsExplorer/DAppsExplorerScreen.test.tsx
+++ b/packages/mobile/src/dappsExplorer/DAppsExplorerScreen.test.tsx
@@ -87,6 +87,18 @@ describe(DAppsExplorerScreen, () => {
     expect(store.getActions()).toMatchInlineSnapshot(`
       Array [
         Object {
+          "dapp": Object {
+            "categoryId": "1",
+            "dappUrl": "https://app.ubeswap.org/",
+            "description": "Swap tokens!",
+            "iconUrl": "https://raw.githubusercontent.com/valora-inc/app-list/main/assets/ubeswap.png",
+            "id": "1",
+            "isFeatured": false,
+            "name": "Ubeswap",
+          },
+          "type": "APP/RECENT_DAPP_SELECTED",
+        },
+        Object {
           "isSecureOrigin": true,
           "openExternal": true,
           "type": "APP/OPEN_URL",
@@ -119,6 +131,18 @@ describe(DAppsExplorerScreen, () => {
     expect(store.getActions()).toMatchInlineSnapshot(`
       Array [
         Object {
+          "dapp": Object {
+            "categoryId": "1",
+            "dappUrl": "https://app.sushi.com/",
+            "description": "Swap some tokens!",
+            "iconUrl": "https://raw.githubusercontent.com/valora-inc/app-list/main/assets/sushiswap.png",
+            "id": "3",
+            "isFeatured": true,
+            "name": "SushiSwap",
+          },
+          "type": "APP/RECENT_DAPP_SELECTED",
+        },
+        Object {
           "isSecureOrigin": true,
           "openExternal": true,
           "type": "APP/OPEN_URL",
@@ -147,6 +171,18 @@ describe(DAppsExplorerScreen, () => {
 
     expect(store.getActions()).toMatchInlineSnapshot(`
       Array [
+        Object {
+          "dapp": Object {
+            "categoryId": "2",
+            "dappUrl": "celo://wallet/moolaScreen",
+            "description": "Lend and borrow tokens!",
+            "iconUrl": "https://raw.githubusercontent.com/valora-inc/app-list/main/assets/moola.png",
+            "id": "2",
+            "isFeatured": false,
+            "name": "Moola",
+          },
+          "type": "APP/RECENT_DAPP_SELECTED",
+        },
         Object {
           "isSecureOrigin": true,
           "openExternal": true,

--- a/packages/mobile/src/dappsExplorer/DAppsExplorerScreen.tsx
+++ b/packages/mobile/src/dappsExplorer/DAppsExplorerScreen.tsx
@@ -24,6 +24,7 @@ import { DappExplorerEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import { openUrl } from 'src/app/actions'
 import { dappsListApiUrlSelector } from 'src/app/selectors'
+import { Dapp } from 'src/app/types'
 import BottomSheet from 'src/components/BottomSheet'
 import Dialog from 'src/components/Dialog'
 import LinkArrow from 'src/icons/LinkArrow'
@@ -52,16 +53,6 @@ interface CategoryWithDapps {
   fontColor: string
   backgroundColor: string
   dapps: Dapp[]
-}
-
-interface Dapp {
-  id: string
-  categoryId: string
-  iconUrl: string
-  name: string
-  description: string
-  dappUrl: string
-  isFeatured: boolean
 }
 
 interface DappProps {

--- a/packages/mobile/src/dappsExplorer/DAppsExplorerScreen.tsx
+++ b/packages/mobile/src/dappsExplorer/DAppsExplorerScreen.tsx
@@ -22,7 +22,7 @@ import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useDispatch, useSelector } from 'react-redux'
 import { DappExplorerEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
-import { openUrl } from 'src/app/actions'
+import { openUrl, recentDappSelected } from 'src/app/actions'
 import { dappsListApiUrlSelector } from 'src/app/selectors'
 import { Dapp } from 'src/app/types'
 import BottomSheet from 'src/components/BottomSheet'
@@ -193,6 +193,7 @@ export function DAppsExplorerScreen() {
       section: dapp.isFeatured ? 'featured' : 'all',
       horizontalPosition: 0,
     })
+    dispatch(recentDappSelected(dapp))
     dispatch(openUrl(dapp.dappUrl, true, true))
   }
 
@@ -302,7 +303,7 @@ export function DAppsExplorerScreen() {
             scrollEventThrottle={16}
             onScroll={onScroll}
             sections={parseResultIntoSections(result.categories)}
-            renderItem={({ item: dapp }) => <Dapp dapp={dapp} onPressDapp={onPressDapp} />}
+            renderItem={({ item: dapp }) => <DappCard dapp={dapp} onPressDapp={onPressDapp} />}
             keyExtractor={(dapp: Dapp) => `${dapp.categoryId}-${dapp.id}`}
             stickySectionHeadersEnabled={false}
             renderSectionHeader={({ section }: { section: SectionListData<any, SectionData> }) => (
@@ -361,7 +362,7 @@ function FeaturedDapp({ dapp, onPressDapp }: DappProps) {
   )
 }
 
-function Dapp({ dapp, onPressDapp }: DappProps) {
+function DappCard({ dapp, onPressDapp }: DappProps) {
   const onPress = () => onPressDapp(dapp)
 
   return (

--- a/packages/mobile/src/dappsExplorer/useOpenDapp.ts
+++ b/packages/mobile/src/dappsExplorer/useOpenDapp.ts
@@ -1,0 +1,81 @@
+import { useState } from 'react'
+import { useDispatch } from 'react-redux'
+import { DappExplorerEvents } from 'src/analytics/Events'
+import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
+import { openUrl, recentDappSelected } from 'src/app/actions'
+import { Dapp } from 'src/app/types'
+import { isDeepLink } from 'src/utils/linking'
+import Logger from 'src/utils/Logger'
+
+const TAG = 'DApps'
+
+// Open the dapp if deep linked, or require confirmation to open the dapp
+const useOpenDapp = () => {
+  const [showOpenDappConfirmation, setShowOpenDappConfirmation] = useState(false)
+  const [selectedDapp, setSelectedDapp] = useState<Dapp | null>(null)
+  const dispatch = useDispatch()
+
+  const onCancelOpenDapp = () => {
+    setShowOpenDappConfirmation(false)
+    if (selectedDapp) {
+      ValoraAnalytics.track(DappExplorerEvents.dapp_bottom_sheet_dismiss, {
+        categoryId: selectedDapp.categoryId,
+        dappId: selectedDapp.id,
+        dappName: selectedDapp.name,
+        horizontalPosition: 0,
+        section: selectedDapp.isFeatured ? 'featured' : 'all',
+      })
+    }
+  }
+
+  const openDapp = (dapp: Dapp) => {
+    ValoraAnalytics.track(DappExplorerEvents.dapp_open, {
+      categoryId: dapp.categoryId,
+      dappId: dapp.id,
+      dappName: dapp.name,
+      section: dapp.isFeatured ? 'featured' : 'all',
+      horizontalPosition: 0,
+    })
+    dispatch(recentDappSelected(dapp))
+    dispatch(openUrl(dapp.dappUrl, true, true))
+  }
+
+  const onOpenDapp = () => {
+    if (!selectedDapp) {
+      // Should never happen
+      Logger.error(TAG, 'Internal error. There was no dapp selected')
+      return
+    }
+    openDapp(selectedDapp)
+    setShowOpenDappConfirmation(false)
+  }
+
+  const onSelectDapp = (dapp: Dapp) => {
+    const dappEventProps = {
+      categoryId: dapp.categoryId,
+      dappId: dapp.id,
+      dappName: dapp.name,
+      horizontalPosition: 0,
+      section: dapp.isFeatured ? 'featured' : 'all',
+    }
+    ValoraAnalytics.track(DappExplorerEvents.dapp_select, dappEventProps)
+
+    if (!isDeepLink(dapp.dappUrl)) {
+      setSelectedDapp(dapp)
+      setShowOpenDappConfirmation(true)
+      ValoraAnalytics.track(DappExplorerEvents.dapp_bottom_sheet_open, dappEventProps)
+    } else {
+      openDapp(dapp)
+    }
+  }
+
+  return {
+    onSelectDapp,
+    onOpenDapp,
+    onCancelOpenDapp,
+    showOpenDappConfirmation,
+    selectedDapp,
+  }
+}
+
+export default useOpenDapp

--- a/packages/mobile/src/firebase/firebase.ts
+++ b/packages/mobile/src/firebase/firebase.ts
@@ -276,6 +276,7 @@ export async function fetchRemoteConfigValues(): Promise<RemoteConfigValues | nu
     sentryNetworkErrors: flags.sentryNetworkErrors.asString().split(','),
     biometryEnabled: flags.biometryEnabled.asBoolean(),
     superchargeButtonType: flags.superchargeButtonType.asString() as SuperchargeButtonType,
+    recentDappsEnabled: flags.recentDappsEnabled.asBoolean(),
   }
 }
 

--- a/packages/mobile/src/firebase/remoteConfigValuesDefaults.e2e.ts
+++ b/packages/mobile/src/firebase/remoteConfigValuesDefaults.e2e.ts
@@ -45,4 +45,5 @@ export const REMOTE_CONFIG_VALUES_DEFAULTS: Omit<
   dappListApiUrl:
     'https://raw.githubusercontent.com/valora-inc/dapp-list/main/translations/valora-dapp-list-base.json',
   superchargeButtonType: SuperchargeButtonType.PillRewards,
+  recentDappsEnabled: false,
 }

--- a/packages/mobile/src/firebase/remoteConfigValuesDefaults.ts
+++ b/packages/mobile/src/firebase/remoteConfigValuesDefaults.ts
@@ -50,4 +50,5 @@ export const REMOTE_CONFIG_VALUES_DEFAULTS: Omit<
   sentryNetworkErrors: DEFAULT_SENTRY_NETWORK_ERRORS.join(','),
   biometryEnabled: false,
   superchargeButtonType: SuperchargeButtonType.PillRewards,
+  recentDappsEnabled: false,
 }

--- a/packages/mobile/src/home/RecentlyUsedDapps.tsx
+++ b/packages/mobile/src/home/RecentlyUsedDapps.tsx
@@ -15,12 +15,17 @@ import {
   View,
 } from 'react-native'
 import { recentDappsSelector } from 'src/app/selectors'
+import { Dapp } from 'src/app/types'
 import ProgressArrow from 'src/icons/ProgressArrow'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import useSelector from 'src/redux/useSelector'
 
-function RecentlyUsedDapps() {
+interface Props {
+  onSelectDapp(dapp: Dapp): void
+}
+
+function RecentlyUsedDapps({ onSelectDapp }: Props) {
   const recentlyUsedDapps = useSelector(recentDappsSelector)
   const [currentIndex, setCurrentIndex] = useState(0)
   const { t } = useTranslation()
@@ -48,7 +53,7 @@ function RecentlyUsedDapps() {
         <Text style={styles.title}>{t('recentlyUsedDapps')}</Text>
         <TouchableOpacity style={styles.row} onPress={onPressAllDapps} testID="AllDapps">
           <Text style={styles.allDapps}>{t('allDapps')}</Text>
-          <ProgressArrow height={10} color={Colors.greenUI} />
+          <ProgressArrow color={Colors.greenUI} />
         </TouchableOpacity>
       </View>
 
@@ -59,7 +64,12 @@ function RecentlyUsedDapps() {
         testID="RecentlyUsedDapps/ScrollContainer"
       >
         {recentlyUsedDapps.map((recentlyUsedDapp, index) => (
-          <View key={recentlyUsedDapp.id} style={styles.dappContainer}>
+          <TouchableOpacity
+            key={recentlyUsedDapp.id}
+            onPress={() => onSelectDapp(recentlyUsedDapp)}
+            style={styles.dappContainer}
+            testID={`RecentDapp/${index}`}
+          >
             <View style={[styles.dappLogoContainer, index === 0 ? { marginLeft: 0 } : undefined]}>
               <Image
                 source={{ uri: recentlyUsedDapp.iconUrl }}
@@ -70,7 +80,7 @@ function RecentlyUsedDapps() {
             <Text style={styles.dappName} numberOfLines={1} ellipsizeMode="tail">
               {recentlyUsedDapp.name}
             </Text>
-          </View>
+          </TouchableOpacity>
         ))}
       </ScrollView>
     </View>

--- a/packages/mobile/src/home/RecentlyUsedDapps.tsx
+++ b/packages/mobile/src/home/RecentlyUsedDapps.tsx
@@ -1,0 +1,131 @@
+import { Colors } from '@celo/react-components/styles/colors'
+import fontStyles from '@celo/react-components/styles/fonts'
+import { Spacing } from '@celo/react-components/styles/styles'
+import variables from '@celo/react-components/styles/variables'
+import * as React from 'react'
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import {
+  Image,
+  NativeScrollEvent,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native'
+import { recentDappsSelector } from 'src/app/selectors'
+import ProgressArrow from 'src/icons/ProgressArrow'
+import { navigate } from 'src/navigator/NavigationService'
+import { Screens } from 'src/navigator/Screens'
+import useSelector from 'src/redux/useSelector'
+
+function RecentlyUsedDapps() {
+  const recentlyUsedDapps = useSelector(recentDappsSelector)
+  const [currentIndex, setCurrentIndex] = useState(0)
+  const { t } = useTranslation()
+
+  const handleScroll = (event: { nativeEvent: NativeScrollEvent }) => {
+    const nextIndex = Math.round(event.nativeEvent.contentOffset.x / variables.width)
+    if (nextIndex === currentIndex) {
+      return
+    }
+
+    setCurrentIndex(nextIndex)
+  }
+
+  const onPressAllDapps = () => {
+    navigate(Screens.DAppsExplorerScreen)
+  }
+
+  if (!recentlyUsedDapps.length) {
+    return null
+  }
+
+  return (
+    <View style={styles.body}>
+      <View style={[styles.titleContainer, styles.row]}>
+        <Text style={styles.title}>{t('recentlyUsedDapps')}</Text>
+        <TouchableOpacity style={styles.row} onPress={onPressAllDapps} testID="AllDapps">
+          <Text style={styles.allDapps}>{t('allDapps')}</Text>
+          <ProgressArrow height={10} color={Colors.greenUI} />
+        </TouchableOpacity>
+      </View>
+
+      <ScrollView
+        horizontal={true}
+        showsHorizontalScrollIndicator={false}
+        onScroll={handleScroll}
+        testID="RecentlyUsedDapps/ScrollContainer"
+      >
+        {recentlyUsedDapps.map((recentlyUsedDapp, index) => (
+          <View key={recentlyUsedDapp.id} style={styles.dappContainer}>
+            <View style={[styles.dappLogoContainer, index === 0 ? { marginLeft: 0 } : undefined]}>
+              <Image
+                source={{ uri: recentlyUsedDapp.iconUrl }}
+                style={styles.icon}
+                resizeMode="cover"
+              />
+            </View>
+            <Text style={styles.dappName} numberOfLines={1} ellipsizeMode="tail">
+              {recentlyUsedDapp.name}
+            </Text>
+          </View>
+        ))}
+      </ScrollView>
+    </View>
+  )
+}
+
+const DAPP_LOGO_SIZE = 44
+
+const styles = StyleSheet.create({
+  body: {
+    maxWidth: variables.width,
+    width: variables.width,
+    paddingTop: Spacing.Regular16,
+    paddingBottom: Spacing.Thick24,
+  },
+  titleContainer: {
+    paddingHorizontal: Spacing.Regular16,
+    paddingBottom: Spacing.Regular16,
+  },
+  row: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  title: {
+    ...fontStyles.sectionHeader,
+    color: Colors.gray4,
+  },
+  allDapps: {
+    ...fontStyles.label,
+    color: Colors.greenUI,
+    marginRight: Spacing.Smallest8,
+  },
+  arrow: {
+    paddingLeft: Spacing.Smallest8,
+  },
+  dappContainer: {
+    alignItems: 'center',
+    marginHorizontal: Spacing.Small12,
+  },
+  dappLogoContainer: {
+    padding: Spacing.Small12,
+    borderRadius: 100,
+    borderWidth: 1,
+    borderColor: Colors.gray2,
+    marginBottom: Spacing.Small12,
+  },
+  dappName: {
+    ...fontStyles.small,
+    textAlign: 'center',
+  },
+  icon: {
+    height: DAPP_LOGO_SIZE,
+    width: DAPP_LOGO_SIZE,
+  },
+})
+
+export default RecentlyUsedDapps

--- a/packages/mobile/src/home/WalletHome.tsx
+++ b/packages/mobile/src/home/WalletHome.tsx
@@ -12,7 +12,9 @@ import {
   appStateSelector,
   multiTokenShowHomeBalancesSelector,
   multiTokenUseUpdatedFeedSelector,
+  recentDappsEnabledSelector,
 } from 'src/app/selectors'
+import { HomeTokenBalance } from 'src/components/TokenBalance'
 import {
   ALERT_BANNER_DURATION,
   CELO_TRANSACTION_MIN_AMOUNT,
@@ -22,8 +24,8 @@ import {
 } from 'src/config'
 import { refreshAllBalances } from 'src/home/actions'
 import CashInBottomSheet from 'src/home/CashInBottomSheet'
-import { HomeTokenBalance } from 'src/components/TokenBalance'
 import NotificationBox from 'src/home/NotificationBox'
+import RecentlyUsedDapps from 'src/home/RecentlyUsedDapps'
 import SendOrRequestBar from 'src/home/SendOrRequestBar'
 import Logo from 'src/icons/Logo'
 import { importContacts } from 'src/identity/actions'
@@ -48,6 +50,7 @@ function WalletHome() {
   const recipientCache = useSelector(phoneRecipientCacheSelector)
   const isNumberVerified = useSelector((state) => state.app.numberVerified)
   const showTokensInHome = useSelector(multiTokenShowHomeBalancesSelector)
+  const showRecentDapps = useSelector(recentDappsEnabledSelector)
   const useUpdatedFeed = useSelector(multiTokenUseUpdatedFeedSelector)
   const balances = useSelector(balancesSelector)
   const cashInButtonExpEnabled = useSelector((state) => state.app.cashInButtonExpEnabled)
@@ -132,6 +135,13 @@ function WalletHome() {
     sections.push({
       data: [{}],
       renderItem: () => <HomeTokenBalance key={'HomeTokenBalance'} />,
+    })
+  }
+
+  if (showRecentDapps) {
+    sections.push({
+      data: [{}],
+      renderItem: () => <RecentlyUsedDapps key="RecentlyUsedDapps" />,
     })
   }
 

--- a/packages/mobile/src/home/WalletHome.tsx
+++ b/packages/mobile/src/home/WalletHome.tsx
@@ -22,6 +22,8 @@ import {
   SHOW_TESTNET_BANNER,
   STABLE_TRANSACTION_MIN_AMOUNT,
 } from 'src/config'
+import DAppsBottomSheet from 'src/dappsExplorer/DAppsBottomSheet'
+import useOpenDapp from 'src/dappsExplorer/useOpenDapp'
 import { refreshAllBalances } from 'src/home/actions'
 import CashInBottomSheet from 'src/home/CashInBottomSheet'
 import NotificationBox from 'src/home/NotificationBox'
@@ -59,6 +61,14 @@ function WalletHome() {
   const onScroll = Animated.event([{ nativeEvent: { contentOffset: { y: scrollPosition } } }])
 
   const dispatch = useDispatch()
+
+  const {
+    onSelectDapp,
+    onOpenDapp,
+    onCancelOpenDapp,
+    showOpenDappConfirmation,
+    selectedDapp,
+  } = useOpenDapp()
 
   const showTestnetBanner = () => {
     dispatch(
@@ -141,7 +151,7 @@ function WalletHome() {
   if (showRecentDapps) {
     sections.push({
       data: [{}],
-      renderItem: () => <RecentlyUsedDapps key="RecentlyUsedDapps" />,
+      renderItem: () => <RecentlyUsedDapps key="RecentlyUsedDapps" onSelectDapp={onSelectDapp} />,
     })
   }
 
@@ -170,6 +180,14 @@ function WalletHome() {
       />
       <SendOrRequestBar />
       {shouldShowCashInBottomSheet() && <CashInBottomSheet />}
+      {showRecentDapps && (
+        <DAppsBottomSheet
+          onClose={onCancelOpenDapp}
+          onConfirmOpenDapp={onOpenDapp}
+          selectedDapp={selectedDapp}
+          isVisible={showOpenDappConfirmation}
+        />
+      )}
     </SafeAreaView>
   )
 }

--- a/packages/mobile/src/redux/migrations.ts
+++ b/packages/mobile/src/redux/migrations.ts
@@ -423,4 +423,11 @@ export const migrations = {
       ranVerificationMigrationAt: null,
     },
   }),
+  34: (state: any) => ({
+    ...state,
+    app: {
+      ...state.app,
+      recentDappsEnabled: false,
+    },
+  }),
 }

--- a/packages/mobile/src/redux/migrations.ts
+++ b/packages/mobile/src/redux/migrations.ts
@@ -428,6 +428,7 @@ export const migrations = {
     app: {
       ...state.app,
       recentDappsEnabled: false,
+      recentDapps: [],
     },
   }),
 }

--- a/packages/mobile/src/redux/store.ts
+++ b/packages/mobile/src/redux/store.ts
@@ -19,7 +19,7 @@ let lastEventTime = Date.now()
 
 const persistConfig: PersistConfig<RootState> = {
   key: 'root',
-  version: 33, // default is -1, increment as we make migrations
+  version: 34, // default is -1, increment as we make migrations
   keyPrefix: `reduxStore-`, // the redux-persist default is `persist:` which doesn't work with some file systems.
   storage: FSStorage(),
   blacklist: ['geth', 'networkInfo', 'alert', 'imports'],

--- a/packages/mobile/test/schemas.ts
+++ b/packages/mobile/test/schemas.ts
@@ -967,9 +967,10 @@ export const v34Schema = {
   app: {
     ...v33Schema.app,
     recentDappsEnabled: false,
+    recentDapps: [],
   },
 }
 
 export function getLatestSchema(): Partial<RootState> {
-  return v33Schema as Partial<RootState>
+  return v34Schema as Partial<RootState>
 }

--- a/packages/mobile/test/schemas.ts
+++ b/packages/mobile/test/schemas.ts
@@ -958,6 +958,18 @@ export const v33Schema = {
   },
 }
 
+export const v34Schema = {
+  ...v33Schema,
+  _persist: {
+    ...v33Schema._persist,
+    version: 34,
+  },
+  app: {
+    ...v33Schema.app,
+    recentDappsEnabled: false,
+  },
+}
+
 export function getLatestSchema(): Partial<RootState> {
   return v33Schema as Partial<RootState>
 }


### PR DESCRIPTION
### Description

Add recently used dapps to the home screen.

[Screenshot here]

In this PR:
- add remote config to show/hide recently used dapps
- store recently used dapps in redux (update this list every time the user opens a dapp from Valora)
- move some dapp logic around to be reused
- TODO: unit tests


### Other changes

N/A

### Tested

Open dapps from dapps explorer screen, see that the most recently opened dapps are displayed on the home screen.

Only the 4 most recently used dapps are displayed.

No duplicate dapps should be displayed.

The most recently used dapp should appear on the left.


### How others should test

As above

### Related issues

- Fixes #1745 

### Backwards compatibility

Yes