### PR TITLE
Use signed typed data for registration endpoint auth

### DIFF
--- a/packages/mobile/src/account/saga.test.ts
+++ b/packages/mobile/src/account/saga.test.ts
@@ -14,7 +14,7 @@ import { getFinclusiveComplianceStatus } from 'src/in-house-liquidity'
 import { userLocationDataSelector } from 'src/networkInfo/selectors'
 import { retrieveSignedMessage, storeSignedMessage } from 'src/pincode/authentication'
 import Logger from 'src/utils/Logger'
-import { getWallet } from 'src/web3/contracts'
+import { getContractKit, getWallet } from 'src/web3/contracts'
 import { getWalletAddress, unlockAccount, UnlockResult } from 'src/web3/saga'
 import { walletAddressSelector } from 'src/web3/selectors'
 import { mockAccount, mockWallet } from 'test/values'
@@ -95,6 +95,11 @@ describe('handleUpdateAccountRegistration', () => {
 
 describe('generateSignedMessage', () => {
   const address = '0x3460806908173E6291960662c17592D423Fb22e5'
+  const contractKit = {
+    connection: {
+      chainId: jest.fn(() => '12345'),
+    },
+  }
 
   beforeEach(() => {
     jest.clearAllMocks()
@@ -113,7 +118,8 @@ describe('generateSignedMessage', () => {
         [select(walletAddressSelector), address],
         [call(getWallet), mockWallet],
         [call(unlockAccount, address), UnlockResult.SUCCESS],
-        [matchers.call.fn(mockWallet.signPersonalMessage), 'someSignedMessage'],
+        [call(getContractKit), contractKit],
+        [matchers.call.fn(mockWallet.signTypedData), 'someSignedMessage'],
         [call(storeSignedMessage, 'someSignedMessage'), undefined],
       ])
       .put(saveSignedMessage())


### PR DESCRIPTION
### Description

For the registration endpoint, we currently use a signed message for authentication. As previously discussed, the main security concern with a signed message is “domain collisions” where a message signed for one purpose/context overlaps with a message signed for a different purpose/context. Therefore, this PR uses a signed typed message instead.

Corresponding backend PR https://github.com/valora-inc/valora-rest-api/pull/80 (these should be merged together to avoid breaking changes)


### Other changes

N/A

### Tested

Manually + updated unit tests


### How others should test

N/A

### Related issues

N/A

### Backwards compatibility

N/A