### PR TITLE
fix: change WebView scroll decelerationRate on iOS to match UIScrollView's behavior

### DIFF
--- a/packages/mobile/src/account/__snapshots__/Licenses.test.tsx.snap
+++ b/packages/mobile/src/account/__snapshots__/Licenses.test.tsx.snap
@@ -26,6 +26,7 @@ exports[`Licenses renders correctly 1`] = `
       androidHardwareAccelerationDisabled={false}
       androidLayerType="none"
       cacheEnabled={true}
+      decelerationRate="normal"
       javaScriptEnabled={true}
       messagingEnabled={false}
       messagingModuleName="WebViewMessageHandler1"

--- a/packages/mobile/src/components/WebView.tsx
+++ b/packages/mobile/src/components/WebView.tsx
@@ -24,6 +24,8 @@ const WebView = React.forwardRef<WebViewRef, WebViewProps>(
       <RNWebView
         ref={ref}
         testID="RNWebView"
+        // Matches UIScrollView behavior on iOS
+        decelerationRate="normal"
         {...passThroughProps}
         style={SHOULD_USE_OPACITY_HACK ? [style, styles.opacityHack] : style}
         onError={onErrorHandler}

--- a/packages/mobile/src/verify/__snapshots__/VerificationEducationScreen.test.tsx.snap
+++ b/packages/mobile/src/verify/__snapshots__/VerificationEducationScreen.test.tsx.snap
@@ -774,6 +774,7 @@ exports[`VerificationEducationScreen shows the \`continue\` button when the user
           androidLayerType="none"
           automaticallyAdjustContentInsets={true}
           cacheEnabled={true}
+          decelerationRate="normal"
           javaScriptEnabled={true}
           messagingEnabled={true}
           messagingModuleName="WebViewMessageHandler2"
@@ -1836,6 +1837,7 @@ exports[`VerificationEducationScreen shows the \`continue\` button when the user
           androidLayerType="none"
           automaticallyAdjustContentInsets={true}
           cacheEnabled={true}
+          decelerationRate="normal"
           javaScriptEnabled={true}
           messagingEnabled={true}
           messagingModuleName="WebViewMessageHandler5"
@@ -2898,6 +2900,7 @@ exports[`VerificationEducationScreen shows the \`skip\` button when already veri
           androidLayerType="none"
           automaticallyAdjustContentInsets={true}
           cacheEnabled={true}
+          decelerationRate="normal"
           javaScriptEnabled={true}
           messagingEnabled={true}
           messagingModuleName="WebViewMessageHandler1"
@@ -3955,6 +3958,7 @@ exports[`VerificationEducationScreen shows the \`skip\` button when user is not 
           androidLayerType="none"
           automaticallyAdjustContentInsets={true}
           cacheEnabled={true}
+          decelerationRate="normal"
           javaScriptEnabled={true}
           messagingEnabled={true}
           messagingModuleName="WebViewMessageHandler3"


### PR DESCRIPTION
### Description

On iOS, scrolling WebViews wasn't feeling natural, decelerating too fast. This fixes it.

This should be the default in [react-native-webview](https://github.com/react-native-webview/react-native-webview).

### Tested

**before**

https://user-images.githubusercontent.com/57791/163124078-bc00af14-298f-4574-babe-442b3d37ce13.mp4

**after**

https://user-images.githubusercontent.com/57791/163124206-402f7b43-bb04-4315-909c-c27347741e7b.mp4

### How others should test

The scroll behavior in WebViews should match normal ScrollViews, as seen in the video above.

### Related issues

N/A

### Backwards compatibility

Yes