### PR TITLE
Mock user location data in E2E tests

### DIFF
--- a/packages/mobile/e2e/src/usecases/OffRamps.js
+++ b/packages/mobile/e2e/src/usecases/OffRamps.js
@@ -1,24 +1,19 @@
 import { DEFAULT_RECIPIENT_ADDRESS } from '../utils/consts'
 import { reloadReactNative } from '../utils/retries'
-import { enterPinUiIfNecessary, sleep } from '../utils/utils'
+import { enterPinUiIfNecessary, sleep, waitForElementId } from '../utils/utils'
 
 export default offRamps = () => {
   beforeEach(async () => {
     await reloadReactNative()
     await element(by.id('Hamburger')).tap()
     await element(by.id('add-and-withdraw')).tap()
-    // Waiting for element to be visible for up to 5 seconds before tap
-    await waitFor(element(by.id('cashOut')))
-      .toBeVisible()
-      .withTimeout(10 * 1000)
+    await waitForElementId('cashOut')
     await element(by.id('cashOut')).tap()
   })
 
   describe('cUSD', () => {
     beforeEach(async () => {
-      await waitFor(element(by.id('radio/cUSD')))
-        .toBeVisible()
-        .withTimeout(10 * 1000)
+      await waitForElementId('radio/cUSD')
       await element(by.id('radio/cUSD')).tap()
     })
 
@@ -29,28 +24,25 @@ export default offRamps = () => {
       })
 
       it('Then Should Be Display No Providers Message', async () => {
-        await waitFor(element(by.id('FiatExchangeInput')))
-          .toBeVisible()
-          .withTimeout(10 * 1000)
+        await waitForElementId('FiatExchangeInput')
         // Enter Amount to Exchange
         await element(by.id('FiatExchangeInput')).replaceText('2')
         // Got To Exchanges
         await element(by.id('FiatExchangeNextButton')).tap()
         // Check Page Elements
-        await waitFor(element(by.id('noProviders')))
-          .toBeVisible()
-          .withTimeout(10 * 1000)
+        await waitForElementId('noProviders')
         await expect(element(by.id('ContactSupport'))).toBeVisible()
       })
     })
 
-    describe.skip('When Gift Cards and Mobile Top Up Selected', () => {
+    describe('When Gift Cards and Mobile Top Up Selected', () => {
       beforeEach(async () => {
         await element(by.id('receiveWithBidali')).tap()
         await element(by.text('Next')).tap()
       })
 
       it('Then Bidali Should Display', async () => {
+        await waitForElementId('RNWebView')
         await expect(element(by.text('Bidali'))).toBeVisible()
       })
     })
@@ -62,21 +54,18 @@ export default offRamps = () => {
       })
 
       it('Then Should Display Exchanges', async () => {
-        await waitFor(element(by.id('provider-Bittrex')))
-          .toBeVisible()
-          .withTimeout(20 * 1000)
-        await expect(element(by.id('provider-Bittrex'))).toBeVisible()
-        await expect(element(by.id('provider-CoinList Pro'))).toBeVisible()
-        await expect(element(by.id('provider-OKCoin'))).toBeVisible()
+        await waitForElementId('provider-KuCoin')
+        await expect(element(by.id('provider-Bittrex'))).toExist()
+        await expect(element(by.id('provider-CoinList Pro'))).toExist()
+        await expect(element(by.id('provider-OKCoin'))).toExist()
+        await expect(element(by.id('provider-Blockchain.com'))).toExist()
       })
     })
   })
 
   describe('cEUR', () => {
     beforeEach(async () => {
-      await waitFor(element(by.id('radio/cEUR')))
-        .toBeVisible()
-        .withTimeout(10 * 1000)
+      await waitForElementId('radio/cEUR')
       await element(by.id('radio/cEUR')).tap()
     })
 
@@ -86,9 +75,8 @@ export default offRamps = () => {
         await element(by.text('Next')).tap()
       })
 
-      // TODO (Tom): figure out why running this test is causing detox connection issues with the app
-      // Most likely culprits is the internal webview we use not playing nice with detox
-      it.skip('Then Display Bidali', async () => {
+      it('Then Bidali Should Display', async () => {
+        await waitForElementId('RNWebView')
         await expect(element(by.text('Bidali'))).toBeVisible()
       })
     })
@@ -99,24 +87,16 @@ export default offRamps = () => {
         await element(by.id('GoToProviderButton')).tap()
       })
 
-      it('Then Should Display No Exchanges Available Text', async () => {
-        // Check page elements
-        await expect(element(by.id('NoExchanges'))).toHaveText(
-          'There are no exchanges available for cEUR in your region.'
-        )
-
-        // Check presence of buttons
-        await expect(element(by.id('SwitchCurrency'))).toBeVisible()
-        await expect(element(by.id('ContactSupport'))).toBeVisible()
+      it('Then Should Display Exchanges', async () => {
+        await waitForElementId('provider-KuCoin')
+        await expect(element(by.id('provider-Blockchain.com'))).toExist()
       })
     })
   })
 
   describe('CELO', () => {
     beforeEach(async () => {
-      await waitFor(element(by.id('radio/CELO')))
-        .toBeVisible()
-        .withTimeout(10 * 1000)
+      await waitForElementId('radio/CELO')
       await element(by.id('radio/CELO')).tap()
     })
 
@@ -150,7 +130,6 @@ export default offRamps = () => {
         // await waitFor(target)
         //   .toBeVisible()
         //   .withTimeout(30 * 1000)
-        // await expect(target).toBeVisible()
       })
     })
 

--- a/packages/mobile/e2e/src/usecases/OnRamps.js
+++ b/packages/mobile/e2e/src/usecases/OnRamps.js
@@ -1,4 +1,5 @@
 import { reloadReactNative } from '../utils/retries'
+import { waitForElementId } from '../utils/utils'
 
 export default onRamps = () => {
   beforeEach(async () => {
@@ -10,9 +11,7 @@ export default onRamps = () => {
 
   describe('cUSD', () => {
     beforeEach(async () => {
-      await waitFor(element(by.id('radio/cUSD')))
-        .toBeVisible()
-        .withTimeout(10 * 1000)
+      await waitForElementId('radio/cUSD')
       await element(by.id('radio/cUSD')).tap()
     })
 
@@ -20,16 +19,23 @@ export default onRamps = () => {
       beforeEach(async () => {
         await element(by.id('payWithCard')).tap()
         await element(by.text('Next')).tap()
-        await element(by.id('FiatExchangeInput')).replaceText('$50')
-        await element(by.id('FiatExchangeNextButton')).tap()
       })
 
-      jest.retryTimes(2)
       it('Then Should Display Providers', async () => {
-        await waitFor(element(by.id('Provider/Simplex')))
-          .toBeVisible()
-          .withTimeout(30 * 1000)
-        await expect(element(by.id('Icon/Simplex'))).toExist()
+        await element(by.id('FiatExchangeInput')).replaceText('50')
+        await element(by.id('FiatExchangeNextButton')).tap()
+        // Ramp displays with with fee
+        await waitForElementId('Provider/Ramp')
+        await waitForElementId('Icon/Ramp')
+        await expect(element(by.id('ProviderFee/Ramp'))).toHaveText('$1.46')
+        // Simplex displays with fee
+        await waitForElementId('Provider/Simplex')
+        await waitForElementId('Icon/Simplex')
+        await expect(element(by.id('ProviderFee/Simplex'))).toHaveText('$10.00')
+        // Transak, Moonpay, Xanpool should not displayed
+        await expect(element(by.id('Provider/Transak'))).not.toExist()
+        await expect(element(by.id('Provider/Moonpay'))).not.toExist()
+        await expect(element(by.id('Provider/Xanpool'))).not.toExist()
       })
     })
 
@@ -37,77 +43,24 @@ export default onRamps = () => {
       beforeEach(async () => {
         await element(by.id('payWithBank')).tap()
         await element(by.text('Next')).tap()
-        await element(by.id('FiatExchangeInput')).replaceText('$50')
-        await element(by.id('FiatExchangeNextButton')).tap()
       })
 
-      jest.retryTimes(2)
       it('Then Should Display Providers', async () => {
-        await waitFor(element(by.id('Provider/Simplex')))
-          .toBeVisible()
-          .withTimeout(30 * 1000)
-        await expect(element(by.id('Icon/Simplex'))).toExist()
-      })
-    })
-
-    describe.skip('When Cryptocurrency Exchange Selected', () => {
-      beforeEach(async () => {
-        await element(by.id('withExchange')).tap()
-        await element(by.text('Next')).tap()
-      })
-
-      jest.retryTimes(2)
-      it('Then Should Display Exchanges & Recovery Phrase', async () => {
-        await waitFor(element(by.id('Bittrex')))
-          .toBeVisible()
-          .withTimeout(20 * 1000)
-        await expect(element(by.id('Bittrex'))).toBeVisible()
-        await expect(element(by.id('CoinList Pro'))).toBeVisible()
-        await expect(element(by.id('OKCoin'))).toBeVisible()
-        await expect(element(by.id('accountBox'))).toBeVisible()
-      })
-    })
-  })
-
-  describe('CELO', () => {
-    beforeEach(async () => {
-      await waitFor(element(by.id('radio/CELO')))
-        .toBeVisible()
-        .withTimeout(10 * 1000)
-      await element(by.id('radio/CELO')).tap()
-    })
-
-    describe('When Debit Card Selected', () => {
-      beforeEach(async () => {
-        await element(by.id('payWithCard')).tap()
-        await element(by.text('Next')).tap()
         await element(by.id('FiatExchangeInput')).replaceText('50')
         await element(by.id('FiatExchangeNextButton')).tap()
-      })
-
-      jest.retryTimes(2)
-      it('Then Should Display Providers', async () => {
-        await waitFor(element(by.id('Provider/Simplex')))
-          .toBeVisible()
-          .withTimeout(30 * 1000)
-        await expect(element(by.id('Icon/Simplex'))).toExist()
-      })
-    })
-
-    describe('When Bank Account Selected', () => {
-      beforeEach(async () => {
-        await element(by.id('payWithBank')).tap()
-        await element(by.text('Next')).tap()
-        await element(by.id('FiatExchangeInput')).replaceText('50')
-        await element(by.id('FiatExchangeNextButton')).tap()
-      })
-
-      jest.retryTimes(2)
-      it('Then Should Display Providers', async () => {
-        await waitFor(element(by.id('Provider/Simplex')))
-          .toBeVisible()
-          .withTimeout(30 * 1000)
-        await expect(element(by.id('Icon/Simplex'))).toExist()
+        // Ramp displays with with fee
+        await waitForElementId('Provider/Ramp')
+        await waitForElementId('Icon/Ramp')
+        await expect(element(by.id('ProviderFee/Ramp'))).toHaveText('$1.46')
+        // Simplex displays restricted with fee
+        await waitForElementId('Provider/Simplex')
+        await waitForElementId('Icon/Simplex')
+        await expect(element(by.id('ProviderFee/Simplex'))).toHaveText('$10.00')
+        await expect(element(by.id('RestrictedText/Simplex'))).toBeVisible()
+        // Transak, Moonpay, Xanpool should not displayed
+        await expect(element(by.id('Provider/Transak'))).not.toExist()
+        await expect(element(by.id('Provider/Moonpay'))).not.toExist()
+        await expect(element(by.id('Provider/Xanpool'))).not.toExist()
       })
     })
 
@@ -117,18 +70,160 @@ export default onRamps = () => {
         await element(by.text('Next')).tap()
       })
 
-      jest.retryTimes(2)
       it('Then Should Display Exchanges & Account Address', async () => {
-        await waitFor(element(by.id('provider-Binance')))
-          .toBeVisible()
-          .withTimeout(30 * 1000)
-        await expect(element(by.id('provider-Binance'))).toBeVisible()
-        await expect(element(by.id('provider-Bittrex'))).toBeVisible()
-        await expect(element(by.id('provider-Coinbase (CELO as CGLD)'))).toBeVisible()
-        await expect(element(by.id('provider-Coinbase Pro (CELO as CGLD)'))).toBeVisible()
-        await expect(element(by.id('provider-CoinList Pro'))).toBeVisible()
-        await expect(element(by.id('provider-OKCoin'))).toBeVisible()
-        await expect(element(by.id('accountBox'))).toBeVisible()
+        await waitForElementId('accountBox')
+        await expect(element(by.id('provider-KuCoin'))).toExist()
+        await expect(element(by.id('provider-Bittrex'))).toExist()
+        await expect(element(by.id('provider-CoinList Pro'))).toExist()
+        await expect(element(by.id('provider-OKCoin'))).toExist()
+        await expect(element(by.id('provider-Blockchain.com'))).toExist()
+      })
+    })
+  })
+
+  describe('cEUR', () => {
+    beforeEach(async () => {
+      await waitForElementId('radio/cEUR')
+      await element(by.id('radio/cEUR')).tap()
+    })
+
+    describe('When Debit Card Selected', () => {
+      beforeEach(async () => {
+        await element(by.id('payWithCard')).tap()
+        await element(by.text('Next')).tap()
+      })
+
+      it('Then Should Display Providers', async () => {
+        await element(by.id('FiatExchangeInput')).replaceText('50')
+        await element(by.id('FiatExchangeNextButton')).tap()
+        // Ramp displays with with fee
+        await waitForElementId('Provider/Ramp')
+        await waitForElementId('Icon/Ramp')
+        await expect(element(by.id('ProviderFee/Ramp'))).toExist()
+        // Transak, Moonpay, Xanpool, Simplex should not displayed
+        await expect(element(by.id('Provider/Transak'))).not.toExist()
+        await expect(element(by.id('Provider/Moonpay'))).not.toExist()
+        await expect(element(by.id('Provider/Xanpool'))).not.toExist()
+        await expect(element(by.id('Provider/Simplex'))).not.toExist()
+      })
+    })
+
+    describe('When Bank Account Selected', () => {
+      beforeEach(async () => {
+        await element(by.id('payWithBank')).tap()
+        await element(by.text('Next')).tap()
+      })
+
+      it('Then Should Display Providers', async () => {
+        await element(by.id('FiatExchangeInput')).replaceText('50')
+        await element(by.id('FiatExchangeNextButton')).tap()
+        // Ramp displays with with fee
+        await waitForElementId('Provider/Ramp')
+        await waitForElementId('Icon/Ramp')
+        await expect(element(by.id('ProviderFee/Ramp'))).toExist()
+        // Transak, Moonpay, Xanpool, Simplex should not displayed
+        await expect(element(by.id('Provider/Transak'))).not.toExist()
+        await expect(element(by.id('Provider/Moonpay'))).not.toExist()
+        await expect(element(by.id('Provider/Xanpool'))).not.toExist()
+        await expect(element(by.id('Provider/Simplex'))).not.toExist()
+      })
+    })
+
+    describe('When Cryptocurrency Exchange Selected', () => {
+      beforeEach(async () => {
+        await element(by.id('withExchange')).tap()
+        await element(by.text('Next')).tap()
+      })
+
+      it('Then Should Display Exchanges & Account Address', async () => {
+        await waitForElementId('accountBox')
+        await expect(element(by.id('provider-KuCoin'))).toExist()
+        await expect(element(by.id('provider-Blockchain.com'))).toExist()
+      })
+    })
+  })
+
+  describe('CELO', () => {
+    beforeEach(async () => {
+      await waitForElementId('radio/CELO')
+      await element(by.id('radio/CELO')).tap()
+    })
+
+    describe('When Debit Card Selected', () => {
+      beforeEach(async () => {
+        await element(by.id('payWithCard')).tap()
+        await element(by.text('Next')).tap()
+      })
+
+      it('Then Should Display Providers', async () => {
+        await element(by.id('FiatExchangeInput')).replaceText('50')
+        await element(by.id('FiatExchangeNextButton')).tap()
+        // Ramp displays with with fee
+        await waitForElementId('Provider/Ramp')
+        await waitForElementId('Icon/Ramp')
+        await expect(element(by.id('ProviderFee/Ramp'))).toExist()
+        // Simplex displays with fee
+        await waitForElementId('Provider/Simplex')
+        await waitForElementId('Icon/Simplex')
+        await expect(element(by.id('ProviderFee/Simplex'))).toHaveText('$10.00')
+        // Transak, Moonpay, Xanpool should not displayed
+        await expect(element(by.id('Provider/Transak'))).not.toExist()
+        await expect(element(by.id('Provider/Moonpay'))).not.toExist()
+        await expect(element(by.id('Provider/Xanpool'))).not.toExist()
+      })
+    })
+
+    describe('When Bank Account Selected', () => {
+      beforeEach(async () => {
+        await element(by.id('payWithBank')).tap()
+        await element(by.text('Next')).tap()
+      })
+
+      it('Then Should Display Providers', async () => {
+        await element(by.id('FiatExchangeInput')).replaceText('50')
+        await element(by.id('FiatExchangeNextButton')).tap()
+        // Ramp displays with with fee
+        await waitForElementId('Provider/Ramp')
+        await waitForElementId('Icon/Ramp')
+        await expect(element(by.id('ProviderFee/Ramp'))).toExist()
+        // Simplex displays restricted with fee
+        await waitForElementId('Provider/Simplex')
+        await waitForElementId('Icon/Simplex')
+        await expect(element(by.id('ProviderFee/Simplex'))).toHaveText('$10.00')
+        await expect(element(by.id('RestrictedText/Simplex'))).toBeVisible()
+        // Transak, Moonpay, Xanpool should not displayed
+        await expect(element(by.id('Provider/Transak'))).not.toExist()
+        await expect(element(by.id('Provider/Moonpay'))).not.toExist()
+        await expect(element(by.id('Provider/Xanpool'))).not.toExist()
+      })
+    })
+
+    describe('When Cryptocurrency Exchange Selected', () => {
+      beforeEach(async () => {
+        await element(by.id('withExchange')).tap()
+        await element(by.text('Next')).tap()
+      })
+
+      it('Then Should Display Exchanges & Account Address', async () => {
+        await waitForElementId('accountBox')
+        await expect(element(by.id('provider-Binance'))).toExist()
+        await expect(element(by.id('provider-Gate.io'))).toExist()
+        await expect(element(by.id('provider-Coinbase (CELO as CGLD)'))).toExist()
+        await expect(element(by.id('provider-Coinbase Pro (CELO as CGLD)'))).toExist()
+        await expect(element(by.id('provider-KuCoin'))).toExist()
+        await expect(element(by.id('provider-Bittrex'))).toExist()
+        await expect(element(by.id('provider-CoinList Pro'))).toExist()
+        await expect(element(by.id('provider-Huobi'))).toExist()
+        await expect(element(by.id('provider-OKCoin'))).toExist()
+        await expect(element(by.id('provider-OKEx'))).toExist()
+        await expect(element(by.id('provider-LBank'))).toExist()
+        await expect(element(by.id('provider-Mexc'))).toExist()
+        await expect(element(by.id('provider-ZB.com'))).toExist()
+        await expect(element(by.id('provider-Hoo.com'))).toExist()
+        await expect(element(by.id('provider-Blockchain.com'))).toExist()
+        await expect(element(by.id('provider-Bitmart'))).toExist()
+        await expect(element(by.id('provider-Changelly'))).toExist()
+        await expect(element(by.id('provider-Bitpanda'))).toExist()
       })
     })
   })

--- a/packages/mobile/src/fiatExchanges/ProviderOptionsScreen.tsx
+++ b/packages/mobile/src/fiatExchanges/ProviderOptionsScreen.tsx
@@ -276,7 +276,10 @@ function ProviderOptionsScreen({ route, navigation }: Props) {
                           {!provider.unavailable &&
                             !provider.restricted &&
                             !provider.paymentMethods.includes(paymentMethod) && (
-                              <Text style={styles.restrictedText}>
+                              <Text
+                                testID={`RestrictedText/${provider.name}`}
+                                style={styles.restrictedText}
+                              >
                                 {t('unsupportedPaymentMethod', {
                                   paymentMethod:
                                     paymentMethod === PaymentMethod.Bank
@@ -289,7 +292,9 @@ function ProviderOptionsScreen({ route, navigation }: Props) {
                       </View>
                     </View>
                     <View style={styles.feeContainer}>
-                      <Text style={styles.text}>{renderFeeAmount(provider.quote)}</Text>
+                      <Text testID={`ProviderFee/${provider.name}`} style={styles.text}>
+                        {renderFeeAmount(provider.quote)}
+                      </Text>
                     </View>
                   </View>
                 </ListItem>

--- a/packages/mobile/src/fiatExchanges/__snapshots__/ProviderOptionsScreen.test.tsx.snap
+++ b/packages/mobile/src/fiatExchanges/__snapshots__/ProviderOptionsScreen.test.tsx.snap
@@ -388,6 +388,7 @@ exports[`ProviderOptionsScreen renders correctly when there are providers 2`] = 
                         "lineHeight": 22,
                       }
                     }
+                    testID="ProviderFee/Simplex"
                   >
                     <Text
                       style={
@@ -550,6 +551,7 @@ exports[`ProviderOptionsScreen renders correctly when there are providers 2`] = 
                         "lineHeight": 22,
                       }
                     }
+                    testID="ProviderFee/Ramp"
                   >
                     free
                   </Text>
@@ -694,6 +696,7 @@ exports[`ProviderOptionsScreen renders correctly when there are providers 2`] = 
                         "lineHeight": 22,
                       }
                     }
+                    testID="ProviderFee/Moonpay"
                   >
                     <Text
                       style={
@@ -873,6 +876,7 @@ exports[`ProviderOptionsScreen renders correctly when there are providers 2`] = 
                         "lineHeight": 22,
                       }
                     }
+                    testID="ProviderFee/Transak"
                   >
                     <Text
                       style={

--- a/packages/mobile/src/networkInfo/saga.ts
+++ b/packages/mobile/src/networkInfo/saga.ts
@@ -4,6 +4,7 @@ import { getIpAddress } from 'react-native-device-info'
 import { eventChannel } from 'redux-saga'
 import { call, cancelled, put, select, spawn, take } from 'redux-saga/effects'
 import { defaultCountryCodeSelector } from 'src/account/selectors'
+import { isE2EEnv } from 'src/config'
 import networkConfig from 'src/geth/networkConfig'
 import { setNetworkConnectivity, updateUserLocationData } from 'src/networkInfo/actions'
 import { fetchWithTimeout } from 'src/utils/fetchWithTimeout'
@@ -25,6 +26,12 @@ function createNetworkStatusChannel() {
   return eventChannel((emit) => {
     return NetInfo.addEventListener((state) => emit(state))
   })
+}
+
+const MOCK_USER_LOCATION = {
+  countryCodeAlpha2: 'US',
+  region: 'CA',
+  ipAddress: '196.17.37.246',
 }
 
 const isConnected = (connectionInfo: NetInfoState) => {
@@ -84,7 +91,9 @@ export function* fetchUserLocationData() {
     userLocationData = { countryCodeAlpha2, region: null, ipAddress }
   }
 
-  yield put(updateUserLocationData(userLocationData))
+  yield isE2EEnv
+    ? put(updateUserLocationData(MOCK_USER_LOCATION))
+    : put(updateUserLocationData(userLocationData))
 }
 
 export function* networkInfoSaga() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -20672,9 +20672,9 @@ tmp@^0.0.31:
     os-tmpdir "~1.0.1"
 
 tmpl@1.0.x:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/tmpl/-/tmpl-1.0.4.tgz#23640dd7b42d00433911140820e5cf440e521dd1"
-  integrity sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/tmpl/-/tmpl-1.0.5.tgz#8683e0b902bb9c20c4f726e3c0b69f36518c07cc"
+  integrity sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==
 
 to-arraybuffer@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
### Description

Mocks the user location data so a consistent list of providers and exchanges are served during the e2e tests. This will make it easier to run tests locally regardless of developer location while still testing the integration of services dependent on user location.

### Other changes

- Snapshots updated
- Additional tests for Bidali and Providers added.
- Includes changes from #2398 to unblock CI.

### Tested

Tested locally on iOS.

### How others should test

Run the E2E tests locally and ensure that they pass.

### Related issues

N/A

### Backwards compatibility

Yes