### PR TITLE
chore(flipper): add fiatConnect to stateWhitelist

### DIFF
--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -126,6 +126,7 @@ export const setupStore = (initialState = {}, config = persistConfig) => {
           'imports',
           'paymentRequest',
           'verify',
+          'fiatConnect',
         ],
       })
     )


### PR DESCRIPTION
### Description

This allows viewing fiatConnect state in flipper redux debugger

### Other changes

N/A

### Tested

N/A


### How others should test

N/A

### Related issues

N/A

### Backwards compatibility

N/A