### PR TITLE
Only run emerge on pull request and push

### DIFF
--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -135,8 +135,8 @@ jobs:
           yarn detox build -c ios.release
       - name: Upload Detox Build to Emerge
         if: |
-          ${{ env.SECRETS_AVAILABLE }} &&
-          (github.event_name == 'pull_request' || github.event_name == 'push')
+          env.SECRETS_AVAILABLE
+            && (github.event_name == 'pull_request' || github.event_name == 'push')
         run: yarn ts-node .github/scripts/uploadE2eBuildToEmerge.ts
         env:
           EMERGE_API_TOKEN: ${{ steps.google-secrets.outputs.EMERGE_API_TOKEN }}

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -134,7 +134,9 @@ jobs:
           export CELO_TEST_CONFIG=e2e
           yarn detox build -c ios.release
       - name: Upload Detox Build to Emerge
-        if: ${{ env.SECRETS_AVAILABLE }}
+        if: |
+          ${{ env.SECRETS_AVAILABLE }} &&
+          (github.event_name == 'pull_request' || github.event_name == 'push')
         run: yarn ts-node .github/scripts/uploadE2eBuildToEmerge.ts
         env:
           EMERGE_API_TOKEN: ${{ steps.google-secrets.outputs.EMERGE_API_TOKEN }}


### PR DESCRIPTION
### Description

Emerge runs were failing on scheduled e2e work flows. This would also be the case with manual workflow dispatches. This PR sets Emerge to only run on pull requests and pushes. [Sample failing scheduled run](https://github.com/valora-inc/wallet/runs/6068125862?check_suite_focus=true).

### Other changes

N/A

### Tested

Tested in CI.

### How others should test

This does not need to be tested by QA. Reviewers should observe the following actions.
- [Dispatched](https://github.com/valora-inc/wallet/runs/6103161398)

### Related issues

N/A

### Backwards compatibility

Yes