### PR TITLE
feat: Support "address only" QR codes in release builds 

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -177,7 +177,7 @@ android {
     }
     signingConfigs {
         release {
-            if (isDetoxTestBuild) {
+            if (isDetoxTestBuild || true) {
                 storeFile file('debug.keystore')
                 storePassword 'android'
                 keyAlias 'androiddebugkey'

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -177,7 +177,7 @@ android {
     }
     signingConfigs {
         release {
-            if (isDetoxTestBuild || true) {
+            if (isDetoxTestBuild) {
                 storeFile file('debug.keystore')
                 storePassword 'android'
                 keyAlias 'androiddebugkey'

--- a/src/qrcode/QRScanner.tsx
+++ b/src/qrcode/QRScanner.tsx
@@ -59,11 +59,6 @@ export default function QRScanner({ onBarCodeDetected }: QRScannerProps) {
   const [value, setValue] = useState('')
   const [displayEntryModal, setDisplayEntryModal] = useState(false)
 
-  // Handles explorer QR Codes & same behavior as scanner another users QRCode
-  const handleAddressOnly = (value: string) => {
-    return /^0x[a-f0-9]{40}$/gi.test(value) ? `celo://wallet/pay?address=${value}` : value
-  }
-
   const openModal = () => {
     setDisplayEntryModal(true)
   }
@@ -74,7 +69,7 @@ export default function QRScanner({ onBarCodeDetected }: QRScannerProps) {
   }
 
   const submitModal = () => {
-    onBarCodeDetected({ type: '', data: handleAddressOnly(value) })
+    onBarCodeDetected({ type: '', data: value })
     closeModal()
   }
 

--- a/src/qrcode/utils.ts
+++ b/src/qrcode/utils.ts
@@ -112,6 +112,9 @@ export function* handleBarcode(
   requesterAddress?: string
 ) {
   const walletConnectEnabled: boolean = yield call(isWalletConnectEnabled, barcode.data)
+  if (/^0x[a-f0-9]{40}$/gi.test(barcode.data)) {
+    barcode.data = `celo://wallet/pay?address=${barcode.data}`
+  }
   if (barcode.data.startsWith('wc:') && walletConnectEnabled) {
     yield fork(handleLoadingWithTimeout, WalletConnectPairingOrigin.Scan)
     yield call(initialiseWalletConnect, barcode.data, WalletConnectPairingOrigin.Scan)

--- a/src/qrcode/utils.ts
+++ b/src/qrcode/utils.ts
@@ -112,6 +112,7 @@ export function* handleBarcode(
   requesterAddress?: string
 ) {
   const walletConnectEnabled: boolean = yield call(isWalletConnectEnabled, barcode.data)
+  // Regex matches any 40 hexadecimal characters prefixed with "0x" (case insensitive)
   if (/^0x[a-f0-9]{40}$/gi.test(barcode.data)) {
     barcode.data = `celo://wallet/pay?address=${barcode.data}`
   }


### PR DESCRIPTION
### Description

When scanning a QR code that only contains an address, we will now convert it to a deep link by prefixing the address with: `celo://wallet/pay?address=`. From home screen and "Send" screen, scanning this QR code leads to payment UI. When scanning from the "Receive" UI, it attempts to send a receive request to the given request.

### Other changes

None

### Tested

Manually tested on phone using both release and non-release builds. 

### How others should test

Scan a blockscout QR code, and verify that the address in the "review" page matches the address in blockscout. (eg. https://explorer.celo.org/address/0x55D0B67dBFcEcF218E498Ac29F1A851eF90f1CB8/)

### Related issues

- Related to #2678. Previous fix only handled dev builds (not release)

### Backwards compatibility

N/A