### PR TITLE
fix(homefeed): avoid showing 'no more transactions' toast when too few transactions

### DIFF
--- a/src/transactions/feed/queryHelper.ts
+++ b/src/transactions/feed/queryHelper.ts
@@ -178,7 +178,10 @@ export function useFetchTransactions(): QueryHookResult {
     fetchMoreTransactions: () => {
       if (!fetchedResult.pageInfo) {
         dispatch(showError(ErrorMessages.FETCH_FAILED))
-      } else if (!fetchedResult.pageInfo?.hasNextPage) {
+      } else if (
+        !fetchedResult.pageInfo?.hasNextPage &&
+        fetchedResult.transactions.length > MIN_NUM_TRANSACTIONS
+      ) {
         Toast.showWithGravity(t('noMoreTransactions'), Toast.SHORT, Toast.CENTER)
       } else {
         setFetchingMoreTransactions(true)


### PR DESCRIPTION

### Description

Annoyingly, the `onEndReached` callback is triggered on the SectionList used to render the transaction feed when navigating away from the screen on iOS, when the transaction list is too short. This causes the "no more transactions" toast to appear on the next page that is navigated to, but only once. 

This check for length of transactions used to exist, and I had removed it thinking it was strange https://github.com/valora-inc/wallet/pull/2779#discussion_r944308531 - but it seems like we need it.

### Other changes

N/A

### Tested

Manually

### How others should test

N/A

### Related issues

N/A

### Backwards compatibility

Yes