### PR TITLE
Fix mismatch in WebView page title and host

### DIFF
--- a/packages/mobile/src/app/WebViewScreen.tsx
+++ b/packages/mobile/src/app/WebViewScreen.tsx
@@ -41,7 +41,7 @@ function WebViewScreen({ route, navigation }: Props) {
   const [canGoForward, setCanGoForward] = useState(false)
 
   const handleSetNavigationTitle = useCallback(
-    (url: string, title: string) => {
+    (url: string, title: string, loading: boolean) => {
       let hostname = ' '
       let displayedTitle = ' '
 
@@ -51,7 +51,9 @@ function WebViewScreen({ route, navigation }: Props) {
         // defaults to the url - display a loading placeholder in this case
         const parsedTitleUrl = parse(title)
         displayedTitle =
-          !title || (parsedTitleUrl.protocol && parsedTitleUrl.hostname) ? t('loading') : title
+          loading || !title || (parsedTitleUrl.protocol && parsedTitleUrl.hostname)
+            ? t('loading')
+            : title
       } catch (error) {
         Logger.error(
           'WebViewScreen',
@@ -149,7 +151,7 @@ function WebViewScreen({ route, navigation }: Props) {
         onNavigationStateChange={(navState) => {
           setCanGoBack(navState.canGoBack)
           setCanGoForward(navState.canGoForward)
-          handleSetNavigationTitle(navState.url, navState.title)
+          handleSetNavigationTitle(navState.url, navState.title, navState.loading)
         }}
       />
       <View style={styles.navBar}>


### PR DESCRIPTION
### Description

The Webview sometimes displays incorrect information in the header during loading. e.g. the video below.

https://user-images.githubusercontent.com/20150449/167415173-b57cfcfb-674e-4771-abaf-74120d6eda86.mov


This PR adds a loading state to the header on navigation state change, so that this mismatch does not happen. e.g. the video below.

https://user-images.githubusercontent.com/20150449/167414622-6b7c1c53-0750-4e99-860a-ce114d7b65fd.mov

TECHNICAL NOTE:
We are using `onNavigationStateChange` to update the screen header information. This seems to be [unreliable](https://stackoverflow.com/a/50137971 ) depending on the implementation of the particular web page displayed. A symptom of this problem is outlined in #2339 but it does not affect all dapps (navigation back from external links in dapps like Revo/Moola/Good Ghosting did not repro this behaviour). This PR ensures that at least there will not be a mismatch in page title/url displayed, on Ubeswap the "Loading..." title may be displayed on navigating back from an external link but will be reloaded on the next user actions.

### Other changes

N/A

### Tested

Manually


### How others should test

Go to different dapps, and click on links. You should observe that the screen title displays the correct pair of title and url always (sometimes the title is  "Loading..." when navigating back from an external link, e.g. in Ubeswap, click on Celo Tracker in the menu, then click the back button on the bottom navigation bar. this is okay, at least the information is not wrong.)

### Related issues

- Fixes #2339

### Backwards compatibility

_Brief explanation of why these changes are/are not backwards compatible._