### PR TITLE
Fix webview crash on iOS due to missing page title during loading

### DIFF
--- a/packages/mobile/src/app/WebViewScreen.tsx
+++ b/packages/mobile/src/app/WebViewScreen.tsx
@@ -50,7 +50,8 @@ function WebViewScreen({ route, navigation }: Props) {
         // when first loading, the title of the webpage is unknown and the title
         // defaults to the url - display a loading placeholder in this case
         const parsedTitleUrl = parse(title)
-        displayedTitle = parsedTitleUrl.protocol && parsedTitleUrl.hostname ? t('loading') : title
+        displayedTitle =
+          !title || (parsedTitleUrl.protocol && parsedTitleUrl.hostname) ? t('loading') : title
       } catch (error) {
         Logger.error(
           'WebViewScreen',


### PR DESCRIPTION
### Description

Title says it all, during page load the title is never empty for Android but is empty for iOS. Needed to update the display title condition so that iOS correctly displays "Loading"

### Other changes

N/A

### Tested

Manually on iOS and Android


### How others should test

N/A

### Related issues

N/A

### Backwards compatibility

Yes