### PR TITLE
fix: handle dapplist fetch correctly on account load

### DIFF
--- a/src/dapps/saga.ts
+++ b/src/dapps/saga.ts
@@ -18,6 +18,7 @@ import { isDeepLink } from 'src/utils/linking'
 import Logger from 'src/utils/Logger'
 import { isWalletConnectEnabled } from 'src/walletConnect/saga'
 import { isWalletConnectDeepLink } from 'src/walletConnect/walletConnect'
+import { Actions } from 'src/web3/actions'
 import { walletAddressSelector } from 'src/web3/selectors'
 
 const TAG = 'DappsSaga'
@@ -49,6 +50,11 @@ export function* handleOpenDapp(action: PayloadAction<DappSelectedAction>) {
 
 export function* handleFetchDappsList() {
   const dappsListApiUrl = yield select(dappsListApiUrlSelector)
+  if (!dappsListApiUrl) {
+    Logger.warn(TAG, 'dappsListApiUrl not found')
+    return
+  }
+
   const address = yield select(walletAddressSelector)
   const language = yield select(currentLanguageSelector)
   const shortLanguage = language.split('-')[0]
@@ -100,10 +106,11 @@ export function* watchDappSelected() {
 }
 
 export function* watchFetchDappsList() {
-  yield takeLeading(fetchDappsList.type, handleFetchDappsList)
+  yield takeLeading([fetchDappsList.type, Actions.SET_ACCOUNT], handleFetchDappsList)
 }
 
 export function* dappsSaga() {
   yield spawn(watchDappSelected)
   yield spawn(watchFetchDappsList)
+  yield put(fetchDappsList())
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -16831,14 +16831,7 @@ redux-thunk@^2.4.1:
   resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.4.1.tgz#0dd8042cf47868f4b29699941de03c9301a75714"
   integrity sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q==
 
-redux@^4.0.0, redux@^4.0.4, redux@^4.0.5:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/redux/-/redux-4.1.1.tgz#76f1c439bb42043f985fbd9bf21990e60bd67f47"
-  integrity sha512-hZQZdDEM25UY2P493kPYuKqviVwZ58lEmGQNeQ+gXa+U0gYPUBf7NKYazbe3m+bs/DzM/ahN12DbF+NG8i0CWw==
-  dependencies:
-    "@babel/runtime" "^7.9.2"
-
-redux@^4.1.2:
+redux@^4.0.0, redux@^4.0.4, redux@^4.0.5, redux@^4.1.2:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/redux/-/redux-4.2.0.tgz#46f10d6e29b6666df758780437651eeb2b969f13"
   integrity sha512-oSBmcKKIuIR4ME29/AeNUnl5L+hvBq7OaJWzaptTQJAntaPvxIJqfnjbaEiCzzaIz+XmVILfqAM3Ob0aXLPfjA==
@@ -17153,12 +17146,7 @@ requires-port@^1.0.0:
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
 
-reselect@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.0.0.tgz#f2529830e5d3d0e021408b246a206ef4ea4437f7"
-  integrity sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA==
-
-reselect@^4.1.5:
+reselect@^4.0.0, reselect@^4.1.5:
   version "4.1.6"
   resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.1.6.tgz#19ca2d3d0b35373a74dc1c98692cdaffb6602656"
   integrity sha512-ZovIuXqto7elwnxyXbBtCPo9YFEr3uJqj2rRbcOOog1bmu2Ag85M4hixSwFWyaBMKXNgvPaJ9OSu9SkBPIeJHQ==


### PR DESCRIPTION
### Description

This PR continues from https://github.com/valora-inc/wallet/pull/2811

On initial account creation/restore, the fetch dapp list action is dispatched too early (before the remote config variable for the dapps list url and the account address are loaded) - the lack of dapps list url causes the saga to hang and subsequent calls to it are not processed.

This PR:
- return early when remote config for dapps list url is not available
- fetch dapps list on account set

### Other changes

Tidies up the yarn.lock from the previous update

### Tested

Manually

### How others should test

Verify that https://github.com/valora-inc/wallet/issues/2754 cannot be reproduced

### Related issues

- Fixes #2754 

### Backwards compatibility

Yes