### PR TITLE
Async vulnerability Fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "simple-get": "^4.0.1",
     "plist": "^3.0.5",
     "simple-plist": "^1.3.1",
-    "moment": "^2.29.2"
+    "moment": "^2.29.2",
+    "async": "^3.2.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7505,12 +7505,10 @@ async-retry@^1.3.1, async-retry@^1.3.3:
   dependencies:
     retry "0.13.1"
 
-async@^2.1.2, async@^2.4.0:
-  version "2.6.3"
-  resolved "https://registry.yarnpkg.com/async/-/async-2.6.3.tgz#d72625e2344a3656e3a3ad4fa749fa83299d82ff"
-  integrity sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==
-  dependencies:
-    lodash "^4.17.14"
+async@^2.1.2, async@^2.4.0, async@^3.2.2:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/async/-/async-3.2.3.tgz#ac53dafd3f4720ee9e8a160628f18ea91df196c9"
+  integrity sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==
 
 asynckit@^0.4.0:
   version "0.4.0"


### PR DESCRIPTION
### Description

Resolves to use async version `3.2.2` to address [Prototype Pollution in async](https://github.com/advisories/GHSA-fwr7-v2mv-hh25).

### Other changes

N/A

### Tested

Tested in CI.

### How others should test

This does not need to be tested by QA.

### Related issues

N/A

### Backwards compatibility

Yes