### PR TITLE
fix: prevent saving empty name

### DIFF
--- a/src/account/Profile.test.tsx
+++ b/src/account/Profile.test.tsx
@@ -4,6 +4,8 @@ import 'react-native'
 import { Provider } from 'react-redux'
 import { saveNameAndPicture } from 'src/account/actions'
 import Profile from 'src/account/Profile'
+import { showError } from 'src/alert/actions'
+import { ErrorMessages } from 'src/app/ErrorMessages'
 import { Screens } from 'src/navigator/Screens'
 import { RootState } from 'src/redux/reducers'
 import { createMockStore, getMockStackScreenProps } from 'test/utils'
@@ -42,6 +44,30 @@ describe('Profile', () => {
 
       fireEvent.press(getByTestId('SaveButton'))
       expect(store.getActions()).toEqual(expect.arrayContaining([saveNameAndPicture(name, null)]))
+    })
+
+    it('serves error banner when attempting to save empty name', () => {
+      let headerSaveButton: React.ReactNode
+      ;(mockNavigation.setOptions as jest.Mock).mockImplementation((options) => {
+        headerSaveButton = options.headerRight()
+      })
+
+      const { getByDisplayValue } = render(
+        <Provider store={store}>
+          <Profile {...getMockStackScreenProps(Screens.Profile)} />
+        </Provider>
+      )
+
+      const input = getByDisplayValue((store.getState() as RootState).account.name!)
+      fireEvent.changeText(input, '')
+
+      const { getByTestId } = render(<Provider store={store}>{headerSaveButton}</Provider>)
+
+      fireEvent.press(getByTestId('SaveButton'))
+
+      expect(store.getActions()).toEqual(
+        expect.arrayContaining([showError(ErrorMessages.MISSING_FULL_NAME)])
+      )
     })
   })
 })

--- a/src/account/Profile.tsx
+++ b/src/account/Profile.tsx
@@ -33,6 +33,10 @@ function Profile({ navigation, route }: Props) {
 
   useLayoutEffect(() => {
     const onSave = () => {
+      if (newName.length === 0) {
+        dispatch(showError(ErrorMessages.MISSING_FULL_NAME))
+        return
+      }
       dispatch(saveNameAndPicture(newName, newPictureUri))
       dispatch(showMessage(t('namePictureSaved')))
       navigation.goBack()


### PR DESCRIPTION
### Description

Prevents users from saving empty names on edit profile screen.

### Other changes

N/A

### Tested

Tested locally on iOS

### How others should test

When attempting to save an empty name on edit profile an error banner should be served with the text, 'Name cannot be empty'

### Related issues

- Fixes #2741

### Backwards compatibility

Yes

_Brief explanation of why these changes are/are not backwards compatible._