### PR TITLE
Reload Dapps and Supercharge screens every time the user navigates to them

### DIFF
--- a/packages/mobile/src/navigator/DrawerNavigator.tsx
+++ b/packages/mobile/src/navigator/DrawerNavigator.tsx
@@ -247,7 +247,7 @@ export default function DrawerNavigator() {
             drawerIcon: DappsExplorer,
             // Special case for the Dapps explorer,
             // so it reloads the list when the user comes back to it
-            // Note: we generally want to avoid this as the reset the scroll position (and all other component state)
+            // Note: we generally want to avoid this as it resets the scroll position (and all other component state)
             // but here it's the right expectation
             unmountOnBlur: true,
           }}

--- a/packages/mobile/src/navigator/DrawerNavigator.tsx
+++ b/packages/mobile/src/navigator/DrawerNavigator.tsx
@@ -242,7 +242,15 @@ export default function DrawerNavigator() {
         <Drawer.Screen
           name={Screens.DAppsExplorerScreen}
           component={DAppsExplorerScreen}
-          options={{ title: t('dappsScreen.title'), drawerIcon: DappsExplorer }}
+          options={{
+            title: t('dappsScreen.title'),
+            drawerIcon: DappsExplorer,
+            // Special case for the Dapps explorer,
+            // so it reloads the list when the user comes back to it
+            // Note: we generally want to avoid this as the reset the scroll position (and all other component state)
+            // but here it's the right expectation
+            unmountOnBlur: true,
+          }}
         />
       )}
       {rewardsEnabled && superchargeButtonType === SuperchargeButtonType.MenuRewards && (

--- a/packages/mobile/src/navigator/DrawerNavigator.tsx
+++ b/packages/mobile/src/navigator/DrawerNavigator.tsx
@@ -257,14 +257,14 @@ export default function DrawerNavigator() {
         <Drawer.Screen
           name={Screens.ConsumerIncentivesHomeScreen}
           component={ConsumerIncentivesHomeScreen}
-          options={{ title: t('rewards'), drawerIcon: MenuRings }}
+          options={{ title: t('rewards'), drawerIcon: MenuRings, unmountOnBlur: true }}
         />
       )}
       {rewardsEnabled && superchargeButtonType === SuperchargeButtonType.MenuSupercharge && (
         <Drawer.Screen
           name={Screens.ConsumerIncentivesHomeScreen}
           component={ConsumerIncentivesHomeScreen}
-          options={{ title: t('supercharge'), drawerIcon: MenuSupercharge }}
+          options={{ title: t('supercharge'), drawerIcon: MenuSupercharge, unmountOnBlur: true }}
         />
       )}
       <Drawer.Screen


### PR DESCRIPTION
### Description

This fixes an edge case with the Dapps page which would keep the same displayed featured dapp until the app is actually fully closed and relaunched.
And fixes the same problem with the Supercharge screen when accessed via the menu item.

### Tested

- The Dapps list is refetched and `dapp_screen_open` is triggered every time the user navigates to the Dapps page.
- The Supercharge screen is reloaded when accessed via the menu item

### How others should test

- Ensure you see the loading indicator every time you navigate to the Dapps page.
- Ensure you see the loading indicator every time you navigate to the Supercharge screen via the menu item (this is under a feature flag).

### Related issues

Discussed on [Slack](https://valora-app.slack.com/archives/C02UAE4MGUF/p1646163385968329).

### Backwards compatibility

Yes