### PR TITLE
Block finclusive unsupported geos 

### DIFF
--- a/packages/mobile/locales/base/translation.json
+++ b/packages/mobile/locales/base/translation.json
@@ -1126,7 +1126,8 @@
     "completed": {
       "title": "Verification complete",
       "description": "We successfully verified your identity. Please continue to finish linking your bank account.",
-      "descriptionStep2NotEnabled": "We successfully verified your identity. We'll let you know when you can finish linking your bank account."
+      "descriptionStep2NotEnabled": "We successfully verified your identity. We'll let you know when you can finish linking your bank account.",
+      "descriptionRegionNotSupported": "We successfully verified your identity. Your region is not currently supported. We'll let you know when you can finish linking your bank account."
     },
     "failed": {
       "title": "Verification denied",

--- a/packages/mobile/locales/base/translation.json
+++ b/packages/mobile/locales/base/translation.json
@@ -1147,7 +1147,7 @@
     "stepTwo": {
       "label": "Step 2",
       "disabledTitle": "Link a bank account",
-      "disabledDescription": "You're almost done! You can connect your bank acount to Valora now via Plaid.",
+      "disabledDescription": "Bank account support coming soon! We'll let you know when you can connect your bank account to Valora.",
       "disabledCta": "Coming Soon!",
       "title": "Enter Bank Details",
       "description": "You're almost done! Enter bank details to link your account to Valora.",

--- a/packages/mobile/src/account/LinkBankAccountScreen.test.tsx
+++ b/packages/mobile/src/account/LinkBankAccountScreen.test.tsx
@@ -214,7 +214,10 @@ describe('LinkBankAccountScreen: unit tests (test one component at a time)', () 
         }
         personaButtonSuccessCallback?.(MockPeronaAddressFromInquiry)
         await waitFor(() => expect(getByText('linkBankAccountScreen.pending.title')).toBeTruthy())
-        expect(Logger.info).toHaveBeenCalledWith()
+        expect(Logger.info).toHaveBeenCalledWith(
+          'LinkBankAccountScreen',
+          new Error('User region state not supported by finclusive')
+        )
       })
       it('shows the pending screen if the user has been approved by persona but has not yet started finclusive', async () => {
         const store = createMockStore({
@@ -287,6 +290,7 @@ describe('LinkBankAccountScreen: unit tests (test one component at a time)', () 
           account: {
             kycStatus: KycStatus.Approved,
             finclusiveKycStatus: FinclusiveKycStatus.Accepted,
+            finclusiveRegionSupported: true,
           },
         })
         const { getByText } = render(
@@ -306,6 +310,7 @@ describe('LinkBankAccountScreen: unit tests (test one component at a time)', () 
           account: {
             kycStatus: KycStatus.Approved,
             finclusiveKycStatus: FinclusiveKycStatus.Accepted,
+            finclusiveRegionSupported: true,
           },
           app: { linkBankAccountStepTwoEnabled: true },
         })
@@ -396,7 +401,10 @@ describe('LinkBankAccountScreen: unit tests (test one component at a time)', () 
       it('step two is enabled when feature flag is switched on and kyc is approved', async () => {
         const store = createMockStore({
           web3: { mtwAddress: mockAccount },
-          account: { finclusiveKycStatus: FinclusiveKycStatus.Accepted },
+          account: {
+            finclusiveKycStatus: FinclusiveKycStatus.Accepted,
+            finclusiveRegionSupported: true,
+          },
           app: { linkBankAccountStepTwoEnabled: true },
         })
 
@@ -423,6 +431,7 @@ describe('LinkBankAccountScreen: unit tests (test one component at a time)', () 
           account: {
             e164PhoneNumber: MOCK_PHONE_NUMBER,
             finclusiveKycStatus: FinclusiveKycStatus.Accepted,
+            finclusiveRegionSupported: true,
           },
           app: { linkBankAccountStepTwoEnabled: true },
         })

--- a/packages/mobile/src/account/LinkBankAccountScreen.test.tsx
+++ b/packages/mobile/src/account/LinkBankAccountScreen.test.tsx
@@ -146,7 +146,7 @@ describe('LinkBankAccountScreen: unit tests (test one component at a time)', () 
         await waitFor(() => expect(getByText('linkBankAccountScreen.begin.title')).toBeTruthy())
         await fireEvent.press(getByTestId('PersonaButton'))
 
-        const MockPeronaAddressFromInquiry: InquiryAttributes['address'] = {
+        const MockPersonaAddressFromInquiry: InquiryAttributes['address'] = {
           street1: '4067 Center Avenue',
           street2: null,
           city: 'Fresno',
@@ -155,7 +155,7 @@ describe('LinkBankAccountScreen: unit tests (test one component at a time)', () 
           countryCode: 'US',
           subdivisionAbbr: 'CA',
         }
-        personaButtonSuccessCallback?.(MockPeronaAddressFromInquiry)
+        personaButtonSuccessCallback?.(MockPersonaAddressFromInquiry)
         await waitFor(() => expect(getByText('linkBankAccountScreen.pending.title')).toBeTruthy())
       })
       it('updates finclusiveRegionSupported state in redux when user from supported states succeeded with Persona', async () => {
@@ -174,7 +174,7 @@ describe('LinkBankAccountScreen: unit tests (test one component at a time)', () 
         await waitFor(() => expect(getByText('linkBankAccountScreen.begin.title')).toBeTruthy())
         await fireEvent.press(getByTestId('PersonaButton'))
 
-        const MockPeronaAddressFromInquiry: InquiryAttributes['address'] = {
+        const MockPersonaAddressFromInquiry: InquiryAttributes['address'] = {
           street1: '4067 Center Avenue',
           street2: null,
           city: 'Fresno',
@@ -183,7 +183,7 @@ describe('LinkBankAccountScreen: unit tests (test one component at a time)', () 
           countryCode: 'US',
           subdivisionAbbr: 'CA',
         }
-        personaButtonSuccessCallback?.(MockPeronaAddressFromInquiry)
+        personaButtonSuccessCallback?.(MockPersonaAddressFromInquiry)
         await waitFor(() => expect(getByText('linkBankAccountScreen.pending.title')).toBeTruthy())
         expect(store.dispatch).toHaveBeenCalledWith(setFinclusiveRegionSupported())
       })
@@ -203,7 +203,7 @@ describe('LinkBankAccountScreen: unit tests (test one component at a time)', () 
         await waitFor(() => expect(getByText('linkBankAccountScreen.begin.title')).toBeTruthy())
         await fireEvent.press(getByTestId('PersonaButton'))
 
-        const MockPeronaAddressFromInquiry: InquiryAttributes['address'] = {
+        const MockPersonaAddressFromInquiry: InquiryAttributes['address'] = {
           street1: '8669 Ketch Harbour Street',
           street2: null,
           city: 'Brooklyn',
@@ -212,7 +212,7 @@ describe('LinkBankAccountScreen: unit tests (test one component at a time)', () 
           countryCode: 'US',
           subdivisionAbbr: 'NY',
         }
-        personaButtonSuccessCallback?.(MockPeronaAddressFromInquiry)
+        personaButtonSuccessCallback?.(MockPersonaAddressFromInquiry)
         await waitFor(() => expect(getByText('linkBankAccountScreen.pending.title')).toBeTruthy())
         expect(Logger.info).toHaveBeenCalledWith(
           'LinkBankAccountScreen',
@@ -396,6 +396,27 @@ describe('LinkBankAccountScreen: unit tests (test one component at a time)', () 
           </Provider>
         )
         const plaidLinkButton = getByTestId('PlaidLinkButton')
+        expect(plaidLinkButton).toBeDisabled()
+      })
+      it('step two is disabled when feature flag is switched on and kyc is approved but user does not live in a region finclusive supports', async () => {
+        const store = createMockStore({
+          web3: { mtwAddress: mockAccount },
+          account: {
+            finclusiveKycStatus: FinclusiveKycStatus.Accepted,
+            finclusiveRegionSupported: false,
+          },
+          app: { linkBankAccountStepTwoEnabled: true },
+        })
+
+        const { getByTestId, queryByText } = render(
+          <Provider store={store}>
+            <StepTwo />
+          </Provider>
+        )
+        const plaidLinkButton = getByTestId('PlaidLinkButton')
+        expect(queryByText('linkBankAccountScreen.stepTwo.disabledTitle')).toBeTruthy()
+        expect(queryByText('linkBankAccountScreen.stepTwo.disabledDescription')).toBeTruthy()
+        expect(queryByText('linkBankAccountScreen.stepTwo.disabledCta')).toBeTruthy()
         expect(plaidLinkButton).toBeDisabled()
       })
       it('step two is enabled when feature flag is switched on and kyc is approved', async () => {

--- a/packages/mobile/src/account/LinkBankAccountScreen.test.tsx
+++ b/packages/mobile/src/account/LinkBankAccountScreen.test.tsx
@@ -216,7 +216,7 @@ describe('LinkBankAccountScreen: unit tests (test one component at a time)', () 
         await waitFor(() => expect(getByText('linkBankAccountScreen.pending.title')).toBeTruthy())
         expect(Logger.info).toHaveBeenCalledWith(
           'LinkBankAccountScreen',
-          new Error('User region state not supported by finclusive')
+          'User state not supported by finclusive'
         )
       })
       it('shows the pending screen if the user has been approved by persona but has not yet started finclusive', async () => {

--- a/packages/mobile/src/account/LinkBankAccountScreen.test.tsx
+++ b/packages/mobile/src/account/LinkBankAccountScreen.test.tsx
@@ -2,6 +2,7 @@ import Button from '@celo/react-components/components/Button'
 import { fireEvent, render, waitFor } from '@testing-library/react-native'
 import * as React from 'react'
 import 'react-native'
+import { InquiryAttributes } from 'react-native-persona'
 import { Provider } from 'react-redux'
 import { StepOne, StepTwo } from 'src/account/LinkBankAccountScreen'
 import openPlaid from 'src/account/openPlaid'
@@ -10,12 +11,13 @@ import { CICOEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
+import Logger from 'src/utils/Logger'
 import { createMockStore } from 'test/utils'
 import { mockAccount } from 'test/values'
-import { fetchFinclusiveKyc } from './actions'
+import { fetchFinclusiveKyc, setFinclusiveRegionSupported } from './actions'
 import PersonaButton from './Persona'
 
-let personaButtonSuccessCallback: (() => any) | undefined // using this to simulate Persona success at any arbitrary time
+let personaButtonSuccessCallback: ((address: InquiryAttributes['address']) => any) | undefined // using this to simulate Persona success at any arbitrary time
 let personaButtonErrorCallback: (() => any) | undefined // using this to simulate Persona error at any arbitrary time
 let personaButtonCancelCallback: (() => any) | undefined // using this to simulate Persona cancel at any arbitrary time
 
@@ -27,7 +29,7 @@ const MockPersona = ({
 }: {
   onCancelled: () => any
   onError: () => any
-  onSuccess: () => any
+  onSuccess: (address: InquiryAttributes['address']) => any
   onPress: () => any
 }) => {
   personaButtonSuccessCallback = onSuccess
@@ -50,6 +52,14 @@ jest.mock('src/account/openPlaid', () => ({
   __esModule: true,
   namedExport: jest.fn(),
   default: jest.fn(),
+}))
+
+jest.mock('src/utils/Logger', () => ({
+  __esModule: true,
+  namedExport: jest.fn(),
+  default: {
+    info: jest.fn(),
+  },
 }))
 
 describe('LinkBankAccountScreen: unit tests (test one component at a time)', () => {
@@ -121,7 +131,7 @@ describe('LinkBankAccountScreen: unit tests (test one component at a time)', () 
         await fireEvent.press(getByTestId('PersonaButton'))
         await waitFor(() => expect(getByText('linkBankAccountScreen.verifying.title')).toBeTruthy())
       })
-      it('shows the pending screen if the user suceeded with Persona', async () => {
+      it('shows the pending screen if the user succeeded with Persona', async () => {
         const store = createMockStore({
           account: {
             kycStatus: undefined,
@@ -135,8 +145,76 @@ describe('LinkBankAccountScreen: unit tests (test one component at a time)', () 
         )
         await waitFor(() => expect(getByText('linkBankAccountScreen.begin.title')).toBeTruthy())
         await fireEvent.press(getByTestId('PersonaButton'))
-        personaButtonSuccessCallback?.()
+
+        const MockPeronaAddressFromInquiry: InquiryAttributes['address'] = {
+          street1: '4067 Center Avenue',
+          street2: null,
+          city: 'Fresno',
+          subdivision: 'California',
+          postalCode: '93711',
+          countryCode: 'US',
+          subdivisionAbbr: 'CA',
+        }
+        personaButtonSuccessCallback?.(MockPeronaAddressFromInquiry)
         await waitFor(() => expect(getByText('linkBankAccountScreen.pending.title')).toBeTruthy())
+      })
+      it('updates finclusiveRegionSupported state in redux when user from supported states succeeded with Persona', async () => {
+        const store = createMockStore({
+          account: {
+            kycStatus: undefined,
+            finclusiveKycStatus: FinclusiveKycStatus.NotSubmitted,
+          },
+        })
+        store.dispatch = jest.fn()
+        const { getByText, getByTestId } = render(
+          <Provider store={store}>
+            <StepOne />
+          </Provider>
+        )
+        await waitFor(() => expect(getByText('linkBankAccountScreen.begin.title')).toBeTruthy())
+        await fireEvent.press(getByTestId('PersonaButton'))
+
+        const MockPeronaAddressFromInquiry: InquiryAttributes['address'] = {
+          street1: '4067 Center Avenue',
+          street2: null,
+          city: 'Fresno',
+          subdivision: 'California',
+          postalCode: '93711',
+          countryCode: 'US',
+          subdivisionAbbr: 'CA',
+        }
+        personaButtonSuccessCallback?.(MockPeronaAddressFromInquiry)
+        await waitFor(() => expect(getByText('linkBankAccountScreen.pending.title')).toBeTruthy())
+        expect(store.dispatch).toHaveBeenCalledWith(setFinclusiveRegionSupported())
+      })
+      it('logs error when user from non-supported states succeeded with Persona', async () => {
+        const store = createMockStore({
+          account: {
+            kycStatus: undefined,
+            finclusiveKycStatus: FinclusiveKycStatus.NotSubmitted,
+          },
+        })
+        store.dispatch = jest.fn()
+        const { getByText, getByTestId } = render(
+          <Provider store={store}>
+            <StepOne />
+          </Provider>
+        )
+        await waitFor(() => expect(getByText('linkBankAccountScreen.begin.title')).toBeTruthy())
+        await fireEvent.press(getByTestId('PersonaButton'))
+
+        const MockPeronaAddressFromInquiry: InquiryAttributes['address'] = {
+          street1: '8669 Ketch Harbour Street',
+          street2: null,
+          city: 'Brooklyn',
+          subdivision: 'New York',
+          postalCode: '11212',
+          countryCode: 'US',
+          subdivisionAbbr: 'NY',
+        }
+        personaButtonSuccessCallback?.(MockPeronaAddressFromInquiry)
+        await waitFor(() => expect(getByText('linkBankAccountScreen.pending.title')).toBeTruthy())
+        expect(Logger.info).toHaveBeenCalledWith()
       })
       it('shows the pending screen if the user has been approved by persona but has not yet started finclusive', async () => {
         const store = createMockStore({
@@ -241,6 +319,27 @@ describe('LinkBankAccountScreen: unit tests (test one component at a time)', () 
           expect(getByText('linkBankAccountScreen.completed.description')).toBeTruthy()
         )
       })
+      it('shows the completed screen with right description when user region is not supported by finclusive', async () => {
+        const store = createMockStore({
+          account: {
+            kycStatus: KycStatus.Approved,
+            finclusiveKycStatus: FinclusiveKycStatus.Accepted,
+            finclusiveRegionSupported: false,
+          },
+          app: { linkBankAccountStepTwoEnabled: true },
+        })
+        const { getByText } = render(
+          <Provider store={store}>
+            <StepOne />
+          </Provider>
+        )
+        await waitFor(() => expect(getByText('linkBankAccountScreen.completed.title')).toBeTruthy())
+        await waitFor(() =>
+          expect(
+            getByText('linkBankAccountScreen.completed.descriptionRegionNotSupported')
+          ).toBeTruthy()
+        )
+      })
     })
     describe('StepTwo', () => {
       it('step two is disabled when feature flag is switched off (even if kyc approved)', async () => {
@@ -265,6 +364,24 @@ describe('LinkBankAccountScreen: unit tests (test one component at a time)', () 
         const store = createMockStore({
           web3: { mtwAddress: mockAccount },
           account: { finclusiveKycStatus: FinclusiveKycStatus.Submitted },
+          app: { linkBankAccountStepTwoEnabled: true },
+        })
+
+        const { getByTestId } = render(
+          <Provider store={store}>
+            <StepTwo />
+          </Provider>
+        )
+        const plaidLinkButton = getByTestId('PlaidLinkButton')
+        expect(plaidLinkButton).toBeDisabled()
+      })
+      it('step two is disabled when user region is not supported', async () => {
+        const store = createMockStore({
+          web3: { mtwAddress: mockAccount },
+          account: {
+            finclusiveKycStatus: FinclusiveKycStatus.Accepted,
+            finclusiveRegionSupported: false,
+          },
           app: { linkBankAccountStepTwoEnabled: true },
         })
 

--- a/packages/mobile/src/account/LinkBankAccountScreen.tsx
+++ b/packages/mobile/src/account/LinkBankAccountScreen.tsx
@@ -11,10 +11,12 @@ import { InquiryAttributes } from 'react-native-persona'
 import { useDeepLinkRedirector, usePlaidEmitter } from 'react-native-plaid-link-sdk'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { useDispatch, useSelector } from 'react-redux'
+import { setFinclusiveRegionSupported } from 'src/account/actions'
 import PersonaButton from 'src/account/Persona'
 import { FinclusiveKycStatus, KycStatus } from 'src/account/reducer'
 import {
   finclusiveKycStatusSelector,
+  finclusiveRegionSupportedSelector,
   kycStatusSelector,
   plaidParamsSelector,
 } from 'src/account/selectors'
@@ -33,6 +35,8 @@ import {
 } from '../app/selectors'
 import { fetchFinclusiveKyc } from './actions'
 import openPlaid, { handleOnEvent } from './openPlaid'
+
+const TAG = 'LinkBankAccountScreen'
 
 function LinkBankAccountScreen() {
   const navigation = useNavigation()
@@ -117,10 +121,6 @@ export function stepOneUIState({
 
   return StepOneUIState.Begin
 }
-
-// Persona data is parsed from step 1 to see whether the user's resident region is supported
-// This is a shared attribute between step 1 and step 2
-let isRegionSupported = false
 
 export function StepOne() {
   const { t } = useTranslation()
@@ -266,8 +266,10 @@ export function StepOne() {
 export function StepTwo() {
   const { t } = useTranslation()
   const finclusiveKycStatus = useSelector(finclusiveKycStatusSelector)
+  const finclusiveRegionSupported = useSelector(finclusiveRegionSupportedSelector)
   const plaidParams = useSelector(plaidParamsSelector)
-  const stepTwoEnabled = useSelector(linkBankAccountStepTwoEnabledSelector) && isRegionSupported
+  const stepTwoEnabled =
+    useSelector(linkBankAccountStepTwoEnabledSelector) && finclusiveRegionSupported
   const disabled = !stepTwoEnabled || finclusiveKycStatus !== FinclusiveKycStatus.Accepted
   // This is used to handle universal links within React Native
   // https://plaid.com/docs/link/oauth/#handling-universal-links-within-react-native

--- a/packages/mobile/src/account/LinkBankAccountScreen.tsx
+++ b/packages/mobile/src/account/LinkBankAccountScreen.tsx
@@ -162,6 +162,8 @@ export function StepOne() {
     try {
       if (isUserRegionSupportedByFinclusive(address, unsupportedRegions)) {
         dispatch(setFinclusiveRegionSupported())
+      } else {
+        Logger.info(TAG, 'User state not supported by finclusive')
       }
     } catch (err) {
       Logger.info(TAG, err)

--- a/packages/mobile/src/account/LinkBankAccountScreen.tsx
+++ b/packages/mobile/src/account/LinkBankAccountScreen.tsx
@@ -16,6 +16,7 @@ import PersonaButton from 'src/account/Persona'
 import { FinclusiveKycStatus, KycStatus } from 'src/account/reducer'
 import {
   finclusiveKycStatusSelector,
+  finclusiveRegionSupportedSelector,
   kycStatusSelector,
   plaidParamsSelector,
 } from 'src/account/selectors'

--- a/packages/mobile/src/account/LinkBankAccountScreen.tsx
+++ b/packages/mobile/src/account/LinkBankAccountScreen.tsx
@@ -15,8 +15,9 @@ import { setFinclusiveRegionSupported } from 'src/account/actions'
 import PersonaButton from 'src/account/Persona'
 import { FinclusiveKycStatus, KycStatus } from 'src/account/reducer'
 import {
-  finclusiveKycStatusSelector, kycStatusSelector,
-  plaidParamsSelector
+  finclusiveKycStatusSelector,
+  kycStatusSelector,
+  plaidParamsSelector,
 } from 'src/account/selectors'
 import { CICOEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
@@ -29,7 +30,7 @@ import { Screens } from 'src/navigator/Screens'
 import { isUserRegionSupportedByFinclusive } from 'src/utils/supportedRegions'
 import {
   finclusiveUnsupportedStatesSelector,
-  linkBankAccountStepTwoEnabledSelector
+  linkBankAccountStepTwoEnabledSelector,
 } from '../app/selectors'
 import { fetchFinclusiveKyc } from './actions'
 import openPlaid, { handleOnEvent } from './openPlaid'
@@ -120,10 +121,6 @@ export function stepOneUIState({
   return StepOneUIState.Begin
 }
 
-// Persona data is parsed from step 1 to see whether the user's resident region is supported
-// This is a shared attribute between step 1 and step 2
-let isRegionSupported = false
-
 export function StepOne() {
   const { t } = useTranslation()
   const dispatch = useDispatch()
@@ -159,31 +156,9 @@ export function StepOne() {
     setTimeout(() => setIsInPersonaFlow(true), 500)
   }
 
-<<<<<<< HEAD
   const onSuccessPersona = (attributes: InquiryAttributes) => {
     if (isUserRegionSupportedByFinclusive(attributes.address, unsupportedRegions, TAG)) {
       dispatch(setFinclusiveRegionSupported())
-=======
-  const isUserRegionSupported = (address: InquiryAttributes['address']) => {
-    if (!address) {
-      return false
-    }
-    if (!address.countryCode || address.countryCode !== 'US') {
-      return false
-    }
-
-    const UNSUPPORTED_REGION_ABBR: string[] = ['NY', 'TX']
-    if (!address.subdivisionAbbr || UNSUPPORTED_REGION_ABBR.includes(address.subdivisionAbbr)) {
-      // Finclusive currently do not support residents of NY and TX
-      return false
-    }
-    return true
-  }
-
-  const onSuccessPersona = (attributes: InquiryAttributes) => {
-    if (isUserRegionSupported(attributes.address)) {
-      isRegionSupported = true
->>>>>>> block geo wip
     }
 
     setSuccessFromPersona(true)

--- a/packages/mobile/src/account/Persona.tsx
+++ b/packages/mobile/src/account/Persona.tsx
@@ -25,7 +25,7 @@ export interface Props {
   onPress?: () => any
   onCancelled?: () => any
   onError?: () => any
-  onSuccess?: () => any
+  onSuccess?: (attributes: InquiryAttributes) => any
 }
 
 const Persona = ({ kycStatus, text, onCancelled, onError, onPress, onSuccess }: Props) => {
@@ -58,7 +58,7 @@ const Persona = ({ kycStatus, text, onCancelled, onError, onPress, onSuccess }: 
       .environment(networkConfig.personaEnvironment)
       .iosTheme(pjson.persona.iosTheme)
       .onSuccess((inquiryId: string, attributes: InquiryAttributes) => {
-        onSuccess?.()
+        onSuccess?.(attributes)
         ValoraAnalytics.track(CICOEvents.persona_kyc_success)
         Logger.info(
           TAG,

--- a/packages/mobile/src/account/Persona.tsx
+++ b/packages/mobile/src/account/Persona.tsx
@@ -25,7 +25,7 @@ export interface Props {
   onPress?: () => any
   onCancelled?: () => any
   onError?: () => any
-  onSuccess?: (attributes: InquiryAttributes) => any
+  onSuccess?: (address: InquiryAttributes['address']) => any
 }
 
 const Persona = ({ kycStatus, text, onCancelled, onError, onPress, onSuccess }: Props) => {
@@ -58,12 +58,9 @@ const Persona = ({ kycStatus, text, onCancelled, onError, onPress, onSuccess }: 
       .environment(networkConfig.personaEnvironment)
       .iosTheme(pjson.persona.iosTheme)
       .onSuccess((inquiryId: string, attributes: InquiryAttributes) => {
-        onSuccess?.(attributes)
+        onSuccess?.(attributes?.address)
         ValoraAnalytics.track(CICOEvents.persona_kyc_success)
-        Logger.info(
-          TAG,
-          `Inquiry completed for ${inquiryId} with attributes: ${JSON.stringify(attributes)}`
-        )
+        Logger.info(TAG, `Inquiry completed for ${inquiryId}`)
       })
       .onCancelled(() => {
         onCancelled?.()

--- a/packages/mobile/src/account/Settings.test.tsx
+++ b/packages/mobile/src/account/Settings.test.tsx
@@ -261,6 +261,34 @@ describe('Account', () => {
         account: {
           ...baseStore.account,
           kycStatus: KycStatus.Approved,
+          finclusiveRegionSupported: true,
+        },
+        app: {
+          ...baseStore.app,
+          linkBankAccountStepTwoEnabled: false,
+        },
+      }
+      const { getByTestId, queryByText } = render(
+        <Provider store={createMockStore(store)}>
+          <Settings {...getMockStackScreenProps(Screens.Settings)} />
+        </Provider>
+      )
+      expect(queryByText('linkBankAccountSettingsTitle')).toBeTruthy()
+      expect(queryByText('linkBankAccountSettingsValue')).toBeNull()
+
+      fireEvent.press(getByTestId('linkBankAccountSettings'))
+      expect(navigate).toHaveBeenCalledWith(Screens.LinkBankAccountScreen, {
+        kycStatus: KycStatus.Approved,
+      })
+      expect(ValoraAnalytics.track).toHaveBeenCalledWith(SettingsEvents.settings_link_bank_account)
+    })
+    it('renders correctly if the user has been approved by KYC, step two is enabled but user region not supported yet', () => {
+      const store = {
+        ...baseStore,
+        account: {
+          ...baseStore.account,
+          kycStatus: KycStatus.Approved,
+          finclusiveRegionSupported: false,
         },
         app: {
           ...baseStore.app,
@@ -287,6 +315,7 @@ describe('Account', () => {
         account: {
           ...baseStore.account,
           kycStatus: KycStatus.Approved,
+          finclusiveRegionSupported: true,
         },
         app: {
           ...baseStore.app,
@@ -314,6 +343,7 @@ describe('Account', () => {
           ...baseStore.account,
           kycStatus: KycStatus.Approved,
           hasLinkedBankAccount: true,
+          finclusiveRegionSupported: true,
         },
         app: {
           ...baseStore.app,

--- a/packages/mobile/src/account/Settings.tsx
+++ b/packages/mobile/src/account/Settings.tsx
@@ -42,6 +42,7 @@ import {
 } from 'src/app/actions'
 import {
   biometryEnabledSelector,
+  linkBankAccountStepTwoEnabledSelector,
   sessionIdSelector,
   supportedBiometryTypeSelector,
   verificationPossibleSelector,
@@ -133,7 +134,7 @@ const mapStateToProps = (state: RootState): StateProps => {
     kycStatus: state.account.kycStatus,
     mtwAddress: state.web3.mtwAddress,
     hasLinkedBankAccount: state.account.hasLinkedBankAccount,
-    linkBankAccountStepTwoEnabled: state.app.linkBankAccountStepTwoEnabled,
+    linkBankAccountStepTwoEnabled: linkBankAccountStepTwoEnabledSelector(state),
   }
 }
 

--- a/packages/mobile/src/account/actions.ts
+++ b/packages/mobile/src/account/actions.ts
@@ -40,6 +40,7 @@ export enum Actions {
   SET_HAS_LINKED_BANK_ACCOUNT = 'ACCOUNT/SET_HAS_LINKED_BANK_ACCOUNT',
   FETCH_FINCLUSIVE_KYC = 'ACCOUNT/FETCH_FINCLUSIVE_KYC',
   SET_FINCLUSIVE_KYC = 'ACCOUNT/SET_FINCLUSIVE_KYC',
+  SET_FINCLUSIVE_REGION_SUPPORTED = 'ACCOUNT/SET_FINCLUSIVE_REGION_SUPPORTED',
 }
 
 export interface ChooseCreateAccountAction {
@@ -189,6 +190,10 @@ export interface SetFinclusiveKyc {
   finclusiveKycStatus: FinclusiveKycStatus
 }
 
+export interface SetFinclusiveRegionSupported {
+  type: Actions.SET_FINCLUSIVE_REGION_SUPPORTED
+}
+
 export type ActionTypes =
   | ChooseCreateAccountAction
   | ChooseRestoreAccountAction
@@ -222,6 +227,7 @@ export type ActionTypes =
   | SetHasLinkedBankAccount
   | FetchFinclusiveKyc
   | SetFinclusiveKyc
+  | SetFinclusiveRegionSupported
 
 export function chooseCreateAccount(): ChooseCreateAccountAction {
   return {
@@ -398,4 +404,8 @@ export const fetchFinclusiveKyc = (): FetchFinclusiveKyc => ({
 export const setFinclusiveKyc = (finclusiveKycStatus: FinclusiveKycStatus): SetFinclusiveKyc => ({
   type: Actions.SET_FINCLUSIVE_KYC,
   finclusiveKycStatus,
+})
+
+export const setFinclusiveRegionSupported = (): SetFinclusiveRegionSupported => ({
+  type: Actions.SET_FINCLUSIVE_REGION_SUPPORTED,
 })

--- a/packages/mobile/src/account/reducer.ts
+++ b/packages/mobile/src/account/reducer.ts
@@ -36,6 +36,7 @@ export interface State {
   kycStatus: KycStatus | undefined
   hasLinkedBankAccount: boolean
   finclusiveKycStatus: FinclusiveKycStatus
+  finclusiveRegionSupported: boolean
 }
 
 export enum PincodeType {
@@ -107,6 +108,7 @@ export const initialState: State = {
   kycStatus: undefined,
   hasLinkedBankAccount: false,
   finclusiveKycStatus: FinclusiveKycStatus.NotSubmitted,
+  finclusiveRegionSupported: false,
 }
 
 export const reducer = (
@@ -292,6 +294,12 @@ export const reducer = (
       return {
         ...state,
         finclusiveKycStatus: action.finclusiveKycStatus,
+      }
+    }
+    case Actions.SET_FINCLUSIVE_REGION_SUPPORTED: {
+      return {
+        ...state,
+        finclusiveRegionSupported: true,
       }
     }
     default:

--- a/packages/mobile/src/account/selectors.ts
+++ b/packages/mobile/src/account/selectors.ts
@@ -46,6 +46,9 @@ export const accountToRecoverSelector = (state: RootState) =>
 export const kycStatusSelector = (state: RootState) => state.account.kycStatus
 export const finclusiveKycStatusSelector = (state: RootState) => state.account.finclusiveKycStatus
 
+export const finclusiveRegionSupportedSelector = (state: RootState) =>
+  state.account.finclusiveRegionSupported
+
 export const backupCompletedSelector = (state: RootState) => state.account.backupCompleted
 
 export const choseToRestoreAccountSelector = (state: RootState) =>

--- a/packages/mobile/src/app/reducers.ts
+++ b/packages/mobile/src/app/reducers.ts
@@ -69,9 +69,7 @@ export interface State {
   dappsWebViewEnabled: boolean
   activeDapp: ActiveDapp | null
   skipProfilePicture: boolean
-  finclusiveUnsupportedStates: {
-    [state_abbr: string]: string
-  }
+  finclusiveUnsupportedStates: string[]
 }
 
 const initialState = {
@@ -122,9 +120,7 @@ const initialState = {
   dappsWebViewEnabled: REMOTE_CONFIG_VALUES_DEFAULTS.dappsWebViewEnabled,
   activeDapp: null,
   skipProfilePicture: REMOTE_CONFIG_VALUES_DEFAULTS.skipProfilePicture,
-  finclusiveUnsupportedStates: JSON.parse(
-    REMOTE_CONFIG_VALUES_DEFAULTS.finclusiveUnsupportedStates
-  ),
+  finclusiveUnsupportedStates: REMOTE_CONFIG_VALUES_DEFAULTS.finclusiveUnsupportedStates.split(','),
 }
 
 export const appReducer = (
@@ -244,7 +240,7 @@ export const appReducer = (
         paymentDeepLinkHandler: action.configValues.paymentDeepLinkHandler,
         dappsWebViewEnabled: action.configValues.dappsWebViewEnabled,
         skipProfilePicture: action.configValues.skipProfilePicture,
-        finclusiveUnsupportedStates: JSON.parse(action.configValues.finclusiveUnsupportedStates),
+        finclusiveUnsupportedStates: action.configValues.finclusiveUnsupportedStates,
       }
     case Actions.TOGGLE_INVITE_MODAL:
       return {

--- a/packages/mobile/src/app/reducers.ts
+++ b/packages/mobile/src/app/reducers.ts
@@ -69,6 +69,9 @@ export interface State {
   dappsWebViewEnabled: boolean
   activeDapp: ActiveDapp | null
   skipProfilePicture: boolean
+  finclusiveUnsupportedStates: {
+    [state_abbr: string]: string
+  }
 }
 
 const initialState = {
@@ -119,6 +122,9 @@ const initialState = {
   dappsWebViewEnabled: REMOTE_CONFIG_VALUES_DEFAULTS.dappsWebViewEnabled,
   activeDapp: null,
   skipProfilePicture: REMOTE_CONFIG_VALUES_DEFAULTS.skipProfilePicture,
+  finclusiveUnsupportedStates: JSON.parse(
+    REMOTE_CONFIG_VALUES_DEFAULTS.finclusiveUnsupportedStates
+  ),
 }
 
 export const appReducer = (
@@ -238,6 +244,7 @@ export const appReducer = (
         paymentDeepLinkHandler: action.configValues.paymentDeepLinkHandler,
         dappsWebViewEnabled: action.configValues.dappsWebViewEnabled,
         skipProfilePicture: action.configValues.skipProfilePicture,
+        finclusiveUnsupportedStates: JSON.parse(action.configValues.finclusiveUnsupportedStates),
       }
     case Actions.TOGGLE_INVITE_MODAL:
       return {

--- a/packages/mobile/src/app/saga.ts
+++ b/packages/mobile/src/app/saga.ts
@@ -194,6 +194,7 @@ export interface RemoteConfigValues {
   paymentDeepLinkHandler: PaymentDeepLinkHandler
   dappsWebViewEnabled: boolean
   skipProfilePicture: boolean
+  finclusiveUnsupportedStates: string
 }
 
 export function* appRemoteFeatureFlagSaga() {

--- a/packages/mobile/src/app/saga.ts
+++ b/packages/mobile/src/app/saga.ts
@@ -194,7 +194,7 @@ export interface RemoteConfigValues {
   paymentDeepLinkHandler: PaymentDeepLinkHandler
   dappsWebViewEnabled: boolean
   skipProfilePicture: boolean
-  finclusiveUnsupportedStates: string
+  finclusiveUnsupportedStates: string[]
 }
 
 export function* appRemoteFeatureFlagSaga() {

--- a/packages/mobile/src/app/selectors.ts
+++ b/packages/mobile/src/app/selectors.ts
@@ -111,7 +111,7 @@ export const multiTokenUseUpdatedFeedSelector = (state: RootState) =>
 export const linkBankAccountEnabledSelector = (state: RootState) => state.app.linkBankAccountEnabled
 
 export const linkBankAccountStepTwoEnabledSelector = (state: RootState) =>
-  state.app.linkBankAccountStepTwoEnabled
+  state.app.linkBankAccountStepTwoEnabled && state.account.finclusiveRegionSupported
 
 export const sentryTracesSampleRateSelector = (state: RootState) => state.app.sentryTracesSampleRate
 

--- a/packages/mobile/src/app/selectors.ts
+++ b/packages/mobile/src/app/selectors.ts
@@ -142,6 +142,9 @@ export const dappsWebViewEnabledSelector = (state: RootState) => state.app.dapps
 export const activeDappSelector = (state: RootState) =>
   state.app.dappsWebViewEnabled ? state.app.activeDapp : null
 
+export const finclusiveUnsupportedStatesSelector = (state: RootState) =>
+  state.app.finclusiveUnsupportedStates
+
 type StoreWipeRecoveryScreens = Extract<
   Screens,
   | Screens.NameAndPicture

--- a/packages/mobile/src/firebase/firebase.ts
+++ b/packages/mobile/src/firebase/firebase.ts
@@ -285,7 +285,7 @@ export async function fetchRemoteConfigValues(): Promise<RemoteConfigValues | nu
     paymentDeepLinkHandler: flags.paymentDeepLinkHandler.asString() as PaymentDeepLinkHandler,
     dappsWebViewEnabled: flags.dappsWebViewEnabled.asBoolean(),
     skipProfilePicture: flags.skipProfilePicture.asBoolean(),
-    finclusiveUnsupportedStates: flags.finclusiveUnsupportedStates.asString(),
+    finclusiveUnsupportedStates: flags.finclusiveUnsupportedStates.asString().split(','),
   }
 }
 

--- a/packages/mobile/src/firebase/firebase.ts
+++ b/packages/mobile/src/firebase/firebase.ts
@@ -285,6 +285,7 @@ export async function fetchRemoteConfigValues(): Promise<RemoteConfigValues | nu
     paymentDeepLinkHandler: flags.paymentDeepLinkHandler.asString() as PaymentDeepLinkHandler,
     dappsWebViewEnabled: flags.dappsWebViewEnabled.asBoolean(),
     skipProfilePicture: flags.skipProfilePicture.asBoolean(),
+    finclusiveUnsupportedStates: flags.finclusiveUnsupportedStates.asString(),
   }
 }
 

--- a/packages/mobile/src/firebase/remoteConfigValuesDefaults.e2e.ts
+++ b/packages/mobile/src/firebase/remoteConfigValuesDefaults.e2e.ts
@@ -56,4 +56,8 @@ export const REMOTE_CONFIG_VALUES_DEFAULTS: Omit<
   paymentDeepLinkHandler: PaymentDeepLinkHandler.Disabled,
   dappsWebViewEnabled: true,
   skipProfilePicture: false,
+  finclusiveUnsupportedStates: JSON.stringify({
+    NY: 'NEW YORK',
+    TX: 'TEXAS',
+  }),
 }

--- a/packages/mobile/src/firebase/remoteConfigValuesDefaults.e2e.ts
+++ b/packages/mobile/src/firebase/remoteConfigValuesDefaults.e2e.ts
@@ -9,11 +9,13 @@ export const REMOTE_CONFIG_VALUES_DEFAULTS: Omit<
   | 'komenciAllowedDeployers'
   | 'sentryNetworkErrors'
   | 'superchargeTokens'
+  | 'finclusiveUnsupportedStates'
 > & {
   komenciAllowedDeployers: string
   sentryNetworkErrors: string
   superchargecUSDMin: number
   superchargecUSDMax: number
+  finclusiveUnsupportedStates: string
 } = {
   hideVerification: false,
   // cannot set defaults to undefined or null
@@ -56,8 +58,5 @@ export const REMOTE_CONFIG_VALUES_DEFAULTS: Omit<
   paymentDeepLinkHandler: PaymentDeepLinkHandler.Disabled,
   dappsWebViewEnabled: true,
   skipProfilePicture: false,
-  finclusiveUnsupportedStates: JSON.stringify({
-    NY: 'NEW YORK',
-    TX: 'TEXAS',
-  }),
+  finclusiveUnsupportedStates: 'NY,TX',
 }

--- a/packages/mobile/src/firebase/remoteConfigValuesDefaults.ts
+++ b/packages/mobile/src/firebase/remoteConfigValuesDefaults.ts
@@ -11,6 +11,7 @@ export const REMOTE_CONFIG_VALUES_DEFAULTS: Omit<
   | 'dappListApiUrl'
   | 'sentryNetworkErrors'
   | 'superchargeTokens'
+  | 'finclusiveUnsupportedStates'
 > & {
   komenciAllowedDeployers: string
   sentryNetworkErrors: string
@@ -20,6 +21,7 @@ export const REMOTE_CONFIG_VALUES_DEFAULTS: Omit<
   superchargecEURMax: number
   superchargecREALMin: number
   superchargecREALMax: number
+  finclusiveUnsupportedStates: string
 } = {
   hideVerification: false,
   // cannot set defaults to undefined or null
@@ -69,8 +71,5 @@ export const REMOTE_CONFIG_VALUES_DEFAULTS: Omit<
   paymentDeepLinkHandler: PaymentDeepLinkHandler.Disabled,
   dappsWebViewEnabled: false,
   skipProfilePicture: false,
-  finclusiveUnsupportedStates: JSON.stringify({
-    NY: 'NEW YORK',
-    TX: 'TEXAS',
-  }),
+  finclusiveUnsupportedStates: 'NY,TX',
 }

--- a/packages/mobile/src/firebase/remoteConfigValuesDefaults.ts
+++ b/packages/mobile/src/firebase/remoteConfigValuesDefaults.ts
@@ -69,4 +69,8 @@ export const REMOTE_CONFIG_VALUES_DEFAULTS: Omit<
   paymentDeepLinkHandler: PaymentDeepLinkHandler.Disabled,
   dappsWebViewEnabled: false,
   skipProfilePicture: false,
+  finclusiveUnsupportedStates: JSON.stringify({
+    NY: 'NEW YORK',
+    TX: 'TEXAS',
+  }),
 }

--- a/packages/mobile/src/redux/createMigrate.test.ts
+++ b/packages/mobile/src/redux/createMigrate.test.ts
@@ -107,7 +107,7 @@ describe(createMigrate, () => {
 
     const migrate = createMigrate(failingMigrations)
     await expect(migrate(vNeg1Stub, 7)).rejects.toThrowErrorMatchingInlineSnapshot(
-      `"Cannot read property 'doesNotExist' of undefined"`
+      `"Cannot read properties of undefined (reading 'doesNotExist')"`
     )
   })
 })

--- a/packages/mobile/src/redux/createMigrate.test.ts
+++ b/packages/mobile/src/redux/createMigrate.test.ts
@@ -107,7 +107,7 @@ describe(createMigrate, () => {
 
     const migrate = createMigrate(failingMigrations)
     await expect(migrate(vNeg1Stub, 7)).rejects.toThrowErrorMatchingInlineSnapshot(
-      `"Cannot read properties of undefined (reading 'doesNotExist')"`
+      `"Cannot read property 'doesNotExist' of undefined"`
     )
   })
 })

--- a/packages/mobile/src/redux/migrations.test.ts
+++ b/packages/mobile/src/redux/migrations.test.ts
@@ -20,6 +20,7 @@ import {
   v36Schema,
   v37Schema,
   v41Schema,
+  v43Schema,
   v7Schema,
   v8Schema,
   vNeg1Schema,
@@ -448,6 +449,16 @@ describe('Redux persist migrations', () => {
 
     const expectedSchema: any = _.cloneDeep(oldSchema)
     expectedSchema.app.skipProfilePicture = false
+
+    expect(migratedSchema).toMatchObject(expectedSchema)
+  })
+  it('works for v43 to v44', () => {
+    const oldSchema = v43Schema
+    const migratedSchema = migrations[44](oldSchema)
+
+    const expectedSchema: any = _.cloneDeep(oldSchema)
+    expectedSchema.account.finclusiveRegionSupported = false
+    expectedSchema.app.finclusiveUnsupportedStates = 'NY,TX'
 
     expect(migratedSchema).toMatchObject(expectedSchema)
   })

--- a/packages/mobile/src/redux/migrations.test.ts
+++ b/packages/mobile/src/redux/migrations.test.ts
@@ -458,7 +458,7 @@ describe('Redux persist migrations', () => {
 
     const expectedSchema: any = _.cloneDeep(oldSchema)
     expectedSchema.account.finclusiveRegionSupported = false
-    expectedSchema.app.finclusiveUnsupportedStates = 'NY,TX'
+    expectedSchema.app.finclusiveUnsupportedStates = ['NY', 'TX']
 
     expect(migratedSchema).toMatchObject(expectedSchema)
   })

--- a/packages/mobile/src/redux/migrations.ts
+++ b/packages/mobile/src/redux/migrations.ts
@@ -566,4 +566,15 @@ export const migrations = {
     },
   }),
   43: (state: any) => state,
+  44: (state: any) => ({
+    ...state,
+    account: {
+      ...state.account,
+      finclusiveRegionSupported: false,
+    },
+    app: {
+      ...state.app,
+      finclusiveUnsupportedStates: REMOTE_CONFIG_VALUES_DEFAULTS.finclusiveUnsupportedStates,
+    },
+  }),
 }

--- a/packages/mobile/src/redux/migrations.ts
+++ b/packages/mobile/src/redux/migrations.ts
@@ -574,7 +574,9 @@ export const migrations = {
     },
     app: {
       ...state.app,
-      finclusiveUnsupportedStates: REMOTE_CONFIG_VALUES_DEFAULTS.finclusiveUnsupportedStates,
+      finclusiveUnsupportedStates: REMOTE_CONFIG_VALUES_DEFAULTS.finclusiveUnsupportedStates.split(
+        ','
+      ),
     },
   }),
 }

--- a/packages/mobile/src/redux/store.test.ts
+++ b/packages/mobile/src/redux/store.test.ts
@@ -93,7 +93,7 @@ describe('store state', () => {
       Object {
         "_persist": Object {
           "rehydrated": true,
-          "version": 43,
+          "version": 44,
         },
         "account": Object {
           "acceptedTerms": false,
@@ -115,6 +115,7 @@ describe('store state', () => {
           "dismissedGoldEducation": false,
           "e164PhoneNumber": "+14155556666",
           "finclusiveKycStatus": 0,
+          "finclusiveRegionSupported": false,
           "hasLinkedBankAccount": false,
           "hasMigratedToNewBip39": false,
           "kycStatus": undefined,
@@ -139,6 +140,10 @@ describe('store state', () => {
           "celoEuroEnabled": true,
           "dappListApiUrl": null,
           "dappsWebViewEnabled": false,
+          "finclusiveUnsupportedStates": Array [
+            "NY",
+            "TX",
+          ],
           "googleMobileServicesAvailable": undefined,
           "hideVerification": false,
           "huaweiMobileServicesAvailable": undefined,

--- a/packages/mobile/src/redux/store.ts
+++ b/packages/mobile/src/redux/store.ts
@@ -24,7 +24,7 @@ const persistConfig: PersistConfig<RootState> = {
   key: 'root',
   // default is -1, increment as we make migrations
   // See https://github.com/valora-inc/wallet/tree/main/packages/mobile#redux-state-migration
-  version: 43,
+  version: 44,
   keyPrefix: `reduxStore-`, // the redux-persist default is `persist:` which doesn't work with some file systems.
   storage: FSStorage(),
   blacklist: ['geth', 'networkInfo', 'alert', 'imports', 'supercharge'],

--- a/packages/mobile/src/utils/supportedRegions.test.tsx
+++ b/packages/mobile/src/utils/supportedRegions.test.tsx
@@ -1,0 +1,59 @@
+import 'react-native'
+import { isUserRegionSupportedByFinclusive } from 'src/utils/supportedRegions'
+
+const unsupportedRegions = ['NY', 'TX']
+describe('finclusive supported regions helper', () => {
+  it('throws error if the address input is null', () => {
+    const mockAddressObject = null
+
+    expect(() => {
+      isUserRegionSupportedByFinclusive(mockAddressObject, unsupportedRegions)
+    }).toThrowError('Persona inquiry attributes missing address info')
+  })
+
+  it('returns false if country code is not in us', () => {
+    const mockAddressObject = {
+      street1: ' 3789 Carling Avenue',
+      street2: null,
+      city: 'Ottawa',
+      subdivision: 'Ontario',
+      postalCode: 'K1Z 7B5',
+      countryCode: 'CAN',
+      subdivisionAbbr: 'OT',
+    }
+
+    expect(() => {
+      isUserRegionSupportedByFinclusive(mockAddressObject, unsupportedRegions)
+    }).toThrowError('User region country code not in US')
+  })
+
+  it('returns false if state is not supported by finclusive', () => {
+    const mockAddressObject = {
+      street1: '8669 Ketch Harbour Street',
+      street2: null,
+      city: 'Brooklyn',
+      subdivision: 'New York',
+      postalCode: '11212',
+      countryCode: 'US',
+      subdivisionAbbr: 'NY',
+    }
+
+    expect(() => {
+      isUserRegionSupportedByFinclusive(mockAddressObject, unsupportedRegions)
+    }).toThrowError('User region state not supported by finclusive')
+  })
+
+  it('returns true if state is supported by finclusive', () => {
+    const mockAddressObject = {
+      street1: '4067 Center Avenue',
+      street2: null,
+      city: 'Fresno',
+      subdivision: 'California',
+      postalCode: '93711',
+      countryCode: 'US',
+      subdivisionAbbr: 'CA',
+    }
+
+    expect(isUserRegionSupportedByFinclusive(mockAddressObject, unsupportedRegions)).toBeTruthy()
+  })
+})

--- a/packages/mobile/src/utils/supportedRegions.test.tsx
+++ b/packages/mobile/src/utils/supportedRegions.test.tsx
@@ -22,9 +22,7 @@ describe('finclusive supported regions helper', () => {
       subdivisionAbbr: 'OT',
     }
 
-    expect(() => {
-      isUserRegionSupportedByFinclusive(mockAddressObject, unsupportedRegions)
-    }).toThrowError('User region country code not in US')
+    expect(isUserRegionSupportedByFinclusive(mockAddressObject, unsupportedRegions)).toBeFalsy()
   })
 
   it('returns false if state is not supported by finclusive', () => {
@@ -38,9 +36,7 @@ describe('finclusive supported regions helper', () => {
       subdivisionAbbr: 'NY',
     }
 
-    expect(() => {
-      isUserRegionSupportedByFinclusive(mockAddressObject, unsupportedRegions)
-    }).toThrowError('User region state not supported by finclusive')
+    expect(isUserRegionSupportedByFinclusive(mockAddressObject, unsupportedRegions)).toBeFalsy()
   })
 
   it('returns true if state is supported by finclusive', () => {

--- a/packages/mobile/src/utils/supportedRegions.ts
+++ b/packages/mobile/src/utils/supportedRegions.ts
@@ -1,24 +1,19 @@
 import { InquiryAttributes } from 'react-native-persona'
-import Logger from 'src/utils/Logger'
 
 export function isUserRegionSupportedByFinclusive(
   address: InquiryAttributes['address'],
-  unsupportedRegions: string[],
-  tag: string
+  unsupportedRegions: string[]
 ): Boolean {
   if (!address || !address.countryCode || !address.subdivisionAbbr) {
-    Logger.error(tag, 'Persona inquiry attributes missing address info')
-    return false
+    throw new Error('Persona inquiry attributes missing address info')
   }
   if (address.countryCode !== 'US') {
-    Logger.info(tag, 'User region country code not in US')
-    return false
+    throw new Error('User region country code not in US')
   }
 
   if (unsupportedRegions.includes(address.subdivisionAbbr)) {
     // Finclusive currently do not support residents of NY and TX
-    Logger.info(tag, 'User region state not supported by finclusive')
-    return false
+    throw new Error('User region state not supported by finclusive')
   }
   return true
 }

--- a/packages/mobile/src/utils/supportedRegions.ts
+++ b/packages/mobile/src/utils/supportedRegions.ts
@@ -1,0 +1,24 @@
+import { InquiryAttributes } from 'react-native-persona'
+import Logger from 'src/utils/Logger'
+
+export function isUserRegionSupportedByFinclusive(
+  address: InquiryAttributes['address'],
+  unsupportedRegions: string[],
+  tag: string
+): Boolean {
+  if (!address || !address.countryCode || !address.subdivisionAbbr) {
+    Logger.error(tag, 'Persona inquiry attributes missing address info')
+    return false
+  }
+  if (address.countryCode !== 'US') {
+    Logger.info(tag, 'User region country code not in US')
+    return false
+  }
+
+  if (unsupportedRegions.includes(address.subdivisionAbbr)) {
+    // Finclusive currently do not support residents of NY and TX
+    Logger.info(tag, 'User region state not supported by finclusive')
+    return false
+  }
+  return true
+}

--- a/packages/mobile/src/utils/supportedRegions.ts
+++ b/packages/mobile/src/utils/supportedRegions.ts
@@ -8,12 +8,12 @@ export function isUserRegionSupportedByFinclusive(
     throw new Error('Persona inquiry attributes missing address info')
   }
   if (address.countryCode !== 'US') {
-    throw new Error('User region country code not in US')
+    return false
   }
 
   if (unsupportedRegions.includes(address.subdivisionAbbr)) {
     // Finclusive currently do not support residents of NY and TX
-    throw new Error('User region state not supported by finclusive')
+    return false
   }
   return true
 }

--- a/packages/mobile/test/RootStateSchema.json
+++ b/packages/mobile/test/RootStateSchema.json
@@ -1844,6 +1844,12 @@
                 "dappsWebViewEnabled": {
                     "type": "boolean"
                 },
+                "finclusiveUnsupportedStates": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
                 "googleMobileServicesAvailable": {
                     "type": "boolean"
                 },
@@ -1983,12 +1989,6 @@
                 },
                 "walletConnectV2Enabled": {
                     "type": "boolean"
-                },
-                "finclusiveUnsupportedStates": {
-                  "additionalProperties": {
-                    "type": "string"
-                  },
-                  "type": "object"
                 }
             },
             "required": [
@@ -2002,6 +2002,7 @@
                 "celoEuroEnabled",
                 "dappListApiUrl",
                 "dappsWebViewEnabled",
+                "finclusiveUnsupportedStates",
                 "hideVerification",
                 "inviteModalVisible",
                 "lastTimeBackgrounded",
@@ -2401,6 +2402,9 @@
                 "finclusiveKycStatus": {
                     "$ref": "#/definitions/FinclusiveKycStatus"
                 },
+                "finclusiveRegionSupported": {
+                    "type": "boolean"
+                },
                 "hasLinkedBankAccount": {
                     "type": "boolean"
                 },
@@ -2466,6 +2470,7 @@
                 "dismissedGoldEducation",
                 "e164PhoneNumber",
                 "finclusiveKycStatus",
+                "finclusiveRegionSupported",
                 "hasLinkedBankAccount",
                 "hasMigratedToNewBip39",
                 "name",

--- a/packages/mobile/test/RootStateSchema.json
+++ b/packages/mobile/test/RootStateSchema.json
@@ -1983,6 +1983,12 @@
                 },
                 "walletConnectV2Enabled": {
                     "type": "boolean"
+                },
+                "finclusiveUnsupportedStates": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
                 }
             },
             "required": [

--- a/packages/mobile/test/schemas.ts
+++ b/packages/mobile/test/schemas.ts
@@ -13,7 +13,7 @@ import {
   mockCeloAddress,
   mockCeurAddress,
   mockCusdAddress,
-  mockTestTokenAddress
+  mockTestTokenAddress,
 } from 'test/values'
 
 // Default (version -1 schema)
@@ -1161,6 +1161,10 @@ export const v43Schema = {
   _persist: {
     ...v42Schema._persist,
     version: 43,
+  },
+  account: {
+    ...v42Schema.account,
+    finclusiveRegionSupported: false,
   },
   app: {
     ...v42Schema.app,

--- a/packages/mobile/test/schemas.ts
+++ b/packages/mobile/test/schemas.ts
@@ -1180,7 +1180,11 @@ export const v44Schema = {
   },
   app: {
     ...v43Schema.app,
-    finclusiveUnsupportedStates: { NY: 'NEW YORK', TX: 'TEXAS' },
+    finclusiveUnsupportedStates: ['NY', 'TX'],
+  },
+  account: {
+    ...v43Schema.account,
+    finclusiveRegionSupported: false,
   },
 }
 

--- a/packages/mobile/test/schemas.ts
+++ b/packages/mobile/test/schemas.ts
@@ -13,7 +13,7 @@ import {
   mockCeloAddress,
   mockCeurAddress,
   mockCusdAddress,
-  mockTestTokenAddress,
+  mockTestTokenAddress
 } from 'test/values'
 
 // Default (version -1 schema)
@@ -1168,6 +1168,18 @@ export const v43Schema = {
   },
 }
 
+export const v44Schema = {
+  ...v43Schema,
+  _persist: {
+    ...v43Schema._persist,
+    version: 44,
+  },
+  app: {
+    ...v43Schema.app,
+    finclusiveUnsupportedStates: { NY: 'NEW YORK', TX: 'TEXAS' },
+  },
+}
+
 export function getLatestSchema(): Partial<RootState> {
-  return v43Schema as Partial<RootState>
+  return v44Schema as Partial<RootState>
 }


### PR DESCRIPTION
### Description
- Fixes #1999 
Finclusive doesn't have license in NY and TX yet. After collecting information from persona, we should prevent user from connecting a bank account if their residence is in NY or TX. 

WIP:
- finalize the copy/design with Nitya
- add tests

### Tested
WIP

