### PR TITLE
ci: speed up e2e workflow

### DIFF
--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -40,8 +40,6 @@ jobs:
         run: yarn
       - name: Fail if someone forgot to commit "yarn.lock"
         run: git diff --exit-code
-      - name: Build mobile dependencies
-        run: yarn build --scope @celo/mobile --include-filtered-dependencies
       - name: Make jest available
         working-directory: ${{env.working-directory}}
         run: cp ../../node_modules/.bin/jest node_modules/.bin/
@@ -123,8 +121,6 @@ jobs:
         run: bundle exec pod install || bundle exec pod install --repo-update
       - name: Fail if someone forgot to commit "Podfile.lock"
         run: git diff --exit-code
-      - name: Build mobile dependencies
-        run: yarn build --scope @celo/mobile --include-filtered-dependencies
       - name: Make jest available
         working-directory: ${{env.working-directory}}
         run: cp ../../node_modules/.bin/jest node_modules/.bin/


### PR DESCRIPTION
### Description

The build step is not necessary anymore before running e2e tests.
This saves ~1m30secs in the e2e workflow.

### Tested

CI passes

### How others should test

N/A

### Related issues

N/A

### Backwards compatibility

Yes