### PR TITLE
Include number verified state in support logs

### DIFF
--- a/src/account/SupportContact.test.tsx
+++ b/src/account/SupportContact.test.tsx
@@ -42,7 +42,7 @@ describe('Contact', () => {
       expect.objectContaining({
         isHTML: true,
         body:
-          'Test Message<br/><br/><b>{"version":"0.0.1","buildNumber":"1","apiLevel":-1,"deviceId":"unknown","address":"0x0000000000000000000000000000000000007e57","sessionId":"","network":"alfajores"}</b><br/><br/><b>Support logs are attached...</b>',
+          'Test Message<br/><br/><b>{"version":"0.0.1","buildNumber":"1","apiLevel":-1,"deviceId":"unknown","address":"0x0000000000000000000000000000000000007e57","sessionId":"","numberVerified":false,"network":"alfajores"}</b><br/><br/><b>Support logs are attached...</b>',
         recipients: [CELO_SUPPORT_EMAIL_ADDRESS],
         subject: i18n.t('supportEmailSubject', { appName: APP_NAME, user: '+1415555XXXX' }),
         attachments: [

--- a/src/account/SupportContact.tsx
+++ b/src/account/SupportContact.tsx
@@ -8,7 +8,7 @@ import { useDispatch, useSelector } from 'react-redux'
 import { Email, sendEmail } from 'src/account/emailSender'
 import { e164NumberSelector } from 'src/account/selectors'
 import { showMessage } from 'src/alert/actions'
-import { sessionIdSelector } from 'src/app/selectors'
+import { numberVerifiedSelector, sessionIdSelector } from 'src/app/selectors'
 import { APP_NAME } from 'src/brandingConfig'
 import Button, { BtnTypes } from 'src/components/Button'
 import KeyboardSpacer from 'src/components/KeyboardSpacer'
@@ -33,6 +33,7 @@ function SupportContact({ route }: Props) {
   const e164PhoneNumber = useSelector(e164NumberSelector)
   const currentAccount = useSelector(currentAccountSelector)
   const sessionId = useSelector(sessionIdSelector)
+  const numberVerified = useSelector(numberVerifiedSelector)
   const dispatch = useDispatch()
 
   const prefilledText = route.params?.prefilledText
@@ -56,6 +57,7 @@ function SupportContact({ route }: Props) {
       deviceId: DeviceInfo.getDeviceId(),
       address: currentAccount,
       sessionId,
+      numberVerified,
       network: DEFAULT_TESTNET,
     }
     const userId = e164PhoneNumber ? anonymizedPhone(e164PhoneNumber) : t('unknown')


### PR DESCRIPTION
### Description

Include connection status in logs, as requested by support team. Currently our L1 team asks users to go to Settings and take a screenshot to see if Valora thinks their phone number is connected, having this info upfront will save them some time.

### Other changes

N/A

### Tested

N/A

### How others should test

N/A

### Related issues

- Fixes #1826 

### Backwards compatibility

Yes