### PR TITLE
Android fix sometimes white text on white background in dark mode

### DIFF
--- a/packages/mobile/android/app/src/main/res/values/styles.xml
+++ b/packages/mobile/android/app/src/main/res/values/styles.xml
@@ -2,7 +2,7 @@
   <style name="AppTheme" parent="Base.V0.AppTheme"/>
 
   <!--  Base theme, also see API specific overrides in values-vXX/styles.xml -->
-  <style name="Base.V0.AppTheme" parent="Theme.AppCompat.DayNight.NoActionBar">
+  <style name="Base.V0.AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
     <item name="android:statusBarColor">@android:color/transparent</item>
     <item name="android:navigationBarColor">@android:color/black</item>
     <!-- The window is always allowed to extend into then notch area -->
@@ -11,6 +11,7 @@
     <item name="android:windowDrawsSystemBarBackgrounds">true</item>
     <!-- Without this we briefly see the theme preview before our own splash screen -->
     <item name="android:windowDisablePreview">true</item>
+    <item name="android:textColor">#000000</item>
   </style>
 
   <!-- Theme for the splash screen, based on AppTheme -->


### PR DESCRIPTION
### Description

Solves the issue of the dev menu (and a couple of other places that use `<Text>` with no styling) appearing white on a white background for android devices with dark mode enabled.

These lines were changed as part of the react native 66 upgrade, reverting them back to the original here. I had followed the react native upgrade guide and thought that day/night mode could not hurt us, however our app does not respond to day/night. If the app background doesn't change, it makes no sense for the text color to change according to system preferences.

context: https://valora-app.slack.com/archives/C025V1D6F3J/p1648221666751949


### Other changes

N/A

### Tested

Manually


### How others should test

N/A

### Related issues

N/A

### Backwards compatibility

N/A