### PR TITLE
Fix missing translation for in app dapp connection success banner

### DIFF
--- a/packages/mobile/locales/base/translation.json
+++ b/packages/mobile/locales/base/translation.json
@@ -981,6 +981,7 @@
   "disconnectTitle": "Disconnect {{dappName}}?",
   "disconnectBody": "Are you sure you want to disconnect from {{dappName}}?",
   "connectionSuccess": "Success! Please go back to {{dappName}} to continue",
+  "inAppConnectionSuccess": "Connection to {{dappName}} was successful!",
   "timeoutTitle": "Time out!",
   "timeoutSubtitle": "Your connection timed out. Please check your internet connection & try again",
   "goBackButton": "Go Back",


### PR DESCRIPTION
### Description

There is a banner text for in app dapp connection success, it was added in #2178 but removed accidentally in #2209 - not sure what happened, but #2209 was open for a long time (broken CI maybe) so probably a bad crowdin sync somewhere along the way.

### Other changes

N/A

### Tested

N/A


### How others should test

N/A

### Related issues

N/A

### Backwards compatibility

N/A