### PR TITLE
fix: manage the abort callback more elegantly

### DIFF
--- a/packages/mobile/locales/base/translation.json
+++ b/packages/mobile/locales/base/translation.json
@@ -1203,7 +1203,7 @@
   "nomSpaceRecipient": "Nomspace: {{name}}",
   "lastDay": "Last 24 hrs",
   "merchant": "Merchant Payment",
-  "merchantMoneyEscrow": "You're about the send a direct payment to a merchant.",
+  "merchantMoneyEscrow": "You're about to send a direct payment to a merchant.",
   "merchantPaymentNumberVerificationMessage": "You need to connect your number",
   "merchantPaymentSubmitFail": "Your payment failed to submit",
   "merchantPaymentSetup": "There was an error loading the merchant information, please try scanning the QRCode again",


### PR DESCRIPTION
### Description

This changes the way the `abort` method is called when the component unmounts. Right now it actually sends an abort after each success which isn't ideal..

### Other changes

Fixed a typo in the english translation

### Tested

via ios ismulator

### How others should test

The payment shouldn't be aborted after a success

### Related issues

- Fixes #[issue number here]

### Backwards compatibility

_Brief explanation of why these changes are/are not backwards compatible._