### PR TITLE
fix(fiatconnect): move exported consts to avoid cyclic dependency

### DIFF
--- a/src/fiatExchanges/quotes/FiatConnectQuote.ts
+++ b/src/fiatExchanges/quotes/FiatConnectQuote.ts
@@ -7,10 +7,6 @@ import {
 import BigNumber from 'bignumber.js'
 import { Dispatch } from 'redux'
 import { FiatConnectQuoteSuccess } from 'src/fiatconnect'
-import {
-  SUPPORTED_FIAT_ACCOUNT_SCHEMAS,
-  SUPPORTED_FIAT_ACCOUNT_TYPES,
-} from 'src/fiatconnect/FiatDetailsScreen'
 import { selectFiatConnectQuote } from 'src/fiatconnect/slice'
 import NormalizedQuote from 'src/fiatExchanges/quotes/NormalizedQuote'
 import { CICOFlow, PaymentMethod } from 'src/fiatExchanges/utils'
@@ -26,6 +22,10 @@ const strings = {
   numDays: i18n.t('selectProviderScreen.numDays'),
   idRequired: i18n.t('selectProviderScreen.idRequired'),
 }
+
+// TODO: When we add support for more types be sure to add more unit tests to the FiatConnectQuotes class
+const SUPPORTED_FIAT_ACCOUNT_TYPES = new Set<FiatAccountType>([FiatAccountType.BankAccount])
+const SUPPORTED_FIAT_ACCOUNT_SCHEMAS = new Set<FiatAccountSchema>([FiatAccountSchema.AccountNumber])
 
 export default class FiatConnectQuote extends NormalizedQuote {
   quote: FiatConnectQuoteSuccess

--- a/src/fiatconnect/FiatDetailsScreen.tsx
+++ b/src/fiatconnect/FiatDetailsScreen.tsx
@@ -40,12 +40,6 @@ type ScreenProps = StackScreenProps<StackParamList, Screens.FiatDetailsScreen>
 
 type Props = ScreenProps
 
-export const SUPPORTED_FIAT_ACCOUNT_TYPES = new Set<FiatAccountType>([FiatAccountType.BankAccount])
-// TODO: When we add support for more types be sure to add more unit tests to the FiatConnectQuotes class
-export const SUPPORTED_FIAT_ACCOUNT_SCHEMAS = new Set<FiatAccountSchema>([
-  FiatAccountSchema.AccountNumber,
-])
-
 interface FormFieldParam {
   name: string
   label: string


### PR DESCRIPTION
### Description

Fixes the following import cycle:
src/navigator/types -> src/fiatExchanges/quotes/FiatConnectQuote -> src/fiatconnect/FiatDetailsScreen -> src/navigator/types
This was also causing the test failure on #2760

### Other changes

N/A

### Tested

N/A

### How others should test

N/A

### Related issues

N/A

### Backwards compatibility

N/A