### PR TITLE
feat(fiatconnect): show validation errors after typing is complete

### DIFF
--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -1339,15 +1339,9 @@
     "selectDone": "Done"
   },
   "fiatAccountSchema": {
-    "accountName": {
-      "label": "Account Name",
-      "placeholderText": "A name for the account",
-      "errorMessage": "An account name is required"
-    },
     "institutionName": {
       "label": "Bank Name",
-      "placeholderText": "Enter Bank Name",
-      "errorMessage": "A bank name is required"
+      "placeholderText": "Enter Bank Name"
     },
     "accountNumber": {
       "label": "Account Number",

--- a/src/fiatconnect/FiatDetailsScreen.test.tsx
+++ b/src/fiatconnect/FiatDetailsScreen.test.tsx
@@ -132,9 +132,10 @@ describe('FiatDetailsScreen', () => {
     expect(queryByText('fiatAccountSchema.accountNumber.label')).toBeTruthy()
     expect(queryByTestId('input-accountNumber')).toBeTruthy()
 
-    expect(queryByTestId('errorMessage')).toBeFalsy()
+    expect(queryByTestId(/errorMessage-.+/)).toBeFalsy()
 
     expect(queryByTestId('nextButton')).toBeTruthy()
+    expect(queryByTestId('nextButton')).toBeDisabled()
   })
   it('renders header with provider image', () => {
     let headerTitle: React.ReactNode
@@ -208,6 +209,21 @@ describe('FiatDetailsScreen', () => {
       fiatAccountSchema: quoteWithAllowedValues.getFiatAccountSchema(),
     })
   })
+  it('button remains disabled if required input field is empty', () => {
+    const { queryByText, getByTestId, queryByTestId } = render(
+      <Provider store={store}>
+        <FiatDetailsScreen {...mockScreenPropsWithAllowedValues} />
+      </Provider>
+    )
+
+    expect(queryByText('fiatAccountSchema.institutionName.label')).toBeTruthy()
+    expect(queryByText('fiatAccountSchema.accountNumber.label')).toBeTruthy()
+    expect(queryByTestId(/errorMessage-.+/)).toBeFalsy()
+
+    fireEvent.changeText(getByTestId('input-accountNumber'), fakeAccountNumber)
+
+    expect(queryByTestId('nextButton')).toBeDisabled()
+  })
   it('shows validation error if the input field does not fulfill the requirement after delay', () => {
     const { queryByText, getByTestId, queryByTestId } = render(
       <Provider store={store}>
@@ -217,16 +233,17 @@ describe('FiatDetailsScreen', () => {
 
     expect(queryByText('fiatAccountSchema.institutionName.label')).toBeTruthy()
     expect(queryByText('fiatAccountSchema.accountNumber.label')).toBeTruthy()
-    expect(queryByTestId('errorMessage')).toBeFalsy()
+    expect(queryByTestId(/errorMessage-.+/)).toBeFalsy()
 
     fireEvent.changeText(getByTestId('input-accountNumber'), '12dtfa')
 
     // Should see an error message saying the account number field is invalid
     // after delay
-    expect(queryByTestId('errorMessage')).toBeFalsy()
+    expect(queryByTestId(/errorMessage-.+/)).toBeFalsy()
     jest.advanceTimersByTime(1500)
-    expect(queryByTestId('errorMessage')).toBeTruthy()
+    expect(queryByTestId('errorMessage-accountNumber')).toBeTruthy()
     expect(queryByText('fiatAccountSchema.accountNumber.errorMessage')).toBeTruthy()
+    expect(queryByTestId('nextButton')).toBeDisabled()
   })
   it('shows validation error if the input field does not fulfill the requirement immediately on blur', () => {
     const { queryByText, getByTestId, queryByTestId } = render(
@@ -237,15 +254,16 @@ describe('FiatDetailsScreen', () => {
 
     expect(queryByText('fiatAccountSchema.institutionName.label')).toBeTruthy()
     expect(queryByText('fiatAccountSchema.accountNumber.label')).toBeTruthy()
-    expect(queryByTestId('errorMessage')).toBeFalsy()
+    expect(queryByTestId(/errorMessage-.+/)).toBeFalsy()
 
     fireEvent.changeText(getByTestId('input-accountNumber'), '12dtfa')
     fireEvent(getByTestId('input-accountNumber'), 'blur')
 
     // Should see an error message saying the account number field is invalid
     // immediately since the field loses focus
-    expect(queryByTestId('errorMessage')).toBeTruthy()
+    expect(queryByTestId('errorMessage-accountNumber')).toBeTruthy()
     expect(queryByText('fiatAccountSchema.accountNumber.errorMessage')).toBeTruthy()
+    expect(queryByTestId('nextButton')).toBeDisabled()
   })
   it('sends a successful request to add new fiat account after pressing the next button [Schema: AccountName]', async () => {
     const { getByTestId } = render(

--- a/src/fiatconnect/FiatDetailsScreen.test.tsx
+++ b/src/fiatconnect/FiatDetailsScreen.test.tsx
@@ -58,6 +58,7 @@ jest.mock('@fiatconnect/fiatconnect-sdk', () => ({
   })),
 }))
 jest.mock('src/fiatconnect/clients')
+jest.useFakeTimers()
 
 const store = createMockStore({})
 const quoteWithAllowedValues = new FiatConnectQuote({
@@ -207,7 +208,7 @@ describe('FiatDetailsScreen', () => {
       fiatAccountSchema: quoteWithAllowedValues.getFiatAccountSchema(),
     })
   })
-  it('shows validation error if the input field does not fulfill the requirement', () => {
+  it('shows validation error if the input field does not fulfill the requirement after delay', () => {
     const { queryByText, getByTestId, queryByTestId } = render(
       <Provider store={store}>
         <FiatDetailsScreen {...mockScreenPropsWithAllowedValues} />
@@ -221,6 +222,28 @@ describe('FiatDetailsScreen', () => {
     fireEvent.changeText(getByTestId('input-accountNumber'), '12dtfa')
 
     // Should see an error message saying the account number field is invalid
+    // after delay
+    expect(queryByTestId('errorMessage')).toBeFalsy()
+    jest.advanceTimersByTime(1500)
+    expect(queryByTestId('errorMessage')).toBeTruthy()
+    expect(queryByText('fiatAccountSchema.accountNumber.errorMessage')).toBeTruthy()
+  })
+  it('shows validation error if the input field does not fulfill the requirement immediately on blur', () => {
+    const { queryByText, getByTestId, queryByTestId } = render(
+      <Provider store={store}>
+        <FiatDetailsScreen {...mockScreenProps} />
+      </Provider>
+    )
+
+    expect(queryByText('fiatAccountSchema.institutionName.label')).toBeTruthy()
+    expect(queryByText('fiatAccountSchema.accountNumber.label')).toBeTruthy()
+    expect(queryByTestId('errorMessage')).toBeFalsy()
+
+    fireEvent.changeText(getByTestId('input-accountNumber'), '12dtfa')
+    fireEvent(getByTestId('input-accountNumber'), 'blur')
+
+    // Should see an error message saying the account number field is invalid
+    // immediately since the field loses focus
     expect(queryByTestId('errorMessage')).toBeTruthy()
     expect(queryByText('fiatAccountSchema.accountNumber.errorMessage')).toBeTruthy()
   })

--- a/src/fiatconnect/FiatDetailsScreen.tsx
+++ b/src/fiatconnect/FiatDetailsScreen.tsx
@@ -76,7 +76,7 @@ const getAccountNumberSchema = (implicitParams: {
   institutionName: {
     name: 'institutionName',
     label: i18n.t('fiatAccountSchema.institutionName.label'),
-    regex: /.*?/,
+    regex: /.+/,
     placeholderText: i18n.t('fiatAccountSchema.institutionName.placeholderText'),
     keyboardType: 'default',
   },
@@ -407,7 +407,7 @@ function FormField({
         />
       )}
       {field.errorMessage && hasError && showError && (
-        <Text testID="errorMessage" style={styles.error}>
+        <Text testID={`errorMessage-${field.name}`} style={styles.error}>
           {field.errorMessage}
         </Text>
       )}


### PR DESCRIPTION
### Description

Currently, the error message shows up immediately on typing the AccountNumber field. This updates so that the error message shows up after a 1.5s delay after typing or the field loses focus. Also, this doesn't clear the error message on a blank field. 

https://user-images.githubusercontent.com/5062591/183801146-d7fc81ce-0021-4079-9677-0b8861d438d8.mp4

https://user-images.githubusercontent.com/5062591/183801159-e1bbb052-6043-4609-98bc-45a7c3a2d61a.mp4


### Other changes

- Use indexes for error state instead of field names
- Use memo for schema
- Removed error for bank name as this is never displayed

### Tested

Unit tests, manual


### How others should test

1. Ensure you've not already linked a bank account with Valora test provider
2. Navigate to Withdraw flow on Alfajores
3. Select Bank Account with Valora test provider and click on Continue
4. On the bank details page, enter an invalid account number (valid account numbers have exactly 10 digits)
5. Error should pop up after a delay
6. Navigate back and click on Continue again
7. Enter an invalid account number and click outside the text field
8. Error should pop up immediately

### Related issues

- Fixes ACT-181

### Backwards compatibility

Yes