### PR TITLE
Add language support for Ukrainian

### DIFF
--- a/packages/mobile/ios/celo.xcodeproj/project.pbxproj
+++ b/packages/mobile/ios/celo.xcodeproj/project.pbxproj
@@ -101,6 +101,7 @@
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = celo/Info.plist; sourceTree = "<group>"; };
 		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = celo/main.m; sourceTree = "<group>"; };
 		1931B4D04F9947C23D830F1D /* Pods-celoTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-celoTests.release.xcconfig"; path = "Target Support Files/Pods-celoTests/Pods-celoTests.release.xcconfig"; sourceTree = "<group>"; };
+		2772E8DC27CEE9D900171137 /* uk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = uk; path = uk.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		27A21C992796DA560008F219 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		27A21C9A2796DA620008F219 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		27A21C9D2796DA920008F219 /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/InfoPlist.strings; sourceTree = "<group>"; };
@@ -449,6 +450,7 @@
 				fr,
 				it,
 				ru,
+				uk,
 			);
 			mainGroup = 83CBB9F61A601CBA00E9B192;
 			productRefGroup = 83CBBA001A601CBA00E9B192 /* Products */;
@@ -946,6 +948,7 @@
 				27A21C992796DA560008F219 /* fr */,
 				27A21C9A2796DA620008F219 /* it */,
 				27A21C9D2796DA920008F219 /* ru */,
+				2772E8DC27CEE9D900171137 /* uk */,
 			);
 			name = InfoPlist.strings;
 			path = celo;

--- a/packages/mobile/locales/index.ts
+++ b/packages/mobile/locales/index.ts
@@ -86,6 +86,17 @@ const locales: Locales = {
       return require('date-fns/locale/it')
     },
   },
+  'uk-UA': {
+    name: 'Українська',
+    get strings() {
+      return {
+        translation: require('./uk-UA/translation.json'),
+      }
+    },
+    get dateFns() {
+      return require('date-fns/locale/uk')
+    },
+  },
 }
 
 export default locales


### PR DESCRIPTION
### Description

Add language support for Ukrainian 🇺🇦

### Other changes

N/A

### Tested

Manually


### How others should test

The app correctly displays in Ukrainian if you select that as your language.

The app is launched in Ukrainian for a new user with device language uk-UA

### Related issues

- Fixes #2069 

### Backwards compatibility

Yes