### PR TITLE
Open external links in dapps with best installed app

### DIFF
--- a/packages/mobile/src/app/WebViewScreen.tsx
+++ b/packages/mobile/src/app/WebViewScreen.tsx
@@ -1,7 +1,7 @@
 import { StackScreenProps } from '@react-navigation/stack'
 import React, { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { ActivityIndicator, StyleSheet, View } from 'react-native'
+import { ActivityIndicator, Linking, StyleSheet, View } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { ShouldStartLoadRequest } from 'react-native-webview/lib/WebViewTypes'
 import { useDispatch, useSelector } from 'react-redux'
@@ -108,6 +108,13 @@ function WebViewScreen({ route, navigation }: Props) {
       dispatch(openDeepLink(event.url))
       return false
     }
+
+    if (event.url && parse(uri).hostname !== parse(event.url).hostname) {
+      // open external links with the best installed app
+      Linking.openURL(event.url)
+      return false
+    }
+
     return true
   }
 

--- a/packages/mobile/src/app/WebViewScreen.tsx
+++ b/packages/mobile/src/app/WebViewScreen.tsx
@@ -1,7 +1,7 @@
 import { StackScreenProps } from '@react-navigation/stack'
 import React, { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { ActivityIndicator, Linking, StyleSheet, View } from 'react-native'
+import { ActivityIndicator, StyleSheet, View } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { ShouldStartLoadRequest } from 'react-native-webview/lib/WebViewTypes'
 import { useDispatch, useSelector } from 'react-redux'
@@ -21,6 +21,7 @@ import { TopBarTextButton } from 'src/navigator/TopBarButton'
 import { StackParamList } from 'src/navigator/types'
 import colors from 'src/styles/colors'
 import { iconHitslop } from 'src/styles/variables'
+import { navigateToURI } from 'src/utils/linking'
 import useBackHandler from 'src/utils/useBackHandler'
 import { isWalletConnectDeepLink } from 'src/walletConnect/walletConnect'
 import { parse } from 'url'
@@ -111,7 +112,7 @@ function WebViewScreen({ route, navigation }: Props) {
 
     if (event.url && parse(uri).hostname !== parse(event.url).hostname) {
       // open external links with the best installed app
-      Linking.openURL(event.url)
+      navigateToURI(event.url)
       return false
     }
 


### PR DESCRIPTION
### Description

On Android, the social media links in dapps do not open the expected installed social media app on the device. Actually in general, Android opens all urls within the Webview. We can either keep a list of url's that we want to open with `Linking.openUrl` instead, or use a rule to open all external links this way. 

Context: https://valora-app.slack.com/archives/C02TH9GNERL/p1649673404933149

### Other changes

N/A
### Tested

Manually


### How others should test

On a phone with the Twitter app installed:
- go to MentoFi (or any other dapp that you know has the Twitter link inside the dapp)
- click on the Twitter icon
- the Twitter app should be opened and the Twitter web page should not be loaded in the in-app browser 

Go to Ubeswap
- Go to the menu and click on any of the "bridge" menu items, e.g. Allbridge
- An external browser should be opened and the link should not be loaded in the in-app browser

Dapps should continue to work as normal, and the dapp should never be opened in an external browser during the user journey.

### Related issues

N/A

### Backwards compatibility

Yes