### PR TITLE
build(deps): update detox to 19.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -252,7 +252,7 @@
     "babel-core": "7.0.0-bridge.0",
     "babel-jest": "^26.6.3",
     "codecov": "^3.6.5",
-    "detox": "^19.9.0",
+    "detox": "^19.10.0",
     "escape-string-regexp": "^1.0.5",
     "eslint": "^7.27.0",
     "eslint-plugin-import": "^2.23.3",

--- a/src/components/TokenBalance.tsx
+++ b/src/components/TokenBalance.tsx
@@ -8,6 +8,7 @@ import { FiatExchangeEvents, HomeEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import Dialog from 'src/components/Dialog'
 import { formatValueToDisplay } from 'src/components/TokenDisplay'
+import { isE2EEnv } from 'src/config'
 import { refreshAllBalances } from 'src/home/actions'
 import InfoIcon from 'src/icons/InfoIcon'
 import ProgressArrow from 'src/icons/ProgressArrow'
@@ -81,7 +82,8 @@ function useErrorMessageWithRefresh() {
 
   const dispatch = useDispatch()
 
-  const shouldShowError = tokensInfoUnavailable && (tokenFetchError || localCurrencyError)
+  const shouldShowError =
+    !isE2EEnv && tokensInfoUnavailable && (tokenFetchError || localCurrencyError)
 
   useEffect(() => {
     if (shouldShowError) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8595,10 +8595,10 @@ detect-newline@^3.0.0:
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
 
-detox@^19.9.0:
-  version "19.9.0"
-  resolved "https://registry.yarnpkg.com/detox/-/detox-19.9.0.tgz#008f648b7b5f17597c15fbcb3a01cbb6d884c9dd"
-  integrity sha512-VDUzE5XgW/UasyxayD/bPftqdAOK4akHeZdPx3jaH5AKlfi4qobZlZ20hi1RMeMfFChs8isa4TdTZ6kU1jaEzQ==
+detox@^19.10.0:
+  version "19.10.0"
+  resolved "https://registry.yarnpkg.com/detox/-/detox-19.10.0.tgz#a47a1b4f5a4a08f267a86847ab5a48cbe1f9468e"
+  integrity sha512-SVJK/EPi6F2Grm4vSl+uP6xDuDT1gABwypZ3MU+/glylo8ibm3ddTHovXVBd4YDIE1rzD4eQpC8gM2lzJFvWrA==
   dependencies:
     ajv "^8.6.3"
     bunyan "^1.8.12"


### PR DESCRIPTION
### Description

Update to [Detox 19.10.0](https://github.com/wix/Detox/releases/tag/19.10.0)

### Other changes

Don't display out of Sync Banner during e2e tests.

### Tested

Tested in CI.

### How others should test

- Reviewers: check [E2E actions on this branch](https://github.com/valora-inc/wallet/actions/workflows/e2e-ci.yml?query=branch%3Atomm%2Fdetox-19.10.0) - First one was prior to removing out of sync banner.
- QA: N/A

### Related issues

N/A

### Backwards compatibility

Yes