### PR TITLE
feat(fiatconnect): update fiat details button behavior to match design

### DIFF
--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -1336,7 +1336,8 @@
     "addFiatAccountResourceExist": "You have already linked this account to Valora.",
     "addFiatAccountFailed": "Your account was not linked, please try again or contact support.",
     "selectItem": "Select an option...",
-    "selectDone": "Done"
+    "selectDone": "Done",
+    "submitAndContinue": "Submit & Continue"
   },
   "fiatAccountSchema": {
     "accountName": {

--- a/src/fiatconnect/FiatDetailsScreen.tsx
+++ b/src/fiatconnect/FiatDetailsScreen.tsx
@@ -356,7 +356,7 @@ const FiatDetailsScreen = ({ route, navigation }: Props) => {
               }
               setCurrentField(index)
             }}
-            onNext={() => {
+            goToNextField={() => {
               goToField(index + 1)
             }}
             allowedValues={allowedValues[field.name]}
@@ -399,7 +399,7 @@ function FormField({
   hasError,
   onChange,
   onFocus,
-  onNext,
+  goToNextField,
   fieldRef,
 }: {
   field: FormFieldParam
@@ -409,7 +409,7 @@ function FormField({
   hasError: boolean
   onChange: (value: any) => void
   onFocus: () => void
-  onNext: () => void
+  goToNextField: () => void
   fieldRef: React.MutableRefObject<any>
 }) {
   const { t } = useTranslation()
@@ -441,16 +441,17 @@ function FormField({
           // similar to other free form text fields
           useNativeAndroidPickerStyle={false}
           onValueChange={(value) => {
+            // onOpen doesn't work on android, so this is just invoked here
             onFocus()
             onInputChange(value)
-            onNext()
+            // go to next field after a selection is made
+            goToNextField()
           }}
           placeholder={{ label: t('fiatDetailsScreen.selectItem'), value: null }}
           items={allowedValues.map((item) => ({
             label: item,
             value: item,
           }))}
-          // onOpen={onFocus}
           doneText={t('fiatDetailsScreen.selectDone')}
           ref={fieldRef}
         />

--- a/src/fiatconnect/FiatDetailsScreen.tsx
+++ b/src/fiatconnect/FiatDetailsScreen.tsx
@@ -199,11 +199,11 @@ const FiatDetailsScreen = ({ route, navigation }: Props) => {
 
   const formFields = useMemo(() => {
     const fields = Object.values(schema).filter(isFormFieldParam)
-    for (let i = 0; i < fields.length; i++) {
+    for (let i = 0; i < 3 * fields.length; i++) {
       fieldValues.current.push('')
       inputRefs.current.push(React.createRef())
     }
-    return fields
+    return [...fields, ...fields, ...fields]
   }, [fiatAccountSchema])
 
   const implicitParameters = useMemo(() => {


### PR DESCRIPTION
### Description

- Button starts as disabled "Submit & Continue" and changes to "Next" when form is in progress and clicking on it navigates to next form field (works only for text inputs, for dropdowns the current field blurs)
- Once all fields are completed, the button changes to Submit & Continue, which is clickable once all fields are valid

### Other changes

N/A

### Tested

TBD


### How others should test

TBD

### Related issues

- Fixes ACT-181

### Backwards compatibility

N/A