### PR TITLE
Add configurable logging levels

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -136,10 +136,10 @@ export const DEFAULT_SENTRY_NETWORK_ERRORS = [
 ]
 
 const configLoggerLevels: { [key: string]: LoggerLevel } = {
-  debug: LoggerLevel.debug,
-  info: LoggerLevel.info,
-  warn: LoggerLevel.warn,
-  error: LoggerLevel.error,
+  debug: LoggerLevel.Debug,
+  info: LoggerLevel.Info,
+  warn: LoggerLevel.Warn,
+  error: LoggerLevel.Error,
 }
 
-export const LOGGER_LEVEL = configLoggerLevels[Config.LOGGER_LEVEL] || LoggerLevel.debug
+export const LOGGER_LEVEL = configLoggerLevels[Config.LOGGER_LEVEL] || LoggerLevel.Debug

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,6 +6,7 @@ import { SpendMerchant } from 'src/fiatExchanges/Spend'
 // eslint-disable-next-line import/no-relative-packages
 import * as secretsFile from '../secrets.json'
 import { ONE_HOUR_IN_MILLIS } from './utils/time'
+import { LoggerLevel } from 'src/services/ReactNativeLogger'
 
 export * from 'src/brandingConfig'
 
@@ -127,8 +128,17 @@ export const FETCH_TIMEOUT_DURATION = 15000 // 15 seconds
 
 export const DEFAULT_APP_LANGUAGE = 'en-US'
 
+// Logging and monitoring
 export const DEFAULT_SENTRY_TRACES_SAMPLE_RATE = 0.2
 export const DEFAULT_SENTRY_NETWORK_ERRORS = [
   'network request failed',
   'The network connection was lost',
 ]
+
+export const LOGGER_LEVEL =
+  {
+    debug: LoggerLevel.debug,
+    info: LoggerLevel.info,
+    warn: LoggerLevel.warn,
+    error: LoggerLevel.error,
+  }[Config.LOGGER_LEVEL] || LoggerLevel.debug

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,7 +6,7 @@ import { SpendMerchant } from 'src/fiatExchanges/Spend'
 // eslint-disable-next-line import/no-relative-packages
 import * as secretsFile from '../secrets.json'
 import { ONE_HOUR_IN_MILLIS } from './utils/time'
-import { LoggerLevel } from 'src/services/ReactNativeLogger'
+import { LoggerLevel } from 'src/utils/LoggerLevels'
 
 export * from 'src/brandingConfig'
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -135,10 +135,11 @@ export const DEFAULT_SENTRY_NETWORK_ERRORS = [
   'The network connection was lost',
 ]
 
-export const LOGGER_LEVEL =
-  {
-    debug: LoggerLevel.debug,
-    info: LoggerLevel.info,
-    warn: LoggerLevel.warn,
-    error: LoggerLevel.error,
-  }[Config.LOGGER_LEVEL] || LoggerLevel.debug
+const configLoggerLevels: { [key: string]: LoggerLevel } = {
+  debug: LoggerLevel.debug,
+  info: LoggerLevel.info,
+  warn: LoggerLevel.warn,
+  error: LoggerLevel.error,
+}
+
+export const LOGGER_LEVEL = configLoggerLevels[Config.LOGGER_LEVEL] || LoggerLevel.debug

--- a/src/services/ReactNativeLogger.ts
+++ b/src/services/ReactNativeLogger.ts
@@ -4,10 +4,20 @@ import * as RNFS from 'react-native-fs'
 import Toast from 'react-native-simple-toast'
 import { DEFAULT_SENTRY_NETWORK_ERRORS } from 'src/config'
 
+export enum LoggerLevel {
+  debug = 3,
+  info = 2,
+  warn = 1,
+  error = 0,
+}
+
 export default class ReactNativeLogger {
   isNetworkConnected: boolean
   networkErrors: string[]
-  constructor() {
+  level: LoggerLevel
+
+  constructor({ level }: { level: LoggerLevel } = { level: LoggerLevel.debug }) {
+    this.level = level
     this.isNetworkConnected = true
     this.networkErrors = DEFAULT_SENTRY_NETWORK_ERRORS || []
   }
@@ -19,14 +29,23 @@ export default class ReactNativeLogger {
    * For example, `send/actions/refreshGasPrice` since there are many actions.ts files.
    */
   debug = (tag: string, ...messages: any[]) => {
+    if (this.level < LoggerLevel.debug) {
+      return
+    }
     console.debug(`${tag}/${messages.join(', ')}`)
   }
 
   info = (tag: string, ...messages: any[]) => {
+    if (this.level < LoggerLevel.info) {
+      return
+    }
     console.info(`${tag}/${messages.join(', ')}`)
   }
 
   warn = (tag: string, ...messages: any[]) => {
+    if (this.level < LoggerLevel.warn) {
+      return
+    }
     // console.warn would display yellow box, therefore, we will log to console.info instead.
     console.info(`${tag}/${messages.join(', ')}`)
   }

--- a/src/services/ReactNativeLogger.ts
+++ b/src/services/ReactNativeLogger.ts
@@ -3,13 +3,7 @@ import * as Sentry from '@sentry/react-native'
 import * as RNFS from 'react-native-fs'
 import Toast from 'react-native-simple-toast'
 import { DEFAULT_SENTRY_NETWORK_ERRORS } from 'src/config'
-
-export enum LoggerLevel {
-  debug = 3,
-  info = 2,
-  warn = 1,
-  error = 0,
-}
+import { LoggerLevel } from 'src/utils/LoggerLevels'
 
 export default class ReactNativeLogger {
   isNetworkConnected: boolean

--- a/src/services/ReactNativeLogger.ts
+++ b/src/services/ReactNativeLogger.ts
@@ -10,7 +10,7 @@ export default class ReactNativeLogger {
   networkErrors: string[]
   level: LoggerLevel
 
-  constructor({ level }: { level: LoggerLevel } = { level: LoggerLevel.debug }) {
+  constructor({ level }: { level: LoggerLevel } = { level: LoggerLevel.Debug }) {
     this.level = level
     this.isNetworkConnected = true
     this.networkErrors = DEFAULT_SENTRY_NETWORK_ERRORS || []
@@ -23,21 +23,21 @@ export default class ReactNativeLogger {
    * For example, `send/actions/refreshGasPrice` since there are many actions.ts files.
    */
   debug = (tag: string, ...messages: any[]) => {
-    if (this.level < LoggerLevel.debug) {
+    if (this.level < LoggerLevel.Debug) {
       return
     }
     console.debug(`${tag}/${messages.join(', ')}`)
   }
 
   info = (tag: string, ...messages: any[]) => {
-    if (this.level < LoggerLevel.info) {
+    if (this.level < LoggerLevel.Info) {
       return
     }
     console.info(`${tag}/${messages.join(', ')}`)
   }
 
   warn = (tag: string, ...messages: any[]) => {
-    if (this.level < LoggerLevel.warn) {
+    if (this.level < LoggerLevel.Warn) {
       return
     }
     // console.warn would display yellow box, therefore, we will log to console.info instead.

--- a/src/utils/Logger.ts
+++ b/src/utils/Logger.ts
@@ -1,6 +1,7 @@
 import { Platform } from 'react-native'
 import * as RNFS from 'react-native-fs'
 import ReactNativeLogger from 'src/services/ReactNativeLogger'
+import { LOGGER_LEVEL } from 'src/config'
 
 class Logger extends ReactNativeLogger {
   getGethLogFilePath = () => {
@@ -65,4 +66,4 @@ class Logger extends ReactNativeLogger {
   }
 }
 
-export default new Logger()
+export default new Logger({ level: LOGGER_LEVEL })

--- a/src/utils/LoggerLevels.ts
+++ b/src/utils/LoggerLevels.ts
@@ -1,6 +1,6 @@
 export enum LoggerLevel {
-  debug = 3,
-  info = 2,
-  warn = 1,
-  error = 0,
+  Debug = 3,
+  Info = 2,
+  Warn = 1,
+  Error = 0,
 }

--- a/src/utils/LoggerLevels.ts
+++ b/src/utils/LoggerLevels.ts
@@ -1,0 +1,6 @@
+export enum LoggerLevel {
+  debug = 3,
+  info = 2,
+  warn = 1,
+  error = 0,
+}


### PR DESCRIPTION
With the default (debug) the logs can be impenetrable during "normal" local
development.

By default this change shouldn't impact the previous logging behavior.

### How others should test

This doesn't require additional testing.
