### PR TITLE
refactor(fiatconnect): move client creation outside quote class

### DIFF
--- a/src/fiatExchanges/quotes/FiatConnectQuote.test.ts
+++ b/src/fiatExchanges/quotes/FiatConnectQuote.test.ts
@@ -8,7 +8,6 @@ import { CICOFlow, PaymentMethod } from 'src/fiatExchanges/utils'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import { Currency } from 'src/utils/currencies'
-import { getWalletAsync } from 'src/web3/contracts'
 import { mockFiatConnectQuotes } from 'test/values'
 
 jest.mock('src/analytics/ValoraAnalytics')
@@ -288,25 +287,6 @@ describe('FiatConnectQuote', () => {
       expect(quote.getFiatAccountSchemaAllowedValues()).toEqual({
         institutionName: ['Bank A', 'Bank B'],
       })
-    })
-  })
-
-  describe('.getFiatConnectClient', () => {
-    it('returns the client if one exists', async () => {
-      const quote = new FiatConnectQuote({
-        flow: CICOFlow.CashIn,
-        quote: mockFiatConnectQuotes[1] as FiatConnectQuoteSuccess,
-        fiatAccountType: FiatAccountType.BankAccount,
-      })
-      expect(quote.fiatConnectClient).toBeUndefined()
-      await quote.getFiatConnectClient()
-      expect(getWalletAsync).toHaveBeenCalled()
-      expect(quote.fiatConnectClient).not.toBeUndefined()
-
-      jest.clearAllMocks()
-
-      await quote.getFiatConnectClient()
-      expect(getWalletAsync).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/fiatExchanges/quotes/FiatConnectQuote.ts
+++ b/src/fiatExchanges/quotes/FiatConnectQuote.ts
@@ -1,4 +1,3 @@
-import { FiatConnectApiClient } from '@fiatconnect/fiatconnect-sdk'
 import {
   FiatAccountSchema,
   FiatAccountType,
@@ -33,7 +32,6 @@ export default class FiatConnectQuote extends NormalizedQuote {
   fiatAccountType: FiatAccountType
   flow: CICOFlow
   quoteResponseFiatAccountSchema: QuoteResponseFiatAccountSchema
-  fiatConnectClient?: FiatConnectApiClient
 
   constructor({
     quote,

--- a/src/fiatExchanges/quotes/FiatConnectQuote.ts
+++ b/src/fiatExchanges/quotes/FiatConnectQuote.ts
@@ -1,3 +1,4 @@
+import { FiatConnectApiClient } from '@fiatconnect/fiatconnect-sdk'
 import {
   FiatAccountSchema,
   FiatAccountType,
@@ -19,11 +20,6 @@ import {
 } from 'src/localCurrency/convert'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
-import { FiatConnectApiClient, FiatConnectClient } from '@fiatconnect/fiatconnect-sdk'
-import { UnlockableWallet } from '@celo/wallet-base'
-import { getSigningFunction } from 'src/fiatconnect/index'
-import { getWalletAsync } from 'src/web3/contracts'
-import { FIATCONNECT_NETWORK } from 'src/config'
 import { Currency, resolveCurrency } from 'src/utils/currencies'
 
 const strings = {
@@ -178,22 +174,5 @@ export default class FiatConnectQuote extends NormalizedQuote {
 
   getFiatAccountSchemaAllowedValues(): { [key: string]: string[] } {
     return this.quoteResponseFiatAccountSchema.allowedValues
-  }
-
-  async getFiatConnectClient(): Promise<FiatConnectApiClient> {
-    if (this.fiatConnectClient) {
-      return this.fiatConnectClient
-    }
-    const wallet = (await getWalletAsync()) as UnlockableWallet
-    const [account] = wallet.getAccounts()
-    this.fiatConnectClient = new FiatConnectClient(
-      {
-        baseUrl: this.getProviderBaseUrl(),
-        network: FIATCONNECT_NETWORK,
-        accountAddress: account,
-      },
-      getSigningFunction(wallet)
-    )
-    return this.fiatConnectClient
   }
 }

--- a/src/fiatconnect/FiatDetailsScreen.test.tsx
+++ b/src/fiatconnect/FiatDetailsScreen.test.tsx
@@ -17,6 +17,7 @@ import { Provider } from 'react-redux'
 import { showError, showMessage } from 'src/alert/actions'
 import { ErrorMessages } from 'src/app/ErrorMessages'
 import { FiatConnectQuoteSuccess } from 'src/fiatconnect'
+import { getFiatConnectClient } from 'src/fiatconnect/clients'
 import FiatConnectQuote from 'src/fiatExchanges/quotes/FiatConnectQuote'
 import { CICOFlow } from 'src/fiatExchanges/utils'
 import i18n from 'src/i18n'
@@ -25,6 +26,7 @@ import { Screens } from 'src/navigator/Screens'
 import Logger from 'src/utils/Logger'
 import { createMockStore, getMockStackScreenProps } from 'test/utils'
 import { mockFiatConnectQuotes } from 'test/values'
+import { mocked } from 'ts-jest/utils'
 import FiatDetailsScreen, { TAG } from './FiatDetailsScreen'
 
 jest.mock('src/alert/actions')
@@ -52,6 +54,7 @@ jest.mock('@fiatconnect/fiatconnect-sdk', () => ({
     addFiatAccount: jest.fn(() => mockResult),
   })),
 }))
+jest.mock('src/fiatconnect/clients')
 
 const store = createMockStore({})
 const quoteWithAllowedValues = new FiatConnectQuote({
@@ -94,7 +97,7 @@ describe('FiatDetailsScreen', () => {
       fiatAccountId: '1234',
       accountName: '7890',
       institutionName: fakeInstitutionName,
-      fiatAccountType: 'BankAccount',
+      fiatAccountType: FiatAccountType.BankAccount,
     })
     fiatConnectClient = new FiatConnectClient(
       {
@@ -105,9 +108,7 @@ describe('FiatDetailsScreen', () => {
       (msg: string) => Promise.resolve(msg)
     )
     store.dispatch = jest.fn()
-    jest
-      .spyOn(FiatConnectQuote.prototype, 'getFiatConnectClient')
-      .mockImplementation(() => Promise.resolve(fiatConnectClient))
+    mocked(getFiatConnectClient).mockResolvedValue(fiatConnectClient)
   })
   afterEach(() => {
     jest.clearAllMocks()
@@ -168,7 +169,10 @@ describe('FiatDetailsScreen', () => {
     }
     await fireEvent.press(getByTestId('nextButton'))
 
-    expect(quote.getFiatConnectClient).toHaveBeenCalled()
+    expect(getFiatConnectClient).toHaveBeenCalledWith(
+      quote.getProviderId(),
+      quote.getProviderBaseUrl()
+    )
     expect(fiatConnectClient.addFiatAccount).toHaveBeenCalledWith({
       fiatAccountSchema: 'AccountNumber',
       data: expectedBody,
@@ -204,7 +208,10 @@ describe('FiatDetailsScreen', () => {
 
     await fireEvent.press(getByTestId('nextButton'))
 
-    expect(quote.getFiatConnectClient).toHaveBeenCalled()
+    expect(getFiatConnectClient).toHaveBeenCalledWith(
+      quote.getProviderId(),
+      quote.getProviderBaseUrl()
+    )
     expect(fiatConnectClient.addFiatAccount).toHaveBeenCalledWith({
       fiatAccountSchema: 'AccountNumber',
       data: expectedBody,
@@ -239,7 +246,10 @@ describe('FiatDetailsScreen', () => {
 
     await fireEvent.press(getByTestId('nextButton'))
 
-    expect(quote.getFiatConnectClient).toHaveBeenCalled()
+    expect(getFiatConnectClient).toHaveBeenCalledWith(
+      quote.getProviderId(),
+      quote.getProviderBaseUrl()
+    )
     expect(fiatConnectClient.addFiatAccount).toHaveBeenCalledWith({
       fiatAccountSchema: 'AccountNumber',
       data: expectedBody,

--- a/src/fiatconnect/FiatDetailsScreen.tsx
+++ b/src/fiatconnect/FiatDetailsScreen.tsx
@@ -16,6 +16,7 @@ import { ErrorMessages } from 'src/app/ErrorMessages'
 import BorderlessButton from 'src/components/BorderlessButton'
 import Button, { BtnSizes } from 'src/components/Button'
 import TextInput, { LINE_HEIGHT } from 'src/components/TextInput'
+import { getFiatConnectClient } from 'src/fiatconnect/clients'
 import i18n from 'src/i18n'
 import ForwardChevron from 'src/icons/ForwardChevron'
 import { navigate, navigateBack } from 'src/navigator/NavigationService'
@@ -177,7 +178,10 @@ const FiatDetailsScreen = ({ route, navigation }: Props) => {
 
       const fiatAccountSchema = quote.getFiatAccountSchema()
 
-      const fiatConnectClient = await quote.getFiatConnectClient()
+      const fiatConnectClient = await getFiatConnectClient(
+        quote.getProviderId(),
+        quote.getProviderBaseUrl()
+      )
       const result = await fiatConnectClient.addFiatAccount({
         fiatAccountSchema: fiatAccountSchema,
         data: body as FiatAccountSchemas[typeof fiatAccountSchema],

--- a/src/fiatconnect/clients.test.tsx
+++ b/src/fiatconnect/clients.test.tsx
@@ -58,6 +58,12 @@ describe('getFiatConnectClient', () => {
     expect(fcClient).toBeInstanceOf(FiatConnectClient)
   })
 
+  it('returns a new client if provider url changes', async () => {
+    const fcClient = await getFiatConnectClient('provider1', 'https://provider1.url/v2')
+    expect(getWalletAsync).toHaveBeenCalled()
+    expect(fcClient).toBeInstanceOf(FiatConnectClient)
+  })
+
   it('returns a new client for a different provider', async () => {
     const fcClient = await getFiatConnectClient('provider2', 'https://provider2.url')
     expect(getWalletAsync).toHaveBeenCalled()

--- a/src/fiatconnect/clients.test.tsx
+++ b/src/fiatconnect/clients.test.tsx
@@ -1,0 +1,66 @@
+import { FiatConnectClient } from '@fiatconnect/fiatconnect-sdk'
+import { getFiatConnectClient, getSigningFunction } from 'src/fiatconnect/clients'
+import { getPassword } from 'src/pincode/authentication'
+import { getWalletAsync } from 'src/web3/contracts'
+import { KeychainWallet } from 'src/web3/KeychainWallet'
+
+jest.mock('src/web3/contracts', () => ({
+  getWalletAsync: jest.fn(() => ({
+    getAccounts: jest.fn(() => ['fake-account']),
+  })),
+}))
+
+jest.mock('src/pincode/authentication')
+
+describe('getSigningFunction', () => {
+  const wallet = new KeychainWallet({
+    address: 'some address',
+    createdAt: new Date(),
+  })
+  beforeEach(() => {
+    wallet.getAccounts = jest.fn().mockReturnValue(['fakeAccount'])
+    wallet.isAccountUnlocked = jest.fn().mockReturnValue(true)
+    wallet.signPersonalMessage = jest.fn().mockResolvedValue('some signed message')
+    wallet.unlockAccount = jest.fn().mockResolvedValue(undefined)
+  })
+  it('returns a signing function that signs a message', async () => {
+    const signingFunction = getSigningFunction(wallet)
+    const signedMessage = await signingFunction('test')
+    expect(wallet.signPersonalMessage).toHaveBeenCalled()
+    expect(wallet.unlockAccount).not.toHaveBeenCalled()
+    expect(signedMessage).toEqual('some signed message')
+  })
+  it('returns a signing function that attempts to unlock accout if locked', async () => {
+    wallet.isAccountUnlocked = jest.fn().mockReturnValue(false)
+    const signingFunction = getSigningFunction(wallet)
+    const signedMessage = await signingFunction('test')
+    expect(wallet.signPersonalMessage).toHaveBeenCalled()
+    expect(wallet.unlockAccount).toHaveBeenCalled()
+    expect(getPassword).toHaveBeenCalled()
+    expect(signedMessage).toEqual('some signed message')
+  })
+})
+
+describe('getFiatConnectClient', () => {
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('makes and returns a new client the first time', async () => {
+    const fcClient = await getFiatConnectClient('provider1', 'https://provider1.url')
+    expect(getWalletAsync).toHaveBeenCalled()
+    expect(fcClient).toBeInstanceOf(FiatConnectClient)
+  })
+
+  it('returns an already existing client', async () => {
+    const fcClient = await getFiatConnectClient('provider1', 'https://provider1.url')
+    expect(getWalletAsync).not.toHaveBeenCalled()
+    expect(fcClient).toBeInstanceOf(FiatConnectClient)
+  })
+
+  it('returns a new client for a different provider', async () => {
+    const fcClient = await getFiatConnectClient('provider2', 'https://provider2.url')
+    expect(getWalletAsync).toHaveBeenCalled()
+    expect(fcClient).toBeInstanceOf(FiatConnectClient)
+  })
+})

--- a/src/fiatconnect/clients.ts
+++ b/src/fiatconnect/clients.ts
@@ -1,0 +1,36 @@
+import { ensureLeading0x } from '@celo/utils/lib/address'
+import { UnlockableWallet } from '@celo/wallet-base'
+import { FiatConnectApiClient, FiatConnectClient } from '@fiatconnect/fiatconnect-sdk'
+import { FIATCONNECT_NETWORK } from 'src/config'
+import { getPassword } from 'src/pincode/authentication'
+import { UNLOCK_DURATION } from 'src/web3/consts'
+import { getWalletAsync } from 'src/web3/contracts'
+
+const fiatConnectClients: Record<string, FiatConnectApiClient> = {}
+
+export function getSigningFunction(wallet: UnlockableWallet): (message: string) => Promise<string> {
+  return async function (message: string): Promise<string> {
+    const [account] = wallet.getAccounts()
+    if (!wallet.isAccountUnlocked(account)) {
+      await wallet.unlockAccount(account, await getPassword(account), UNLOCK_DURATION)
+    }
+    const encodedMessage = ensureLeading0x(Buffer.from(message, 'utf8').toString('hex'))
+    return await wallet.signPersonalMessage(account, encodedMessage)
+  }
+}
+
+export async function getFiatConnectClient(providerId: string, providerBaseUrl: string) {
+  if (!fiatConnectClients[providerId]) {
+    const wallet = (await getWalletAsync()) as UnlockableWallet
+    const [account] = wallet.getAccounts()
+    fiatConnectClients[providerId] = new FiatConnectClient(
+      {
+        baseUrl: providerBaseUrl,
+        network: FIATCONNECT_NETWORK,
+        accountAddress: account,
+      },
+      getSigningFunction(wallet)
+    )
+  }
+  return fiatConnectClients[providerId]
+}

--- a/src/fiatconnect/index.test.ts
+++ b/src/fiatconnect/index.test.ts
@@ -20,7 +20,6 @@ import {
   getFiatConnectProviders,
   getFiatConnectQuotes,
   getObfuscatedAccountNumber,
-  getSigningFunction,
   loginWithFiatConnectProvider,
   QuotesInput,
 } from './index'
@@ -134,34 +133,6 @@ describe('FiatConnect helpers', () => {
       const quotes = await getFiatConnectQuotes(getQuotesInput)
       expect(quotes).toEqual([mockFiatConnectQuotes[1], mockFiatConnectQuotes[0]])
       expect(Logger.error).not.toHaveBeenCalled()
-    })
-  })
-  describe('getSigningFunction', () => {
-    const wallet = new KeychainWallet({
-      address: 'some address',
-      createdAt: new Date(),
-    })
-    beforeEach(() => {
-      wallet.getAccounts = jest.fn().mockReturnValue(['fakeAccount'])
-      wallet.isAccountUnlocked = jest.fn().mockReturnValue(true)
-      wallet.signPersonalMessage = jest.fn().mockResolvedValue('some signed message')
-      wallet.unlockAccount = jest.fn().mockResolvedValue(undefined)
-    })
-    it('returns a signing function that signs a message', async () => {
-      const signingFunction = getSigningFunction(wallet)
-      const signedMessage = await signingFunction('test')
-      expect(wallet.signPersonalMessage).toHaveBeenCalled()
-      expect(wallet.unlockAccount).not.toHaveBeenCalled()
-      expect(signedMessage).toEqual('some signed message')
-    })
-    it('returns a signing function that attempts to unlock accout if locked', async () => {
-      wallet.isAccountUnlocked = jest.fn().mockReturnValue(false)
-      const signingFunction = getSigningFunction(wallet)
-      const signedMessage = await signingFunction('test')
-      expect(wallet.signPersonalMessage).toHaveBeenCalled()
-      expect(wallet.unlockAccount).toHaveBeenCalled()
-      expect(getPassword).toHaveBeenCalled()
-      expect(signedMessage).toEqual('some signed message')
     })
   })
   describe('loginWithFiatConnectProvider', () => {

--- a/src/fiatconnect/index.ts
+++ b/src/fiatconnect/index.ts
@@ -1,4 +1,3 @@
-import { ensureLeading0x } from '@celo/utils/lib/address'
 import { UnlockableWallet } from '@celo/wallet-base'
 import { FiatConnectApiClient } from '@fiatconnect/fiatconnect-sdk'
 import {
@@ -87,17 +86,6 @@ export async function loginWithFiatConnectProvider(
   if (!response.isOk) {
     Logger.error(TAG, `Failure logging in with FiatConnect provider: ${response.error}, throwing`)
     throw response.error
-  }
-}
-
-export function getSigningFunction(wallet: UnlockableWallet): (message: string) => Promise<string> {
-  return async function (message: string): Promise<string> {
-    const [account] = wallet.getAccounts()
-    if (!wallet.isAccountUnlocked(account)) {
-      await wallet.unlockAccount(account, await getPassword(account), UNLOCK_DURATION)
-    }
-    const encodedMessage = ensureLeading0x(Buffer.from(message, 'utf8').toString('hex'))
-    return await wallet.signPersonalMessage(account, encodedMessage)
   }
 }
 


### PR DESCRIPTION
### Description

There can be multiple quotes for the same provider (when quote expires or a transfer is retried), this allows reusing the same FiatConnectClient instance across quotes.

### Other changes

Moved `getSigningFunction` to src/fiatconnect/clients.tsx since it's only used here

### Tested

unit tests


### How others should test

N/A

### Related issues

- For [ACT-277](https://linear.app/valora/issue/ACT-277/initiate-transfer-out-implementation) and [ACT-349](https://linear.app/valora/issue/ACT-349/fc-return-user-flow)

### Backwards compatibility

Yes