### PR TITLE
Set Sentry release explicitly to solve filtering issue

### DIFF
--- a/src/sentry/Sentry.ts
+++ b/src/sentry/Sentry.ts
@@ -53,6 +53,7 @@ export function* initializeSentry() {
   Sentry.init({
     dsn: SENTRY_CLIENT_URL,
     environment: DeviceInfo.getBundleId(),
+    release: `valora@${DeviceInfo.getVersion()}`,
     enableAutoSessionTracking: true,
     integrations: [
       new Sentry.ReactNativeTracing({


### PR DESCRIPTION
The docs are confusing:

  https://docs.sentry.io/product/data-management-settings/filtering/

Specifically the passive voice:

> The filter matches the full release name provided during SDK initialization.

I'm not sure who/what needs to set the release name, but since we weren't
doing it explicitly I thought this might be worth a try.
