### PR TITLE
Invite rewards tweaks for v2

### DIFF
--- a/packages/mobile/locales/base/translation.json
+++ b/packages/mobile/locales/base/translation.json
@@ -589,8 +589,12 @@
     "button": "Finish sending"
   },
   "inviteRewardsBanner": {
-    "title": "Get {{amount}} {{currency}} by sharing Valora with a friend!",
-    "body": "Earn {{amount}} {{currency}} when you send crypto to a friend and they join. <0>Learn more</0>"
+    "title": "Invite a friend by sending them their first crypto!",
+    "body": "Both of you will earn {{amount}} {{currency}} when they set up their wallet. <0>Learn more</0>"
+  },
+  "inviteRewardsHomeCard": {
+    "body": "Send crypto to invite a friend. Both of you get {{amount}} {{currency}} once they join!",
+    "cta": "Send Crypto & Invite"
   },
   "getReward": "Get ${{reward}}",
   "welcomeCelo": "Welcome to {{appName}}",

--- a/packages/mobile/src/home/NotificationBox.tsx
+++ b/packages/mobile/src/home/NotificationBox.tsx
@@ -24,7 +24,7 @@ import { getReclaimableEscrowPayments } from 'src/escrow/reducer'
 import { dismissNotification } from 'src/home/actions'
 import { DEFAULT_PRIORITY } from 'src/home/reducers'
 import { getExtraNotifications } from 'src/home/selectors'
-import { backupKey, boostRewards, getVerified, learnCelo } from 'src/images/Images'
+import { backupKey, boostRewards, getVerified, inviteFriends, learnCelo } from 'src/images/Images'
 import { ensurePincode, navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import IncomingPaymentRequestSummaryNotification from 'src/paymentRequest/IncomingPaymentRequestSummaryNotification'
@@ -35,6 +35,7 @@ import {
 } from 'src/paymentRequest/selectors'
 import useSelector from 'src/redux/useSelector'
 import { getContentForCurrentLang } from 'src/utils/contentTranslations'
+import { Currency } from 'src/utils/currencies'
 import Logger from 'src/utils/Logger'
 
 const TAG = 'NotificationBox'
@@ -86,6 +87,9 @@ function useSimpleActions() {
   const verificationPossible = useSelector(verificationPossibleSelector)
 
   const rewardsEnabled = useSelector(rewardsEnabledSelector)
+  const inviteRewardsEnabled = useSelector((state) => state.send.inviteRewardsEnabled)
+  const inviteRewardAmount = useSelector((state) => state.send.inviteRewardCusd)
+  const inviteRewardsCurrency = Currency.Dollar // invite rewards v2 experiment is only for US region
 
   const { t } = useTranslation()
 
@@ -139,6 +143,29 @@ function useSimpleActions() {
             ValoraAnalytics.track(RewardsEvents.rewards_screen_opened, {
               origin: RewardsScreenOrigin.RewardAvailableNotification,
             })
+          },
+        },
+      ],
+    })
+  }
+
+  if (inviteRewardsEnabled) {
+    actions.push({
+      text: t('inviteRewardsHomeCard.body', {
+        amount: inviteRewardAmount,
+        currency: inviteRewardsCurrency,
+      }),
+      icon: inviteFriends,
+      priority: INVITES_PRIORITY,
+      callToActions: [
+        {
+          text: t('inviteRewardsHomeCard.cta'),
+          onPress: () => {
+            ValoraAnalytics.track(HomeEvents.notification_select, {
+              notificationType: NotificationBannerTypes.invite_prompt,
+              selectedAction: NotificationBannerCTATypes.accept,
+            })
+            navigate(Screens.Send)
           },
         },
       ],

--- a/packages/mobile/src/send/InviteRewardsBanner.tsx
+++ b/packages/mobile/src/send/InviteRewardsBanner.tsx
@@ -9,7 +9,6 @@ import { notificationInvite } from 'src/images/Images'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import useSelector from 'src/redux/useSelector'
-import { useCountryFeatures } from 'src/utils/countryFeatures'
 import { Currency } from 'src/utils/currencies'
 
 export function InviteRewardsBanner() {
@@ -19,9 +18,7 @@ export function InviteRewardsBanner() {
   const openInviteTerms = () => {
     navigate(Screens.WebViewScreen, { uri: INVITE_REWARDS_TERMS_LINK })
   }
-
-  const { IS_IN_EUROPE } = useCountryFeatures()
-  const currency = IS_IN_EUROPE ? Currency.Euro : Currency.Dollar
+  const currency = Currency.Dollar // invite rewards v2 experiment is only for US region
 
   return (
     <Touchable testID="InviteRewardsBanner" onPress={openInviteTerms}>


### PR DESCRIPTION
### Description

Tweak the invite rewards v1 program to work for v2:
- reuse everything from v1 including the remote config variables (no reason to add new ones since the programs will not co-exist)
- add home card for invites. the priority is unchanged from v1, and should come after backup/supercharge/payment request
- update translations

<img width="431" alt="Screenshot 2022-03-25 at 10 18 33" src="https://user-images.githubusercontent.com/20150449/160092128-a35208f5-00ef-4d0f-b368-6e93b2a9ae1d.png">


To come:
- maybe update website link
- maybe update home card image

### Other changes

N/A

### Tested

Manually, existing unit tests


### How others should test

When the remote config variable "inviteRewardsEnabled" is true, you should see a home card for invite rewards. On the send screen, you should see the invite rewards banner.

### Related issues

- Fixes #2203 

### Backwards compatibility

Yes