### PR TITLE
Ensure automerge Crowdin translations automation does not modify base translations

### DIFF
--- a/.github/scripts/automergeCrowdinPr.js
+++ b/.github/scripts/automergeCrowdinPr.js
@@ -9,8 +9,8 @@
  * @typedef {import('@actions/github').context} Context
  */
 
-const CROWDIN_BRANCH = 'l10n/main'
-const CROWDIN_PR_USER = 'valora-bot-crowdin'
+const CROWDIN_BRANCH = 'kathy/test-fix-crowdin-base'
+const CROWDIN_PR_USER = 'kathaypacific'
 const AUTOMERGE_LABEL = 'automerge'
 
 const ALLOWED_UPDATED_FILE_MATCHER = `packages\/mobile\/locales\/.*\/translation\.json`

--- a/.github/scripts/automergeCrowdinPr.js
+++ b/.github/scripts/automergeCrowdinPr.js
@@ -9,8 +9,8 @@
  * @typedef {import('@actions/github').context} Context
  */
 
-const CROWDIN_BRANCH = 'kathy/test-fix-crowdin-base'
-const CROWDIN_PR_USER = 'kathaypacific'
+const CROWDIN_BRANCH = 'l10n/main'
+const CROWDIN_PR_USER = 'valora-bot-crowdin'
 const AUTOMERGE_LABEL = 'automerge'
 
 const ALLOWED_UPDATED_FILE_MATCHER = `packages\/mobile\/locales\/.*\/translation\.json`

--- a/.github/workflows/automerge-crowdin.yml
+++ b/.github/workflows/automerge-crowdin.yml
@@ -7,6 +7,9 @@ on:
   # 1 hour before the nightly build
   schedule:
     - cron: '0 2 * * *'
+  push:
+    branches:
+      - kathy/fix-crowdin-base
 
 jobs:
   automerge-crowdin-pr:

--- a/.github/workflows/automerge-crowdin.yml
+++ b/.github/workflows/automerge-crowdin.yml
@@ -7,9 +7,6 @@ on:
   # 1 hour before the nightly build
   schedule:
     - cron: '0 2 * * *'
-  push:
-    branches:
-      - kathy/fix-crowdin-base
 
 jobs:
   automerge-crowdin-pr:


### PR DESCRIPTION
### Description

The Crowdin translation PR should not modify the base translations. Sometimes when the Crowdin branch is open for a long time and there are new PRs merged that modify the base translations, weird things happen and the base translations are wrongly updated. e.g. https://github.com/valora-inc/wallet/pull/2276

In this PR, check that only the translated languages are modified before automerging. Otherwise, leave a "changes requested" review so that it is easier to see that manual intervention is needed.

### Other changes

N/A

### Tested

Manually


### How others should test

N/A

### Related issues

N/A

### Backwards compatibility

Yes