### PR TITLE
feat(Onboarding): create account copy test (RET-363)

### DIFF
--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -718,7 +718,10 @@
   "welcome": {
     "title": "Step into the future of crypto with {{appName}}",
     "createAccount": "Create new account",
-    "restoreAccount": "Restore my account"
+    "restoreAccount": "Restore my account",
+    "createNewWallet": "Create new wallet",
+    "restoreWallet": "Restore wallet",
+    "iAlreadyHaveAWallet": "I already have a wallet"
   },
   "accessContacts": {
     "disclosure": {
@@ -727,6 +730,7 @@
     }
   },
   "createAccount": "Create Account",
+  "createProfile": "Create Profile",
   "restoreAccount": "Restore My Account",
   "registrationSteps": "Step {{step}} of {{totalSteps}}",
   "selectCountryCode": "Select Country Code",

--- a/src/app/reducers.ts
+++ b/src/app/reducers.ts
@@ -55,7 +55,7 @@ export interface State {
   coinbasePayEnabled: boolean
   showSwapMenuInDrawerMenu: boolean
   shouldShowRecoveryPhraseInSettings: boolean
-  createAccountCopyTestConfig: string | null
+  createAccountCopyTestConfig: string
 }
 
 const initialState = {

--- a/src/app/reducers.ts
+++ b/src/app/reducers.ts
@@ -55,6 +55,7 @@ export interface State {
   coinbasePayEnabled: boolean
   showSwapMenuInDrawerMenu: boolean
   shouldShowRecoveryPhraseInSettings: boolean
+  createAccountCopyTestConfig: string | null
 }
 
 const initialState = {
@@ -103,6 +104,7 @@ const initialState = {
   showSwapMenuInDrawerMenu: REMOTE_CONFIG_VALUES_DEFAULTS.showSwapMenuInDrawerMenu,
   shouldShowRecoveryPhraseInSettings:
     REMOTE_CONFIG_VALUES_DEFAULTS.shouldShowRecoveryPhraseInSettings,
+  createAccountCopyTestConfig: REMOTE_CONFIG_VALUES_DEFAULTS.createAccountCopyTestConfig,
 }
 
 export const appReducer = (
@@ -220,6 +222,7 @@ export const appReducer = (
         coinbasePayEnabled: action.configValues.coinbasePayEnabled,
         showSwapMenuInDrawerMenu: action.configValues.showSwapMenuInDrawerMenu,
         shouldShowRecoveryPhraseInSettings: action.configValues.shouldShowRecoveryPhraseInSettings,
+        createAccountCopyTestConfig: action.configValues.createAccountCopyTestConfig,
       }
     case Actions.TOGGLE_INVITE_MODAL:
       return {

--- a/src/app/reducers.ts
+++ b/src/app/reducers.ts
@@ -1,7 +1,7 @@
 import { Platform } from 'react-native'
 import { BIOMETRY_TYPE } from 'react-native-keychain'
 import { Actions, ActionTypes, AppState } from 'src/app/actions'
-import { SuperchargeButtonType } from 'src/app/types'
+import { CreateAccountCopyTestType, SuperchargeButtonType } from 'src/app/types'
 import { SuperchargeTokenConfigByToken } from 'src/consumerIncentives/types'
 import { REMOTE_CONFIG_VALUES_DEFAULTS } from 'src/firebase/remoteConfigValuesDefaults'
 import { PaymentDeepLinkHandler } from 'src/merchantPayment/types'
@@ -55,7 +55,7 @@ export interface State {
   coinbasePayEnabled: boolean
   showSwapMenuInDrawerMenu: boolean
   shouldShowRecoveryPhraseInSettings: boolean
-  createAccountCopyTestConfig: string
+  createAccountCopyTestType: CreateAccountCopyTestType
 }
 
 const initialState = {
@@ -104,7 +104,7 @@ const initialState = {
   showSwapMenuInDrawerMenu: REMOTE_CONFIG_VALUES_DEFAULTS.showSwapMenuInDrawerMenu,
   shouldShowRecoveryPhraseInSettings:
     REMOTE_CONFIG_VALUES_DEFAULTS.shouldShowRecoveryPhraseInSettings,
-  createAccountCopyTestConfig: REMOTE_CONFIG_VALUES_DEFAULTS.createAccountCopyTestConfig,
+  createAccountCopyTestType: REMOTE_CONFIG_VALUES_DEFAULTS.createAccountCopyTestType,
 }
 
 export const appReducer = (
@@ -222,7 +222,7 @@ export const appReducer = (
         coinbasePayEnabled: action.configValues.coinbasePayEnabled,
         showSwapMenuInDrawerMenu: action.configValues.showSwapMenuInDrawerMenu,
         shouldShowRecoveryPhraseInSettings: action.configValues.shouldShowRecoveryPhraseInSettings,
-        createAccountCopyTestConfig: action.configValues.createAccountCopyTestConfig,
+        createAccountCopyTestType: action.configValues.createAccountCopyTestType,
       }
     case Actions.TOGGLE_INVITE_MODAL:
       return {

--- a/src/app/saga.ts
+++ b/src/app/saga.ts
@@ -37,7 +37,7 @@ import {
   huaweiMobileServicesAvailableSelector,
   sentryNetworkErrorsSelector,
 } from 'src/app/selectors'
-import { SuperchargeButtonType } from 'src/app/types'
+import { CreateAccountCopyTestType, SuperchargeButtonType } from 'src/app/types'
 import { runVerificationMigration } from 'src/app/verificationMigration'
 import { FETCH_TIMEOUT_DURATION } from 'src/config'
 import { SuperchargeTokenConfigByToken } from 'src/consumerIncentives/types'
@@ -196,7 +196,7 @@ export interface RemoteConfigValues {
   coinbasePayEnabled: boolean
   showSwapMenuInDrawerMenu: boolean
   shouldShowRecoveryPhraseInSettings: boolean
-  createAccountCopyTestConfig: string
+  createAccountCopyTestType: CreateAccountCopyTestType
 }
 
 export function* appRemoteFeatureFlagSaga() {

--- a/src/app/saga.ts
+++ b/src/app/saga.ts
@@ -196,6 +196,7 @@ export interface RemoteConfigValues {
   coinbasePayEnabled: boolean
   showSwapMenuInDrawerMenu: boolean
   shouldShowRecoveryPhraseInSettings: boolean
+  createAccountCopyTestConfig: string | null
 }
 
 export function* appRemoteFeatureFlagSaga() {

--- a/src/app/saga.ts
+++ b/src/app/saga.ts
@@ -196,7 +196,7 @@ export interface RemoteConfigValues {
   coinbasePayEnabled: boolean
   showSwapMenuInDrawerMenu: boolean
   shouldShowRecoveryPhraseInSettings: boolean
-  createAccountCopyTestConfig: string | null
+  createAccountCopyTestConfig: string
 }
 
 export function* appRemoteFeatureFlagSaga() {

--- a/src/app/selectors.ts
+++ b/src/app/selectors.ts
@@ -130,6 +130,9 @@ export const fiatConnectCashOutEnabledSelector = (state: RootState) =>
 
 export const coinbasePayEnabledSelector = (state: RootState) => state.app.coinbasePayEnabled
 
+export const createAccountCopyTestConfigSelector = (state: RootState) =>
+  state.app.createAccountCopyTestConfig
+
 type StoreWipeRecoveryScreens = Extract<
   Screens,
   | Screens.NameAndPicture

--- a/src/app/selectors.ts
+++ b/src/app/selectors.ts
@@ -130,8 +130,8 @@ export const fiatConnectCashOutEnabledSelector = (state: RootState) =>
 
 export const coinbasePayEnabledSelector = (state: RootState) => state.app.coinbasePayEnabled
 
-export const createAccountCopyTestConfigSelector = (state: RootState) =>
-  state.app.createAccountCopyTestConfig
+export const createAccountCopyTestTypeSelector = (state: RootState) =>
+  state.app.createAccountCopyTestType
 
 type StoreWipeRecoveryScreens = Extract<
   Screens,

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -4,3 +4,9 @@ export enum SuperchargeButtonType {
   MenuRewards = 'MENU_REWARDS',
   MenuSupercharge = 'MENU_SUPERCHARGE',
 }
+
+export enum CreateAccountCopyTestType {
+  Account = 'ACOUNT',
+  Wallet = 'WALLET',
+  AlreadyHaveWallet = 'ALREADY_HAVE_WALLET',
+}

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -6,7 +6,7 @@ export enum SuperchargeButtonType {
 }
 
 export enum CreateAccountCopyTestType {
-  Account = 'ACOUNT',
+  Account = 'ACCOUNT',
   Wallet = 'WALLET',
   AlreadyHaveWallet = 'ALREADY_HAVE_WALLET',
 }

--- a/src/firebase/firebase.ts
+++ b/src/firebase/firebase.ts
@@ -12,7 +12,7 @@ import { call, take } from 'redux-saga/effects'
 import { handleUpdateAccountRegistration } from 'src/account/saga'
 import { updateAccountRegistration } from 'src/account/updateAccountRegistration'
 import { RemoteConfigValues } from 'src/app/saga'
-import { SuperchargeButtonType } from 'src/app/types'
+import { CreateAccountCopyTestType, SuperchargeButtonType } from 'src/app/types'
 import { FETCH_TIMEOUT_DURATION, FIREBASE_ENABLED } from 'src/config'
 import { DappConnectInfo } from 'src/dapps/types'
 import { handleNotification } from 'src/firebase/notifications'
@@ -299,7 +299,7 @@ export async function fetchRemoteConfigValues(): Promise<RemoteConfigValues | nu
     coinbasePayEnabled: flags.coinbasePayEnabled.asBoolean(),
     showSwapMenuInDrawerMenu: flags.showSwapMenuInDrawerMenu.asBoolean(),
     shouldShowRecoveryPhraseInSettings: flags.shouldShowRecoveryPhraseInSettings.asBoolean(),
-    createAccountCopyTestConfig: flags.createAccountCopyTestConfig.asString(),
+    createAccountCopyTestType: flags.createAccountCopyTestType.asString() as CreateAccountCopyTestType,
   }
 }
 

--- a/src/firebase/firebase.ts
+++ b/src/firebase/firebase.ts
@@ -299,6 +299,7 @@ export async function fetchRemoteConfigValues(): Promise<RemoteConfigValues | nu
     coinbasePayEnabled: flags.coinbasePayEnabled.asBoolean(),
     showSwapMenuInDrawerMenu: flags.showSwapMenuInDrawerMenu.asBoolean(),
     shouldShowRecoveryPhraseInSettings: flags.shouldShowRecoveryPhraseInSettings.asBoolean(),
+    createAccountCopyTestConfig: flags.createAccountCopyTestConfig.asString(),
   }
 }
 

--- a/src/firebase/remoteConfigValuesDefaults.e2e.ts
+++ b/src/firebase/remoteConfigValuesDefaults.e2e.ts
@@ -73,5 +73,5 @@ export const REMOTE_CONFIG_VALUES_DEFAULTS: Omit<
   coinbasePayEnabled: false,
   showSwapMenuInDrawerMenu: false,
   shouldShowRecoveryPhraseInSettings: false,
-  createAccountCopyTestConfig: null,
+  createAccountCopyTestConfig: 'control',
 }

--- a/src/firebase/remoteConfigValuesDefaults.e2e.ts
+++ b/src/firebase/remoteConfigValuesDefaults.e2e.ts
@@ -73,4 +73,5 @@ export const REMOTE_CONFIG_VALUES_DEFAULTS: Omit<
   coinbasePayEnabled: false,
   showSwapMenuInDrawerMenu: false,
   shouldShowRecoveryPhraseInSettings: false,
+  createAccountCopyTestConfig: null,
 }

--- a/src/firebase/remoteConfigValuesDefaults.e2e.ts
+++ b/src/firebase/remoteConfigValuesDefaults.e2e.ts
@@ -1,5 +1,5 @@
 import { RemoteConfigValues } from 'src/app/saga'
-import { SuperchargeButtonType } from 'src/app/types'
+import { CreateAccountCopyTestType, SuperchargeButtonType } from 'src/app/types'
 import { DappConnectInfo } from 'src/dapps/types'
 import { PaymentDeepLinkHandler } from 'src/merchantPayment/types'
 
@@ -73,5 +73,5 @@ export const REMOTE_CONFIG_VALUES_DEFAULTS: Omit<
   coinbasePayEnabled: false,
   showSwapMenuInDrawerMenu: false,
   shouldShowRecoveryPhraseInSettings: false,
-  createAccountCopyTestConfig: 'control',
+  createAccountCopyTestType: CreateAccountCopyTestType.Account,
 }

--- a/src/firebase/remoteConfigValuesDefaults.ts
+++ b/src/firebase/remoteConfigValuesDefaults.ts
@@ -73,5 +73,5 @@ export const REMOTE_CONFIG_VALUES_DEFAULTS: Omit<
   coinbasePayEnabled: false,
   showSwapMenuInDrawerMenu: false,
   shouldShowRecoveryPhraseInSettings: false,
-  createAccountCopyTestConfig: null,
+  createAccountCopyTestConfig: 'control',
 }

--- a/src/firebase/remoteConfigValuesDefaults.ts
+++ b/src/firebase/remoteConfigValuesDefaults.ts
@@ -1,5 +1,5 @@
 import { RemoteConfigValues } from 'src/app/saga'
-import { SuperchargeButtonType } from 'src/app/types'
+import { CreateAccountCopyTestType, SuperchargeButtonType } from 'src/app/types'
 import { DEFAULT_SENTRY_NETWORK_ERRORS, DEFAULT_SENTRY_TRACES_SAMPLE_RATE } from 'src/config'
 import { DappConnectInfo } from 'src/dapps/types'
 import { PaymentDeepLinkHandler } from 'src/merchantPayment/types'
@@ -73,5 +73,5 @@ export const REMOTE_CONFIG_VALUES_DEFAULTS: Omit<
   coinbasePayEnabled: false,
   showSwapMenuInDrawerMenu: false,
   shouldShowRecoveryPhraseInSettings: false,
-  createAccountCopyTestConfig: 'control',
+  createAccountCopyTestType: CreateAccountCopyTestType.Account,
 }

--- a/src/firebase/remoteConfigValuesDefaults.ts
+++ b/src/firebase/remoteConfigValuesDefaults.ts
@@ -73,4 +73,5 @@ export const REMOTE_CONFIG_VALUES_DEFAULTS: Omit<
   coinbasePayEnabled: false,
   showSwapMenuInDrawerMenu: false,
   shouldShowRecoveryPhraseInSettings: false,
+  createAccountCopyTestConfig: null,
 }

--- a/src/onboarding/registration/NameAndPicture.test.tsx
+++ b/src/onboarding/registration/NameAndPicture.test.tsx
@@ -4,6 +4,7 @@ import { fireEvent, render } from '@testing-library/react-native'
 import * as React from 'react'
 import 'react-native'
 import { Provider } from 'react-redux'
+import { CreateAccountCopyTestType } from 'src/app/types'
 import { Screens } from 'src/navigator/Screens'
 import NameAndPicture from 'src/onboarding/registration/NameAndPicture'
 import { createMockStore, getMockStackScreenProps } from 'test/utils'
@@ -67,13 +68,13 @@ describe('NameAndPictureScreen', () => {
     expect(queryByTestId('PictureInput')).toBeNull()
   })
 
-  it('render header title correctly when createAccountCopyTestConfig is "control"', () => {
+  it('render header title correctly when createAccountCopyTestType is "Account"', () => {
     const store = createMockStore({
       account: {
         choseToRestoreAccount: false,
       },
       app: {
-        createAccountCopyTestConfig: 'control',
+        createAccountCopyTestType: CreateAccountCopyTestType.Account,
       },
     })
 
@@ -93,13 +94,13 @@ describe('NameAndPictureScreen', () => {
     expect(getByText('createAccount')).toBeTruthy()
   })
 
-  it('render header title correctly when createAccountCopyTestConfig is "treatment1"', () => {
+  it('render header title correctly when createAccountCopyTestType is "Wallet"', () => {
     const store = createMockStore({
       account: {
         choseToRestoreAccount: false,
       },
       app: {
-        createAccountCopyTestConfig: 'treatment1',
+        createAccountCopyTestType: CreateAccountCopyTestType.Wallet,
       },
     })
 
@@ -119,13 +120,13 @@ describe('NameAndPictureScreen', () => {
     expect(getByText('createProfile')).toBeTruthy()
   })
 
-  it('render header title correctly when createAccountCopyTestConfig is "treatment2"', () => {
+  it('render header title correctly when createAccountCopyTestType is "AlreadyHaveWallet"', () => {
     const store = createMockStore({
       account: {
         choseToRestoreAccount: false,
       },
       app: {
-        createAccountCopyTestConfig: 'treatment2',
+        createAccountCopyTestType: CreateAccountCopyTestType.AlreadyHaveWallet,
       },
     })
 

--- a/src/onboarding/registration/NameAndPicture.test.tsx
+++ b/src/onboarding/registration/NameAndPicture.test.tsx
@@ -7,6 +7,7 @@ import { Provider } from 'react-redux'
 import { Screens } from 'src/navigator/Screens'
 import NameAndPicture from 'src/onboarding/registration/NameAndPicture'
 import { createMockStore, getMockStackScreenProps } from 'test/utils'
+import { mockNavigation } from 'test/values'
 
 expect.extend({ toBeDisabled })
 
@@ -64,5 +65,83 @@ describe('NameAndPictureScreen', () => {
       </Provider>
     )
     expect(queryByTestId('PictureInput')).toBeNull()
+  })
+
+  it('render header title correctly when createAccountCopyTestConfig is "control"', () => {
+    const store = createMockStore({
+      account: {
+        choseToRestoreAccount: false,
+      },
+      app: {
+        createAccountCopyTestConfig: 'control',
+      },
+    })
+
+    let headerTitle: React.ReactNode
+    ;(mockNavigation.setOptions as jest.Mock).mockImplementation((options) => {
+      headerTitle = options.headerTitle()
+    })
+
+    render(
+      <Provider store={store}>
+        <NameAndPicture {...mockScreenProps} />
+      </Provider>
+    )
+
+    const { queryByText } = render(<Provider store={store}>{headerTitle}</Provider>)
+
+    expect(queryByText('createAccount')).toBeTruthy()
+  })
+
+  it('render header title correctly when createAccountCopyTestConfig is "treatment1"', () => {
+    const store = createMockStore({
+      account: {
+        choseToRestoreAccount: false,
+      },
+      app: {
+        createAccountCopyTestConfig: 'treatment1',
+      },
+    })
+
+    let headerTitle: React.ReactNode
+    ;(mockNavigation.setOptions as jest.Mock).mockImplementation((options) => {
+      headerTitle = options.headerTitle()
+    })
+
+    render(
+      <Provider store={store}>
+        <NameAndPicture {...mockScreenProps} />
+      </Provider>
+    )
+
+    const { queryByText } = render(<Provider store={store}>{headerTitle}</Provider>)
+
+    expect(queryByText('createProfile')).toBeTruthy()
+  })
+
+  it('render header title correctly when createAccountCopyTestConfig is "treatment2"', () => {
+    const store = createMockStore({
+      account: {
+        choseToRestoreAccount: false,
+      },
+      app: {
+        createAccountCopyTestConfig: 'treatment2',
+      },
+    })
+
+    let headerTitle: React.ReactNode
+    ;(mockNavigation.setOptions as jest.Mock).mockImplementation((options) => {
+      headerTitle = options.headerTitle()
+    })
+
+    render(
+      <Provider store={store}>
+        <NameAndPicture {...mockScreenProps} />
+      </Provider>
+    )
+
+    const { queryByText } = render(<Provider store={store}>{headerTitle}</Provider>)
+
+    expect(queryByText('createProfile')).toBeTruthy()
   })
 })

--- a/src/onboarding/registration/NameAndPicture.test.tsx
+++ b/src/onboarding/registration/NameAndPicture.test.tsx
@@ -88,9 +88,9 @@ describe('NameAndPictureScreen', () => {
       </Provider>
     )
 
-    const { queryByText } = render(<Provider store={store}>{headerTitle}</Provider>)
+    const { getByText } = render(<Provider store={store}>{headerTitle}</Provider>)
 
-    expect(queryByText('createAccount')).toBeTruthy()
+    expect(getByText('createAccount')).toBeTruthy()
   })
 
   it('render header title correctly when createAccountCopyTestConfig is "treatment1"', () => {
@@ -114,9 +114,9 @@ describe('NameAndPictureScreen', () => {
       </Provider>
     )
 
-    const { queryByText } = render(<Provider store={store}>{headerTitle}</Provider>)
+    const { getByText } = render(<Provider store={store}>{headerTitle}</Provider>)
 
-    expect(queryByText('createProfile')).toBeTruthy()
+    expect(getByText('createProfile')).toBeTruthy()
   })
 
   it('render header title correctly when createAccountCopyTestConfig is "treatment2"', () => {
@@ -140,8 +140,8 @@ describe('NameAndPictureScreen', () => {
       </Provider>
     )
 
-    const { queryByText } = render(<Provider store={store}>{headerTitle}</Provider>)
+    const { getByText } = render(<Provider store={store}>{headerTitle}</Provider>)
 
-    expect(queryByText('createProfile')).toBeTruthy()
+    expect(getByText('createProfile')).toBeTruthy()
   })
 })

--- a/src/onboarding/registration/NameAndPicture.tsx
+++ b/src/onboarding/registration/NameAndPicture.tsx
@@ -51,7 +51,7 @@ function NameAndPicture({ navigation }: Props) {
           title={t(
             choseToRestoreAccount
               ? 'restoreAccount'
-              : createAccountCopyTestConfig === null || createAccountCopyTestConfig === 'control'
+              : createAccountCopyTestConfig === 'control'
               ? 'createAccount'
               : 'createProfile'
           )}

--- a/src/onboarding/registration/NameAndPicture.tsx
+++ b/src/onboarding/registration/NameAndPicture.tsx
@@ -10,7 +10,7 @@ import { hideAlert, showError } from 'src/alert/actions'
 import { OnboardingEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import { ErrorMessages } from 'src/app/ErrorMessages'
-import { registrationStepsSelector } from 'src/app/selectors'
+import { createAccountCopyTestConfigSelector, registrationStepsSelector } from 'src/app/selectors'
 import Button, { BtnSizes, BtnTypes } from 'src/components/Button'
 import DevSkipButton from 'src/components/DevSkipButton'
 import FormInput from 'src/components/FormInput'
@@ -20,7 +20,7 @@ import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import { StackParamList } from 'src/navigator/types'
 import PictureInput from 'src/onboarding/registration/PictureInput'
-import useTypedSelector from 'src/redux/useSelector'
+import { default as useSelector, default as useTypedSelector } from 'src/redux/useSelector'
 import colors from 'src/styles/colors'
 import { saveProfilePicture } from 'src/utils/image'
 import { useAsyncKomenciReadiness } from 'src/verify/hooks'
@@ -42,11 +42,19 @@ function NameAndPicture({ navigation }: Props) {
   // CB TEMPORARY HOTFIX: Pinging Komenci endpoint to ensure availability
   const asyncKomenciReadiness = useAsyncKomenciReadiness()
 
+  const createAccountCopyTestConfig = useSelector(createAccountCopyTestConfigSelector)
+
   useLayoutEffect(() => {
     navigation.setOptions({
       headerTitle: () => (
         <HeaderTitleWithSubtitle
-          title={t(choseToRestoreAccount ? 'restoreAccount' : 'createAccount')}
+          title={t(
+            choseToRestoreAccount
+              ? 'restoreAccount'
+              : createAccountCopyTestConfig === null || createAccountCopyTestConfig === 'control'
+              ? 'createAccount'
+              : 'createProfile'
+          )}
           subTitle={t('registrationSteps', { step, totalSteps })}
         />
       ),

--- a/src/onboarding/registration/NameAndPicture.tsx
+++ b/src/onboarding/registration/NameAndPicture.tsx
@@ -10,7 +10,8 @@ import { hideAlert, showError } from 'src/alert/actions'
 import { OnboardingEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import { ErrorMessages } from 'src/app/ErrorMessages'
-import { createAccountCopyTestConfigSelector, registrationStepsSelector } from 'src/app/selectors'
+import { createAccountCopyTestTypeSelector, registrationStepsSelector } from 'src/app/selectors'
+import { CreateAccountCopyTestType } from 'src/app/types'
 import Button, { BtnSizes, BtnTypes } from 'src/components/Button'
 import DevSkipButton from 'src/components/DevSkipButton'
 import FormInput from 'src/components/FormInput'
@@ -42,7 +43,7 @@ function NameAndPicture({ navigation }: Props) {
   // CB TEMPORARY HOTFIX: Pinging Komenci endpoint to ensure availability
   const asyncKomenciReadiness = useAsyncKomenciReadiness()
 
-  const createAccountCopyTestConfig = useSelector(createAccountCopyTestConfigSelector)
+  const createAccountCopyTestType = useSelector(createAccountCopyTestTypeSelector)
 
   useLayoutEffect(() => {
     navigation.setOptions({
@@ -51,9 +52,10 @@ function NameAndPicture({ navigation }: Props) {
           title={t(
             choseToRestoreAccount
               ? 'restoreAccount'
-              : createAccountCopyTestConfig === 'control'
-              ? 'createAccount'
-              : 'createProfile'
+              : createAccountCopyTestType === CreateAccountCopyTestType.Wallet ||
+                createAccountCopyTestType === CreateAccountCopyTestType.AlreadyHaveWallet
+              ? 'createProfile'
+              : 'createAccount'
           )}
           subTitle={t('registrationSteps', { step, totalSteps })}
         />

--- a/src/onboarding/welcome/Welcome.test.tsx
+++ b/src/onboarding/welcome/Welcome.test.tsx
@@ -39,4 +39,52 @@ describe('Welcome', () => {
       ]
     `)
   })
+
+  it('render header title correctly when createAccountCopyTestConfig is "control"', () => {
+    const store = createMockStore({
+      app: {
+        createAccountCopyTestConfig: 'control',
+      },
+    })
+    const { queryByTestId } = render(
+      <Provider store={store}>
+        <Welcome />
+      </Provider>
+    )
+
+    expect(queryByTestId('CreateAccountButton')).toHaveTextContent('welcome.createAccount')
+    expect(queryByTestId('RestoreAccountButton')).toHaveTextContent('welcome.restoreAccount')
+  })
+
+  it('render header title correctly when createAccountCopyTestConfig is "treatment1"', () => {
+    const store = createMockStore({
+      app: {
+        createAccountCopyTestConfig: 'treatment1',
+      },
+    })
+    const { queryByTestId } = render(
+      <Provider store={store}>
+        <Welcome />
+      </Provider>
+    )
+
+    expect(queryByTestId('CreateAccountButton')).toHaveTextContent('welcome.createNewWallet')
+    expect(queryByTestId('RestoreAccountButton')).toHaveTextContent('welcome.restoreWallet')
+  })
+
+  it('render header title correctly when createAccountCopyTestConfig is "treatment2"', () => {
+    const store = createMockStore({
+      app: {
+        createAccountCopyTestConfig: 'treatment2',
+      },
+    })
+    const { queryByTestId } = render(
+      <Provider store={store}>
+        <Welcome />
+      </Provider>
+    )
+
+    expect(queryByTestId('CreateAccountButton')).toHaveTextContent('welcome.createNewWallet')
+    expect(queryByTestId('RestoreAccountButton')).toHaveTextContent('welcome.iAlreadyHaveAWallet')
+  })
 })

--- a/src/onboarding/welcome/Welcome.test.tsx
+++ b/src/onboarding/welcome/Welcome.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render } from '@testing-library/react-native'
 import * as React from 'react'
 import { Provider } from 'react-redux'
+import { CreateAccountCopyTestType } from 'src/app/types'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import Welcome from 'src/onboarding/welcome/Welcome'
@@ -40,10 +41,10 @@ describe('Welcome', () => {
     `)
   })
 
-  it('render header title correctly when createAccountCopyTestConfig is "control"', () => {
+  it('render header title correctly when createAccountCopyTestType is "Account"', () => {
     const store = createMockStore({
       app: {
-        createAccountCopyTestConfig: 'control',
+        createAccountCopyTestType: CreateAccountCopyTestType.Account,
       },
     })
     const { queryByTestId } = render(
@@ -56,10 +57,10 @@ describe('Welcome', () => {
     expect(queryByTestId('RestoreAccountButton')).toHaveTextContent('welcome.restoreAccount')
   })
 
-  it('render header title correctly when createAccountCopyTestConfig is "treatment1"', () => {
+  it('render header title correctly when createAccountCopyTestType is "Wallet"', () => {
     const store = createMockStore({
       app: {
-        createAccountCopyTestConfig: 'treatment1',
+        createAccountCopyTestType: CreateAccountCopyTestType.Wallet,
       },
     })
     const { queryByTestId } = render(
@@ -72,10 +73,10 @@ describe('Welcome', () => {
     expect(queryByTestId('RestoreAccountButton')).toHaveTextContent('welcome.restoreWallet')
   })
 
-  it('render header title correctly when createAccountCopyTestConfig is "treatment2"', () => {
+  it('render header title correctly when createAccountCopyTestType is "AlreadyHaveWallet"', () => {
     const store = createMockStore({
       app: {
-        createAccountCopyTestConfig: 'treatment2',
+        createAccountCopyTestType: CreateAccountCopyTestType.AlreadyHaveWallet,
       },
     })
     const { queryByTestId } = render(

--- a/src/onboarding/welcome/Welcome.tsx
+++ b/src/onboarding/welcome/Welcome.tsx
@@ -6,6 +6,7 @@ import { useDispatch } from 'react-redux'
 import { chooseCreateAccount, chooseRestoreAccount } from 'src/account/actions'
 import { OnboardingEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
+import { createAccountCopyTestConfigSelector } from 'src/app/selectors'
 import Button, { BtnSizes, BtnTypes } from 'src/components/Button'
 import Logo, { LogoTypes } from 'src/icons/Logo'
 import { welcomeBackground } from 'src/images/Images'
@@ -23,6 +24,8 @@ export default function Welcome() {
   const dispatch = useDispatch()
   const acceptedTerms = useSelector((state) => state.account.acceptedTerms)
   const insets = useSafeAreaInsets()
+
+  const createAccountCopyTestConfig = useSelector(createAccountCopyTestConfigSelector)
 
   const navigateNext = () => {
     if (!acceptedTerms) {
@@ -54,7 +57,11 @@ export default function Welcome() {
       <View style={{ marginBottom: Math.max(0, 40 - insets.bottom) }}>
         <Button
           onPress={onPressCreateAccount}
-          text={t('welcome.createAccount')}
+          text={
+            createAccountCopyTestConfig === null || createAccountCopyTestConfig === 'control'
+              ? t('welcome.createAccount')
+              : t('welcome.createNewWallet')
+          }
           size={BtnSizes.FULL}
           type={BtnTypes.ONBOARDING}
           style={styles.createAccountButton}
@@ -62,7 +69,13 @@ export default function Welcome() {
         />
         <Button
           onPress={onPressRestoreAccount}
-          text={t('welcome.restoreAccount')}
+          text={
+            createAccountCopyTestConfig === null || createAccountCopyTestConfig === 'control'
+              ? t('welcome.restoreAccount')
+              : createAccountCopyTestConfig === 'treatment1'
+              ? t('welcome.restoreWallet')
+              : t('welcome.iAlreadyHaveAWallet')
+          }
           size={BtnSizes.FULL}
           type={BtnTypes.ONBOARDING_SECONDARY}
           testID={'RestoreAccountButton'}

--- a/src/onboarding/welcome/Welcome.tsx
+++ b/src/onboarding/welcome/Welcome.tsx
@@ -58,7 +58,7 @@ export default function Welcome() {
         <Button
           onPress={onPressCreateAccount}
           text={
-            createAccountCopyTestConfig === null || createAccountCopyTestConfig === 'control'
+            createAccountCopyTestConfig === 'control'
               ? t('welcome.createAccount')
               : t('welcome.createNewWallet')
           }
@@ -70,7 +70,7 @@ export default function Welcome() {
         <Button
           onPress={onPressRestoreAccount}
           text={
-            createAccountCopyTestConfig === null || createAccountCopyTestConfig === 'control'
+            createAccountCopyTestConfig === 'control'
               ? t('welcome.restoreAccount')
               : createAccountCopyTestConfig === 'treatment1'
               ? t('welcome.restoreWallet')

--- a/src/onboarding/welcome/Welcome.tsx
+++ b/src/onboarding/welcome/Welcome.tsx
@@ -6,7 +6,8 @@ import { useDispatch } from 'react-redux'
 import { chooseCreateAccount, chooseRestoreAccount } from 'src/account/actions'
 import { OnboardingEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
-import { createAccountCopyTestConfigSelector } from 'src/app/selectors'
+import { createAccountCopyTestTypeSelector } from 'src/app/selectors'
+import { CreateAccountCopyTestType } from 'src/app/types'
 import Button, { BtnSizes, BtnTypes } from 'src/components/Button'
 import Logo, { LogoTypes } from 'src/icons/Logo'
 import { welcomeBackground } from 'src/images/Images'
@@ -25,7 +26,7 @@ export default function Welcome() {
   const acceptedTerms = useSelector((state) => state.account.acceptedTerms)
   const insets = useSafeAreaInsets()
 
-  const createAccountCopyTestConfig = useSelector(createAccountCopyTestConfigSelector)
+  const createAccountCopyTestType = useSelector(createAccountCopyTestTypeSelector)
 
   const navigateNext = () => {
     if (!acceptedTerms) {
@@ -58,9 +59,10 @@ export default function Welcome() {
         <Button
           onPress={onPressCreateAccount}
           text={
-            createAccountCopyTestConfig === 'control'
-              ? t('welcome.createAccount')
-              : t('welcome.createNewWallet')
+            createAccountCopyTestType === CreateAccountCopyTestType.Wallet ||
+            createAccountCopyTestType === CreateAccountCopyTestType.AlreadyHaveWallet
+              ? t('welcome.createNewWallet')
+              : t('welcome.createAccount')
           }
           size={BtnSizes.FULL}
           type={BtnTypes.ONBOARDING}
@@ -70,11 +72,11 @@ export default function Welcome() {
         <Button
           onPress={onPressRestoreAccount}
           text={
-            createAccountCopyTestConfig === 'control'
-              ? t('welcome.restoreAccount')
-              : createAccountCopyTestConfig === 'treatment1'
+            createAccountCopyTestType === CreateAccountCopyTestType.Wallet
               ? t('welcome.restoreWallet')
-              : t('welcome.iAlreadyHaveAWallet')
+              : createAccountCopyTestType === CreateAccountCopyTestType.AlreadyHaveWallet
+              ? t('welcome.iAlreadyHaveAWallet')
+              : t('welcome.restoreAccount')
           }
           size={BtnSizes.FULL}
           type={BtnTypes.ONBOARDING_SECONDARY}

--- a/src/redux/migrations.ts
+++ b/src/redux/migrations.ts
@@ -784,4 +784,11 @@ export const migrations = {
         REMOTE_CONFIG_VALUES_DEFAULTS.shouldShowRecoveryPhraseInSettings,
     },
   }),
+  71: (state: any) => ({
+    ...state,
+    app: {
+      ...state.app,
+      createAccountCopyTestConfig: REMOTE_CONFIG_VALUES_DEFAULTS.createAccountCopyTestConfig,
+    },
+  }),
 }

--- a/src/redux/migrations.ts
+++ b/src/redux/migrations.ts
@@ -788,7 +788,7 @@ export const migrations = {
     ...state,
     app: {
       ...state.app,
-      createAccountCopyTestConfig: REMOTE_CONFIG_VALUES_DEFAULTS.createAccountCopyTestConfig,
+      createAccountCopyTestType: REMOTE_CONFIG_VALUES_DEFAULTS.createAccountCopyTestType,
     },
   }),
 }

--- a/src/redux/store.test.ts
+++ b/src/redux/store.test.ts
@@ -135,7 +135,7 @@ describe('store state', () => {
           "celoEuroEnabled": true,
           "celoWithdrawalEnabledInExchange": true,
           "coinbasePayEnabled": false,
-          "createAccountCopyTestConfig": "control",
+          "createAccountCopyTestType": "ACCOUNT",
           "fiatConnectCashInEnabled": false,
           "fiatConnectCashOutEnabled": false,
           "googleMobileServicesAvailable": undefined,

--- a/src/redux/store.test.ts
+++ b/src/redux/store.test.ts
@@ -135,7 +135,7 @@ describe('store state', () => {
           "celoEuroEnabled": true,
           "celoWithdrawalEnabledInExchange": true,
           "coinbasePayEnabled": false,
-          "createAccountCopyTestConfig": null,
+          "createAccountCopyTestConfig": "control",
           "fiatConnectCashInEnabled": false,
           "fiatConnectCashOutEnabled": false,
           "googleMobileServicesAvailable": undefined,

--- a/src/redux/store.test.ts
+++ b/src/redux/store.test.ts
@@ -93,7 +93,7 @@ describe('store state', () => {
       Object {
         "_persist": Object {
           "rehydrated": true,
-          "version": 70,
+          "version": 71,
         },
         "account": Object {
           "acceptedTerms": false,
@@ -135,6 +135,7 @@ describe('store state', () => {
           "celoEuroEnabled": true,
           "celoWithdrawalEnabledInExchange": true,
           "coinbasePayEnabled": false,
+          "createAccountCopyTestConfig": null,
           "fiatConnectCashInEnabled": false,
           "fiatConnectCashOutEnabled": false,
           "googleMobileServicesAvailable": undefined,

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -23,7 +23,7 @@ const persistConfig: PersistConfig<RootState> = {
   key: 'root',
   // default is -1, increment as we make migrations
   // See https://github.com/valora-inc/wallet/tree/main/WALLET.md#redux-state-migration
-  version: 70,
+  version: 71,
   keyPrefix: `reduxStore-`, // the redux-persist default is `persist:` which doesn't work with some file systems.
   storage: FSStorage(),
   blacklist: ['networkInfo', 'alert', 'imports', 'supercharge'],

--- a/test/RootStateSchema.json
+++ b/test/RootStateSchema.json
@@ -291,8 +291,8 @@
         "CreateAccountCopyTestType": {
             "enum": [
                 "ACCOUNT",
-                "WALLET",
-                "ALREADY_HAVE_WALLET"
+                "ALREADY_HAVE_WALLET",
+                "WALLET"
             ],
             "type": "string"
         },

--- a/test/RootStateSchema.json
+++ b/test/RootStateSchema.json
@@ -1913,10 +1913,7 @@
                     "type": "boolean"
                 },
                 "createAccountCopyTestConfig": {
-                    "type": [
-                      "null",
-                      "string"
-                    ]
+                    "type": "string"
                 },
                 "fiatConnectCashInEnabled": {
                     "type": "boolean"

--- a/test/RootStateSchema.json
+++ b/test/RootStateSchema.json
@@ -1912,6 +1912,12 @@
                 "coinbasePayEnabled": {
                     "type": "boolean"
                 },
+                "createAccountCopyTestConfig": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                },
                 "fiatConnectCashInEnabled": {
                     "type": "boolean"
                 },
@@ -2048,6 +2054,7 @@
                 "celoEuroEnabled",
                 "celoWithdrawalEnabledInExchange",
                 "coinbasePayEnabled",
+                "createAccountCopyTestConfig",
                 "fiatConnectCashInEnabled",
                 "fiatConnectCashOutEnabled",
                 "hideVerification",

--- a/test/RootStateSchema.json
+++ b/test/RootStateSchema.json
@@ -288,6 +288,14 @@
             },
             "type": "object"
         },
+        "CreateAccountCopyTestType": {
+            "enum": [
+                "ACOUNT",
+                "WALLET",
+                "ALREADY_HAVE_WALLET"
+            ],
+            "type": "string"
+        },
         "CryptoType": {
             "enum": [
                 "CELO",
@@ -1912,8 +1920,8 @@
                 "coinbasePayEnabled": {
                     "type": "boolean"
                 },
-                "createAccountCopyTestConfig": {
-                    "type": "string"
+                "createAccountCopyTestType": {
+                    "$ref": "#/definitions/CreateAccountCopyTestType"
                 },
                 "fiatConnectCashInEnabled": {
                     "type": "boolean"
@@ -2051,7 +2059,7 @@
                 "celoEuroEnabled",
                 "celoWithdrawalEnabledInExchange",
                 "coinbasePayEnabled",
-                "createAccountCopyTestConfig",
+                "createAccountCopyTestType",
                 "fiatConnectCashInEnabled",
                 "fiatConnectCashOutEnabled",
                 "hideVerification",

--- a/test/RootStateSchema.json
+++ b/test/RootStateSchema.json
@@ -290,7 +290,7 @@
         },
         "CreateAccountCopyTestType": {
             "enum": [
-                "ACOUNT",
+                "ACCOUNT",
                 "WALLET",
                 "ALREADY_HAVE_WALLET"
             ],

--- a/test/schemas.ts
+++ b/test/schemas.ts
@@ -1554,7 +1554,7 @@ export const v71Schema = {
   },
   app: {
     ...v70Schema.app,
-    createAccountCopyTestConfig: 'control',
+    createAccountCopyTestType: 'ACCOUNT',
   },
 }
 

--- a/test/schemas.ts
+++ b/test/schemas.ts
@@ -1546,6 +1546,18 @@ export const v70Schema = {
   },
 }
 
+export const v71Schema = {
+  ...v70Schema,
+  _persist: {
+    ...v70Schema._persist,
+    version: 71,
+  },
+  app: {
+    ...v70Schema.app,
+    createAccountCopyTestConfig: null,
+  },
+}
+
 export function getLatestSchema(): Partial<RootState> {
-  return v70Schema as Partial<RootState>
+  return v71Schema as Partial<RootState>
 }

--- a/test/schemas.ts
+++ b/test/schemas.ts
@@ -1554,7 +1554,7 @@ export const v71Schema = {
   },
   app: {
     ...v70Schema.app,
-    createAccountCopyTestConfig: null,
+    createAccountCopyTestConfig: 'control',
   },
 }
 


### PR DESCRIPTION
### Description

This is a simple copy test controlled by remote config `createAccountCopyTestConfig`.

There are three conditions:

Control: `createAccountCopyTestConfig` = "ACCOUNT"
- CTA text: “Create new account” / “Restore my account”
- Step 1 title: “Create account”
<img width="362" alt="Screen Shot 2022-08-10 at 3 23 26 PM" src="https://user-images.githubusercontent.com/47931506/184031720-4b887daf-179c-4800-bbea-bfc1312bdc97.png"> <img width="357" alt="Screen Shot 2022-08-10 at 3 23 40 PM" src="https://user-images.githubusercontent.com/47931506/184031733-a66ee925-0140-4c50-b3f6-faa79876574e.png">


Treatment 1: `createAccountCopyTestConfig` = "WALLET"
- CTA text: “Create new wallet” / “Restore wallet”
- Step 1 title: “Create profile”
<img width="361" alt="Screen Shot 2022-08-10 at 3 28 37 PM" src="https://user-images.githubusercontent.com/47931506/184031780-87ee5f4a-411a-4ee4-8b95-545e2119ddd1.png"> <img width="361" alt="Screen Shot 2022-08-10 at 3 28 49 PM" src="https://user-images.githubusercontent.com/47931506/184031845-3beb2042-9dc9-402e-aad7-c543cc3d41e0.png">


Treatment 2: `createAccountCopyTestConfig` = "ALREADY_HAVE_WALLET"
- “Create new wallet” / “I already have a wallet”
- Step 1 title: “Create profile”
<img width="361" alt="Screen Shot 2022-08-10 at 3 30 42 PM" src="https://user-images.githubusercontent.com/47931506/184031863-4325e549-7d4a-4b8a-b8ec-e9eb17fb21f8.png"> <img width="359" alt="Screen Shot 2022-08-10 at 3 30 52 PM" src="https://user-images.githubusercontent.com/47931506/184031871-b7fed82e-2db7-4d66-9dc4-a4786195f623.png">


### Other changes
N/A


### Tested
With iOS emulator


### How others should test


### Related issues
- https://linear.app/valora/issue/RET-363/onboarding-create-account-copy-test


### Backwards compatibility
Yes