### PR TITLE
Upgrade typescript to 4.1.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,8 +68,8 @@
     "pretty-quick": "^2.0.1",
     "solc": "0.5.8",
     "ts-jest": "^26.5.1",
-    "ts-node": "^8.3.0",
-    "typescript": "^3.8.3"
+    "ts-node": "10.7.0",
+    "typescript": "4.1.6"
   },
   "resolutions": {
     "ethers": "5.0.5",

--- a/packages/mobile/src/identity/privateHashing.ts
+++ b/packages/mobile/src/identity/privateHashing.ts
@@ -173,7 +173,7 @@ function* navigateToQuotaPurchaseScreen() {
   try {
     yield new Promise((resolve, reject) => {
       navigate(Screens.PhoneNumberLookupQuota, {
-        onBuy: resolve,
+        onBuy: resolve as () => void,
         onSkip: () => reject('skipped'),
       })
     })

--- a/packages/mobile/src/paymentRequest/OutgoingPaymentRequestListItem.test.tsx
+++ b/packages/mobile/src/paymentRequest/OutgoingPaymentRequestListItem.test.tsx
@@ -1,13 +1,15 @@
 import { render } from '@testing-library/react-native'
+import { noop } from 'lodash'
 import * as React from 'react'
 import 'react-native'
 import { Provider } from 'react-redux'
+import { cancelPaymentRequest, updatePaymentRequestNotified } from 'src/paymentRequest/actions'
 import OutgoingPaymentRequestListItem from 'src/paymentRequest/OutgoingPaymentRequestListItem'
 import { createMockStore } from 'test/utils'
 const store = createMockStore()
 
 const commonProps = {
-  id: 1,
+  id: '1',
   amount: '24',
   comment: 'Hey thanks for the loan, Ill pay you back ASAP. LOVE YOU',
   requestee: {
@@ -17,13 +19,14 @@ const commonProps = {
     name: '5126608970',
     contact: undefined,
   },
+  cancelPaymentRequest: noop as typeof cancelPaymentRequest,
+  updatePaymentRequestNotified: noop as typeof updatePaymentRequestNotified,
 }
 
 describe('OutgoingPaymentRequestListItem', () => {
   it('renders correctly', () => {
     const tree = render(
       <Provider store={store}>
-        // @ts-ignore -- kind is not assignable?
         <OutgoingPaymentRequestListItem {...commonProps} />
       </Provider>
     )

--- a/packages/mobile/src/paymentRequest/__snapshots__/OutgoingPaymentRequestListItem.test.tsx.snap
+++ b/packages/mobile/src/paymentRequest/__snapshots__/OutgoingPaymentRequestListItem.test.tsx.snap
@@ -1,267 +1,264 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OutgoingPaymentRequestListItem renders correctly 1`] = `
-Array [
-  "// @ts-ignore -- kind is not assignable?",
+<View
+  style={
+    Object {
+      "marginBottom": 16,
+    }
+  }
+>
   <View
     style={
-      Object {
-        "marginBottom": 16,
-      }
+      Array [
+        Object {
+          "backgroundColor": "#FFFFFF",
+          "padding": 16,
+        },
+        Object {
+          "borderRadius": 8,
+        },
+        Object {
+          "elevation": 12,
+          "shadowColor": "rgba(156, 164, 169, 0.4)",
+          "shadowOffset": Object {
+            "height": 2,
+            "width": 0,
+          },
+          "shadowOpacity": 1,
+          "shadowRadius": 12,
+        },
+        Array [
+          Object {
+            "flex": 1,
+            "minHeight": 144,
+          },
+          Object {},
+        ],
+      ]
     }
+    testID="OutgoingPaymentRequestNotification/1"
   >
     <View
       style={
-        Array [
-          Object {
-            "backgroundColor": "#FFFFFF",
-            "padding": 16,
-          },
-          Object {
-            "borderRadius": 8,
-          },
-          Object {
-            "elevation": 12,
-            "shadowColor": "rgba(156, 164, 169, 0.4)",
-            "shadowOffset": Object {
-              "height": 2,
-              "width": 0,
-            },
-            "shadowOpacity": 1,
-            "shadowRadius": 12,
-          },
-          Array [
-            Object {
-              "flex": 1,
-              "minHeight": 144,
-            },
-            Object {},
-          ],
-        ]
+        Object {
+          "flex": 1,
+          "flexDirection": "row",
+        }
       }
-      testID="OutgoingPaymentRequestNotification/1"
     >
       <View
         style={
           Object {
             "flex": 1,
-            "flexDirection": "row",
+            "marginRight": 16,
           }
         }
       >
-        <View
+        <Text
+          numberOfLines={2}
           style={
             Object {
-              "flex": 1,
-              "marginRight": 16,
+              "color": "#9CA4A9",
+              "fontFamily": "Inter-Regular",
+              "fontSize": 13,
+              "lineHeight": 16,
+              "marginBottom": 4,
             }
           }
+          testID="OutgoingPaymentRequestNotification/1/Title"
+        >
+          outgoingPaymentRequestNotificationTitle, {"name":"5126608970"}
+        </Text>
+        <Text
+          numberOfLines={1}
+          style={
+            Object {
+              "color": "#2E3338",
+              "fontFamily": "Inter-SemiBold",
+              "fontSize": 24,
+              "lineHeight": 28,
+              "marginBottom": 2,
+            }
+          }
+          testID="OutgoingPaymentRequestNotification/1/Amount"
         >
           <Text
-            numberOfLines={2}
             style={
-              Object {
-                "color": "#9CA4A9",
-                "fontFamily": "Inter-Regular",
-                "fontSize": 13,
-                "lineHeight": 16,
-                "marginBottom": 4,
-              }
+              Array [
+                undefined,
+                Object {
+                  "color": undefined,
+                },
+              ]
             }
-            testID="OutgoingPaymentRequestNotification/1/Title"
+            testID="undefined/value"
           >
-            outgoingPaymentRequestNotificationTitle, {"name":"5126608970"}
+            
+            ₱
+            31.92
           </Text>
-          <Text
-            numberOfLines={1}
-            style={
-              Object {
-                "color": "#2E3338",
-                "fontFamily": "Inter-SemiBold",
-                "fontSize": 24,
-                "lineHeight": 28,
-                "marginBottom": 2,
-              }
+        </Text>
+        <Text
+          style={
+            Object {
+              "color": "#2E3338",
+              "fontFamily": "Inter-Regular",
+              "fontSize": 14,
+              "lineHeight": 18,
             }
-            testID="OutgoingPaymentRequestNotification/1/Amount"
-          >
-            <Text
-              style={
-                Array [
-                  undefined,
-                  Object {
-                    "color": undefined,
-                  },
-                ]
-              }
-              testID="undefined/value"
-            >
-              
-              ₱
-              31.92
-            </Text>
-          </Text>
-          <Text
-            style={
-              Object {
-                "color": "#2E3338",
-                "fontFamily": "Inter-Regular",
-                "fontSize": 14,
-                "lineHeight": 18,
-              }
-            }
-            testID="OutgoingPaymentRequestNotification/1/Details"
-          >
-            Hey thanks for the loan, Ill pay you back ASAP. LOVE YOU
-          </Text>
-        </View>
+          }
+          testID="OutgoingPaymentRequestNotification/1/Details"
+        >
+          Hey thanks for the loan, Ill pay you back ASAP. LOVE YOU
+        </Text>
+      </View>
+      <View
+        style={Object {}}
+      >
         <View
-          style={Object {}}
+          style={
+            Array [
+              Object {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "justifyContent": "center",
+              },
+              undefined,
+            ]
+          }
         >
           <View
             style={
               Array [
                 Object {
                   "alignItems": "center",
-                  "flexDirection": "row",
                   "justifyContent": "center",
                 },
-                undefined,
+                Object {
+                  "backgroundColor": "hsl(166, 53%, 93%)",
+                  "borderRadius": 20,
+                  "height": 40,
+                  "width": 40,
+                },
               ]
             }
           >
-            <View
+            <Text
+              allowFontScaling={false}
               style={
                 Array [
                   Object {
-                    "alignItems": "center",
-                    "justifyContent": "center",
+                    "color": "#FFFFFF",
+                    "fontFamily": "Inter-Medium",
+                    "fontSize": 16,
                   },
                   Object {
-                    "backgroundColor": "hsl(166, 53%, 93%)",
-                    "borderRadius": 20,
-                    "height": 40,
-                    "width": 40,
+                    "color": "hsl(166, 67%, 24%)",
+                    "fontSize": 20,
                   },
                 ]
               }
             >
-              <Text
-                allowFontScaling={false}
-                style={
-                  Array [
-                    Object {
-                      "color": "#FFFFFF",
-                      "fontFamily": "Inter-Medium",
-                      "fontSize": 16,
-                    },
-                    Object {
-                      "color": "hsl(166, 67%, 24%)",
-                      "fontSize": 20,
-                    },
-                  ]
-                }
-              >
-                5
-              </Text>
-            </View>
+              5
+            </Text>
           </View>
         </View>
       </View>
+    </View>
+    <View
+      style={
+        Object {
+          "flexDirection": "row",
+          "flexWrap": "wrap",
+          "justifyContent": "flex-start",
+        }
+      }
+      testID="OutgoingPaymentRequestNotification/1/CallToActions"
+    >
       <View
-        style={
+        accessible={true}
+        focusable={true}
+        nativeBackgroundAndroid={
           Object {
-            "flexDirection": "row",
-            "flexWrap": "wrap",
-            "justifyContent": "flex-start",
+            "attribute": "selectableItemBackgroundBorderless",
+            "rippleRadius": undefined,
+            "type": "ThemeAttrAndroid",
           }
         }
-        testID="OutgoingPaymentRequestNotification/1/CallToActions"
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        testID="OutgoingPaymentRequestNotification/1/CallToActions/remind/Button"
       >
-        <View
-          accessible={true}
-          focusable={true}
-          nativeBackgroundAndroid={
-            Object {
-              "attribute": "selectableItemBackgroundBorderless",
-              "rippleRadius": undefined,
-              "type": "ThemeAttrAndroid",
-            }
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "#1AB775",
+                "fontFamily": "Inter-SemiBold",
+                "fontSize": 16,
+                "lineHeight": 22,
+              },
+              Object {
+                "fontSize": 14,
+                "lineHeight": 16,
+                "marginRight": 24,
+                "minHeight": 16,
+                "minWidth": 48,
+              },
+            ]
           }
-          onClick={[Function]}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
-          testID="OutgoingPaymentRequestNotification/1/CallToActions/remind/Button"
         >
-          <Text
-            style={
-              Array [
-                Object {
-                  "color": "#1AB775",
-                  "fontFamily": "Inter-SemiBold",
-                  "fontSize": 16,
-                  "lineHeight": 22,
-                },
-                Object {
-                  "fontSize": 14,
-                  "lineHeight": 16,
-                  "marginRight": 24,
-                  "minHeight": 16,
-                  "minWidth": 48,
-                },
-              ]
-            }
-          >
-            remind
-          </Text>
-        </View>
-        <View
-          accessible={true}
-          focusable={true}
-          nativeBackgroundAndroid={
-            Object {
-              "attribute": "selectableItemBackgroundBorderless",
-              "rippleRadius": undefined,
-              "type": "ThemeAttrAndroid",
-            }
+          remind
+        </Text>
+      </View>
+      <View
+        accessible={true}
+        focusable={true}
+        nativeBackgroundAndroid={
+          Object {
+            "attribute": "selectableItemBackgroundBorderless",
+            "rippleRadius": undefined,
+            "type": "ThemeAttrAndroid",
           }
-          onClick={[Function]}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
-          testID="OutgoingPaymentRequestNotification/1/CallToActions/cancel/Button"
+        }
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        testID="OutgoingPaymentRequestNotification/1/CallToActions/cancel/Button"
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "#1AB775",
+                "fontFamily": "Inter-SemiBold",
+                "fontSize": 16,
+                "lineHeight": 22,
+              },
+              Object {
+                "fontSize": 14,
+                "lineHeight": 16,
+                "marginRight": 24,
+                "minHeight": 16,
+                "minWidth": 48,
+              },
+            ]
+          }
         >
-          <Text
-            style={
-              Array [
-                Object {
-                  "color": "#1AB775",
-                  "fontFamily": "Inter-SemiBold",
-                  "fontSize": 16,
-                  "lineHeight": 22,
-                },
-                Object {
-                  "fontSize": 14,
-                  "lineHeight": 16,
-                  "marginRight": 24,
-                  "minHeight": 16,
-                  "minWidth": 48,
-                },
-              ]
-            }
-          >
-            cancel
-          </Text>
-        </View>
+          cancel
+        </Text>
       </View>
     </View>
-  </View>,
-]
+  </View>
+</View>
 `;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2590,6 +2590,18 @@
   dependencies:
     axios "0.21.3"
 
+"@cspotcode/source-map-consumer@0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz#33bf4b7b39c178821606f669bbc447a6a629786b"
+  integrity sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==
+
+"@cspotcode/source-map-support@0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz#4789840aa859e46d2f3173727ab707c66bf344f5"
+  integrity sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==
+  dependencies:
+    "@cspotcode/source-map-consumer" "0.8.0"
+
 "@egjs/hammerjs@^2.0.17":
   version "2.0.17"
   resolved "https://registry.yarnpkg.com/@egjs/hammerjs/-/hammerjs-2.0.17.tgz#5dc02af75a6a06e4c2db0202cae38c9263895124"
@@ -5590,6 +5602,26 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.0.tgz#f544a148d3ab35801c1f633a7441fd87c2e484bf"
   integrity sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==
 
+"@tsconfig/node10@^1.0.7":
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.8.tgz#c1e4e80d6f964fbecb3359c43bd48b40f7cadad9"
+  integrity sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==
+
+"@tsconfig/node12@^1.0.7":
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node12/-/node12-1.0.9.tgz#62c1f6dee2ebd9aead80dc3afa56810e58e1a04c"
+  integrity sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==
+
+"@tsconfig/node14@^1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node14/-/node14-1.0.1.tgz#95f2d167ffb9b8d2068b0b235302fafd4df711f2"
+  integrity sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==
+
+"@tsconfig/node16@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.2.tgz#423c77877d0569db20e1fc80885ac4118314010e"
+  integrity sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==
+
 "@types/abstract-leveldown@*":
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/@types/abstract-leveldown/-/abstract-leveldown-5.0.1.tgz#3c7750d0186b954c7f2d2f6acc8c3c7ba0c3412e"
@@ -6760,6 +6792,11 @@ acorn-walk@^7.1.1:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.1.1.tgz#345f0dffad5c735e7373d2fec9a1023e6a44b83e"
   integrity sha512-wdlPY2tm/9XBr7QkKlq0WQVgiuGTX6YWPyRyBviSoScBuLfTVQhvwg6wJ369GJ/1nPfTLMfnrFIfjqVg6d+jQQ==
 
+acorn-walk@^8.1.1:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
+  integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
+
 acorn@^4.0.3:
   version "4.0.13"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.13.tgz#105495ae5361d697bd195c825192e1ad7f253787"
@@ -6779,6 +6816,11 @@ acorn@^7.4.0:
   version "7.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
+
+acorn@^8.4.1:
+  version "8.7.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.7.0.tgz#90951fde0f8f09df93549481e5fc141445b791cf"
+  integrity sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==
 
 aes-js@3.0.0:
   version "3.0.0"
@@ -9366,6 +9408,11 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4, create-hmac@^1.1.7:
     ripemd160 "^2.0.0"
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
+
+create-require@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
+  integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
 cross-fetch@2.2.2, cross-fetch@3.0.4, cross-fetch@3.0.6, cross-fetch@^3.0.2, cross-fetch@^3.0.4:
   version "3.1.4"
@@ -21162,7 +21209,26 @@ ts-log@2.1.4:
   resolved "https://registry.yarnpkg.com/ts-log/-/ts-log-2.1.4.tgz#063c5ad1cbab5d49d258d18015963489fb6fb59a"
   integrity sha512-P1EJSoyV+N3bR/IWFeAqXzKPZwHpnLY6j7j58mAvewHRipo+BQM2Y1f9Y9BjEQznKwgqqZm7H8iuixmssU7tYQ==
 
-ts-node@^8, ts-node@^8.3.0, ts-node@^8.4.1:
+ts-node@10.7.0:
+  version "10.7.0"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.7.0.tgz#35d503d0fab3e2baa672a0e94f4b40653c2463f5"
+  integrity sha512-TbIGS4xgJoX2i3do417KSaep1uRAW/Lu+WAL2doDHC0D6ummjirVOXU5/7aiZotbQ5p1Zp9tP7U6cYhA0O7M8A==
+  dependencies:
+    "@cspotcode/source-map-support" "0.7.0"
+    "@tsconfig/node10" "^1.0.7"
+    "@tsconfig/node12" "^1.0.7"
+    "@tsconfig/node14" "^1.0.0"
+    "@tsconfig/node16" "^1.0.2"
+    acorn "^8.4.1"
+    acorn-walk "^8.1.1"
+    arg "^4.1.0"
+    create-require "^1.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    v8-compile-cache-lib "^3.0.0"
+    yn "3.1.1"
+
+ts-node@^8, ts-node@^8.4.1:
   version "8.5.4"
   resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.5.4.tgz#a152add11fa19c221d0b48962c210cf467262ab2"
   integrity sha512-izbVCRV68EasEPQ8MSIGBNK9dc/4sYJJKYA+IarMQct1RtEot6Xp0bXuClsbUSnKpg50ho+aOAx8en5c+y4OFw==
@@ -21359,7 +21425,12 @@ typescript-tuple@^2.2.1:
   dependencies:
     typescript-compare "^0.0.2"
 
-typescript@^3.6.4, typescript@^3.8.3:
+typescript@4.1.6:
+  version "4.1.6"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.6.tgz#1becd85d77567c3c741172339e93ce2e69932138"
+  integrity sha512-pxnwLxeb/Z5SP80JDRzVjh58KsM6jZHRAOtTpS7sXLS4ogXNKC9ANxHHZqLLeVHZN35jCtI4JdmLLbLiC1kBow==
+
+typescript@^3.6.4:
   version "3.8.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
   integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
@@ -21770,6 +21841,11 @@ uuid@^8.3.0:
   version "8.3.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.0.tgz#ab738085ca22dc9a8c92725e459b1d507df5d6ea"
   integrity sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ==
+
+v8-compile-cache-lib@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.0.tgz#0582bcb1c74f3a2ee46487ceecf372e46bce53e8"
+  integrity sha512-mpSYqfsFvASnSn5qMiwrr4VKfumbPyONLCOPmsR3A6pTY/r0+tSaVbgPWSAIuzbk3lCTa+FForeTiO+wBQGkjA==
 
 v8-compile-cache@^2.0.3:
   version "2.3.0"
@@ -23572,6 +23648,11 @@ yauzl@^2.10.0:
   dependencies:
     buffer-crc32 "~0.2.3"
     fd-slicer "~1.1.0"
+
+yn@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
+  integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
 
 yn@^3.0.0:
   version "3.1.0"


### PR DESCRIPTION
### Description

This PR upgrades typescript to the current major version. It is a stepping stone to having it up-to-date. Next step will be (from >= 4.2 yield typings are handled differently) to fix all the `yield` typings.

### Other changes

Minor types fixes

### Tested

Relying on automated tests


### How others should test

_Does this need to be tested by QA in the next release cycle? If so please give a brief explanation of how to test these changes._

### Related issues

- Unblocks #1976 

### Backwards compatibility

Should be fully compatible.