### PR TITLE
fix(homefeed): ensure that users can scroll to load more

### DIFF
--- a/src/transactions/feed/TransactionFeed.test.tsx
+++ b/src/transactions/feed/TransactionFeed.test.tsx
@@ -49,6 +49,20 @@ const MOCK_STANDBY_TRANSACTIONS: StandbyTransaction[] = [
 
 const END_CURSOR = 'YXJyYXljb25uZWN0aW9uOjk='
 
+const MOCK_EMPTY_RESPONSE: QueryResponse = {
+  data: {
+    tokenTransactionsV2: {
+      pageInfo: {
+        startCursor: 'YXJyYXljb25uZWN0aW9uOjA=',
+        endCursor: END_CURSOR,
+        hasNextPage: true,
+        hasPreviousPage: false,
+      },
+      transactions: [],
+    },
+  },
+}
+
 const MOCK_RESPONSE: QueryResponse = {
   data: {
     tokenTransactionsV2: {
@@ -217,6 +231,24 @@ describe('TransactionFeed', () => {
 
     await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(2))
     expect(getNumTransactionItems(tree.getByTestId('TransactionList'))).toBe(2)
+  })
+
+  it('tries to fetch 10 transactions, and stores empty pages', async () => {
+    mockFetch.mockImplementation((url: any, request: any) => {
+      const body: string = request.body
+      let response = ''
+      if (body.includes(END_CURSOR)) {
+        response = JSON.stringify(MOCK_RESPONSE_NO_NEXT_PAGE)
+      } else {
+        response = JSON.stringify(MOCK_EMPTY_RESPONSE)
+      }
+      return Promise.resolve(new Response(response))
+    })
+
+    const tree = renderScreen({})
+
+    await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(2))
+    expect(getNumTransactionItems(tree.getByTestId('TransactionList'))).toBe(1)
   })
 
   it('fetches the next page by scrolling to the end of the list', async () => {

--- a/src/transactions/feed/TransactionFeed.test.tsx
+++ b/src/transactions/feed/TransactionFeed.test.tsx
@@ -2,16 +2,35 @@ import { fireEvent, render, waitFor } from '@testing-library/react-native'
 import { FetchMock } from 'jest-fetch-mock/types'
 import React from 'react'
 import { Provider } from 'react-redux'
+import { ReactTestInstance } from 'react-test-renderer'
 import { RootState } from 'src/redux/reducers'
 import { QueryResponse } from 'src/transactions/feed/queryHelper'
 import TransactionFeed from 'src/transactions/feed/TransactionFeed'
 import {
   StandbyTransaction,
+  TokenTransaction,
   TokenTransactionTypeV2,
   TransactionStatus,
 } from 'src/transactions/types'
 import { createMockStore, RecursivePartial } from 'test/utils'
 import { mockCusdAddress } from 'test/values'
+
+const mockTransaction = (transactionHash: string): TokenTransaction => {
+  return {
+    __typename: 'TokenTransferV2',
+    address: '0xd68360cce1f1ff696d898f58f03e0f1252f2ea33',
+    amount: {
+      tokenAddress: mockCusdAddress,
+      value: '0.1',
+    },
+    block: '8648978',
+    fees: [],
+    metadata: {},
+    timestamp: 1542306118,
+    transactionHash,
+    type: TokenTransactionTypeV2.Received,
+  }
+}
 
 const STAND_BY_TRANSACTION_SUBTITLE_KEY = 'confirmingTransaction'
 
@@ -40,50 +59,38 @@ const MOCK_RESPONSE: QueryResponse = {
         hasPreviousPage: false,
       },
       transactions: [
-        {
-          __typename: 'TokenTransferV2',
-          address: '0xd68360cce1f1ff696d898f58f03e0f1252f2ea33',
-          amount: {
-            tokenAddress: mockCusdAddress,
-            value: '0.1',
-          },
-          block: '8648978',
-          fees: [],
-          metadata: {},
-          timestamp: 1542306118,
-          transactionHash: '0x544367eaf2b01622dd1c7b75a6b19bf278d72127aecfb2e5106424c40c268e8b',
-          type: TokenTransactionTypeV2.Received,
-        },
+        mockTransaction('0x544367eaf2b01622dd1c7b75a6b19bf278d72127aecfb2e5106424c40c268e8b'),
       ],
     },
   },
 }
 
-const MOCK_RESPONSE_NEXT_PAGE: QueryResponse = {
+const MOCK_RESPONSE_NO_NEXT_PAGE: QueryResponse = {
   data: {
     tokenTransactionsV2: {
       pageInfo: {
         startCursor: 'YXJyYXljb25uZWN0aW9uOjA=',
-        endCursor: 'YXJyYXljb25uZWN0aW9uOjI',
-        hasNextPage: true,
+        endCursor: END_CURSOR,
+        hasNextPage: false,
         hasPreviousPage: false,
       },
       transactions: [
-        {
-          __typename: 'TokenTransferV2',
-          address: '0xd68360cce1f1ff696d898f58f03e0f1252f2ea32',
-          amount: {
-            tokenAddress: mockCusdAddress,
-            value: '0.5',
-          },
-          block: '8648977',
-          fees: [],
-          metadata: {},
-          timestamp: 1500306110,
-          transactionHash: '0x544367eaf2b01622dd1c7b75a6b19bf278d72127aecfb2e5106424c40c268e8a',
-          type: TokenTransactionTypeV2.Received,
-        },
+        mockTransaction('0x544367eaf2b01622dd1c7b75a6b19bf278d72127aecfb2e5106424c40c268e8b2'),
       ],
+    },
+  },
+}
+
+const MOCK_RESPONSE_MANY_ITEMS: QueryResponse = {
+  data: {
+    tokenTransactionsV2: {
+      pageInfo: {
+        startCursor: 'YXJyYXljb25uZWN0aW9uOjA=',
+        endCursor: END_CURSOR,
+        hasNextPage: true,
+        hasPreviousPage: false,
+      },
+      transactions: [...Array(10).keys()].map((id) => mockTransaction(id.toString())),
     },
   },
 }
@@ -113,21 +120,26 @@ describe('TransactionFeed', () => {
     }
   }
 
+  function getNumTransactionItems(sectionList: ReactTestInstance) {
+    // data[0] is the first section in the section list - all mock transactions
+    // are for the same section / date
+    return sectionList.props.data[0].data.length
+  }
+
   it('renders correctly when there is a response', async () => {
-    mockFetch.mockResponse(JSON.stringify(MOCK_RESPONSE))
+    mockFetch.mockResponse(JSON.stringify(MOCK_RESPONSE_NO_NEXT_PAGE))
 
     const tree = renderScreen({})
-
-    await waitFor(() => tree.getByTestId('TransactionList'))
+    await waitFor(() => expect(tree.getByTestId('TransactionList').props.data.length).toBe(1))
 
     expect(tree.queryByTestId('NoActivity/loading')).toBeNull()
     expect(tree.queryByTestId('NoActivity/error')).toBeNull()
-
+    expect(mockFetch).toHaveBeenCalledTimes(1)
     expect(tree).toMatchSnapshot()
   })
 
   it("doesn't render transfers for tokens that we don't know about", async () => {
-    mockFetch.mockResponse(JSON.stringify(MOCK_RESPONSE))
+    mockFetch.mockResponse(JSON.stringify(MOCK_RESPONSE_NO_NEXT_PAGE))
 
     const { getAllByTestId, getByTestId } = renderScreen({})
 
@@ -168,7 +180,7 @@ describe('TransactionFeed', () => {
   })
 
   it('renders correctly when there are confirmed transactions and stand by transactions', async () => {
-    mockFetch.mockResponse(JSON.stringify(MOCK_RESPONSE))
+    mockFetch.mockResponse(JSON.stringify(MOCK_RESPONSE_NO_NEXT_PAGE))
 
     const tree = renderScreen({
       transactions: {
@@ -189,12 +201,12 @@ describe('TransactionFeed', () => {
     expect(pendingSubtitles.length).toBe(1)
   })
 
-  it('renders correctly when a next paginated batch is requested', async () => {
+  it('tries to fetch 10 transactions, until the end is reached', async () => {
     mockFetch.mockImplementation((url: any, request: any) => {
       const body: string = request.body
       let response = ''
       if (body.includes(END_CURSOR)) {
-        response = JSON.stringify(MOCK_RESPONSE_NEXT_PAGE)
+        response = JSON.stringify(MOCK_RESPONSE_NO_NEXT_PAGE)
       } else {
         response = JSON.stringify(MOCK_RESPONSE)
       }
@@ -203,12 +215,30 @@ describe('TransactionFeed', () => {
 
     const tree = renderScreen({})
 
+    await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(2))
+    expect(getNumTransactionItems(tree.getByTestId('TransactionList'))).toBe(2)
+  })
+
+  it('fetches the next page by scrolling to the end of the list', async () => {
+    mockFetch.mockImplementation((url: any, request: any) => {
+      const body: string = request.body
+      let response = ''
+      if (body.includes(END_CURSOR)) {
+        response = JSON.stringify(MOCK_RESPONSE_NO_NEXT_PAGE)
+      } else {
+        response = JSON.stringify(MOCK_RESPONSE_MANY_ITEMS)
+      }
+      return Promise.resolve(new Response(response))
+    })
+
+    const tree = renderScreen({})
     await waitFor(() => tree.getByTestId('TransactionList'))
 
     expect(mockFetch).toHaveBeenCalledTimes(1)
-    expect(tree.getByTestId('TransactionList').props.data.length).toBe(1)
+    expect(getNumTransactionItems(tree.getByTestId('TransactionList'))).toBe(10)
+
     fireEvent(tree.getByTestId('TransactionList'), 'onEndReached')
     await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(2))
-    expect(tree.getByTestId('TransactionList').props.data.length).toBe(2)
+    expect(getNumTransactionItems(tree.getByTestId('TransactionList'))).toBe(11)
   })
 })

--- a/src/transactions/feed/TransactionFeed.test.tsx
+++ b/src/transactions/feed/TransactionFeed.test.tsx
@@ -273,4 +273,33 @@ describe('TransactionFeed', () => {
     await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(2))
     expect(getNumTransactionItems(tree.getByTestId('TransactionList'))).toBe(11)
   })
+
+  it('fetches the next page automatically if there are no transactions returned and next page exists', async () => {
+    let mockFetchCount = 0
+    mockFetch.mockImplementation(() => {
+      let response = ''
+      switch (mockFetchCount) {
+        case 1:
+          response = JSON.stringify(MOCK_EMPTY_RESPONSE)
+          break
+        case 2:
+          response = JSON.stringify(MOCK_RESPONSE)
+          break
+        default:
+          response = JSON.stringify(MOCK_RESPONSE_MANY_ITEMS)
+      }
+      mockFetchCount += 1
+      return Promise.resolve(new Response(response))
+    })
+
+    const tree = renderScreen({})
+    await waitFor(() => tree.getByTestId('TransactionList'))
+
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+    expect(getNumTransactionItems(tree.getByTestId('TransactionList'))).toBe(10)
+
+    fireEvent(tree.getByTestId('TransactionList'), 'onEndReached')
+    await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(3))
+    expect(getNumTransactionItems(tree.getByTestId('TransactionList'))).toBe(11)
+  })
 })

--- a/src/transactions/feed/TransactionFeed.test.tsx
+++ b/src/transactions/feed/TransactionFeed.test.tsx
@@ -59,7 +59,7 @@ const MOCK_RESPONSE: QueryResponse = {
         hasPreviousPage: false,
       },
       transactions: [
-        mockTransaction('0x544367eaf2b01622dd1c7b75a6b19bf278d72127aecfb2e5106424c40c268e8b'),
+        mockTransaction('0x544367eaf2b01622dd1c7b75a6b19bf278d72127aecfb2e5106424c40c268e8b2'),
       ],
     },
   },
@@ -75,7 +75,7 @@ const MOCK_RESPONSE_NO_NEXT_PAGE: QueryResponse = {
         hasPreviousPage: false,
       },
       transactions: [
-        mockTransaction('0x544367eaf2b01622dd1c7b75a6b19bf278d72127aecfb2e5106424c40c268e8b2'),
+        mockTransaction('0x544367eaf2b01622dd1c7b75a6b19bf278d72127aecfb2e5106424c40c268e8b'),
       ],
     },
   },
@@ -201,7 +201,7 @@ describe('TransactionFeed', () => {
     expect(pendingSubtitles.length).toBe(1)
   })
 
-  it('tries to fetch 10 transactions, until the end is reached', async () => {
+  it('tries to fetch 10 transactions, unless the end is reached', async () => {
     mockFetch.mockImplementation((url: any, request: any) => {
       const body: string = request.body
       let response = ''

--- a/src/transactions/feed/queryHelper.ts
+++ b/src/transactions/feed/queryHelper.ts
@@ -78,7 +78,14 @@ export function useFetchTransactions(): QueryHookResult {
   const [counter, setCounter] = useState(0)
   useInterval(() => setCounter((n) => n + 1), POLL_INTERVAL)
 
+  // Store the lastFetchEndCursor so that we can fetch older transactions after polling for awhile
+  const [lastFetchEndCursor, setLastFetchEndCursor] = useState<string | null>(null)
+
   const handleResult = (result: QueryResponse, hasPreviousPage: boolean) => {
+    // Handle polling resetting last page info
+    if (hasPreviousPage) {
+      setLastFetchEndCursor(result.data?.tokenTransactionsV2?.pageInfo.endCursor)
+    }
     Logger.info(TAG, `Fetched ${hasPreviousPage ? 'next page' : 'new'} transactions`)
 
     const returnedTransactions = result.data?.tokenTransactionsV2?.transactions ?? []
@@ -124,11 +131,7 @@ export function useFetchTransactions(): QueryHookResult {
         return
       }
 
-      const result = await queryTransactionsFeed(
-        address,
-        localCurrencyCode,
-        fetchedResult.pageInfo?.endCursor
-      )
+      const result = await queryTransactionsFeed(address, localCurrencyCode, lastFetchEndCursor)
       setFetchingMoreTransactions(false)
       handleResult(result, true)
     },
@@ -178,7 +181,7 @@ export function useFetchTransactions(): QueryHookResult {
 async function queryTransactionsFeed(
   address: string | null,
   localCurrencyCode: string,
-  afterCursor?: string
+  afterCursor?: string | null
 ) {
   Logger.info(
     `Request to fetch transactions with params: ${JSON.stringify({

--- a/src/transactions/feed/queryHelper.ts
+++ b/src/transactions/feed/queryHelper.ts
@@ -81,10 +81,10 @@ export function useFetchTransactions(): QueryHookResult {
   const handleResult = (result: QueryResponse, hasPreviousPage: boolean) => {
     Logger.info(TAG, `Fetched ${hasPreviousPage ? 'next page' : 'new'} transactions`)
 
-    const returnedTransactions = result.data?.tokenTransactionsV2?.transactions
+    const returnedTransactions = result.data?.tokenTransactionsV2?.transactions ?? []
     const returnedPageInfo = result.data?.tokenTransactionsV2?.pageInfo
 
-    if (returnedTransactions?.length) {
+    if (returnedTransactions?.length || returnedPageInfo?.hasNextPage) {
       setFetchedResult((prev) => ({
         transactions: deduplicateTransactions(prev.transactions, returnedTransactions),
         pageInfo: returnedPageInfo ?? null,
@@ -148,12 +148,7 @@ export function useFetchTransactions(): QueryHookResult {
     // `onEndReached`, in the event that blockchain-api returns a small number
     // of results for the first page(s)
     const { transactions, pageInfo } = fetchedResult
-    if (
-      !loading &&
-      transactions.length > 0 &&
-      transactions.length < MIN_NUM_TRANSACTIONS &&
-      pageInfo?.hasNextPage
-    ) {
+    if (!loading && transactions.length < MIN_NUM_TRANSACTIONS && pageInfo?.hasNextPage) {
       setFetchingMoreTransactions(true)
     }
   }, [fetchedResult, loading])

--- a/src/transactions/feed/queryHelper.ts
+++ b/src/transactions/feed/queryHelper.ts
@@ -68,11 +68,11 @@ export function useFetchTransactions(): QueryHookResult {
   const [fetchedResult, setFetchedResult] = useState<{
     transactions: TokenTransaction[]
     pageInfo: PageInfo | null
-    hasReturnedTransactions: boolean
+    hasTransactionsOnCurrentPage: boolean
   }>({
     transactions: [],
     pageInfo: null,
-    hasReturnedTransactions: false,
+    hasTransactionsOnCurrentPage: false,
   })
   const [fetchingMoreTransactions, setFetchingMoreTransactions] = useState(false)
 
@@ -94,8 +94,8 @@ export function useFetchTransactions(): QueryHookResult {
         // avoid updating pageInfo and hasReturnedTransactions for polled
         // updates, as these variables are used for fetching the next pages
         pageInfo: isPolledUpdate ? prev.pageInfo : returnedPageInfo,
-        hasReturnedTransactions: isPolledUpdate
-          ? prev.hasReturnedTransactions
+        hasTransactionsOnCurrentPage: isPolledUpdate
+          ? prev.hasTransactionsOnCurrentPage
           : returnedTransactions.length > 0,
       }))
 
@@ -160,11 +160,11 @@ export function useFetchTransactions(): QueryHookResult {
     // 2. sometimes blockchain-api returns 0 transactions for a page (as we only
     //    display certain transaction types in the app) and for this case,
     //    automatically fetch the next page(s) until some transactions are returned
-    const { transactions, pageInfo, hasReturnedTransactions } = fetchedResult
+    const { transactions, pageInfo, hasTransactionsOnCurrentPage } = fetchedResult
     if (
       !loading &&
       pageInfo?.hasNextPage &&
-      (transactions.length < MIN_NUM_TRANSACTIONS || !hasReturnedTransactions)
+      (transactions.length < MIN_NUM_TRANSACTIONS || !hasTransactionsOnCurrentPage)
     ) {
       setFetchingMoreTransactions(true)
     }

--- a/src/transactions/feed/queryHelper.ts
+++ b/src/transactions/feed/queryHelper.ts
@@ -164,22 +164,20 @@ export function useFetchTransactions(): QueryHookResult {
     }
   }, [fetchedResult, loading])
 
-  const fetchMoreTransactions = () => {
-    if (!fetchedResult.pageInfo) {
-      dispatch(showError(ErrorMessages.FETCH_FAILED))
-    } else if (!fetchedResult.pageInfo?.hasNextPage) {
-      Toast.showWithGravity(t('noMoreTransactions'), Toast.SHORT, Toast.CENTER)
-    } else {
-      setFetchingMoreTransactions(true)
-    }
-  }
-
   return {
     loading,
     error,
     transactions: fetchedResult.transactions,
     fetchingMoreTransactions,
-    fetchMoreTransactions,
+    fetchMoreTransactions: () => {
+      if (!fetchedResult.pageInfo) {
+        dispatch(showError(ErrorMessages.FETCH_FAILED))
+      } else if (!fetchedResult.pageInfo?.hasNextPage) {
+        Toast.showWithGravity(t('noMoreTransactions'), Toast.SHORT, Toast.CENTER)
+      } else {
+        setFetchingMoreTransactions(true)
+      }
+    },
   }
 }
 

--- a/src/transactions/feed/queryHelper.ts
+++ b/src/transactions/feed/queryHelper.ts
@@ -1,5 +1,5 @@
 import { isEmpty } from 'lodash'
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useAsync } from 'react-async-hook'
 import { useTranslation } from 'react-i18next'
 import Toast from 'react-native-simple-toast'
@@ -13,6 +13,8 @@ import { TokenTransaction } from 'src/transactions/types'
 import Logger from 'src/utils/Logger'
 import config from 'src/web3/networkConfig'
 import { walletAddressSelector } from 'src/web3/selectors'
+
+const MIN_NUM_TRANSACTIONS = 10
 
 export interface QueryHookResult {
   loading: boolean
@@ -41,23 +43,18 @@ const TAG = 'transactions/feed/queryHelper'
 // Query poll interval
 const POLL_INTERVAL = 10000 // 10 secs
 
-function useDeduplicatedTransactions() {
-  const [transactions, setTransactions] = useState<TokenTransaction[]>([])
-  const addTransactions = (newTransactions: TokenTransaction[]) => {
-    const currentHashes = new Set(transactions.map((tx) => tx.transactionHash))
-    const transactionsWithoutDuplicatedHash = transactions.concat(
-      newTransactions.filter((tx) => !currentHashes.has(tx.transactionHash))
-    )
-    transactionsWithoutDuplicatedHash.sort((a, b) => {
-      return b.timestamp - a.timestamp
-    })
-    setTransactions(transactionsWithoutDuplicatedHash)
-  }
-
-  return {
-    transactions,
-    addTransactions,
-  }
+const deduplicateTransactions = (
+  existingTxs: TokenTransaction[],
+  incomingTxs: TokenTransaction[]
+) => {
+  const currentHashes = new Set(existingTxs.map((tx) => tx.transactionHash))
+  const transactionsWithoutDuplicatedHash = existingTxs.concat(
+    incomingTxs.filter((tx) => !isEmpty(tx) && !currentHashes.has(tx.transactionHash))
+  )
+  transactionsWithoutDuplicatedHash.sort((a, b) => {
+    return b.timestamp - a.timestamp
+  })
+  return transactionsWithoutDuplicatedHash
 }
 
 export function useFetchTransactions(): QueryHookResult {
@@ -66,33 +63,40 @@ export function useFetchTransactions(): QueryHookResult {
   const address = useSelector(walletAddressSelector)
   const localCurrencyCode = useSelector(getLocalCurrencyCode)
 
-  const pageInfo = useRef<PageInfo | null>(null)
+  // track cumulative transactions and most recent page info in one state, so
+  // that they do not become out of sync
+  const [fetchedResult, setFetchedResult] = useState<{
+    transactions: TokenTransaction[]
+    pageInfo: PageInfo | null
+  }>({
+    transactions: [],
+    pageInfo: null,
+  })
   const [fetchingMoreTransactions, setFetchingMoreTransactions] = useState(false)
-  const { transactions, addTransactions } = useDeduplicatedTransactions()
 
   // Update the counter variable every |POLL_INTERVAL| so that a query is made to the backend.
   const [counter, setCounter] = useState(0)
   useInterval(() => setCounter((n) => n + 1), POLL_INTERVAL)
 
-  const handleResult = (result: QueryResponse, paginatedResult: boolean) => {
-    Logger.info(TAG, `Fetched ${paginatedResult ? 'next page' : 'new'} transactions`)
+  const handleResult = (result: QueryResponse, hasPreviousPage: boolean) => {
+    Logger.info(TAG, `Fetched ${hasPreviousPage ? 'next page' : 'new'} transactions`)
 
     const returnedTransactions = result.data?.tokenTransactionsV2?.transactions
+    const returnedPageInfo = result.data?.tokenTransactionsV2?.pageInfo
 
     if (returnedTransactions?.length) {
-      const nonEmptyTransactions = returnedTransactions.filter(
-        (returnedTransaction) => !isEmpty(returnedTransaction)
-      )
-      addTransactions(nonEmptyTransactions)
-      // We store non-paginated results in redux to show them to the users when they open the app.
-      if (!paginatedResult) {
+      setFetchedResult((prev) => ({
+        transactions: deduplicateTransactions(prev.transactions, returnedTransactions),
+        pageInfo: returnedPageInfo ?? null,
+      }))
+
+      // We store the first page in redux to show them to the users when they open the app.
+      if (!hasPreviousPage) {
+        const nonEmptyTransactions = returnedTransactions.filter(
+          (returnedTransaction) => !isEmpty(returnedTransaction)
+        )
         dispatch(updateTransactions(nonEmptyTransactions))
       }
-    }
-
-    const returnedPageInfo = result.data?.tokenTransactionsV2?.pageInfo
-    if ((!pageInfo.current || paginatedResult) && returnedPageInfo) {
-      pageInfo.current = returnedPageInfo
     }
   }
 
@@ -115,7 +119,7 @@ export function useFetchTransactions(): QueryHookResult {
   // Query for next page of transaction if requested
   useAsync(
     async () => {
-      if (!fetchingMoreTransactions || !pageInfo.current?.hasNextPage) {
+      if (!fetchingMoreTransactions || !fetchedResult.pageInfo?.hasNextPage) {
         setFetchingMoreTransactions(false)
         return
       }
@@ -123,7 +127,7 @@ export function useFetchTransactions(): QueryHookResult {
       const result = await queryTransactionsFeed(
         address,
         localCurrencyCode,
-        pageInfo.current?.endCursor
+        fetchedResult.pageInfo?.endCursor
       )
       setFetchingMoreTransactions(false)
       handleResult(result, true)
@@ -139,26 +143,27 @@ export function useFetchTransactions(): QueryHookResult {
   )
 
   useEffect(() => {
-    // this hook ensures that we populate the screen with transactions on load
-    // so that future refetches can be correctly triggered by `onEndReached`,
-    // in the event that blockchain-api returns a small number of results for
-    // the first page
+    // this hook ensures that we populate the entire screen with transactions
+    // on load so that future refetches can be correctly triggered by
+    // `onEndReached`, in the event that blockchain-api returns a small number
+    // of results for the first page(s)
+    const { transactions, pageInfo } = fetchedResult
     if (
       !loading &&
       transactions.length > 0 &&
-      transactions.length < 10 &&
-      pageInfo.current?.hasNextPage
+      transactions.length < MIN_NUM_TRANSACTIONS &&
+      pageInfo?.hasNextPage
     ) {
       setFetchingMoreTransactions(true)
     }
-  }, [transactions, pageInfo.current, loading])
+  }, [fetchedResult, loading])
 
   const fetchMoreTransactions = () => {
-    if (!pageInfo) {
+    if (!fetchedResult.pageInfo) {
       dispatch(showError(ErrorMessages.FETCH_FAILED))
-    } else if (!pageInfo.current?.hasNextPage) {
+    } else if (!fetchedResult.pageInfo?.hasNextPage) {
       // If the user has a few transactions, don't show any message
-      if (transactions.length > 20) {
+      if (fetchedResult.transactions.length > 20) {
         Toast.showWithGravity(t('noMoreTransactions'), Toast.SHORT, Toast.CENTER)
       }
     } else {
@@ -169,7 +174,7 @@ export function useFetchTransactions(): QueryHookResult {
   return {
     loading,
     error,
-    transactions,
+    transactions: fetchedResult.transactions,
     fetchingMoreTransactions,
     fetchMoreTransactions,
   }


### PR DESCRIPTION
### Description

Context: https://valora-app.slack.com/archives/C018VLA3YAK/p1660091022594799

The solution chosen for this issue is to continue to fetch transactions from the client until a minimum threshold is met (currently 10) so that the section list is filled and the user can scroll to load more.

In this PR:
- To ensure no weird bugs and avoid concurrency issues, i refactored the state variables to keep the cumulative transactions + pageInfo in the same state variable so that they are always in sync. 
- Added a hook to refetch transactions until we have 10, and refetch transactions if the returned page is empty
- Updated tests

### Other changes

N/A

### Tested

Manually and with unit tests

### How others should test

Please try this with many accounts that have varying number of transactions - load the app (from a fresh install, and from cold start) and ensure that the home feed displays transactions. If the account has many transactions, ensure that you can scroll down to load more transactions.

### Related issues

N/A

### Backwards compatibility

Yes