### PR TITLE
fix: bottom sheet not displaying second time after dismiss

### DIFF
--- a/packages/mobile/src/components/BottomSheet.tsx
+++ b/packages/mobile/src/components/BottomSheet.tsx
@@ -38,7 +38,10 @@ function BottomSheet({ children, isVisible, onBackgroundPress }: Props) {
     progress,
     isVisible,
     () => setOptionsVisible(true),
-    () => setOptionsVisible(false)
+    () => {
+      setPickerHeight(0)
+      setOptionsVisible(false)
+    }
   )
 
   if (!showingOptions) {

--- a/packages/mobile/src/components/BottomSheet.tsx
+++ b/packages/mobile/src/components/BottomSheet.tsx
@@ -21,15 +21,15 @@ function BottomSheet({ children, isVisible, onBackgroundPress }: Props) {
   const safeAreaInsets = useSafeAreaInsets()
 
   const progress = useSharedValue(0)
-  const animatedPickerPosition = useAnimatedStyle(
-    () => ({
-      transform: [{ translateY: (1 - progress.value) * pickerHeight }],
-      // Hide until we have the height of the picker,
-      // otherwise there's a 1 frame flicker with the fully visible picker
-      opacity: pickerHeight > 0 ? 1 : 0,
-    }),
-    [pickerHeight]
-  )
+  const animatedPickerPosition = useAnimatedStyle(() => {
+    return {
+      transform: [
+        {
+          translateY: (1 - progress.value) * pickerHeight,
+        },
+      ],
+    }
+  })
   const animatedOpacity = useAnimatedStyle(() => ({
     opacity: 0.5 * progress.value,
   }))

--- a/packages/mobile/src/components/BottomSheet.tsx
+++ b/packages/mobile/src/components/BottomSheet.tsx
@@ -21,15 +21,15 @@ function BottomSheet({ children, isVisible, onBackgroundPress }: Props) {
   const safeAreaInsets = useSafeAreaInsets()
 
   const progress = useSharedValue(0)
-  const animatedPickerPosition = useAnimatedStyle(() => {
-    return {
-      transform: [
-        {
-          translateY: (1 - progress.value) * pickerHeight,
-        },
-      ],
-    }
-  })
+  const animatedPickerPosition = useAnimatedStyle(
+    () => ({
+      transform: [{ translateY: (1 - progress.value) * pickerHeight }],
+      // Hide until we have the height of the picker,
+      // otherwise there's a 1 frame flicker with the fully visible picker
+      opacity: pickerHeight > 0 ? 1 : 0,
+    }),
+    [pickerHeight]
+  )
   const animatedOpacity = useAnimatedStyle(() => ({
     opacity: 0.5 * progress.value,
   }))


### PR DESCRIPTION
### Description

The bottom sheet was not displaying a second time after being dismissed as described in #2245. This aims to fix that issue on wherever the `BottomSheet.tsx` is used such as the Dapps page and token bottom sheet.

### Other changes

N/A

### Tested

Tested locally on Android 10 & Android 5 in dev and release mode.

### How others should test

Follow the reproduction steps for #2245 and ensure that the issue does not reproduce.
Follow the reproduction steps for #1973 and ensure that the issue does not reproduce.
Follow the testing steps for #2230.

### Related issues

- Fixes #2245

### Backwards compatibility

Yes