### PR TITLE
Track all core tokens balances

### DIFF
--- a/packages/mobile/src/analytics/ValoraAnalytics.test.ts
+++ b/packages/mobile/src/analytics/ValoraAnalytics.test.ts
@@ -45,6 +45,7 @@ const state = getMockStoreData({
         usdPrice: '1',
         balance: '10',
         priceFetchedAt: Date.now(),
+        isCoreToken: true,
       },
       [mockCeurAddress]: {
         address: mockCeurAddress,
@@ -52,6 +53,7 @@ const state = getMockStoreData({
         usdPrice: '1.2',
         balance: '20',
         priceFetchedAt: Date.now(),
+        isCoreToken: true,
       },
       [mockCeloAddress]: {
         address: mockCeloAddress,
@@ -59,6 +61,7 @@ const state = getMockStoreData({
         usdPrice: '5',
         balance: '0',
         priceFetchedAt: Date.now(),
+        isCoreToken: true,
       },
       [mockTestTokenAddress]: {
         address: mockTestTokenAddress,

--- a/packages/mobile/src/analytics/selectors.test.ts
+++ b/packages/mobile/src/analytics/selectors.test.ts
@@ -20,6 +20,7 @@ describe('getCurrentUserTraits', () => {
             usdPrice: '1',
             balance: '10',
             priceFetchedAt: Date.now(),
+            isCoreToken: true,
           },
           '0xceur': {
             name: 'Celo Euros',
@@ -30,6 +31,7 @@ describe('getCurrentUserTraits', () => {
             usdPrice: '1.2',
             balance: '20',
             priceFetchedAt: Date.now(),
+            isCoreToken: true,
           },
           '0xcelo': {
             name: 'Celo',
@@ -40,6 +42,7 @@ describe('getCurrentUserTraits', () => {
             usdPrice: '5',
             balance: '0',
             priceFetchedAt: Date.now(),
+            isCoreToken: true,
           },
           '0xa': {
             name: 'a',

--- a/packages/mobile/src/analytics/selectors.ts
+++ b/packages/mobile/src/analytics/selectors.ts
@@ -76,7 +76,7 @@ export const getCurrentUserTraits = createSelector(
             )}`
         )
         .join(','),
-      // Maps core token balances
+      // Map core tokens balances
       // Example: [Celo, cUSD, cEUR] to { celoBalance: X, cusdBalance: Y, ceurBalance: Z }
       ...Object.fromEntries(
         coreTokens.map((token) => [

--- a/packages/mobile/src/analytics/selectors.ts
+++ b/packages/mobile/src/analytics/selectors.ts
@@ -9,9 +9,8 @@ import { backupCompletedSelector } from 'src/backup/selectors'
 import { currentLanguageSelector } from 'src/i18n/selectors'
 import { getLocalCurrencyCode } from 'src/localCurrency/selectors'
 import { userLocationDataSelector } from 'src/networkInfo/selectors'
-import { tokensByCurrencySelector, tokensWithTokenBalanceSelector } from 'src/tokens/selectors'
+import { coreTokensSelector, tokensWithTokenBalanceSelector } from 'src/tokens/selectors'
 import { sortByUsdBalance } from 'src/tokens/utils'
-import { Currency } from 'src/utils/currencies'
 import { accountAddressSelector, walletAddressSelector } from 'src/web3/selectors'
 
 export const getCurrentUserTraits = createSelector(
@@ -22,7 +21,7 @@ export const getCurrentUserTraits = createSelector(
     userLocationDataSelector,
     currentLanguageSelector,
     tokensWithTokenBalanceSelector,
-    tokensByCurrencySelector,
+    coreTokensSelector,
     getLocalCurrencyCode,
     numberVerifiedSelector,
     backupCompletedSelector,
@@ -35,15 +34,13 @@ export const getCurrentUserTraits = createSelector(
     { countryCodeAlpha2 },
     language,
     tokens,
-    tokensByCurrency,
+    coreTokens,
     localCurrencyCode,
     hasVerifiedNumber,
     hasCompletedBackup,
     pincodeType
   ) => {
-    const currencyAddresses = new Set(
-      Object.values(tokensByCurrency).map((token) => token?.address)
-    )
+    const coreTokensAddresses = new Set(coreTokens.map((token) => token?.address))
     const tokensByUsdBalance = tokens.sort(sortByUsdBalance)
 
     let totalBalanceUsd = new BigNumber(0)
@@ -69,7 +66,7 @@ export const getCurrentUserTraits = createSelector(
       totalBalanceUsd: totalBalanceUsd?.toNumber(),
       tokenCount: tokensByUsdBalance.length,
       otherTenTokens: tokensByUsdBalance
-        .filter((token) => !currencyAddresses.has(token.address))
+        .filter((token) => !coreTokensAddresses.has(token.address))
         .slice(0, 10)
         .map(
           (token) =>
@@ -79,13 +76,17 @@ export const getCurrentUserTraits = createSelector(
             )}`
         )
         .join(','),
-      // Maps balances
+      // Maps core token balances
       // Example: [Celo, cUSD, cEUR] to { celoBalance: X, cusdBalance: Y, ceurBalance: Z }
       ...Object.fromEntries(
-        (Object.keys(tokensByCurrency) as Currency[]).map((currency) => [
-          `${currency === Currency.Celo ? 'celo' : currency.toLowerCase()}Balance`,
-          tokensByCurrency[currency]?.balance.toNumber(),
+        coreTokens.map((token) => [
+          `${token.symbol.toLowerCase()}Balance`,
+          token.balance.toNumber(),
         ])
+        // (Object.keys(tokensByCurrency) as Currency[]).map((currency) => [
+        //   `${currency === Currency.Celo ? 'celo' : currency.toLowerCase()}Balance`,
+        //   tokensByCurrency[currency]?.balance.toNumber(),
+        // ])
       ),
       localCurrencyCode,
       hasVerifiedNumber,

--- a/packages/mobile/src/analytics/selectors.ts
+++ b/packages/mobile/src/analytics/selectors.ts
@@ -83,10 +83,6 @@ export const getCurrentUserTraits = createSelector(
           `${token.symbol.toLowerCase()}Balance`,
           token.balance.toNumber(),
         ])
-        // (Object.keys(tokensByCurrency) as Currency[]).map((currency) => [
-        //   `${currency === Currency.Celo ? 'celo' : currency.toLowerCase()}Balance`,
-        //   tokensByCurrency[currency]?.balance.toNumber(),
-        // ])
       ),
       localCurrencyCode,
       hasVerifiedNumber,


### PR DESCRIPTION
### Description

cReal was only tracked in `otherTenTokens` which made targeting cReal users more difficult.
This fixes it and makes it future proof when other core tokens are added.

### Tested

- Updated unit tests

### How others should test

N/A

### Related issues

Discussed on [Slack](https://valora-app.slack.com/archives/C02N2BJ03QA/p1644871855329069).

### Backwards compatibility

Yes