### PR TITLE
Resolve node-forge version to 1.3.0 to resolve vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "dot-prop": "^5.2.0",
     "bl": "^4.0.3",
     "node-libs-react-native": "^1.2.0",
-    "node-forge": "^1.0.0",
+    "node-forge": "^1.3.0",
     "web3-eth-contract": "1.3.0",
     "ua-parser-js": "^0.7.24",
     "underscore": "^1.12.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16625,10 +16625,10 @@ node-fetch@2.6.1, node-fetch@^1.0.1, node-fetch@^2.1.2, node-fetch@^2.2.0, node-
   dependencies:
     whatwg-url "^5.0.0"
 
-node-forge@^0.10.0, node-forge@^1.0.0:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.2.1.tgz#82794919071ef2eb5c509293325cec8afd0fd53c"
-  integrity sha512-Fcvtbb+zBcZXbTTVwqGA5W+MKBj56UjVRevvchv5XrcyXbmNdesfZL37nlcWOfpgHhgmxApw3tQbTr4CqNmX4w==
+node-forge@^0.10.0, node-forge@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.3.0.tgz#37a874ea723855f37db091e6c186e5b67a01d4b2"
+  integrity sha512-08ARB91bUi6zNKzVmaj3QO7cr397uiDT2nJ63cHjyNtCTWIgvS47j3eT0WfzUwS9+6Z5YshRaoasFkXCKrIYbA==
 
 node-gyp-build@^4.2.0:
   version "4.2.3"


### PR DESCRIPTION
### Description

The vulnerabilities CI is failing due to https://github.com/advisories/GHSA-cfm4-qjh2-4765 

This PR resolves the node-forge package to 1.3.0 to fix this vulnerability. 

### Other changes

N/A
### Tested

N/A

### How others should test

N/A

### Related issues
N/A

### Backwards compatibility
N/A