### PR TITLE
fix: navigating to connect phone number with existing wallet

### DIFF
--- a/src/verify/VerificationEducationScreen.tsx
+++ b/src/verify/VerificationEducationScreen.tsx
@@ -58,7 +58,7 @@ import { getPhoneNumberState } from 'src/verify/utils'
 import VerificationLearnMoreDialog from 'src/verify/VerificationLearnMoreDialog'
 import VerificationSkipDialog from 'src/verify/VerificationSkipDialog'
 import networkConfig from 'src/web3/networkConfig'
-import { currentAccountSelector } from 'src/web3/selectors'
+import { currentAccountSelector, walletAddressSelector } from 'src/web3/selectors'
 
 type ScreenProps = StackScreenProps<StackParamList, Screens.VerificationEducationScreen>
 
@@ -92,6 +92,7 @@ function VerificationEducationScreen({ route, navigation }: Props) {
   const shouldUseKomenci = useSelector(shouldUseKomenciSelector)
   const verificationStatus = useSelector(verificationStatusSelector)
   const choseToRestoreAccount = useSelector(choseToRestoreAccountSelector)
+  const walletAddress = useSelector(walletAddressSelector)
   const { step, totalSteps } = useSelector(registrationStepsSelector)
 
   const onPressStart = async () => {
@@ -194,7 +195,7 @@ function VerificationEducationScreen({ route, navigation }: Props) {
 
   useAsync(async () => {
     await waitUntilSagasFinishLoading()
-    dispatch(initializeAccount())
+    if (walletAddress === null) dispatch(initializeAccount())
     dispatch(checkIfKomenciAvailable())
   }, [])
 


### PR DESCRIPTION
### Description

When navigating to the connect phone number with an existing account users were being served 'Failed to create your wallet' screen due to a dispatch to initialize wallet. This PR checks via the walletAddressSelector returns null prior to attempting to initialize the wallet.

### Other changes

N/A

### Tested

Tested locally on iOS.

### How others should test

1. Re-install with new account.
2. Restart-app.
3. Attempt to connect phone number from the home card, settings, or supercharger card.
4. Pin Entry is not served.
5. Tapping back takes user back to the previous screen and failed to create your wallet screen is not served.

### Related issues

- Fixes #2511

### Backwards compatibility

Yes