### PR TITLE
Some changes to Supercharge self-claim

### DIFF
--- a/packages/mobile/locales/base/translation.json
+++ b/packages/mobile/locales/base/translation.json
@@ -181,6 +181,8 @@
   "superchargeConnectNumber": "Connect your phone number",
   "superchargeMinimumBalance": "Add a minimum balance of {{amount}} {{token}}",
   "superchargeDisclaimer": "Max-out rewards by adding up to {{amount}} {{token}}",
+  "superchargeDisclaimerMaxRewards": "You’re getting maximum rewards on your {{token}}",
+  "superchargeDisclaimerDayLimit": "Your rewards must be claimed within 28 days. <0>Learn more</0>",
   "superchargeTokenDetailsDialog": {
     "title": "Which assets can I Supercharge?",
     "body": "You’ll get rewarded weekly on your Celo stablecoin with the highest value (cEUR, cUSD, cREAL).",
@@ -195,6 +197,8 @@
   "superchargeFetchRewardsFailed": "Error while fetching pending Supercharge rewards. Please try again later.",
   "superchargeClaimSuccess": "Your Supercharge rewards have been added to your Total Balance.",
   "superchargeClaimFailure": "There was an issue claiming your Supercharge rewards.",
+  "superchargeNotificationBody": "Supercharge rewards are here! Claim them now.",
+  "superchargeNotificationStart": "Claim rewards",
   "cashIn": "Add {{currency}}",
   "connectNumber": "Connect Number",
   "connectToWallet": "{{dappName}} would like to connect to {{appName}}",

--- a/packages/mobile/src/analytics/Events.tsx
+++ b/packages/mobile/src/analytics/Events.tsx
@@ -483,6 +483,8 @@ export enum NavigationEvents {
 export enum RewardsEvents {
   rewards_screen_opened = 'rewards_screen_opened',
   rewards_screen_cta_pressed = 'rewards_screen_cta_pressed',
+  learn_more_pressed = 'learn_more_pressed',
+  claimed_reward = 'claimed_reward',
 }
 
 export enum WalletConnectEvents {

--- a/packages/mobile/src/analytics/Properties.tsx
+++ b/packages/mobile/src/analytics/Properties.tsx
@@ -1061,6 +1061,11 @@ interface RewardsProperties {
   [RewardsEvents.rewards_screen_cta_pressed]: {
     buttonPressed: RewardsScreenCta
   }
+  [RewardsEvents.learn_more_pressed]: undefined
+  [RewardsEvents.claimed_reward]: {
+    amount: string
+    token: string
+  }
 }
 
 interface WalletConnect1Properties {

--- a/packages/mobile/src/api/slice.ts
+++ b/packages/mobile/src/api/slice.ts
@@ -18,6 +18,7 @@ export const cloudFunctionsApi = createApi({
   }),
 })
 
+// @ts-ignore This works but throws a build error because we're using an old typescript version :(
 const { useFetchSuperchargeRewardsQuery } = cloudFunctionsApi
 
 export function useFetchSuperchargeRewards() {

--- a/packages/mobile/src/api/slice.ts
+++ b/packages/mobile/src/api/slice.ts
@@ -1,0 +1,29 @@
+import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
+import { SuperchargePendingReward } from 'src/consumerIncentives/types'
+import config from 'src/geth/networkConfig'
+import useSelector from 'src/redux/useSelector'
+import { walletAddressSelector } from 'src/web3/selectors'
+
+export const cloudFunctionsApi = createApi({
+  reducerPath: 'cloudFunctionsApi',
+  baseQuery: fetchBaseQuery({ baseUrl: config.cloudFunctionsBaseUrl }),
+  tagTypes: ['Supercharge'],
+  endpoints: (builder) => ({
+    fetchSuperchargeRewards: builder.query<SuperchargePendingReward[], string>({
+      query: (address) => `fetchAvailableSuperchargeRewards?address=${address}`,
+      transformResponse: (response: { availableRewards: SuperchargePendingReward[] }) =>
+        response?.availableRewards,
+      providesTags: ['Supercharge'],
+    }),
+  }),
+})
+
+const { useFetchSuperchargeRewardsQuery } = cloudFunctionsApi
+
+export function useFetchSuperchargeRewards() {
+  const address = useSelector(walletAddressSelector)
+  const { data, isLoading, isError } = useFetchSuperchargeRewardsQuery(address ?? '', {
+    refetchOnMountOrArgChange: true,
+  })
+  return { superchargeRewards: data ?? [], isLoading, isError }
+}

--- a/packages/mobile/src/api/slice.ts
+++ b/packages/mobile/src/api/slice.ts
@@ -6,7 +6,7 @@ import { walletAddressSelector } from 'src/web3/selectors'
 
 export const cloudFunctionsApi = createApi({
   reducerPath: 'cloudFunctionsApi',
-  baseQuery: fetchBaseQuery({ baseUrl: config.cloudFunctionsBaseUrl }),
+  baseQuery: fetchBaseQuery({ baseUrl: config.cloudFunctionsUrl }),
   tagTypes: ['Supercharge'],
   endpoints: (builder) => ({
     fetchSuperchargeRewards: builder.query<SuperchargePendingReward[], string>({

--- a/packages/mobile/src/config.ts
+++ b/packages/mobile/src/config.ts
@@ -155,6 +155,8 @@ export const VALORA_LOGO_URL =
   'https://storage.googleapis.com/celo-mobile-mainnet.appspot.com/images/valora-icon.png'
 export const CELO_LOGO_URL =
   'https://firebasestorage.googleapis.com/v0/b/celo-mobile-mainnet.appspot.com/o/images%2Fcelo.jpeg?alt=media'
+export const SUPERCHARGE_LOGO_URL =
+  'https://firebasestorage.googleapis.com/v0/b/celo-mobile-mainnet.appspot.com/o/images%2Fsupercharge_logo.png?alt=media'
 
 export const SIMPLEX_URI = 'https://valoraapp.com/simplex'
 export const SIMPLEX_FEES_URL =

--- a/packages/mobile/src/consumerIncentives/ConsumerIncentivesHomeScreen.tsx
+++ b/packages/mobile/src/consumerIncentives/ConsumerIncentivesHomeScreen.tsx
@@ -211,7 +211,6 @@ export default function ConsumerIncentivesHomeScreen() {
   const isSupercharging = userIsVerified && hasBalanceForSupercharge
   const tokenToSupercharge = useTokenToSupercharge()
 
-  console.log('QQ', useFetchSuperchargeRewards, JSON.stringify(useFetchSuperchargeRewards))
   const {
     superchargeRewards,
     isLoading: loadingAvailableRewards,

--- a/packages/mobile/src/consumerIncentives/ConsumerIncentivesHomeScreen.tsx
+++ b/packages/mobile/src/consumerIncentives/ConsumerIncentivesHomeScreen.tsx
@@ -211,6 +211,7 @@ export default function ConsumerIncentivesHomeScreen() {
   const isSupercharging = userIsVerified && hasBalanceForSupercharge
   const tokenToSupercharge = useTokenToSupercharge()
 
+  console.log('QQ', useFetchSuperchargeRewards, JSON.stringify(useFetchSuperchargeRewards))
   const {
     superchargeRewards,
     isLoading: loadingAvailableRewards,

--- a/packages/mobile/src/consumerIncentives/analyticsEventsTracker.ts
+++ b/packages/mobile/src/consumerIncentives/analyticsEventsTracker.ts
@@ -5,6 +5,7 @@ import { Screens } from 'src/navigator/Screens'
 export enum RewardsScreenOrigin {
   RewardPill = 'RewardPill',
   NotificationBox = 'NotificationBox',
+  RewardAvailableNotification = 'RewardAvailableNotification',
   PaymentDetail = 'PaymentDetail',
   PushNotification = 'PushNotification',
   SideMenu = 'SideMenu',

--- a/packages/mobile/src/consumerIncentives/saga.test.ts
+++ b/packages/mobile/src/consumerIncentives/saga.test.ts
@@ -1,6 +1,6 @@
 import { toTransactionObject } from '@celo/connect'
 import { expectSaga } from 'redux-saga-test-plan'
-import { call } from 'redux-saga-test-plan/matchers'
+import { call, select } from 'redux-saga-test-plan/matchers'
 import { Actions as AlertActions, AlertTypes } from 'src/alert/actions'
 import { ONE_CUSD_REWARD_RESPONSE } from 'src/consumerIncentives/ConsumerIncentivesHomeScreen.test'
 import { claimRewardsSaga } from 'src/consumerIncentives/saga'
@@ -10,6 +10,7 @@ import {
   claimRewardsSuccess,
 } from 'src/consumerIncentives/slice'
 import { navigateHome } from 'src/navigator/NavigationService'
+import { tokensByAddressSelector } from 'src/tokens/selectors'
 import { Actions as TransactionActions } from 'src/transactions/actions'
 import { getContractKit } from 'src/web3/contracts'
 import { getConnectedUnlockedAccount } from 'src/web3/saga'
@@ -47,6 +48,15 @@ const mockTxo = {
   })),
 }
 
+const mockTokens = {
+  [mockCusdAddress]: {
+    symbol: 'cUSD',
+  },
+  [mockCeurAddress]: {
+    symbol: 'cEUR',
+  },
+}
+
 describe('claimRewardsSaga', () => {
   beforeEach(() => {
     jest.clearAllMocks()
@@ -58,6 +68,7 @@ describe('claimRewardsSaga', () => {
       .provide([
         [call(getContractKit), contractKit],
         [call(getConnectedUnlockedAccount), mockAccount],
+        [select(tokensByAddressSelector), {}],
       ])
       .put(claimRewardsSuccess())
       .put.like({ action: { type: AlertActions.SHOW, message: 'superchargeClaimSuccess' } })
@@ -71,6 +82,7 @@ describe('claimRewardsSaga', () => {
       .provide([
         [call(getContractKit), contractKit],
         [call(getConnectedUnlockedAccount), mockAccount],
+        [select(tokensByAddressSelector), mockTokens],
       ])
       .put.like({
         action: {
@@ -114,6 +126,7 @@ describe('claimRewardsSaga', () => {
       .provide([
         [call(getContractKit), contractKit],
         [call(getConnectedUnlockedAccount), mockAccount],
+        [select(tokensByAddressSelector), mockTokens],
       ])
       .put.like({
         action: {
@@ -151,6 +164,7 @@ describe('claimRewardsSaga', () => {
       .provide([
         [call(getContractKit), contractKit],
         [call(getConnectedUnlockedAccount), mockAccount],
+        [select(tokensByAddressSelector), mockTokens],
       ])
       .not.put(claimRewardsSuccess())
       .put(claimRewardsFailure())

--- a/packages/mobile/src/consumerIncentives/saga.ts
+++ b/packages/mobile/src/consumerIncentives/saga.ts
@@ -6,6 +6,7 @@ import merkleDistributor from 'src/abis/MerkleDistributor.json'
 import { showError, showMessage } from 'src/alert/actions'
 import { RewardsEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
+import { cloudFunctionsApi } from 'src/api/slice'
 import { ErrorMessages } from 'src/app/ErrorMessages'
 import {
   claimRewards,
@@ -92,6 +93,7 @@ export function* claimRewardsSaga({ payload: rewards }: ReturnType<typeof claimR
         })
       )
     }
+    yield put(cloudFunctionsApi.util.invalidateTags(['Supercharge']))
     yield put(claimRewardsSuccess())
     yield put(showMessage(i18n.t('superchargeClaimSuccess')))
     navigateHome()

--- a/packages/mobile/src/consumerIncentives/saga.ts
+++ b/packages/mobile/src/consumerIncentives/saga.ts
@@ -1,9 +1,11 @@
 import { toTransactionObject } from '@celo/connect'
 import { ContractKit } from '@celo/contractkit'
 import BigNumber from 'bignumber.js'
-import { all, call, put, spawn, takeEvery } from 'redux-saga/effects'
+import { all, call, put, select, spawn, takeEvery } from 'redux-saga/effects'
 import merkleDistributor from 'src/abis/MerkleDistributor.json'
 import { showError, showMessage } from 'src/alert/actions'
+import { RewardsEvents } from 'src/analytics/Events'
+import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import { ErrorMessages } from 'src/app/ErrorMessages'
 import {
   claimRewards,
@@ -13,6 +15,8 @@ import {
 import { WEI_PER_TOKEN } from 'src/geth/consts'
 import i18n from 'src/i18n'
 import { navigateHome } from 'src/navigator/NavigationService'
+import { TokenBalances } from 'src/tokens/reducer'
+import { tokensByAddressSelector } from 'src/tokens/selectors'
 import { addStandbyTransaction } from 'src/transactions/actions'
 import {
   newTransactionContext,
@@ -30,6 +34,7 @@ export function* claimRewardsSaga({ payload: rewards }: ReturnType<typeof claimR
   try {
     const kit: ContractKit = yield call(getContractKit)
     const walletAddress: string = yield call(getConnectedUnlockedAccount)
+    const tokens: TokenBalances = yield select(tokensByAddressSelector)
     const baseNonce: number = yield call(
       // @ts-ignore I can't figure out the syntax for this, it works but TS complains :'(
       [kit.web3.eth, kit.web3.eth.getTransactionCount],
@@ -58,10 +63,16 @@ export function* claimRewardsSaga({ payload: rewards }: ReturnType<typeof claimR
           nonce: baseNonce + index,
         })
         Logger.info(TAG, `Claimed reward at index ${index}: ${JSON.stringify(receipt)}`)
+        const amount = new BigNumber(reward.amount, 16).div(WEI_PER_TOKEN).toString()
+        const tokenAddress = reward.tokenAddress.toLowerCase()
+        ValoraAnalytics.track(RewardsEvents.claimed_reward, {
+          amount,
+          token: tokens[tokenAddress]?.symbol ?? '',
+        })
         return {
           fundsSource: fundsSource.toLowerCase(),
-          tokenAddress: reward.tokenAddress.toLowerCase(),
-          amount: new BigNumber(reward.amount, 16).div(WEI_PER_TOKEN).toString(),
+          tokenAddress,
+          amount,
           txHash: receipt.transactionHash,
         }
       })

--- a/packages/mobile/src/geth/networkConfig.ts
+++ b/packages/mobile/src/geth/networkConfig.ts
@@ -43,7 +43,7 @@ interface NetworkConfig {
   walletConnectEndpoint: string
   personaEnvironment: PersonaEnvironment
   inHouseLiquidityURL: string
-  superchargeAvailableRewardsUrl: string
+  cloudFunctionsBaseUrl: string
 }
 
 const KOMENCI_URL_MAINNET = 'https://mainnet-komenci.azurefd.net'
@@ -81,10 +81,10 @@ const FETCH_USER_LOCATION_DATA_PROD = `${CLOUD_FUNCTIONS_MAINNET}/fetchUserLocat
 const KOMENCI_LOAD_CHECK_ENDPOINT_STAGING = 'https://staging-komenci.azurefd.net/v1/ready'
 const KOMENCI_LOAD_CHECK_ENDPOINT_PROD = 'https://mainnet-komenci.azurefd.net/v1/ready'
 
-const SUPERCHARGE_AVAILABLE_REWARDS_URL_ALFAJORES =
-  'https://us-central1-celo-mobile-alfajores.cloudfunctions.net/fetchAvailableSuperchargeRewards'
-const SUPERCHARGE_AVAILABLE_REWARDS_URL_MAINNET =
-  'https://us-central1-celo-mobile-mainnet.cloudfunctions.net/fetchAvailableSuperchargeRewards'
+const CLOUD_FUNCTIONS_BASE_URL_ALFAJORES =
+  'https://us-central1-celo-mobile-alfajores.cloudfunctions.net'
+const CLOUD_FUNCTIONS_BASE_URL_MAINNET =
+  'https://us-central1-celo-mobile-mainnet.cloudfunctions.net'
 
 const networkConfigs: { [testnet: string]: NetworkConfig } = {
   [Testnets.alfajores]: {
@@ -113,7 +113,7 @@ const networkConfigs: { [testnet: string]: NetworkConfig } = {
     walletConnectEndpoint: 'wss://relay.walletconnect.org',
     personaEnvironment: PersonaEnvironment.SANDBOX,
     inHouseLiquidityURL: 'https://liquidity-dot-celo-mobile-alfajores.appspot.com',
-    superchargeAvailableRewardsUrl: SUPERCHARGE_AVAILABLE_REWARDS_URL_ALFAJORES,
+    cloudFunctionsBaseUrl: CLOUD_FUNCTIONS_BASE_URL_ALFAJORES,
   },
   [Testnets.mainnet]: {
     networkId: '42220',
@@ -140,7 +140,7 @@ const networkConfigs: { [testnet: string]: NetworkConfig } = {
     walletConnectEndpoint: 'wss://relay.walletconnect.org',
     personaEnvironment: PersonaEnvironment.PRODUCTION,
     inHouseLiquidityURL: 'https://liquidity-dot-celo-mobile-mainnet.appspot.com',
-    superchargeAvailableRewardsUrl: SUPERCHARGE_AVAILABLE_REWARDS_URL_MAINNET,
+    cloudFunctionsBaseUrl: CLOUD_FUNCTIONS_BASE_URL_MAINNET,
   },
 }
 

--- a/packages/mobile/src/geth/networkConfig.ts
+++ b/packages/mobile/src/geth/networkConfig.ts
@@ -43,7 +43,6 @@ interface NetworkConfig {
   walletConnectEndpoint: string
   personaEnvironment: PersonaEnvironment
   inHouseLiquidityURL: string
-  cloudFunctionsBaseUrl: string
 }
 
 const KOMENCI_URL_MAINNET = 'https://mainnet-komenci.azurefd.net'
@@ -81,11 +80,6 @@ const FETCH_USER_LOCATION_DATA_PROD = `${CLOUD_FUNCTIONS_MAINNET}/fetchUserLocat
 const KOMENCI_LOAD_CHECK_ENDPOINT_STAGING = 'https://staging-komenci.azurefd.net/v1/ready'
 const KOMENCI_LOAD_CHECK_ENDPOINT_PROD = 'https://mainnet-komenci.azurefd.net/v1/ready'
 
-const CLOUD_FUNCTIONS_BASE_URL_ALFAJORES =
-  'https://us-central1-celo-mobile-alfajores.cloudfunctions.net'
-const CLOUD_FUNCTIONS_BASE_URL_MAINNET =
-  'https://us-central1-celo-mobile-mainnet.cloudfunctions.net'
-
 const networkConfigs: { [testnet: string]: NetworkConfig } = {
   [Testnets.alfajores]: {
     networkId: '44787',
@@ -113,7 +107,6 @@ const networkConfigs: { [testnet: string]: NetworkConfig } = {
     walletConnectEndpoint: 'wss://relay.walletconnect.org',
     personaEnvironment: PersonaEnvironment.SANDBOX,
     inHouseLiquidityURL: 'https://liquidity-dot-celo-mobile-alfajores.appspot.com',
-    cloudFunctionsBaseUrl: CLOUD_FUNCTIONS_BASE_URL_ALFAJORES,
   },
   [Testnets.mainnet]: {
     networkId: '42220',
@@ -140,7 +133,6 @@ const networkConfigs: { [testnet: string]: NetworkConfig } = {
     walletConnectEndpoint: 'wss://relay.walletconnect.org',
     personaEnvironment: PersonaEnvironment.PRODUCTION,
     inHouseLiquidityURL: 'https://liquidity-dot-celo-mobile-mainnet.appspot.com',
-    cloudFunctionsBaseUrl: CLOUD_FUNCTIONS_BASE_URL_MAINNET,
   },
 }
 

--- a/packages/mobile/src/home/NotificationBox.test.tsx
+++ b/packages/mobile/src/home/NotificationBox.test.tsx
@@ -12,6 +12,11 @@ const TWO_DAYS_MS = 2 * 24 * 60 * 1000
 const RECENT_BACKUP_TIME = new Date().getTime() - TWO_DAYS_MS
 const EXPIRED_BACKUP_TIME = RECENT_BACKUP_TIME - DAYS_TO_BACKUP
 
+jest.mock('src/api/slice', () => ({
+  ...(jest.requireActual('src/api/slice') as any),
+  useFetchSuperchargeRewards: jest.fn(() => ({ superchargeRewards: [] })),
+}))
+
 const testNotification = {
   ctaUri: 'https://celo.org',
   priority: 20,

--- a/packages/mobile/src/home/NotificationBox.tsx
+++ b/packages/mobile/src/home/NotificationBox.tsx
@@ -12,13 +12,13 @@ import { dismissGetVerified, dismissGoldEducation } from 'src/account/actions'
 import { HomeEvents, RewardsEvents } from 'src/analytics/Events'
 import { ScrollDirection } from 'src/analytics/types'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
+import { useFetchSuperchargeRewards } from 'src/api/slice'
 import { openUrl } from 'src/app/actions'
 import { rewardsEnabledSelector, verificationPossibleSelector } from 'src/app/selectors'
 import {
   RewardsScreenOrigin,
   trackRewardsScreenOpenEvent,
 } from 'src/consumerIncentives/analyticsEventsTracker'
-import { useFetchAvailableRewards } from 'src/consumerIncentives/ConsumerIncentivesHomeScreen'
 import EscrowedPaymentReminderSummaryNotification from 'src/escrow/EscrowedPaymentReminderSummaryNotification'
 import { getReclaimableEscrowPayments } from 'src/escrow/reducer'
 import { dismissNotification } from 'src/home/actions'
@@ -91,7 +91,7 @@ function useSimpleActions() {
 
   const dispatch = useDispatch()
 
-  const { availableRewards: superchargeRewards } = useFetchAvailableRewards()
+  const { superchargeRewards } = useFetchSuperchargeRewards()
 
   const actions: SimpleMessagingCardProps[] = []
   if (!backupCompleted) {

--- a/packages/mobile/src/home/WalletHome.test.tsx
+++ b/packages/mobile/src/home/WalletHome.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render } from '@testing-library/react-native'
+import { FetchMock } from 'jest-fetch-mock/types'
 import * as React from 'react'
 import { Provider } from 'react-redux'
 import { dappSelected } from 'src/app/actions'
@@ -73,6 +74,9 @@ jest.mock('src/transactions/TransactionsList', () => 'TransactionsList')
 describe('WalletHome', () => {
   beforeAll(() => {
     jest.useFakeTimers()
+    const mockFetch = fetch as FetchMock
+    mockFetch.resetMocks()
+    mockFetch.mockResponse(JSON.stringify({ availableRewards: [] }))
   })
 
   afterAll(() => {

--- a/packages/mobile/src/home/WalletHome.test.tsx
+++ b/packages/mobile/src/home/WalletHome.test.tsx
@@ -1,5 +1,4 @@
 import { fireEvent, render } from '@testing-library/react-native'
-import { FetchMock } from 'jest-fetch-mock/types'
 import * as React from 'react'
 import { Provider } from 'react-redux'
 import { dappSelected } from 'src/app/actions'
@@ -70,13 +69,14 @@ const recentDapps = [dapp, deepLinkedDapp]
 
 jest.mock('src/exchange/CeloGoldOverview', () => 'CeloGoldOverview')
 jest.mock('src/transactions/TransactionsList', () => 'TransactionsList')
+jest.mock('src/api/slice', () => ({
+  ...(jest.requireActual('src/api/slice') as any),
+  useFetchSuperchargeRewards: jest.fn(() => ({ superchargeRewards: [] })),
+}))
 
 describe('WalletHome', () => {
   beforeAll(() => {
     jest.useFakeTimers()
-    const mockFetch = fetch as FetchMock
-    mockFetch.resetMocks()
-    mockFetch.mockResponse(JSON.stringify({ availableRewards: [] }))
   })
 
   afterAll(() => {

--- a/packages/mobile/src/home/__snapshots__/NotificationBox.test.tsx.snap
+++ b/packages/mobile/src/home/__snapshots__/NotificationBox.test.tsx.snap
@@ -155,6 +155,12 @@ exports[`NotificationBox renders correctly for with all notifications 1`] = `
                     "testUri": "../../../packages/mobile/src/images/backup-key.png",
                   }
                 }
+                style={
+                  Object {
+                    "height": "100%",
+                    "width": "100%",
+                  }
+                }
                 testID="undefined/Icon"
               />
             </View>
@@ -494,6 +500,12 @@ exports[`NotificationBox renders correctly for with all notifications 1`] = `
                 source={
                   Object {
                     "testUri": "../../../packages/mobile/src/images/get-verified.png",
+                  }
+                }
+                style={
+                  Object {
+                    "height": "100%",
+                    "width": "100%",
                   }
                 }
                 testID="undefined/Icon"
@@ -846,6 +858,12 @@ exports[`NotificationBox renders correctly for with all notifications 1`] = `
                 source={
                   Object {
                     "testUri": "../../../packages/mobile/src/images/learn-celo.png",
+                  }
+                }
+                style={
+                  Object {
+                    "height": "100%",
+                    "width": "100%",
                   }
                 }
                 testID="undefined/Icon"

--- a/packages/mobile/src/home/__snapshots__/WalletHome.test.tsx.snap
+++ b/packages/mobile/src/home/__snapshots__/WalletHome.test.tsx.snap
@@ -330,6 +330,12 @@ exports[`WalletHome Renders correctly and fires initial actions 1`] = `
                             "testUri": "../../../packages/mobile/src/images/backup-key.png",
                           }
                         }
+                        style={
+                          Object {
+                            "height": "100%",
+                            "width": "100%",
+                          }
+                        }
                         testID="undefined/Icon"
                       />
                     </View>
@@ -514,6 +520,12 @@ exports[`WalletHome Renders correctly and fires initial actions 1`] = `
                         source={
                           Object {
                             "testUri": "../../../packages/mobile/src/images/learn-celo.png",
+                          }
+                        }
+                        style={
+                          Object {
+                            "height": "100%",
+                            "width": "100%",
                           }
                         }
                         testID="undefined/Icon"

--- a/packages/mobile/src/redux/reducers.ts
+++ b/packages/mobile/src/redux/reducers.ts
@@ -3,6 +3,7 @@ import { PersistState } from 'redux-persist'
 import { Actions } from 'src/account/actions'
 import { reducer as account, State as AccountState } from 'src/account/reducer'
 import { reducer as alert, State as AlertState } from 'src/alert/reducer'
+import { cloudFunctionsApi } from 'src/api/slice'
 import { appReducer as app, State as AppState } from 'src/app/reducers'
 import superchargeReducer, { State as SuperchargeState } from 'src/consumerIncentives/slice'
 import { escrowReducer as escrow, State as EscrowState } from 'src/escrow/reducer'
@@ -53,6 +54,7 @@ const appReducer = combineReducers({
   walletConnect,
   tokens,
   supercharge: superchargeReducer,
+  [cloudFunctionsApi.reducerPath]: cloudFunctionsApi.reducer,
 }) as (state: RootState | undefined, action: Action) => RootState
 
 const rootReducer = (state: RootState | undefined, action: Action): RootState => {
@@ -101,6 +103,7 @@ export interface RootState {
   walletConnect: WalletConnectState
   tokens: TokensState
   supercharge: SuperchargeState
+  [cloudFunctionsApi.reducerPath]: unknown
 }
 
 export interface PersistedRootState {

--- a/packages/mobile/src/transactions/transferFeedUtils.ts
+++ b/packages/mobile/src/transactions/transferFeedUtils.ts
@@ -7,7 +7,7 @@ import {
   TransferItemFragment,
   UserTransactionsQuery,
 } from 'src/apollo/types'
-import { CELO_LOGO_URL, DEFAULT_TESTNET } from 'src/config'
+import { CELO_LOGO_URL, DEFAULT_TESTNET, SUPERCHARGE_LOGO_URL } from 'src/config'
 import { ProviderFeedInfo, txHashToFeedInfoSelector } from 'src/fiatExchanges/reducer'
 import { decryptComment } from 'src/identity/commentEncryption'
 import { AddressToE164NumberType } from 'src/identity/reducer'
@@ -313,7 +313,7 @@ export function useTransferFeedDetails(transfer: FeedTokenTransfer) {
       } else if (isRewardSender) {
         title = t('feedItemRewardReceivedTitle')
         subtitle = t('feedItemRewardReceivedInfo')
-        Object.assign(recipient, { thumbnailPath: CELO_LOGO_URL })
+        Object.assign(recipient, { thumbnailPath: SUPERCHARGE_LOGO_URL })
       } else if (isInviteRewardSender) {
         title = t('feedItemInviteRewardReceivedTitle')
         subtitle = t('feedItemInviteRewardReceivedInfo')

--- a/packages/react-components/components/Button.tsx
+++ b/packages/react-components/components/Button.tsx
@@ -33,6 +33,7 @@ export interface ButtonProps {
   loadingColor?: string
   accessibilityLabel?: string
   type?: BtnTypes
+  icon?: ReactNode
   rounded?: boolean
   disabled?: boolean
   size?: BtnSizes
@@ -46,6 +47,7 @@ export default React.memo(function Button(props: ButtonProps) {
     size,
     testID,
     text,
+    icon,
     type = BtnTypes.PRIMARY,
     rounded = true,
     style,
@@ -75,13 +77,16 @@ export default React.memo(function Button(props: ButtonProps) {
           {showLoading ? (
             <ActivityIndicator size="small" color={loadingColor ?? textColor} />
           ) : (
-            <Text
-              maxFontSizeMultiplier={1}
-              accessibilityLabel={accessibilityLabel}
-              style={{ ...fontStyles.regular600, color: textColor }}
-            >
-              {text}
-            </Text>
+            <>
+              {icon}
+              <Text
+                maxFontSizeMultiplier={1}
+                accessibilityLabel={accessibilityLabel}
+                style={{ ...fontStyles.regular600, color: textColor }}
+              >
+                {text}
+              </Text>
+            </>
           )}
         </Touchable>
       </View>

--- a/packages/react-components/components/SimpleMessagingCard.tsx
+++ b/packages/react-components/components/SimpleMessagingCard.tsx
@@ -26,9 +26,7 @@ export default function SimpleMessagingCard({
         // @ts-ignore isValidElement check above ensures image is an image source type
         source={iconProp}
         resizeMode="contain"
-        style={
-          Object.prototype.hasOwnProperty.call(iconProp, 'uri') ? styles.remoteIcon : undefined
-        }
+        style={styles.icon}
         testID={`${testID}/Icon`}
       />
     )
@@ -68,7 +66,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
   },
-  remoteIcon: {
+  icon: {
     width: '100%',
     height: '100%',
   },


### PR DESCRIPTION
### Description

Changes to Supercharge include:
- Add a Valora icon to the "claim rewards" button.
- Change copy of the disclaimer in the Supercharge screen if the user has more than the max balance or if they have rewards available to claim.
- Add a couple of analytics events.
- Change Supercharge icon in the feed to a bolt.
- Fix error message if loading rewards fails.
- Add an in-app card if the user has rewards available in the first place with a CTA to claim.

![Simulator Screen Shot - iPhone SE (2nd generation) - 2022-03-03 at 18 58 07](https://user-images.githubusercontent.com/6062888/156659661-652479f0-511b-41f3-8348-fa25f7e0749e.png)
![Simulator Screen Shot - iPhone SE (2nd generation) - 2022-03-03 at 18 58 15](https://user-images.githubusercontent.com/6062888/156659666-60c1bdab-dc68-4201-a8f3-f8f0742260c0.png)


### Other changes

N/A

### Tested

Manually


### How others should test

Some of these changes are hard to test but try opening the rewards screen and making sure it looks as expected? Just test that screen generally like you already do.

### Related issues

- Fixes #2082
- Fixes #2084

### Backwards compatibility

N/A