### PR TITLE
chore(firebase): allow IHL to write to fiatconnect node

### DIFF
--- a/src/firebase/db-rules.json
+++ b/src/firebase/db-rules.json
@@ -110,6 +110,13 @@
         ".write": false,
         ".read": "auth.uid != null && $address === root.child('users').child(auth.uid).child('address').val()"
       }
+    },
+    "fiatConnect": {
+      ".write": "auth.uid === 'ihl-service-worker'",
+      ".read": "auth.uid === 'ihl-service-worker'",
+      "$address": {
+        ".read": true
+      }
     }
   }
 }


### PR DESCRIPTION
### Description

Allow IHL to read and write fiatConnect node to track kyc and transfer status via webhook

### Other changes

N/A

### Tested

N/A


### How others should test

N/A

### Related issues

- Related to ACT-39

### Backwards compatibility

N/A