### PR TITLE
chore: apply code from 1.36.1 and 1.37.1 patches

### DIFF
--- a/src/redux/migrations.test.ts
+++ b/src/redux/migrations.test.ts
@@ -31,7 +31,8 @@ import {
   v56Schema,
   v57Schema,
   v58Schema,
-  v61Schema,
+  v59Schema,
+  v62Schema,
   v7Schema,
   v8Schema,
   vNeg1Schema,
@@ -597,8 +598,51 @@ describe('Redux persist migrations', () => {
   })
 
   it('works for v58 to v59', () => {
-    const oldSchema = v58Schema
+    const oldTransactions = [
+      {
+        metadata: {
+          title: null,
+          comment: '',
+          subtitle: null,
+          image: null,
+        },
+        __typename: 'TokenTransferV2',
+        block: '14255636',
+        transactionHash: '0xf4e59db43c9051947ffe8a29a09c8f85dcf540699855166aa68f11cda3014b72',
+        type: 'RECEIVED',
+        amount: {
+          value: '0.01',
+          tokenAddress: '0x765de816845861e75a25fca122bb6898b8b1282a',
+          localAmount: {
+            currencyCode: 'USD',
+            exchangeRate: '1',
+            value: '0.01',
+          },
+        },
+        fees: null,
+        timestamp: 1658945996000,
+        address: '0xde33e71faecdead20e6a8af8f362d2236cba005f',
+      },
+      {},
+    ]
+    const oldSchema = {
+      ...v58Schema,
+      transactions: {
+        ...v58Schema.transactions,
+        transactions: oldTransactions,
+      },
+    }
     const migratedSchema = migrations[59](oldSchema)
+
+    const expectedSchema: any = _.cloneDeep(oldSchema)
+    expectedSchema.transactions.transactions = [oldTransactions[0]]
+
+    expect(migratedSchema).toMatchObject(expectedSchema)
+  })
+
+  it('works for v59 to v60', () => {
+    const oldSchema = v59Schema
+    const migratedSchema = migrations[60](oldSchema)
 
     const expectedSchema: any = _.cloneDeep(oldSchema)
     expectedSchema.fiatConnect = {}
@@ -609,9 +653,9 @@ describe('Redux persist migrations', () => {
     expect(migratedSchema).toMatchObject(expectedSchema)
   })
 
-  it('works for v61 to v62', () => {
-    const oldSchema = v61Schema
-    const migratedSchema = migrations[62](oldSchema)
+  it('works for v62 to v63', () => {
+    const oldSchema = v62Schema
+    const migratedSchema = migrations[63](oldSchema)
 
     const expectedSchema: any = _.cloneDeep(oldSchema)
     expectedSchema.app.superchargeTokenConfigByToken = {}

--- a/src/redux/migrations.ts
+++ b/src/redux/migrations.ts
@@ -13,6 +13,7 @@ import { REMOTE_CONFIG_VALUES_DEFAULTS } from 'src/firebase/remoteConfigValuesDe
 import { AddressToDisplayNameType } from 'src/identity/reducer'
 import { VerificationStatus } from 'src/identity/types'
 import { PaymentDeepLinkHandler } from 'src/merchantPayment/types'
+import { TokenTransaction } from 'src/transactions/types'
 import { Currency } from 'src/utils/currencies'
 
 export const migrations = {
@@ -695,42 +696,51 @@ export const migrations = {
   }),
   59: (state: any) => ({
     ...state,
+    transactions: {
+      ...state.transactions,
+      transactions: (state.transactions.transactions || []).filter(
+        (transaction: TokenTransaction) => Object.keys(transaction).length > 0
+      ),
+    },
+  }),
+  60: (state: any) => ({
+    ...state,
     fiatConnect: {
       quotes: [],
       quotesLoading: false,
       quotesError: null,
     },
   }),
-  60: (state: any) => ({
+  61: (state: any) => ({
     ...state,
     app: {
       ...state.app,
       showSwapMenuInDrawerMenu: REMOTE_CONFIG_VALUES_DEFAULTS.showSwapMenuInDrawerMenu,
     },
   }),
-  61: (state: any) => ({
+  62: (state: any) => ({
     ...state,
     fiatConnect: {
       ...state.fiatConnect,
       transfer: null,
     },
   }),
-  62: (state: any) => ({
+  63: (state: any) => ({
     ...state,
     app: {
       ..._.omit(state.app, 'superchargeTokens'),
       superchargeTokenConfigByToken: {},
     },
   }),
-  63: (state: any) => ({
+  64: (state: any) => ({
     ...state,
     fiatConnect: {
       ...state.fiatConnect,
       providers: null,
     },
   }),
-  64: (state: any) => state,
-  65: (state: any) => ({
+  65: (state: any) => state,
+  66: (state: any) => ({
     ...state,
     fiatConnect: {
       ...state.fiatConnect,

--- a/src/redux/migrations.ts
+++ b/src/redux/migrations.ts
@@ -748,7 +748,7 @@ export const migrations = {
       attemptReturnUserFlowLoading: false,
     },
   }),
-  66: (state: any) => ({
+  67: (state: any) => ({
     ...state,
     fiatConnect: {
       ...state.fiatConnect,

--- a/src/redux/store.test.ts
+++ b/src/redux/store.test.ts
@@ -93,7 +93,7 @@ describe('store state', () => {
       Object {
         "_persist": Object {
           "rehydrated": true,
-          "version": 66,
+          "version": 67,
         },
         "account": Object {
           "acceptedTerms": false,

--- a/src/redux/store.test.ts
+++ b/src/redux/store.test.ts
@@ -93,7 +93,7 @@ describe('store state', () => {
       Object {
         "_persist": Object {
           "rehydrated": true,
-          "version": 65,
+          "version": 66,
         },
         "account": Object {
           "acceptedTerms": false,

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -23,7 +23,7 @@ const persistConfig: PersistConfig<RootState> = {
   key: 'root',
   // default is -1, increment as we make migrations
   // See https://github.com/valora-inc/wallet/tree/main/WALLET.md#redux-state-migration
-  version: 65,
+  version: 66,
   keyPrefix: `reduxStore-`, // the redux-persist default is `persist:` which doesn't work with some file systems.
   storage: FSStorage(),
   blacklist: ['networkInfo', 'alert', 'imports', 'supercharge'],

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -23,7 +23,7 @@ const persistConfig: PersistConfig<RootState> = {
   key: 'root',
   // default is -1, increment as we make migrations
   // See https://github.com/valora-inc/wallet/tree/main/WALLET.md#redux-state-migration
-  version: 66,
+  version: 67,
   keyPrefix: `reduxStore-`, // the redux-persist default is `persist:` which doesn't work with some file systems.
   storage: FSStorage(),
   blacklist: ['networkInfo', 'alert', 'imports', 'supercharge'],

--- a/src/transactions/feed/queryHelper.ts
+++ b/src/transactions/feed/queryHelper.ts
@@ -1,3 +1,4 @@
+import { isEmpty } from 'lodash'
 import { useState } from 'react'
 import { useAsync } from 'react-async-hook'
 import { useTranslation } from 'react-i18next'
@@ -78,10 +79,13 @@ export function useFetchTransactions(): QueryHookResult {
 
     const returnedTransactions = result.data?.tokenTransactionsV2?.transactions
     if (returnedTransactions?.length) {
-      addTransactions(returnedTransactions)
+      const nonEmptyTransactions = returnedTransactions.filter(
+        (returnedTransaction) => !isEmpty(returnedTransaction)
+      )
+      addTransactions(nonEmptyTransactions)
       // We store non-paginated results in redux to show them to the users when they open the app.
       if (!paginatedResult) {
-        dispatch(updateTransactions(returnedTransactions))
+        dispatch(updateTransactions(nonEmptyTransactions))
       }
     }
 

--- a/test/schemas.ts
+++ b/test/schemas.ts
@@ -1488,18 +1488,18 @@ export const v66Schema = {
     attemptReturnUserFlowLoading: false,
   },
 }
-export const v66Schema = {
-  ...v65Schema,
+export const v67Schema = {
+  ...v66Schema,
   _persist: {
-    ...v65Schema._persist,
-    version: 66,
+    ...v66Schema._persist,
+    version: 67,
   },
   fiatConnect: {
-    ...v65Schema.fiatConnect,
+    ...v66Schema.fiatConnect,
     selectFiatConnectQuoteLoading: false,
   },
 }
 
 export function getLatestSchema(): Partial<RootState> {
-  return v66Schema as Partial<RootState>
+  return v67Schema as Partial<RootState>
 }

--- a/test/schemas.ts
+++ b/test/schemas.ts
@@ -1385,11 +1385,6 @@ export const v59Schema = {
     ...v58Schema._persist,
     version: 59,
   },
-  fiatConnect: {
-    quotes: [],
-    quotesLoading: false,
-    quotesError: null,
-  },
 }
 
 export const v60Schema = {
@@ -1398,9 +1393,10 @@ export const v60Schema = {
     ...v59Schema._persist,
     version: 60,
   },
-  app: {
-    ...v59Schema.app,
-    showSwapMenuInDrawerMenu: false,
+  fiatConnect: {
+    quotes: [],
+    quotesLoading: false,
+    quotesError: null,
   },
 }
 
@@ -1410,9 +1406,9 @@ export const v61Schema = {
     ...v60Schema._persist,
     version: 61,
   },
-  fiatConnect: {
-    ...v60Schema.fiatConnect,
-    transfer: null,
+  app: {
+    ...v60Schema.app,
+    showSwapMenuInDrawerMenu: false,
   },
 }
 
@@ -1422,8 +1418,20 @@ export const v62Schema = {
     ...v61Schema._persist,
     version: 62,
   },
+  fiatConnect: {
+    ...v61Schema.fiatConnect,
+    transfer: null,
+  },
+}
+
+export const v63Schema = {
+  ...v62Schema,
+  _persist: {
+    ...v62Schema._persist,
+    version: 63,
+  },
   app: {
-    ..._.omit(v61Schema.app, 'superchargeTokens'),
+    ..._.omit(v62Schema.app, 'superchargeTokens'),
     superchargeTokenConfigByToken: {
       [mockCusdAddress]: {
         minBalance: 10,
@@ -1437,27 +1445,27 @@ export const v62Schema = {
   },
 }
 
-export const v63Schema = {
-  ...v62Schema,
-  _persist: {
-    ...v62Schema._persist,
-    version: 63,
-  },
-  fiatConnect: {
-    ...v62Schema.fiatConnect,
-    providers: null,
-  },
-}
-
 export const v64Schema = {
   ...v63Schema,
   _persist: {
     ...v63Schema._persist,
     version: 64,
   },
+  fiatConnect: {
+    ...v63Schema.fiatConnect,
+    providers: null,
+  },
+}
+
+export const v65Schema = {
+  ...v64Schema,
+  _persist: {
+    ...v64Schema._persist,
+    version: 64,
+  },
   fees: {
-    ...v63Schema.fees,
-    estimates: Object.entries(v63Schema.fees.estimates).reduce((acc, [address, estimate]) => {
+    ...v64Schema.fees,
+    estimates: Object.entries(v64Schema.fees.estimates).reduce((acc, [address, estimate]) => {
       return {
         ...acc,
         [address]: {
@@ -1468,19 +1476,19 @@ export const v64Schema = {
     }, {}),
   },
 }
-export const v65Schema = {
-  ...v64Schema,
+export const v66Schema = {
+  ...v65Schema,
   _persist: {
-    ...v64Schema._persist,
-    version: 65,
+    ...v65Schema._persist,
+    version: 66,
   },
   fiatConnect: {
-    ...v64Schema.fiatConnect,
+    ...v65Schema.fiatConnect,
     cachedFiatAccountUses: [],
     attemptReturnUserFlowLoading: false,
   },
 }
 
 export function getLatestSchema(): Partial<RootState> {
-  return v65Schema as Partial<RootState>
+  return v66Schema as Partial<RootState>
 }


### PR DESCRIPTION
### Description

Applies the schema changes and fixes from the 1.36.1 and 1.37.1 patches.

### Other changes

N/A 

### Tested

Tested locally on iOS.

### How others should test

N/A

### Related issues

N/A

### Backwards compatibility

For users - Yes.
For developers who have been working off main a reinstall of the app my be needed, due to changes in redux migrations.