### PR TITLE
Disable Sentry if bundle id doesn't match the one set at build time

### DIFF
--- a/packages/mobile/src/config.ts
+++ b/packages/mobile/src/config.ts
@@ -71,6 +71,8 @@ export const DEFAULT_FORNO_URL =
     : 'https://alfajores-forno.celo-testnet.org/'
 export const BLOCKSCOUT_BASE_URL = Config.BLOCKSCOUT_BASE_URL
 
+export const APP_BUNDLE_ID = Config.APP_BUNDLE_ID
+
 // FEATURE FLAGS
 export const FIREBASE_ENABLED = stringToBoolean(Config.FIREBASE_ENABLED || 'true')
 export const SHOW_TESTNET_BANNER = stringToBoolean(Config.SHOW_TESTNET_BANNER || 'false')

--- a/packages/mobile/src/sentry/Sentry.ts
+++ b/packages/mobile/src/sentry/Sentry.ts
@@ -2,7 +2,7 @@ import * as Sentry from '@sentry/react-native'
 import DeviceInfo from 'react-native-device-info'
 import { select } from 'redux-saga/effects'
 import { sentryTracesSampleRateSelector } from 'src/app/selectors'
-import { DEFAULT_FORNO_URL, SENTRY_CLIENT_URL, SENTRY_ENABLED } from 'src/config'
+import { APP_BUNDLE_ID, DEFAULT_FORNO_URL, SENTRY_CLIENT_URL, SENTRY_ENABLED } from 'src/config'
 import networkConfig from 'src/geth/networkConfig'
 import Logger from 'src/utils/Logger'
 import { currentAccountSelector } from 'src/web3/selectors'
@@ -21,6 +21,15 @@ export function* initializeSentry() {
 
   if (!SENTRY_CLIENT_URL) {
     Logger.info(TAG, 'installSentry', 'Sentry URL not found, skipping installation')
+    return
+  }
+
+  // Tentative to avoid Sentry reports from apps that modified the bundle id from published builds
+  // We're not yet sure who/what does that. Suspecting an automated tool testing the published builds.
+  // It's polluting the Sentry dashboard unnecessarily, since the environment is based on the bundle id.
+  const bundleId = DeviceInfo.getBundleId()
+  if (bundleId !== APP_BUNDLE_ID) {
+    Logger.info(TAG, 'Sentry skipped for this app')
     return
   }
 


### PR DESCRIPTION
### Description

This is a tentative to avoid the environment pollution we currently see in Sentry.
See [Slack discussion](https://valora-app.slack.com/archives/C025V1D6F3J/p1645782671954849?thread_ts=1645758296.049519&cid=C025V1D6F3J).

### Tested

- Sentry init is skipped if bundle id doesn't match the one set at build time

### How others should test

N/A

### Related issues

N/A

### Backwards compatibility

Yes