### PR TITLE
Côte d’Ivoire Phone Number Fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "form-data": "^4.0.0",
     "fp-ts": "2.1.1",
     "fuzzysort": "^1.1.4",
-    "google-libphonenumber": "^3.2.15",
+    "google-libphonenumber": "^3.2.27",
     "graphql": "^14.1.1",
     "hermes-engine": "0.9.0",
     "i18next": "^19.4.3",

--- a/src/components/PhoneNumberInput.test.tsx
+++ b/src/components/PhoneNumberInput.test.tsx
@@ -4,6 +4,7 @@ import { fireEvent, render } from '@testing-library/react-native'
 import * as React from 'react'
 import { Platform } from 'react-native'
 import PhoneNumberInput from 'src/components/PhoneNumberInput'
+import { waitFor } from 'src/redux/sagas-helpers'
 import { flushMicrotasksQueue } from 'test/utils'
 
 jest.mock('@celo/react-native-sms-retriever', () => {
@@ -135,5 +136,24 @@ describe('PhoneNumberInput', () => {
     fireEvent(getByTestId('PhoneNumberField'), 'focus')
     await flushMicrotasksQueue()
     expect(onChange).toHaveBeenCalledWith('(415) 426-5200', '+1')
+  })
+
+  it('can read Côte d’Ivoire phone numbers', async () => {
+    const { getByTestId, getByText } = render(
+      <PhoneNumberInput
+        label="Phone number"
+        country={countries.getCountryByCodeAlpha2('CI')}
+        internationalPhoneNumber=""
+        onChange={jest.fn()}
+        onPressCountry={jest.fn()}
+      />
+    )
+
+    waitFor(async () => {
+      expect(getByText('🇨🇮')).toBeTruthy()
+      expect(getByTestId('PhoneNumberField').props.placeholder).toBe('00 00 0 00000')
+      fireEvent.changeText(getByTestId('PhoneNumberField'), '21 23 4 56789')
+      expect(getByText('+255 21 23 4 56789')).toBeTruthy()
+    })
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -10686,6 +10686,11 @@ google-libphonenumber@^3.2.15:
   resolved "https://registry.yarnpkg.com/google-libphonenumber/-/google-libphonenumber-3.2.15.tgz#3a01dc554dbf83c754f249c16df3605e5d154bb9"
   integrity sha512-tbCIuzMoH34RdrbFRw5kijAZn/p6JMQvsgtr1glg2ugbwqrMPlOL8pHNK8cyGo9B6SXpcMm4hdyDqwomR+HPRg==
 
+google-libphonenumber@^3.2.27:
+  version "3.2.27"
+  resolved "https://registry.yarnpkg.com/google-libphonenumber/-/google-libphonenumber-3.2.27.tgz#06a0c1d42be712a6fd4189e2e3b07fc36cacee01"
+  integrity sha512-et3QlrfWemNPhyUfXZmJG8TfzitfAN71ygNI15+B35zNge/7vyZxkpDsc13oninkf8RAtN2kNEzvMr4L1n3vfQ==
+
 google-p12-pem@^3.0.3:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/google-p12-pem/-/google-p12-pem-3.1.2.tgz#c3d61c2da8e10843ff830fdb0d2059046238c1d4"


### PR DESCRIPTION
### Description

Updates [google-libphonenumber](https://www.npmjs.com/package/google-libphonenumber) to `3.2.27`

### Other changes

Added a unit test in `PhoneNumberInput.test.tsx` for Côte d’Ivoire phone numbers.

### Tested

Tested locally on iOS and with unit tests.

### How others should test

1. Navigate to `Connect your phone number` select the Côte d’Ivoire flag - 🇨🇮
2. Observe correct place holder - `00 00 0 00000`
3. Enter in a valid Côte d’Ivoire phone number e.g. `21 23 4 56789` and tap next.
4. Should begin phone verification - no need to complete but ensure that it starts.

### Related issues

- Fixes: [Côte divoire 10 digit phone # instead of 8 digit #104](https://github.com/valora-inc/support-issues/issues/104)

### Backwards compatibility

Yes