### PR TITLE
Avoid sending expected CleverTap errors to sentry

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -73,8 +73,8 @@ export class App extends React.Component<Props> {
     // Handles opening Clevertap deeplinks when app is closed / in background
     CleverTap.getInitialUrl(async (err: any, url) => {
       if (err) {
-        if (err?.message?.includes('CleverTap InitialUrl is null')) {
-          Logger.warn('App/componentDidMount', 'CleverTap InitialUrl is null', err)
+        if (/CleverTap initialUrl is (nil|null)/gi.test(err)) {
+          Logger.warn('App/componentDidMount', 'CleverTap InitialUrl is nil|null', err)
         } else {
           Logger.error('App/componentDidMount', 'App CleverTap Deeplink on Load', err)
         }


### PR DESCRIPTION
### Description

Sentry is getting a lot of errors for `CleverTap initialUrl is nil` and `CleverTap initialUrl is null` this is expected when the app launches normally and not from a deep link. These are now warnings and not sent to sentry. Once live these issues should not be seen in sentry [CleverTap InitialUrl is null](https://sentry.io/organizations/valora-inc/issues/3020003220/?query=is%3Aignored&sort=user&statsPeriod=14d) and [CleverTap initialUrl is nil](https://sentry.io/organizations/valora-inc/issues/3020505928/?query=is%3Aignored&sort=user&statsPeriod=14d).

### Other changes

- Use regex to test error and adjusted matching.

### Tested

Tested locally on iOS. 

### How others should test

This does not need to be tested by QA.

### Related issues

- Fixes #2350

### Backwards compatibility

Yes