### PR TITLE
Update dapps bottom screen text

### DIFF
--- a/packages/mobile/locales/base/translation.json
+++ b/packages/mobile/locales/base/translation.json
@@ -1191,7 +1191,7 @@
     "dismiss": "Dismiss"
   },
   "dappsScreenBottomSheet": {
-    "title": "{{dappName}} will open in an external application",
+    "title": "{{dappName}} is an external application",
     "message": "You are about to open an application not operated by Valora.\n\nValora makes no representations about this application. Use at your own risk.",
     "button": "Go to {{dappName}}"
   },


### PR DESCRIPTION
### Description

Updates the dapps bottom screen text to be appropriate for the in app browser.

### Other changes

N/A

### Tested

Tested locally. 


### How others should test

From the Dapps page tap a Dapp and observe bottom sheet text. It should read:  `{{dappName}} is an external application`.

### Related issues

N/A

### Backwards compatibility

Yes