### PR TITLE
fix(fiatconnect): review screen copy updates

### DIFF
--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -1267,20 +1267,21 @@
     "continue": "Continue"
   },
   "fiatConnectReviewScreen": {
-    "paymentMethod": "Payment Method",
     "transactionDetails": "Transaction Details",
     "paymentMethodVia": "Linked via {{providerName}}",
     "receiveAmount": "You will receive",
     "cashIn": {
       "header": "Review Add Funds",
       "button": "Add Funds",
-      "transactionDetailsAmount": "Total Price"
+      "transactionDetailsAmount": "Total Price",
+      "paymentMethodHeader": "Payment Method"
     },
     "cashOut": {
       "header": "Review",
       "button": "Withdraw Funds",
       "transactionDetailsAmount": "Total Withdraw",
-      "transactionDetailsAmountConverted": "Amount Withdrawn"
+      "transactionDetailsAmountConverted": "Amount Withdrawn",
+      "paymentMethodHeader": "Withdraw To"
     },
     "failedRefetch": {
       "title": "Connection lost!",

--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -1274,7 +1274,7 @@
       "header": "Review Add Funds",
       "button": "Add Funds",
       "transactionDetailsAmount": "Total Price",
-      "paymentMethodHeader": "Payment Method"
+      "paymentMethodHeader": "Deposit From"
     },
     "cashOut": {
       "header": "Review",

--- a/src/fiatconnect/ReviewScreen.test.tsx
+++ b/src/fiatconnect/ReviewScreen.test.tsx
@@ -83,7 +83,7 @@ describe('ReviewScreen', () => {
       expect(queryByTestId('txDetails-fee')).toBeTruthy()
       expect(queryByTestId('txDetails-exchangeRate/value')?.children).toEqual(['', '$', '1.0053'])
       expect(queryByTestId('txDetails-exchangeAmount/value')?.children).toEqual(['', '$', '100.00'])
-      expect(queryByText('fiatConnectReviewScreen.paymentMethod')).toBeTruthy()
+      expect(queryByText('fiatConnectReviewScreen.cashOut.paymentMethodHeader')).toBeTruthy()
       expect(queryByTestId('paymentMethod-text')?.children).toEqual(['Chase (...2345)'])
       expect(queryByTestId('paymentMethod-via')?.children).toEqual([
         'fiatConnectReviewScreen.paymentMethodVia, {"providerName":"Provider Two"}',
@@ -150,7 +150,7 @@ describe('ReviewScreen', () => {
       expect(queryByTestId('txDetails-fee')).toBeFalsy()
       expect(queryByTestId('txDetails-exchangeRate/value')?.children).toEqual(['', '$', '1'])
       expect(queryByTestId('txDetails-exchangeAmount/value')?.children).toEqual(['', '$', '100.00'])
-      expect(queryByText('fiatConnectReviewScreen.paymentMethod')).toBeTruthy()
+      expect(queryByText('fiatConnectReviewScreen.cashOut.paymentMethodHeader')).toBeTruthy()
       expect(queryByTestId('paymentMethod-text')?.children).toEqual(['Chase (...2345)'])
       expect(queryByTestId('paymentMethod-via')?.children).toEqual([
         'fiatConnectReviewScreen.paymentMethodVia, {"providerName":"Provider Two"}',

--- a/src/fiatconnect/ReviewScreen.tsx
+++ b/src/fiatconnect/ReviewScreen.tsx
@@ -157,7 +157,7 @@ export default function FiatConnectReviewScreen({ route, navigation }: Props) {
       <View>
         <ReceiveAmount flow={flow} normalizedQuote={normalizedQuote} />
         <TransactionDetails flow={flow} normalizedQuote={normalizedQuote} />
-        <PaymentMethod normalizedQuote={normalizedQuote} fiatAccount={fiatAccount} />
+        <PaymentMethod flow={flow} normalizedQuote={normalizedQuote} fiatAccount={fiatAccount} />
       </View>
       <Button
         testID="submitButton"
@@ -357,9 +357,11 @@ function TransactionDetails({
 }
 
 function PaymentMethod({
+  flow,
   normalizedQuote,
   fiatAccount,
 }: {
+  flow: CICOFlow
   normalizedQuote: FiatConnectQuote
   fiatAccount: ObfuscatedFiatAccountData
 }) {
@@ -379,7 +381,11 @@ function PaymentMethod({
   return (
     <Touchable onPress={onPress}>
       <View style={styles.sectionContainer}>
-        <Text style={styles.sectionHeaderText}>{t('fiatConnectReviewScreen.paymentMethod')}</Text>
+        <Text style={styles.sectionHeaderText}>
+          {flow === CICOFlow.CashIn
+            ? t('fiatConnectReviewScreen.cashIn.paymentMethodHeader')
+            : t('fiatConnectReviewScreen.cashOut.paymentMethodHeader')}
+        </Text>
         <View style={styles.sectionMainTextContainer}>
           <Text style={styles.sectionMainText} testID="paymentMethod-text">
             {fiatAccount.accountName}


### PR DESCRIPTION
### Description

Change copy of payment method header

### Other changes

N/A

### Tested

Manual, unit tests

### How others should test

Go through the withdraw flow with the test provider on Alfajores and check copy of the payment method header

### Related issues

- Fixes ACT-181

### Backwards compatibility

Yes