### PR TITLE
fix(dapps): WebView error when connecting dapps with slow Android devices

### DIFF
--- a/packages/mobile/src/account/__snapshots__/Licenses.test.tsx.snap
+++ b/packages/mobile/src/account/__snapshots__/Licenses.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`Licenses renders correctly 1`] = `
       javaScriptEnabled={true}
       messagingEnabled={false}
       messagingModuleName="WebViewMessageHandler1"
+      onError={[Function]}
       onHttpError={[Function]}
       onLoadingError={[Function]}
       onLoadingFinish={[Function]}

--- a/packages/mobile/src/components/WebView.tsx
+++ b/packages/mobile/src/components/WebView.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import { Platform, StyleSheet } from 'react-native'
 import { WebView as RNWebView, WebViewProps } from 'react-native-webview'
+import { WebViewErrorEvent } from 'react-native-webview/lib/WebViewTypes'
+import Logger from 'src/utils/Logger'
 
 export type WebViewRef = RNWebView
 
@@ -9,13 +11,22 @@ export type WebViewRef = RNWebView
 const SHOULD_USE_OPACITY_HACK = Platform.OS === 'android' && Platform.Version >= 28
 
 const WebView = React.forwardRef<WebViewRef, WebViewProps>(
-  ({ style, ...passThroughProps }, ref) => {
+  ({ style, onError, ...passThroughProps }, ref) => {
+    function onErrorHandler(event: WebViewErrorEvent) {
+      const { domain, code, description, url } = event.nativeEvent
+      Logger.error(
+        'WebView',
+        `Error: domain:${domain}, code:${code}, description:${description}, url:${url}`
+      )
+      onError?.(event)
+    }
     return (
       <RNWebView
         ref={ref}
         testID="RNWebView"
         {...passThroughProps}
         style={SHOULD_USE_OPACITY_HACK ? [style, styles.opacityHack] : style}
+        onError={onErrorHandler}
       />
     )
   }

--- a/packages/mobile/src/verify/__snapshots__/VerificationEducationScreen.test.tsx.snap
+++ b/packages/mobile/src/verify/__snapshots__/VerificationEducationScreen.test.tsx.snap
@@ -778,6 +778,7 @@ exports[`VerificationEducationScreen shows the \`continue\` button when the user
           messagingEnabled={true}
           messagingModuleName="WebViewMessageHandler2"
           mixedContentMode="always"
+          onError={[Function]}
           onHttpError={[Function]}
           onLoadingError={[Function]}
           onLoadingFinish={[Function]}
@@ -1839,6 +1840,7 @@ exports[`VerificationEducationScreen shows the \`continue\` button when the user
           messagingEnabled={true}
           messagingModuleName="WebViewMessageHandler5"
           mixedContentMode="always"
+          onError={[Function]}
           onHttpError={[Function]}
           onLoadingError={[Function]}
           onLoadingFinish={[Function]}
@@ -2900,6 +2902,7 @@ exports[`VerificationEducationScreen shows the \`skip\` button when already veri
           messagingEnabled={true}
           messagingModuleName="WebViewMessageHandler1"
           mixedContentMode="always"
+          onError={[Function]}
           onHttpError={[Function]}
           onLoadingError={[Function]}
           onLoadingFinish={[Function]}
@@ -3956,6 +3959,7 @@ exports[`VerificationEducationScreen shows the \`skip\` button when user is not 
           messagingEnabled={true}
           messagingModuleName="WebViewMessageHandler3"
           mixedContentMode="always"
+          onError={[Function]}
           onHttpError={[Function]}
           onLoadingError={[Function]}
           onLoadingFinish={[Function]}

--- a/patches/react-native-webview+11.6.5.patch
+++ b/patches/react-native-webview+11.6.5.patch
@@ -1,0 +1,15 @@
+diff --git a/node_modules/react-native-webview/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java b/node_modules/react-native-webview/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+index c9d43d5..8433d99 100644
+--- a/node_modules/react-native-webview/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
++++ b/node_modules/react-native-webview/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+@@ -147,7 +147,9 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
+   // Use `webView.loadUrl("about:blank")` to reliably reset the view
+   // state and release page resources (including any running JavaScript).
+   protected static final String BLANK_URL = "about:blank";
+-  protected static final int SHOULD_OVERRIDE_URL_LOADING_TIMEOUT = 250;
++  // Increasing timeout to 60secs as the original value doesn't work for slower devices
++  // see https://github.com/valora-inc/wallet/issues/2306
++  protected static final int SHOULD_OVERRIDE_URL_LOADING_TIMEOUT = 60000;
+   protected WebViewConfig mWebViewConfig;
+ 
+   protected RNCWebChromeClient mWebChromeClient = null;


### PR DESCRIPTION
### Description

On slower/older Android devices, connecting to Dapps from the in-app WebView would display an error and fail.

This is because the Android WebView mechanism to decide whether to load new urls has a default timeout of 250ms for the JS side to return a value. See https://github.com/react-native-webview/react-native-webview/blob/5e73b2089fc80c2be7aa6eff291b18c81ad4030d/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java#L921-L967

This PR increases the timeout to 60secs which should be way more than enough for slower/older Android devices to respond.

This patch should probably be contributed to [react-native-webview](https://github.com/react-native-webview/react-native-webview) once we confirm it's working as expected on more devices.

I've also added a log to capture WebView errors so we are alerted of similar issues.

### Tested

Connecting to Dapps works within the in-app browser on the Nexus 5 device where I reproduced the issue.

### How others should test

1. Use a slow Android device (Nexus 5, is guaranteed to be able to reproduce this)
2. Open Ubeswap in the dapps browser
3. Connect to Valora
4. Connection should work and the dapp interface should update accordingly.

### Related issues

- Fixes #2306

### Backwards compatibility

Yes