### PR TITLE
fix(fiatconnect): clear button position on fiat details screen

### DIFF
--- a/src/fiatconnect/FiatDetailsScreen.tsx
+++ b/src/fiatconnect/FiatDetailsScreen.tsx
@@ -394,7 +394,8 @@ function FormField({
       ) : (
         <TextInput
           testID={`input-${field.name}`}
-          style={styles.formInput}
+          style={styles.formInputContainer}
+          inputStyle={styles.formInput}
           value={value}
           placeholder={field.placeholderText}
           onChangeText={onInputChange}
@@ -436,15 +437,16 @@ const styles = StyleSheet.create({
   inputView: {
     paddingVertical: 12,
   },
-  formInput: {
-    ...fontStyles.regular,
+  formInputContainer: {
     borderRadius: 4,
     borderWidth: 1.5,
     borderColor: colors.gray2,
     marginBottom: 4,
-    color: colors.dark,
-    alignItems: 'flex-start',
     paddingHorizontal: 8,
+  },
+  formInput: {
+    ...fontStyles.regular,
+    color: colors.dark,
   },
   formSelectInput: {
     ...fontStyles.regular,
@@ -453,7 +455,6 @@ const styles = StyleSheet.create({
     borderColor: colors.gray2,
     marginBottom: 4,
     color: colors.dark,
-    alignItems: 'flex-start',
     paddingHorizontal: 8,
     paddingVertical: 12,
     lineHeight: LINE_HEIGHT,


### PR DESCRIPTION
### Description

Before:
<img alt="fiat-details-clear-before" src="https://user-images.githubusercontent.com/8432644/184025505-8b226d26-0ac2-48c5-91c3-23674fa7ab1a.png" width="200">

After:
<img alt="fiat-details-clear" src="https://user-images.githubusercontent.com/5062591/184043480-3d6ac245-a933-4373-9186-700f8ed3849e.png" width="200">


### Other changes

N/A

### Tested

Manual

### How others should test

1. Ensure you've not already linked a bank account with Valora test provider
2. Navigate to Withdraw flow on Alfajores
3. Select Bank Account with Valora test provider and click on Continue
4. Type on the Bank Name and Account Number text fields and ensure clear button is aligned to the center of the field

### Related issues

- Fixes ACT-181

### Backwards compatibility

Yes