### PR TITLE
ci(emerge): fix PR number sent as "undefined" for non PR builds

### DIFF
--- a/.github/scripts/uploadE2eBuildToEmerge.ts
+++ b/.github/scripts/uploadE2eBuildToEmerge.ts
@@ -74,6 +74,6 @@ $.exec(`bundle exec fastlane run emerge \
   sha:${sha} \
   base_sha:${baseSha} \
   branch:${branchName} \
-  pr_number:${prNumber} \
+  pr_number:${prNumber || ''} \
   build_type:e2e
 `)


### PR DESCRIPTION
### Description

Quick follow up to #2317 to avoid showing `undefined` in the Emerge dashboard for non PR builds.

<img width="210" alt="Screenshot 2022-04-15 at 09 43 17" src="https://user-images.githubusercontent.com/57791/163544132-ab2ff3e6-7f27-4e6c-a2da-24aa153cab94.png">

### Tested

Once it lands on main.

### How others should test

N/A

### Related issues

N/A

### Backwards compatibility

Yes