### PR TITLE
Update copy and remove learn more link for invite rewards v2

### DIFF
--- a/packages/mobile/locales/base/translation.json
+++ b/packages/mobile/locales/base/translation.json
@@ -589,8 +589,8 @@
     "button": "Finish sending"
   },
   "inviteRewardsBanner": {
-    "title": "Get {{amount}} {{currency}} by sharing Valora with a friend!",
-    "body": "Earn {{amount}} {{currency}} when you send crypto to a friend and they join. <0>Learn more</0>"
+    "title": "Invite a friend to {{appName}} by sending them some crypto.",
+    "body": "You'll both get {{amount}} {{currency}} once they finish setting up their account."
   },
   "getReward": "Get ${{reward}}",
   "welcomeCelo": "Welcome to {{appName}}",

--- a/packages/mobile/src/send/InviteRewardsBanner.tsx
+++ b/packages/mobile/src/send/InviteRewardsBanner.tsx
@@ -1,13 +1,9 @@
-import Touchable from '@celo/react-components/components/Touchable'
 import colors from '@celo/react-components/styles/colors'
 import fontStyles from '@celo/react-components/styles/fonts'
 import * as React from 'react'
-import { Trans, useTranslation } from 'react-i18next'
+import { useTranslation } from 'react-i18next'
 import { Image, StyleSheet, Text, View } from 'react-native'
-import { INVITE_REWARDS_TERMS_LINK } from 'src/config'
 import { notificationInvite } from 'src/images/Images'
-import { navigate } from 'src/navigator/NavigationService'
-import { Screens } from 'src/navigator/Screens'
 import useSelector from 'src/redux/useSelector'
 import { useCountryFeatures } from 'src/utils/countryFeatures'
 import { Currency } from 'src/utils/currencies'
@@ -16,32 +12,21 @@ export function InviteRewardsBanner() {
   const { t } = useTranslation()
   const rewardAmount = useSelector((state) => state.send.inviteRewardCusd)
 
-  const openInviteTerms = () => {
-    navigate(Screens.WebViewScreen, { uri: INVITE_REWARDS_TERMS_LINK })
-  }
-
   const { IS_IN_EUROPE } = useCountryFeatures()
   const currency = IS_IN_EUROPE ? Currency.Euro : Currency.Dollar
 
   return (
-    <Touchable testID="InviteRewardsBanner" onPress={openInviteTerms}>
-      <View style={styles.container}>
-        <Image source={notificationInvite} resizeMode="contain" />
-        <View style={styles.textContainer}>
-          <Text style={fontStyles.small500}>
-            {t('inviteRewardsBanner.title', { amount: rewardAmount, currency })}
-          </Text>
-          <Text style={styles.bodyText}>
-            <Trans
-              i18nKey={'inviteRewardsBanner.body'}
-              tOptions={{ amount: rewardAmount, currency }}
-            >
-              <Text style={styles.learnMore} />
-            </Trans>
-          </Text>
-        </View>
+    <View style={styles.container} testID="InviteRewardsBanner">
+      <Image source={notificationInvite} resizeMode="contain" />
+      <View style={styles.textContainer}>
+        <Text style={fontStyles.small500}>
+          {t('inviteRewardsBanner.title', { amount: rewardAmount, currency })}
+        </Text>
+        <Text style={styles.bodyText}>
+          {t('inviteRewardsBanner.body', { amount: rewardAmount, currency })}
+        </Text>
       </View>
-    </Touchable>
+    </View>
   )
 }
 
@@ -58,9 +43,5 @@ const styles = StyleSheet.create({
   },
   bodyText: {
     ...fontStyles.small,
-  },
-  learnMore: {
-    ...fontStyles.small,
-    color: colors.greenUI,
   },
 })


### PR DESCRIPTION
### Description

Update the invite rewards banner on the send screen for the v2 experiment. For short experiments, we do not want to have the T&C's link. https://valora-app.slack.com/archives/C038A310CEL/p1648222238888949?thread_ts=1648198994.077819&cid=C038A310CEL


### Other changes

N/A

### Tested

Manually


### How others should test

Verify that on the send screen, the invite rewards banner is no longer clickable

### Related issues

- Relates #2203

### Backwards compatibility

Yes