### PR TITLE
Fix auto version bump script failure

### DIFF
--- a/.github/scripts/create_app_version_pr.sh
+++ b/.github/scripts/create_app_version_pr.sh
@@ -30,4 +30,4 @@ curl -u "valora-bot:$VALORA_BOT_TOKEN" \
   -X POST \
   -H "Accept: application/vnd.github.v3+json" \
   https://api.github.com/repos/valora-inc/wallet/pulls \
-  -d '{ "head": "'$BRANCH_NAME'", "base": "main", "title": "'$commit_message'" }'
+  -d '{ "head": "'$BRANCH_NAME'", "base": "main", "title": "Bump app version to '$app_version'" }'

--- a/.github/scripts/create_app_version_pr.sh
+++ b/.github/scripts/create_app_version_pr.sh
@@ -1,31 +1,31 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-cd packages/mobile
+# cd packages/mobile
 
-# ensure that we are using ssh
-git remote set-url origin git@github.com:valora-inc/wallet.git
-app_version="$(node -p "require('./package.json').version")"
-commit_message="Bump app version to $app_version"
+# # ensure that we are using ssh
+# git remote set-url origin git@github.com:valora-inc/wallet.git
+# app_version="$(node -p "require('./package.json').version")"
+# commit_message="Bump app version to $app_version"
 
-echo "Create branch from main"
-git checkout -b $BRANCH_NAME
+# echo "Create branch from main"
+# git checkout -b $BRANCH_NAME
 
-echo "Bump app version"
-yarn pre-deploy --minor --no-disclaimer
+# echo "Bump app version"
+# yarn pre-deploy --minor --no-disclaimer
 
-# TODO: remove this step as part of https://github.com/valora-inc/wallet/issues/1856
-echo "Generate disclaimer"
-yarn licenses generate-disclaimer --prod > src/account/LicenseDisclaimer.txt && ./scripts/copy_license_to_android_assets.sh
+# # TODO: remove this step as part of https://github.com/valora-inc/wallet/issues/1856
+# echo "Generate disclaimer"
+# yarn licenses generate-disclaimer --prod > src/account/LicenseDisclaimer.txt && ./scripts/copy_license_to_android_assets.sh
 
-echo "Push changes to branch"
-git add .
-git commit -m $commit_message
-git push --set-upstream origin $BRANCH_NAME
+# echo "Push changes to branch"
+# git add .
+# git commit -m $commit_message
+# git push --set-upstream origin $BRANCH_NAME
 
 echo "Open app version bump PR"
 curl -u "valora-bot:$VALORA_BOT_TOKEN" \
   -X POST \
   -H "Accept: application/vnd.github.v3+json" \
   https://api.github.com/repos/valora-inc/wallet/pulls \
-  -d '{ "head": "'$BRANCH_NAME'", "base": "main", "title": "'$commit_message'" }'
+  -d '{ "head": "'$BRANCH_NAME'", "base": "main" }'

--- a/.github/scripts/create_app_version_pr.sh
+++ b/.github/scripts/create_app_version_pr.sh
@@ -5,8 +5,8 @@ set -euo pipefail
 
 # # ensure that we are using ssh
 # git remote set-url origin git@github.com:valora-inc/wallet.git
-# app_version="$(node -p "require('./package.json').version")"
-# commit_message="Bump app version to $app_version"
+app_version="$(node -p "require('./package.json').version")"
+commit_message="Bump app version to $app_version"
 
 # echo "Create branch from main"
 # git checkout -b $BRANCH_NAME
@@ -28,4 +28,4 @@ curl -u "valora-bot:$VALORA_BOT_TOKEN" \
   -X POST \
   -H "Accept: application/vnd.github.v3+json" \
   https://api.github.com/repos/valora-inc/wallet/pulls \
-  -d '{ "head": "'$BRANCH_NAME'", "base": "main" }'
+  -d '{ "head": "'$BRANCH_NAME'", "base": "main", "title": "'$commit_message'" }'

--- a/.github/scripts/create_app_version_pr.sh
+++ b/.github/scripts/create_app_version_pr.sh
@@ -5,18 +5,26 @@ cd packages/mobile
 
 # ensure that we are using ssh
 git remote set-url origin git@github.com:valora-inc/wallet.git
-
 app_version="$(node -p "require('./package.json').version")"
+commit_message="Bump app version to $app_version"
 
-echo "Create branch"
+echo "Create branch from main"
+# it's important to explicitly checkout the main branch as this job is triggered
+# from a tag that is from a release branch with extra commit(s) for that release
+git checkout main
+git pull origin main
 git checkout -b $BRANCH_NAME
 
 echo "Bump app version"
-yarn pre-deploy --minor
+yarn pre-deploy --minor --no-disclaimer
+
+# TODO: remove this step as part of https://github.com/valora-inc/wallet/issues/1856
+echo "Generate disclaimer"
+yarn licenses generate-disclaimer --prod > src/account/LicenseDisclaimer.txt && ./scripts/copy_license_to_android_assets.sh
 
 echo "Push changes to branch"
 git add .
-git commit -m "Bump app version to $app_version"
+git commit -m $commit_message
 git push --set-upstream origin $BRANCH_NAME
 
 echo "Open app version bump PR"
@@ -24,4 +32,4 @@ curl -u "valora-bot:$VALORA_BOT_TOKEN" \
   -X POST \
   -H "Accept: application/vnd.github.v3+json" \
   https://api.github.com/repos/valora-inc/wallet/pulls \
-  -d '{ "head": "'$BRANCH_NAME'", "base": "main" }'
+  -d '{ "head": "'$BRANCH_NAME'", "base": "main", "title": "'$commit_message'" }'

--- a/.github/scripts/create_app_version_pr.sh
+++ b/.github/scripts/create_app_version_pr.sh
@@ -23,9 +23,11 @@ commit_message="Bump app version to $app_version"
 # git commit -m $commit_message
 # git push --set-upstream origin $BRANCH_NAME
 
+echo "$BRANCH_NAME"
+
 echo "Open app version bump PR"
 curl -u "valora-bot:$VALORA_BOT_TOKEN" \
   -X POST \
   -H "Accept: application/vnd.github.v3+json" \
   https://api.github.com/repos/valora-inc/wallet/pulls \
-  -d '{ "head": "'$BRANCH_NAME'", "base": "main", "title": "'$commit_message'" }'
+  -d '{ "head": "'$BRANCH_NAME'", "base": "main", "title": "[Kathy test]" }'

--- a/.github/scripts/create_app_version_pr.sh
+++ b/.github/scripts/create_app_version_pr.sh
@@ -11,8 +11,6 @@ commit_message="Bump app version to $app_version"
 echo "Create branch from main"
 git checkout -b $BRANCH_NAME
 
-yarn
-
 echo "Bump app version"
 yarn pre-deploy --minor --no-disclaimer
 

--- a/.github/scripts/create_app_version_pr.sh
+++ b/.github/scripts/create_app_version_pr.sh
@@ -3,29 +3,27 @@ set -euo pipefail
 
 cd packages/mobile
 
-# # ensure that we are using ssh
-# git remote set-url origin git@github.com:valora-inc/wallet.git
+# ensure that we are using ssh
+git remote set-url origin git@github.com:valora-inc/wallet.git
+
+echo "Create version bump branch from main"
+git checkout -b $BRANCH_NAME
+
+echo "Bump app version"
+yarn pre-deploy --minor --no-disclaimer
+
+# TODO: remove this step as part of https://github.com/valora-inc/wallet/issues/1856
+echo "Generate licences and disclaimer"
+yarn licenses generate-disclaimer --prod > src/account/LicenseDisclaimer.txt && ./scripts/copy_license_to_android_assets.sh
+
 app_version="$(node -p "require('./package.json').version")"
-commit_message="Bump app version to $app_version"
 
-# echo "Create branch from main"
-# git checkout -b $BRANCH_NAME
+echo "Push changes to branch"
+git add .
+git commit -m "Bump app version to $app_version"
+git push --set-upstream origin $BRANCH_NAME
 
-# echo "Bump app version"
-# yarn pre-deploy --minor --no-disclaimer
-
-# # TODO: remove this step as part of https://github.com/valora-inc/wallet/issues/1856
-# echo "Generate disclaimer"
-# yarn licenses generate-disclaimer --prod > src/account/LicenseDisclaimer.txt && ./scripts/copy_license_to_android_assets.sh
-
-# echo "Push changes to branch"
-# git add .
-# git commit -m $commit_message
-# git push --set-upstream origin $BRANCH_NAME
-
-echo "$commit_message"
-
-echo "Open app version bump PR"
+echo "Open version bump PR"
 curl -u "valora-bot:$VALORA_BOT_TOKEN" \
   -X POST \
   -H "Accept: application/vnd.github.v3+json" \

--- a/.github/scripts/create_app_version_pr.sh
+++ b/.github/scripts/create_app_version_pr.sh
@@ -10,7 +10,7 @@ echo "Create version bump branch from main"
 git checkout -b $BRANCH_NAME
 
 echo "Bump app version"
-yarn pre-deploy --minor --no-disclaimer
+yarn pre-deploy --minor --no-licence-update
 
 # TODO: remove this step as part of https://github.com/valora-inc/wallet/issues/1856
 echo "Generate licences and disclaimer"

--- a/.github/scripts/create_app_version_pr.sh
+++ b/.github/scripts/create_app_version_pr.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# cd packages/mobile
+cd packages/mobile
 
 # # ensure that we are using ssh
 # git remote set-url origin git@github.com:valora-inc/wallet.git
@@ -23,11 +23,11 @@ commit_message="Bump app version to $app_version"
 # git commit -m $commit_message
 # git push --set-upstream origin $BRANCH_NAME
 
-echo "$BRANCH_NAME"
+echo "$commit_message"
 
 echo "Open app version bump PR"
 curl -u "valora-bot:$VALORA_BOT_TOKEN" \
   -X POST \
   -H "Accept: application/vnd.github.v3+json" \
   https://api.github.com/repos/valora-inc/wallet/pulls \
-  -d '{ "head": "'$BRANCH_NAME'", "base": "main", "title": "[Kathy test]" }'
+  -d '{ "head": "'$BRANCH_NAME'", "base": "main", "title": "'$commit_message'" }'

--- a/.github/scripts/create_app_version_pr.sh
+++ b/.github/scripts/create_app_version_pr.sh
@@ -9,11 +9,9 @@ app_version="$(node -p "require('./package.json').version")"
 commit_message="Bump app version to $app_version"
 
 echo "Create branch from main"
-# it's important to explicitly checkout the main branch as this job is triggered
-# from a tag that is from a release branch with extra commit(s) for that release
-git checkout main
-git pull origin main
 git checkout -b $BRANCH_NAME
+
+yarn
 
 echo "Bump app version"
 yarn pre-deploy --minor --no-disclaimer

--- a/.github/workflows/bump-app-version.yml
+++ b/.github/workflows/bump-app-version.yml
@@ -30,7 +30,9 @@ jobs:
         with:
           ssh-private-key: ${{ steps.google-secrets.outputs.BOT_SSH_KEY }}
       - uses: actions/checkout@v2
-      - run: yarn
+        with:
+          ref: main
+      # - run: yarn
       - run: .github/scripts/create_app_version_pr.sh
         env:
           VALORA_BOT_TOKEN: ${{ steps.google-secrets.outputs.VALORA_BOT_TOKEN }}

--- a/.github/workflows/bump-app-version.yml
+++ b/.github/workflows/bump-app-version.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: kathy/fix-auto-version-bump
-      # - run: yarn
+      - run: yarn
       - run: .github/scripts/create_app_version_pr.sh
         env:
           VALORA_BOT_TOKEN: ${{ steps.google-secrets.outputs.VALORA_BOT_TOKEN }}

--- a/.github/workflows/bump-app-version.yml
+++ b/.github/workflows/bump-app-version.yml
@@ -6,8 +6,6 @@ on:
     # trigger on new minor release tags only
     tags:
       - valora-v[0-9]+.[0-9]+.0
-    branches:
-      - kathy/fix-auto-version-bump
 
 jobs:
   bump-app-version:
@@ -31,7 +29,7 @@ jobs:
           ssh-private-key: ${{ steps.google-secrets.outputs.BOT_SSH_KEY }}
       - uses: actions/checkout@v2
         with:
-          ref: kathy/fix-auto-version-bump
+          ref: main
       - run: yarn
       - run: .github/scripts/create_app_version_pr.sh
         env:

--- a/.github/workflows/bump-app-version.yml
+++ b/.github/workflows/bump-app-version.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: main
-      # - run: yarn
+      - run: yarn
       - run: .github/scripts/create_app_version_pr.sh
         env:
           VALORA_BOT_TOKEN: ${{ steps.google-secrets.outputs.VALORA_BOT_TOKEN }}

--- a/.github/workflows/bump-app-version.yml
+++ b/.github/workflows/bump-app-version.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: main
-      - run: yarn
+      # - run: yarn
       - run: .github/scripts/create_app_version_pr.sh
         env:
           VALORA_BOT_TOKEN: ${{ steps.google-secrets.outputs.VALORA_BOT_TOKEN }}

--- a/.github/workflows/bump-app-version.yml
+++ b/.github/workflows/bump-app-version.yml
@@ -31,7 +31,7 @@ jobs:
           ssh-private-key: ${{ steps.google-secrets.outputs.BOT_SSH_KEY }}
       - uses: actions/checkout@v2
         with:
-          ref: main
+          ref: kathy/fix-auto-version-bump
       # - run: yarn
       - run: .github/scripts/create_app_version_pr.sh
         env:

--- a/.github/workflows/bump-app-version.yml
+++ b/.github/workflows/bump-app-version.yml
@@ -6,6 +6,8 @@ on:
     # trigger on new minor release tags only
     tags:
       - valora-v[0-9]+.[0-9]+.0
+    branches:
+      - kathy/fix-auto-version-bump
 
 jobs:
   bump-app-version:

--- a/packages/mobile/scripts/pre-deploy.sh
+++ b/packages/mobile/scripts/pre-deploy.sh
@@ -9,10 +9,12 @@ set -euo pipefail
 # --minor (Optional): Bump minor version automatically (default is to let user input new version number)
 
 MINOR=false
+NO_DISCLAIMER=false
 
 while [[ "$#" -gt 0 ]]; do
   case $1 in
     --minor) MINOR=true ;;
+    --no-disclaimer) NO_DISCLAIMER=true ;;
     *) echo "Unknown parameter passed: $1"; exit 1 ;;
   esac
   shift
@@ -44,8 +46,11 @@ sed -i '' -e "s/MARKETING_VERSION \= [^\;]*\;/MARKETING_VERSION = $new_version;/
 pushd ios; agvtool next-version; popd
 echo "===Done updating versions==="
 
-echo "===Update license list and disclaimer==="
-yarn deploy:update-disclaimer
-echo "===Done updating licenses==="
+if [ "$NO_DISCLAIMER" = false ]
+then
+  echo "===Update license list and disclaimer==="
+  yarn deploy:update-disclaimer
+  echo "===Done updating licenses==="
+fi
 
 echo "Pre-deploy steps complete"

--- a/packages/mobile/scripts/pre-deploy.sh
+++ b/packages/mobile/scripts/pre-deploy.sh
@@ -9,12 +9,12 @@ set -euo pipefail
 # --minor (Optional): Bump minor version automatically (default is to let user input new version number)
 
 MINOR=false
-NO_DISCLAIMER=false
+NO_LICENSE_UPDATE=false
 
 while [[ "$#" -gt 0 ]]; do
   case $1 in
     --minor) MINOR=true ;;
-    --no-disclaimer) NO_DISCLAIMER=true ;;
+    --no-licence-update) NO_LICENSE_UPDATE=true ;;
     *) echo "Unknown parameter passed: $1"; exit 1 ;;
   esac
   shift
@@ -46,7 +46,7 @@ sed -i '' -e "s/MARKETING_VERSION \= [^\;]*\;/MARKETING_VERSION = $new_version;/
 pushd ios; agvtool next-version; popd
 echo "===Done updating versions==="
 
-if [ "$NO_DISCLAIMER" = false ]
+if [ "$NO_LICENSE_UPDATE" = false ]
 then
   echo "===Update license list and disclaimer==="
   yarn deploy:update-disclaimer


### PR DESCRIPTION
### Description

A few things needed to be ironed out after seeing this script in the wild:
- as this job is triggered by a tag, by default the repo is checked out with the tag as reference - need to avoid this as the tag is on the release branch which could contain extra commits (like in the case of 1.28.0) => checkout with `ref: main`
- the disclaimer part of the pre-deploy script executes asynchronously and was still ongoing while the next script step (push branch) was executing => add opt out for disclaimer. it's also nice to separate the disclaimer anyway because we will remove it from the pre-deploy script soon.
- the create PR api request was failing with error 
```
"message": "Validation Failed",
  "errors": [
    ***
      "resource": "Issue",
      "code": "missing_field",
      "field": "title"
    ***
  ],
  "documentation_url": "https://docs.github.com/rest/reference/pulls#create-a-pull-request"
```
=> add "title" to the request body (this was annoying, as the docs clearly say that this param is not required...)

### Other changes

N/A

### Tested

Manually


### How others should test

N/A

### Related issues

N/A

### Backwards compatibility

Yes