### PR TITLE
Add dapp request origin prop to WC/DappKit analytics events

### DIFF
--- a/packages/mobile/src/analytics/Properties.tsx
+++ b/packages/mobile/src/analytics/Properties.tsx
@@ -30,6 +30,7 @@ import {
 } from 'src/analytics/Events'
 import {
   BackQuizProgress,
+  DappRequestOrigin,
   ScrollDirection,
   SendOrigin,
   WalletConnectPairingOrigin,
@@ -1073,8 +1074,9 @@ interface RewardsProperties {
   }
 }
 
-interface WalletConnect1Properties {
+export interface WalletConnect1Properties {
   version: 1
+  dappRequestOrigin: DappRequestOrigin
   dappName: string
   dappUrl: string
   dappDescription: string
@@ -1083,8 +1085,9 @@ interface WalletConnect1Properties {
   chainId: string
 }
 
-interface WalletConnect2Properties {
+export interface WalletConnect2Properties {
   version: 2
+  dappRequestOrigin: DappRequestOrigin
   dappName: string
   dappUrl: string
   dappDescription: string
@@ -1112,10 +1115,12 @@ type WalletConnectRequestDenyProperties = WalletConnectRequestDefaultProperties 
 
 interface WalletConnectProperties {
   [WalletConnectEvents.wc_pairing_start]: {
+    dappRequestOrigin: DappRequestOrigin
     origin: WalletConnectPairingOrigin
   }
-  [WalletConnectEvents.wc_pairing_success]: undefined
+  [WalletConnectEvents.wc_pairing_success]: { dappRequestOrigin: DappRequestOrigin }
   [WalletConnectEvents.wc_pairing_error]: {
+    dappRequestOrigin: DappRequestOrigin
     error: string
   }
 
@@ -1151,6 +1156,7 @@ interface WalletConnectProperties {
 }
 
 interface DappKitRequestDefaultProperties {
+  dappRequestOrigin: DappRequestOrigin
   dappName: string
   dappUrl: string
   requestType: DappKitRequestTypes
@@ -1159,7 +1165,11 @@ interface DappKitRequestDefaultProperties {
 }
 
 interface DappKitProperties {
-  [DappKitEvents.dappkit_parse_deeplink_error]: { deeplink: string; error: string }
+  [DappKitEvents.dappkit_parse_deeplink_error]: {
+    dappRequestOrigin: DappRequestOrigin
+    deeplink: string
+    error: string
+  }
   [DappKitEvents.dappkit_request_propose]: DappKitRequestDefaultProperties
   [DappKitEvents.dappkit_request_cancel]: DappKitRequestDefaultProperties
   [DappKitEvents.dappkit_request_details]: DappKitRequestDefaultProperties

--- a/packages/mobile/src/analytics/types.ts
+++ b/packages/mobile/src/analytics/types.ts
@@ -20,3 +20,9 @@ export enum WalletConnectPairingOrigin {
   Scan = 'scan',
   Deeplink = 'deeplink',
 }
+
+// Origin of WalletConnect/DappKit request
+export enum DappRequestOrigin {
+  InAppWebView = 'in_app_web_view',
+  External = 'external',
+}

--- a/packages/mobile/src/app/saga.test.ts
+++ b/packages/mobile/src/app/saga.test.ts
@@ -7,6 +7,7 @@ import { appLock, dappSelected, openDeepLink, openUrl, setAppState } from 'src/a
 import { DappSection } from 'src/app/reducers'
 import { handleDeepLink, handleOpenDapp, handleOpenUrl, handleSetAppState } from 'src/app/saga'
 import {
+  activeDappSelector,
   activeScreenSelector,
   dappsWebViewEnabledSelector,
   getAppLocked,
@@ -133,6 +134,7 @@ describe('App saga', () => {
         .provide([
           [select(selectHasPendingState), false],
           [select(activeScreenSelector), Screens.WalletConnectLoading],
+          [select(activeDappSelector), null],
           {
             race: () => ({ timedOut: true }),
           },

--- a/packages/mobile/src/app/saga.ts
+++ b/packages/mobile/src/app/saga.ts
@@ -266,7 +266,7 @@ export function* handleDeepLink(action: OpenDeepLink) {
     } else if (rawParams.path.startsWith('/pay')) {
       yield call(handlePaymentDeeplink, deepLink)
     } else if (rawParams.path.startsWith('/dappkit')) {
-      handleDappkitDeepLink(deepLink)
+      yield call(handleDappkitDeepLink, deepLink)
     } else if (rawParams.path === '/cashIn') {
       navigate(Screens.FiatExchangeOptions, { isCashIn: true })
     } else if (rawParams.pathname === '/bidali') {

--- a/packages/mobile/src/app/selectors.ts
+++ b/packages/mobile/src/app/selectors.ts
@@ -140,7 +140,7 @@ export const skipVerificationSelector = (state: RootState) => state.app.skipVeri
 export const dappsWebViewEnabledSelector = (state: RootState) => state.app.dappsWebViewEnabled
 
 export const activeDappSelector = (state: RootState) =>
-  state.app.dappsWebViewEnabled && state.app.activeDapp
+  state.app.dappsWebViewEnabled ? state.app.activeDapp : null
 
 type StoreWipeRecoveryScreens = Extract<
   Screens,

--- a/packages/mobile/src/app/utils.ts
+++ b/packages/mobile/src/app/utils.ts
@@ -1,0 +1,14 @@
+import { DappRequestOrigin } from 'src/analytics/types'
+import { ActiveDapp } from 'src/app/reducers'
+
+// Assume that if we have an active dapp, any WC or DappKit request comes from the in-app webview.
+// Note that this may be incorrect if the user interacts with another dapp while the dapp webview is open.
+// I thought about comparing the request url to the active dapp url, but that could fail too if the dapp url we have is different.
+// For instance the dapp-list could contain a "example.com", while the request is "dapp.something.com".
+export function getDappRequestOrigin(activeDapp: ActiveDapp | null) {
+  if (activeDapp) {
+    return DappRequestOrigin.InAppWebView
+  }
+
+  return DappRequestOrigin.External
+}

--- a/packages/mobile/src/dappkit/DappKitAccountScreen.tsx
+++ b/packages/mobile/src/dappkit/DappKitAccountScreen.tsx
@@ -12,6 +12,8 @@ import { connect } from 'react-redux'
 import { e164NumberSelector } from 'src/account/selectors'
 import { DappKitEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
+import { ActiveDapp } from 'src/app/reducers'
+import { activeDappSelector } from 'src/app/selectors'
 import AccountNumber from 'src/components/AccountNumber'
 import { approveAccountAuth, getDefaultRequestTrackedProperties } from 'src/dappkit/dappkit'
 import { withTranslation } from 'src/i18n'
@@ -29,6 +31,7 @@ const TAG = 'dappkit/DappKitAccountScreen'
 interface StateProps {
   account: string | null
   phoneNumber: string | null
+  activeDapp: ActiveDapp | null
 }
 
 interface DispatchProps {
@@ -43,6 +46,7 @@ type Props = StateProps &
 const mapStateToProps = (state: RootState): StateProps => ({
   account: currentAccountSelector(state),
   phoneNumber: e164NumberSelector(state),
+  activeDapp: activeDappSelector(state),
 })
 
 const mapDispatchToProps = {
@@ -71,7 +75,10 @@ class DappKitAccountAuthScreen extends React.Component<Props> {
   cancel = () => {
     ValoraAnalytics.track(
       DappKitEvents.dappkit_request_cancel,
-      getDefaultRequestTrackedProperties(this.props.route.params.dappKitRequest)
+      getDefaultRequestTrackedProperties(
+        this.props.route.params.dappKitRequest,
+        this.props.activeDapp
+      )
     )
     navigateBack()
   }

--- a/packages/mobile/src/dappkit/DappKitSignTxScreen.tsx
+++ b/packages/mobile/src/dappkit/DappKitSignTxScreen.tsx
@@ -10,6 +10,8 @@ import { SafeAreaView } from 'react-native-safe-area-context'
 import { connect } from 'react-redux'
 import { DappKitEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
+import { ActiveDapp } from 'src/app/reducers'
+import { activeDappSelector } from 'src/app/selectors'
 import { getDefaultRequestTrackedProperties, requestTxSignature } from 'src/dappkit/dappkit'
 import { withTranslation } from 'src/i18n'
 import { noHeader } from 'src/navigator/Headers'
@@ -17,17 +19,27 @@ import { navigate, navigateBack } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import { TopBarTextButton } from 'src/navigator/TopBarButton'
 import { StackParamList } from 'src/navigator/types'
+import { RootState } from 'src/redux/reducers'
 import Logger from 'src/utils/Logger'
 
 const TAG = 'dappkit/DappKitSignTxScreen'
+
+interface StateProps {
+  activeDapp: ActiveDapp | null
+}
 
 interface DispatchProps {
   requestTxSignature: typeof requestTxSignature
 }
 
-type Props = DispatchProps &
+type Props = StateProps &
+  DispatchProps &
   WithTranslation &
   StackScreenProps<StackParamList, Screens.DappKitSignTxScreen>
+
+const mapStateToProps = (state: RootState): StateProps => ({
+  activeDapp: activeDappSelector(state),
+})
 
 const mapDispatchToProps = {
   requestTxSignature,
@@ -62,7 +74,7 @@ class DappKitSignTxScreen extends React.Component<Props> {
 
     ValoraAnalytics.track(
       DappKitEvents.dappkit_request_details,
-      getDefaultRequestTrackedProperties(request)
+      getDefaultRequestTrackedProperties(request, this.props.activeDapp)
     )
 
     // TODO(sallyjyl): figure out which data to pass in for multitx
@@ -74,7 +86,7 @@ class DappKitSignTxScreen extends React.Component<Props> {
   cancel = () => {
     ValoraAnalytics.track(
       DappKitEvents.dappkit_request_cancel,
-      getDefaultRequestTrackedProperties(this.getRequest())
+      getDefaultRequestTrackedProperties(this.getRequest(), this.props.activeDapp)
     )
     navigateBack()
   }
@@ -163,7 +175,7 @@ const styles = StyleSheet.create({
   },
 })
 
-export default connect<null, DispatchProps>(
-  null,
+export default connect<StateProps, DispatchProps, {}, RootState>(
+  mapStateToProps,
   mapDispatchToProps
 )(withTranslation<Props>()(DappKitSignTxScreen))

--- a/packages/mobile/src/walletConnect/walletConnect.ts
+++ b/packages/mobile/src/walletConnect/walletConnect.ts
@@ -3,7 +3,9 @@ import { WalletConnectEvents } from 'src/analytics/Events'
 import { WalletConnectPairingOrigin } from 'src/analytics/types'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import { Actions as AppActions, ActionTypes as AppActionTypes } from 'src/app/actions'
-import { activeScreenSelector } from 'src/app/selectors'
+import { ActiveDapp } from 'src/app/reducers'
+import { activeDappSelector, activeScreenSelector } from 'src/app/selectors'
+import { getDappRequestOrigin } from 'src/app/utils'
 import i18n from 'src/i18n'
 import { navigate, replace } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
@@ -73,7 +75,9 @@ export function* handleLoadingWithTimeout(params: StackParamList[Screens.WalletC
   })
 
   if (timedOut) {
+    const activeDapp: ActiveDapp | null = yield select(activeDappSelector)
     ValoraAnalytics.track(WalletConnectEvents.wc_pairing_error, {
+      dappRequestOrigin: getDappRequestOrigin(activeDapp),
       error: 'timed out while waiting for a session',
     })
     yield call(handleWalletConnectNavigate, Screens.WalletConnectResult, {


### PR DESCRIPTION
### Description

This adds a `dappRequestOrigin` prop for all WC/DappKit events so we know if they came from our in-app WebView or were external (system browser or other apps).

### Tested

Manually and updated unit tests

### How others should test

N/A

### Related issues

- Fixes #2104 

### Backwards compatibility

Yes