### PR TITLE
chore: remove obsolete `l.celo.org` dynamic link

### DIFF
--- a/ios/celo/Info.plist
+++ b/ios/celo/Info.plist
@@ -41,7 +41,6 @@
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>FirebaseDynamicLinksCustomDomains</key>
 	<array>
-		<string>https://l.celo.org</string>
 		<string>https://vlra.app</string>
 	</array>
 	<key>ITSAppUsesNonExemptEncryption</key>

--- a/ios/celo/celo.entitlements
+++ b/ios/celo/celo.entitlements
@@ -6,7 +6,6 @@
 	<string>development</string>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
-		<string>applinks:l.celo.org</string>
 		<string>applinks:vlra.app</string>
 		<string>applinks:valoraapp.com</string>
 	</array>


### PR DESCRIPTION
### Description

Cleanup on the `celo.org` domain prompted this. We're not using it anywhere anymore.

### How others should test

No need to test this.