### PR TITLE
Resolve minimist version to 1.2.6 to resolve vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "mixin-deep": "^2.0.1",
     "js-yaml": "^3.13.1",
     "logkitty": "^0.7.1",
-    "minimist": "^1.2.5",
+    "minimist": "^1.2.6",
     "websocket-extensions": "^0.1.4",
     "elliptic": "^6.5.3",
     "dot-prop": "^5.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16167,10 +16167,10 @@ minimist-options@^3.0.1:
     arrify "^1.0.1"
     is-plain-obj "^1.1.0"
 
-minimist@0.0.8, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
-  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+minimist@0.0.8, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5, minimist@^1.2.6:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
+  integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
 
 minipass@^2.3.5, minipass@^2.6.0, minipass@^2.9.0:
   version "2.9.0"


### PR DESCRIPTION
### Description

The vulnerabilities CI is failing due to https://github.com/advisories/GHSA-xvch-5gv4-984h. 

This PR resolves the minimist package to 1.2.6 to fix this vulnerability. (Even though there isn't an official patched version on the above report, 1.2.6 does seem to include a fix for it https://github.com/substack/minimist/issues/164#issuecomment-1074384679 &  https://github.com/substack/minimist/issues/164#issuecomment-1074670410)

### Other changes

N/A
### Tested

N/A

### How others should test

N/A

### Related issues
N/A

### Backwards compatibility
N/A