### PR TITLE
In-app browser updates - correct title, multiple windows on Android

### DIFF
--- a/packages/mobile/src/app/WebViewScreen.test.tsx
+++ b/packages/mobile/src/app/WebViewScreen.test.tsx
@@ -5,9 +5,7 @@ import WebViewScreen from 'src/app/WebViewScreen'
 import MockedNavigator from 'test/MockedNavigator'
 import { createMockStore } from 'test/utils'
 
-const dappName = 'some dapp name'
-const dappHostName = 'somedapp.url'
-const dappUri = `https://${dappHostName}`
+const dappUri = 'https://somedapp.url'
 
 describe('WebViewScreen', () => {
   it('should render the correct components', () => {
@@ -17,15 +15,12 @@ describe('WebViewScreen', () => {
           component={WebViewScreen}
           params={{
             uri: dappUri,
-            headerTitle: dappName,
           }}
         />
       </Provider>
     )
 
     expect(getByText('close')).toBeTruthy()
-    expect(getByText(dappName)).toBeTruthy()
-    expect(getByText(dappHostName)).toBeTruthy()
     expect(getByTestId('RNWebView').props.source.uri).toEqual(dappUri)
     expect(getByTestId('WebViewScreen/Refresh')).toBeTruthy()
     expect(getByTestId('WebViewScreen/GoBack')).toBeDisabled()

--- a/packages/mobile/src/app/WebViewScreen.tsx
+++ b/packages/mobile/src/app/WebViewScreen.tsx
@@ -39,18 +39,6 @@ function WebViewScreen({ route, navigation }: Props) {
   const [canGoBack, setCanGoBack] = useState(false)
   const [canGoForward, setCanGoForward] = useState(false)
 
-  const handleCloseWebView = () => {
-    if (activeDapp) {
-      ValoraAnalytics.track(DappExplorerEvents.dapp_close, {
-        categoryId: activeDapp.categoryId,
-        dappId: activeDapp.id,
-        dappName: activeDapp.name,
-        section: activeDapp.openedFrom,
-      })
-    }
-    navigateBack()
-  }
-
   const handleSetNavigationTitle = useCallback(
     (uri: string, title: string) => {
       const { hostname } = parse(uri)
@@ -67,7 +55,7 @@ function WebViewScreen({ route, navigation }: Props) {
       headerLeft: () => (
         <TopBarTextButton
           title={t('close')}
-          onPress={handleCloseWebView}
+          onPress={navigateBack}
           titleStyle={{ color: colors.gray4 }}
         />
       ),
@@ -83,6 +71,12 @@ function WebViewScreen({ route, navigation }: Props) {
       // refreshed in the future
       if (activeDapp) {
         dispatch(dappSessionEnded())
+        ValoraAnalytics.track(DappExplorerEvents.dapp_close, {
+          categoryId: activeDapp.categoryId,
+          dappId: activeDapp.id,
+          dappName: activeDapp.name,
+          section: activeDapp.openedFrom,
+        })
       }
     }
   }, [])
@@ -132,7 +126,6 @@ function WebViewScreen({ route, navigation }: Props) {
         ref={webViewRef}
         originWhitelist={['https://*', 'celo://*']}
         onShouldStartLoadWithRequest={handleLoadRequest}
-        setSupportMultipleWindows={false}
         source={{ uri }}
         startInLoadingState={true}
         renderLoading={() => <ActivityIndicator style={styles.loading} size="large" />}

--- a/packages/mobile/src/app/WebViewScreen.tsx
+++ b/packages/mobile/src/app/WebViewScreen.tsx
@@ -101,7 +101,7 @@ function WebViewScreen({ route, navigation }: Props) {
     if (canGoBack) {
       handleGoBack()
     } else {
-      handleCloseWebView()
+      navigateBack()
     }
     return true
   }, [canGoBack, webViewRef.current, navigation])

--- a/packages/mobile/src/app/saga.ts
+++ b/packages/mobile/src/app/saga.ts
@@ -309,7 +309,7 @@ export function* handleOpenUrl(action: OpenUrlAction) {
 }
 
 export function* handleOpenDapp(action: DappSelected) {
-  const { dappUrl, name } = action.dapp
+  const { dappUrl } = action.dapp
   const dappsWebViewEnabled = yield select(dappsWebViewEnabledSelector)
 
   if (dappsWebViewEnabled) {

--- a/packages/mobile/src/app/saga.ts
+++ b/packages/mobile/src/app/saga.ts
@@ -317,7 +317,7 @@ export function* handleOpenDapp(action: DappSelected) {
     if (isDeepLink(dappUrl) || (walletConnectEnabled && isWalletConnectDeepLink(dappUrl))) {
       yield call(handleDeepLink, openDeepLink(dappUrl, true))
     } else {
-      navigate(Screens.WebViewScreen, { uri: dappUrl, headerTitle: name })
+      navigate(Screens.WebViewScreen, { uri: dappUrl })
     }
   } else {
     yield call(handleOpenUrl, openUrl(dappUrl, true, true))

--- a/packages/mobile/src/dappkit/dappkit.ts
+++ b/packages/mobile/src/dappkit/dappkit.ts
@@ -76,7 +76,6 @@ function* handleNavigationWithDeeplink(dappkitDeeplink: string) {
     yield put(showMessage(i18n.t('inAppConnectionSuccess', { dappName: activeDapp.name })))
     navigate(Screens.WebViewScreen, {
       uri: activeDapp.dappUrl,
-      headerTitle: activeDapp.name,
       dappkitDeeplink,
     })
   } else {

--- a/packages/mobile/src/navigator/Headers.tsx
+++ b/packages/mobile/src/navigator/Headers.tsx
@@ -30,6 +30,7 @@ export const noHeaderGestureDisabled: StackNavigationOptions = {
 export const styles = StyleSheet.create({
   headerTitle: {
     ...fontStyles.navigationHeader,
+    maxWidth: 220,
   },
   headerSubTitle: {
     color: colors.gray4,
@@ -194,8 +195,16 @@ export function HeaderTitleWithSubtitle({
 }) {
   return (
     <View style={styles.header} testID={testID}>
-      {title && <Text style={styles.headerTitle}>{title}</Text>}
-      {subTitle && <Text style={styles.headerSubTitle}>{subTitle}</Text>}
+      {title && (
+        <Text style={styles.headerTitle} numberOfLines={1}>
+          {title}
+        </Text>
+      )}
+      {subTitle && (
+        <Text style={styles.headerSubTitle} numberOfLines={1}>
+          {subTitle}
+        </Text>
+      )}
     </View>
   )
 }

--- a/packages/mobile/src/navigator/types.tsx
+++ b/packages/mobile/src/navigator/types.tsx
@@ -329,7 +329,7 @@ export type StackParamList = {
     dappIcon: string
   }
   [Screens.WalletHome]: undefined
-  [Screens.WebViewScreen]: { uri: string; headerTitle?: string; dappkitDeeplink?: string }
+  [Screens.WebViewScreen]: { uri: string; dappkitDeeplink?: string }
   [Screens.Welcome]: undefined
   [Screens.WithdrawCeloQrScannerScreen]: {
     onAddressScanned: (address: string) => void


### PR DESCRIPTION
### Description

Tweaks to the in-app browser:
1. enable multiple tabs on android so that links with `target="_blank"` can be opened in the appropriate installed app. This fixes some reports of social media apps like Twitter opening in the browser on Android. Note that if the dapp has not implemented the `target="_blank"` on their social media links, this won't work.
2. ensure that the screen title always reflects the page displayed, so that it is clear when dapps link to other dapps
3. move close analytics event to the screen unmount callback so that android native back/swipe back actions can also be tracked


https://user-images.githubusercontent.com/20150449/163157966-435b1fd1-993f-4040-b9fa-023f0140a048.mp4



### Other changes

N/A

### Tested

Manually


### How others should test

1. Go to some dapps and click around. *Please do this on iOS AND Android*. Check that the screen title is expected, and that links open in external apps as expected. Some ideas:
- Ubeswap - go to the menu and launch an app under the "bridge" section, and verify that it opens in an external browser on Android, and internally on iOS with a modified screen title
- ChurritoFi - go to the twitter link and ensure that clicking on it opens the Twitter app (please have the twitter app installed)


### Related issues

N/A

### Backwards compatibility

Yes