### PR TITLE
Reduce Memory Consumption on Low Tier Android Devices

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -6,6 +6,7 @@ import { ApolloProvider } from 'react-apollo'
 import { Dimensions, Linking, LogBox, Platform, StatusBar } from 'react-native'
 import { getNumberFormatSettings } from 'react-native-localize'
 import { SafeAreaProvider } from 'react-native-safe-area-context'
+import { enableScreens } from 'react-native-screens'
 import { Provider } from 'react-redux'
 import { PersistGate } from 'redux-persist/integration/react'
 import { AppEvents } from 'src/analytics/Events'
@@ -69,6 +70,7 @@ export class App extends React.Component<Props> {
       LogBox.ignoreAllLogs(true)
     }
     await ValoraAnalytics.init()
+    enableScreens(true)
 
     // Handles opening Clevertap deeplinks when app is closed / in background
     CleverTap.getInitialUrl(async (err: any, url) => {

--- a/src/navigator/DrawerNavigator.tsx
+++ b/src/navigator/DrawerNavigator.tsx
@@ -208,6 +208,9 @@ export default function DrawerNavigator() {
         labelStyle: [fontStyles.regular, { marginLeft: -20, fontWeight: 'normal' }],
         activeBackgroundColor: colors.gray2,
       }}
+      defaultScreenOptions={{
+        unmountOnBlur: true,
+      }}
     >
       <Drawer.Screen
         name={Screens.WalletHome}


### PR DESCRIPTION
### Description

Uses [unmountOnBlur](https://reactnavigation.org/docs/5.x/drawer-navigator#unmountonblur)​ and [detachinactivescreens](https://reactnavigation.org/docs/5.x/drawer-navigator#detachinactivescreens) from @react-navigation/drawer to decrease memory consumption. 

| Build | Device | Average Memory Consumption |
| ----- | ----- | ----- |
| 1.35.0 Release | Galaxy S5 | 293MB | 
| 1.35.0 Release | Galaxy S21 | - | 
| 1.35.0 Release | iPhone 11 | - | 
| Branch (Release Mode) | Galaxy S5 | 200MB | 
| Branch (Release Mode) | Galaxy S21 | - | 
| Branch (Release Mode) | iPhone 11 | - | 


### Other changes

N/A

### Tested

Tested on an iOS simulator, Android Galaxy S5 and S21.

### How others should test

1. Navigate from initial app load onboarding
2. Once arriving on home screen open hamburger menu and navigate to each subsequent drawer item.
3. Note memory usage after navigating to all drawer items. 

### Related issues

Fixes: #2293

### Backwards compatibility

Yes