### PR TITLE
e2e: fix incorrect identifier in OnRamps test

### DIFF
--- a/e2e/src/usecases/OnRamps.js
+++ b/e2e/src/usecases/OnRamps.js
@@ -57,7 +57,7 @@ export default onRamps = () => {
       }
       // Check IF Multiple Bank Providers
       if (await isElementVisible('Bank/numProviders')) {
-        let bankProviders = await element(by.id('Card/numProviders')).getAttributes()
+        let bankProviders = await element(by.id('Bank/numProviders')).getAttributes()
         numBankProviders =
           device.getPlatform() === 'ios'
             ? bankProviders.label.split(' ')[0]


### PR DESCRIPTION
### Description

E2E test [started failing consistently in the OnRamps test](https://valora-app.slack.com/archives/CL7BVQPHB/p1654240204274729).

### Tested

- E2E passes again

### How others should test

N/A

### Backwards compatibility

N/A