### PR TITLE
revert: feature flag for guided onboarding copy

### DIFF
--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -591,10 +591,7 @@
     "goldDisclaimer": "When you create an \"account\" with Valora you are creating a digital wallet to which only you hold the keys. No other person or entity, including cLabs or Valora, can recover your key, change or undo transactions, or recover lost funds. Be aware that CELO, cUSD and cEUR are part of a new asset class and present a risk of financial loss. Carefully consider your financial circumstance and tolerance for financial risk before purchasing any asset."
   },
   "fullName": "Name",
-  "fullNameOrPseudonymPlaceholder": "First and last name or pseudonym",
   "fullNamePlaceholder": "First & Last name",
-  "nameAndPicGuideCopyTitle": "What’s your name?",
-  "nameAndPicGuideCopyContent": "We’d like to know what to call you",
   "importIt": "Restore Wallet",
   "important": "Important",
   "confirmPin": {
@@ -684,9 +681,7 @@
   "enableBiometry": {
     "title": "Secure your wallet",
     "description": "{{biometryType}} secures your wallet and makes it easier to use {{appName}}",
-    "cta": "Turn on {{biometryType}}",
-    "guideTitle": "Want to add {{biometryType}}?",
-    "guideDescription": "{{biometryType}} makes it easier, quicker, and more secure to connect your wallet to dapps & sign transactions."
+    "cta": "Turn on {{biometryType}}"
   },
   "biometryType": {
     "FaceID": "Face ID",
@@ -699,7 +694,6 @@
   "unlockWithBiometryPrompt": "Authenticate to unlock {{appName}}",
   "welcome": {
     "title": "Step into the future of crypto with {{appName}}",
-    "titleGuided": "Welcome to {{appName}}!\nLet’s create your crypto wallet.",
     "createAccount": "Create new account",
     "restoreAccount": "Restore my account",
     "createNewWallet": "Create new wallet",
@@ -721,12 +715,9 @@
     "create": "Create a PIN",
     "createNew": "Create a new PIN",
     "verify": "Enter your PIN again to confirm",
-    "guideTitle": "Choose a 6 digit PIN you’ll remember",
-    "pinCodeGuide": "Keep your PIN safe, it’s how you’ll keep your wallet secure.",
     "changePIN": "Change PIN",
     "pinsDontMatch": "The PINs didn't match",
-    "invalidPin": "Please use a stronger PIN",
-    "selectPIN": "Select PIN"
+    "invalidPin": "Please use a stronger PIN"
   },
   "inviteCode": {
     "title": "Invite Code",

--- a/src/app/reducers.ts
+++ b/src/app/reducers.ts
@@ -52,7 +52,6 @@ export interface State {
   fiatConnectCashOutEnabled: boolean
   visualizeNFTsEnabledInHomeAssetsPage: boolean
   coinbasePayEnabled: boolean
-  showGuidedOnboardingCopy: boolean
   showSwapMenuInDrawerMenu: boolean
   shouldShowRecoveryPhraseInSettings: boolean
   createAccountCopyTestType: CreateAccountCopyTestType
@@ -107,7 +106,6 @@ const initialState = {
   showSwapMenuInDrawerMenu: REMOTE_CONFIG_VALUES_DEFAULTS.showSwapMenuInDrawerMenu,
   shouldShowRecoveryPhraseInSettings:
     REMOTE_CONFIG_VALUES_DEFAULTS.shouldShowRecoveryPhraseInSettings,
-  showGuidedOnboardingCopy: REMOTE_CONFIG_VALUES_DEFAULTS.showGuidedOnboardingCopy,
   createAccountCopyTestType: REMOTE_CONFIG_VALUES_DEFAULTS.createAccountCopyTestType,
   maxSwapSlippagePercentage: REMOTE_CONFIG_VALUES_DEFAULTS.maxSwapSlippagePercentage,
   swapFeeEnabled: REMOTE_CONFIG_VALUES_DEFAULTS.swapFeeEnabled,
@@ -232,7 +230,6 @@ export const appReducer = (
         createAccountCopyTestType: action.configValues.createAccountCopyTestType,
         maxSwapSlippagePercentage: action.configValues.maxSwapSlippagePercentage,
         swapFeeEnabled: action.configValues.swapFeeEnabled,
-        showGuidedOnboardingCopy: action.configValues.showGuidedOnboardingCopy,
         swapFeePercentage: action.configValues.swapFeePercentage,
         inviteMethod: action.configValues.inviteMethod,
       }

--- a/src/app/saga.ts
+++ b/src/app/saga.ts
@@ -200,7 +200,6 @@ export interface RemoteConfigValues {
   swapFeeEnabled: boolean
   swapFeePercentage: number
   inviteMethod: InviteMethodType
-  showGuidedOnboardingCopy: boolean
 }
 
 export function* appRemoteFeatureFlagSaga() {

--- a/src/app/selectors.ts
+++ b/src/app/selectors.ts
@@ -129,8 +129,6 @@ export const swapFeePercentageSelector = (state: RootState) => state.app.swapFee
 
 export const inviteMethodSelector = (state: RootState) => state.app.inviteMethod
 
-export const showGuidedOnboardingSelector = (state: RootState) => state.app.showGuidedOnboardingCopy
-
 type StoreWipeRecoveryScreens = Extract<
   Screens,
   | Screens.NameAndPicture

--- a/src/firebase/firebase.ts
+++ b/src/firebase/firebase.ts
@@ -296,7 +296,6 @@ export async function fetchRemoteConfigValues(): Promise<RemoteConfigValues | nu
     dappConnectInfo: flags.dappConnectInfo.asString() as DappConnectInfo,
     visualizeNFTsEnabledInHomeAssetsPage: flags.visualizeNFTsEnabledInHomeAssetsPage.asBoolean(),
     coinbasePayEnabled: flags.coinbasePayEnabled.asBoolean(),
-    showGuidedOnboardingCopy: flags.showGuidedOnboardingCopy.asBoolean(),
     showSwapMenuInDrawerMenu: flags.showSwapMenuInDrawerMenu.asBoolean(),
     shouldShowRecoveryPhraseInSettings: flags.shouldShowRecoveryPhraseInSettings.asBoolean(),
     createAccountCopyTestType: flags.createAccountCopyTestType.asString() as CreateAccountCopyTestType,

--- a/src/firebase/remoteConfigValuesDefaults.e2e.ts
+++ b/src/firebase/remoteConfigValuesDefaults.e2e.ts
@@ -65,7 +65,6 @@ export const REMOTE_CONFIG_VALUES_DEFAULTS: Omit<
   dappConnectInfo: DappConnectInfo.Basic,
   visualizeNFTsEnabledInHomeAssetsPage: false,
   coinbasePayEnabled: false,
-  showGuidedOnboardingCopy: false,
   showSwapMenuInDrawerMenu: false,
   shouldShowRecoveryPhraseInSettings: false,
   createAccountCopyTestType: CreateAccountCopyTestType.Account,

--- a/src/firebase/remoteConfigValuesDefaults.ts
+++ b/src/firebase/remoteConfigValuesDefaults.ts
@@ -71,5 +71,4 @@ export const REMOTE_CONFIG_VALUES_DEFAULTS: Omit<
   swapFeeEnabled: false,
   swapFeePercentage: 0.743,
   inviteMethod: InviteMethodType.Escrow,
-  showGuidedOnboardingCopy: false,
 }

--- a/src/navigator/types.tsx
+++ b/src/navigator/types.tsx
@@ -216,7 +216,6 @@ export type StackParamList = {
         komenciAvailable?: boolean
         choseToRestoreAccount?: boolean
         registrationStep?: { step: number; totalSteps: number }
-        showGuidedOnboarding?: boolean
       }
     | undefined
   [Screens.PhoneNumberLookupQuota]: {

--- a/src/onboarding/registration/EnableBiometry.test.tsx
+++ b/src/onboarding/registration/EnableBiometry.test.tsx
@@ -135,26 +135,4 @@ describe('EnableBiometry', () => {
 
     expect(navigate).toHaveBeenCalledWith(Screens.VerificationEducationScreen)
   })
-
-  it('should show guided onboarding explaining faceid when enabled to do so', () => {
-    const store = createMockStore({
-      app: {
-        showGuidedOnboardingCopy: true,
-        supportedBiometryType: BIOMETRY_TYPE.FACE_ID,
-        biometryEnabled: true,
-        activeScreen: Screens.EnableBiometry,
-      },
-    })
-    const { getByText } = render(
-      <Provider store={store}>
-        <MockedNavigator component={EnableBiometry} />
-      </Provider>
-    )
-    expect(
-      getByText('enableBiometry.guideTitle, {"biometryType":"biometryType.FaceID"}')
-    ).toBeTruthy()
-    expect(
-      getByText('enableBiometry.guideDescription, {"biometryType":"biometryType.FaceID"}')
-    ).toBeTruthy()
-  })
 })

--- a/src/onboarding/registration/EnableBiometry.tsx
+++ b/src/onboarding/registration/EnableBiometry.tsx
@@ -12,7 +12,6 @@ import { OnboardingEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import {
   registrationStepsSelector,
-  showGuidedOnboardingSelector,
   skipVerificationSelector,
   supportedBiometryTypeSelector,
 } from 'src/app/selectors'
@@ -57,7 +56,6 @@ export default function EnableBiometry({ navigation }: Props) {
   const choseToRestoreAccount = useSelector(choseToRestoreAccountSelector)
   const skipVerification = useSelector(skipVerificationSelector)
   const { step, totalSteps } = useSelector(registrationStepsSelector)
-  const showGuidedOnboarding = useSelector(showGuidedOnboardingSelector)
 
   useEffect(() => {
     ValoraAnalytics.track(OnboardingEvents.biometry_opt_in_start)
@@ -67,11 +65,7 @@ export default function EnableBiometry({ navigation }: Props) {
     navigation.setOptions({
       headerTitle: () => (
         <HeaderTitleWithSubtitle
-          title={
-            showGuidedOnboarding
-              ? t(`biometryType.${supportedBiometryType}`)
-              : t('enableBiometry.title')
-          }
+          title={t('enableBiometry.title')}
           subTitle={t('registrationSteps', { step, totalSteps })}
         />
       ),
@@ -122,28 +116,13 @@ export default function EnableBiometry({ navigation }: Props) {
 
   return (
     <ScrollView style={styles.contentContainer}>
-      <SafeAreaView style={showGuidedOnboarding ? styles.containerLeftAligned : styles.container}>
+      <SafeAreaView style={styles.container}>
         <View style={styles.imageContainer}>{biometryImageMap[supportedBiometryType!]}</View>
-        {showGuidedOnboarding ? (
-          <>
-            <Text style={styles.guideTitle}>
-              {t('enableBiometry.guideTitle', {
-                biometryType: t(`biometryType.${supportedBiometryType}`),
-              })}
-            </Text>
-            <Text style={styles.guideText}>
-              {t('enableBiometry.guideDescription', {
-                biometryType: t(`biometryType.${supportedBiometryType}`),
-              })}
-            </Text>
-          </>
-        ) : (
-          <Text style={styles.description}>
-            {t('enableBiometry.description', {
-              biometryType: t(`biometryType.${supportedBiometryType}`),
-            })}
-          </Text>
-        )}
+        <Text style={styles.description}>
+          {t('enableBiometry.description', {
+            biometryType: t(`biometryType.${supportedBiometryType}`),
+          })}
+        </Text>
         <Button
           onPress={onPressUseBiometry}
           text={t('enableBiometry.cta', {
@@ -166,10 +145,6 @@ const styles = StyleSheet.create({
     paddingHorizontal: 40,
     alignItems: 'center',
   },
-  containerLeftAligned: {
-    paddingTop: 186,
-    paddingHorizontal: 40,
-  },
   contentContainer: {
     flex: 1,
     backgroundColor: colors.onboardingBackground,
@@ -181,14 +156,5 @@ const styles = StyleSheet.create({
     ...fontStyles.regular,
     textAlign: 'center',
     marginBottom: Spacing.Thick24,
-  },
-  guideTitle: {
-    ...fontStyles.h1,
-    marginBottom: Spacing.Thick24,
-  },
-  guideText: {
-    ...fontStyles.regular,
-    marginBottom: Spacing.Thick24,
-    textAlign: 'left',
   },
 })

--- a/src/onboarding/registration/NameAndPicture.test.tsx
+++ b/src/onboarding/registration/NameAndPicture.test.tsx
@@ -145,38 +145,4 @@ describe('NameAndPictureScreen', () => {
 
     expect(getByText('createProfile')).toBeTruthy()
   })
-
-  it('render header title correctly when showGuidedOnboarding is true', () => {
-    const store = createMockStore({
-      app: {
-        showGuidedOnboardingCopy: true,
-      },
-    })
-    let headerTitle: React.ReactNode
-    ;(mockNavigation.setOptions as jest.Mock).mockImplementation((options) => {
-      headerTitle = options.headerTitle()
-    }),
-      render(
-        <Provider store={store}>
-          <NameAndPicture {...mockScreenProps} />
-        </Provider>
-      )
-    const { getByText } = render(<Provider store={store}>{headerTitle}</Provider>)
-    expect(getByText('name')).toBeTruthy()
-  })
-
-  it('render onboarding guide copy correctly when showGuidedOnboarding is true', () => {
-    const store = createMockStore({
-      app: {
-        showGuidedOnboardingCopy: true,
-      },
-    })
-    const { getByText } = render(
-      <Provider store={store}>
-        <NameAndPicture {...mockScreenProps} />{' '}
-      </Provider>
-    )
-    expect(getByText('nameAndPicGuideCopyTitle')).toBeTruthy()
-    expect(getByText('nameAndPicGuideCopyContent')).toBeTruthy()
-  })
 })

--- a/src/onboarding/registration/NameAndPicture.tsx
+++ b/src/onboarding/registration/NameAndPicture.tsx
@@ -1,7 +1,7 @@
 import { StackScreenProps } from '@react-navigation/stack'
 import React, { useLayoutEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { ScrollView, StyleSheet, Text } from 'react-native'
+import { ScrollView, StyleSheet } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { useDispatch } from 'react-redux'
 import { setName, setPicture } from 'src/account/actions'
@@ -10,11 +10,7 @@ import { hideAlert, showError } from 'src/alert/actions'
 import { OnboardingEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import { ErrorMessages } from 'src/app/ErrorMessages'
-import {
-  createAccountCopyTestTypeSelector,
-  registrationStepsSelector,
-  showGuidedOnboardingSelector,
-} from 'src/app/selectors'
+import { createAccountCopyTestTypeSelector, registrationStepsSelector } from 'src/app/selectors'
 import { CreateAccountCopyTestType } from 'src/app/types'
 import Button, { BtnSizes, BtnTypes } from 'src/components/Button'
 import DevSkipButton from 'src/components/DevSkipButton'
@@ -27,7 +23,6 @@ import { StackParamList } from 'src/navigator/types'
 import PictureInput from 'src/onboarding/registration/PictureInput'
 import { default as useSelector, default as useTypedSelector } from 'src/redux/useSelector'
 import colors from 'src/styles/colors'
-import fontStyles from 'src/styles/fonts'
 import { saveProfilePicture } from 'src/utils/image'
 import { useAsyncKomenciReadiness } from 'src/verify/hooks'
 
@@ -47,30 +42,24 @@ function NameAndPicture({ navigation }: Props) {
 
   // CB TEMPORARY HOTFIX: Pinging Komenci endpoint to ensure availability
   const asyncKomenciReadiness = useAsyncKomenciReadiness()
-  const showGuidedOnboarding = useSelector(showGuidedOnboardingSelector)
+
   const createAccountCopyTestType = useSelector(createAccountCopyTestTypeSelector)
 
   useLayoutEffect(() => {
     navigation.setOptions({
-      headerTitle: () => {
-        let pageTitleTranslationKey
-        if (showGuidedOnboarding) {
-          pageTitleTranslationKey = 'name'
-        } else {
-          pageTitleTranslationKey = choseToRestoreAccount
-            ? 'restoreAccount'
-            : createAccountCopyTestType === CreateAccountCopyTestType.Wallet ||
-              createAccountCopyTestType === CreateAccountCopyTestType.AlreadyHaveWallet
-            ? 'createProfile'
-            : 'createAccount'
-        }
-        return (
-          <HeaderTitleWithSubtitle
-            title={t(pageTitleTranslationKey)}
-            subTitle={t('registrationSteps', { step, totalSteps })}
-          />
-        )
-      },
+      headerTitle: () => (
+        <HeaderTitleWithSubtitle
+          title={t(
+            choseToRestoreAccount
+              ? 'restoreAccount'
+              : createAccountCopyTestType === CreateAccountCopyTestType.Wallet ||
+                createAccountCopyTestType === CreateAccountCopyTestType.AlreadyHaveWallet
+              ? 'createProfile'
+              : 'createAccount'
+          )}
+          subTitle={t('registrationSteps', { step, totalSteps })}
+        />
+      ),
     })
   }, [navigation, choseToRestoreAccount, step, totalSteps])
 
@@ -80,7 +69,6 @@ function NameAndPicture({ navigation }: Props) {
     } else {
       navigate(Screens.PincodeSet, {
         komenciAvailable: !!asyncKomenciReadiness.result,
-        showGuidedOnboarding,
       })
     }
   }
@@ -134,21 +122,13 @@ function NameAndPicture({ navigation }: Props) {
             backgroundColor={colors.onboardingBrownLight}
           />
         )}
-        {showGuidedOnboarding && (
-          <>
-            <Text style={styles.guidedOnboardingHeader}>{t('nameAndPicGuideCopyTitle')}</Text>
-            <Text style={styles.guidedOnboardingCopy}>{t('nameAndPicGuideCopyContent')}</Text>
-          </>
-        )}
         <FormInput
           label={t('fullName')}
           style={styles.name}
           onChangeText={setNameInput}
           value={nameInput}
           enablesReturnKeyAutomatically={true}
-          placeholder={
-            showGuidedOnboarding ? t('fullNameOrPseudonymPlaceholder') : t('fullNamePlaceholder')
-          }
+          placeholder={t('fullNamePlaceholder')}
           testID={'NameEntry'}
           multiline={false}
         />
@@ -184,12 +164,5 @@ const styles = StyleSheet.create({
   name: {
     marginTop: 24,
     marginBottom: 32,
-  },
-  guidedOnboardingCopy: {
-    ...fontStyles.regular,
-  },
-  guidedOnboardingHeader: {
-    marginTop: 36,
-    ...fontStyles.h1,
   },
 })

--- a/src/onboarding/welcome/Welcome.test.tsx
+++ b/src/onboarding/welcome/Welcome.test.tsx
@@ -88,32 +88,4 @@ describe('Welcome', () => {
     expect(queryByTestId('CreateAccountButton')).toHaveTextContent('welcome.createNewWallet')
     expect(queryByTestId('RestoreAccountButton')).toHaveTextContent('welcome.iAlreadyHaveAWallet')
   })
-
-  it('render welcome text correctly when showGuidedOnboardingCopy is true', () => {
-    const store = createMockStore({
-      app: {
-        showGuidedOnboardingCopy: true,
-      },
-    })
-    const { queryByTestId } = render(
-      <Provider store={store}>
-        <Welcome />
-      </Provider>
-    )
-    expect(queryByTestId('WelcomeText')).toHaveTextContent('welcome.titleGuided')
-  })
-
-  it('render welcome text correctly when showGuidedOnboardingCopy is false', () => {
-    const store = createMockStore({
-      app: {
-        showGuidedOnboardingCopy: false,
-      },
-    })
-    const { queryByTestId } = render(
-      <Provider store={store}>
-        <Welcome />
-      </Provider>
-    )
-    expect(queryByTestId('WelcomeText')).toHaveTextContent('welcome.title')
-  })
 })

--- a/src/onboarding/welcome/Welcome.tsx
+++ b/src/onboarding/welcome/Welcome.tsx
@@ -6,7 +6,7 @@ import { useDispatch } from 'react-redux'
 import { chooseCreateAccount, chooseRestoreAccount } from 'src/account/actions'
 import { OnboardingEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
-import { createAccountCopyTestTypeSelector, showGuidedOnboardingSelector } from 'src/app/selectors'
+import { createAccountCopyTestTypeSelector } from 'src/app/selectors'
 import { CreateAccountCopyTestType } from 'src/app/types'
 import Button, { BtnSizes, BtnTypes } from 'src/components/Button'
 import Logo, { LogoTypes } from 'src/icons/Logo'
@@ -27,8 +27,6 @@ export default function Welcome() {
   const insets = useSafeAreaInsets()
 
   const createAccountCopyTestType = useSelector(createAccountCopyTestTypeSelector)
-
-  const showGuidedOnboarding = useSelector(showGuidedOnboardingSelector)
 
   const navigateNext = () => {
     if (!acceptedTerms) {
@@ -55,15 +53,7 @@ export default function Welcome() {
       <Image source={welcomeBackground} style={styles.backgroundImage} />
       <ScrollView contentContainerStyle={styles.contentContainer}>
         <Logo type={LogoTypes.COLOR} height={64} />
-        {showGuidedOnboarding ? (
-          <Text style={styles.title} testID={'WelcomeText'}>
-            {t('welcome.titleGuided')}
-          </Text>
-        ) : (
-          <Text style={styles.title} testID={'WelcomeText'}>
-            {t('welcome.title')}
-          </Text>
-        )}
+        <Text style={styles.title}>{t('welcome.title')}</Text>
       </ScrollView>
       <View style={{ marginBottom: Math.max(0, 40 - insets.bottom) }}>
         <Button

--- a/src/pincode/Pincode.tsx
+++ b/src/pincode/Pincode.tsx
@@ -3,10 +3,7 @@
  * with an input, e.g. get/ensure/set pincode.
  */
 import React, { useEffect } from 'react'
-import { useTranslation } from 'react-i18next'
-import { Keyboard, ScrollView, StyleSheet, Text, View } from 'react-native'
-import { useSelector } from 'react-redux'
-import { showGuidedOnboardingSelector } from 'src/app/selectors'
+import { Keyboard, StyleSheet, Text, View } from 'react-native'
 import NumberKeypad from 'src/components/NumberKeypad'
 import { PIN_LENGTH } from 'src/pincode/authentication'
 import PincodeDisplay from 'src/pincode/PincodeDisplay'
@@ -31,7 +28,6 @@ function Pincode({
   onChangePin,
   onCompletePin,
 }: Props) {
-  const { t } = useTranslation()
   const onDigitPress = (digit: number) => {
     if (pin.length >= maxLength) {
       return
@@ -44,8 +40,6 @@ function Pincode({
   const onBackspacePress = () => {
     onChangePin(pin.substring(0, pin.length - 1))
   }
-
-  const showGuidedOnboarding = useSelector(showGuidedOnboardingSelector)
 
   useEffect(() => {
     // Wait for next frame so we the user can see the last digit
@@ -64,14 +58,6 @@ function Pincode({
       <View style={styles.spacer} />
       {!errorText && <Text style={styles.title}>{title || ' '}</Text>}
       {!!errorText && <Text style={styles.error}>{errorText}</Text>}
-      <ScrollView contentContainerStyle={styles.contentContainer}>
-        {showGuidedOnboarding && (
-          <>
-            <Text style={styles.guidedOnboardingHeader}>{t('pincodeSet.guideTitle')}</Text>
-            <Text style={styles.guidedOnboardingCopy}>{t('pincodeSet.pinCodeGuide')}</Text>
-          </>
-        )}
-      </ScrollView>
       <View style={styles.pincodeContainer}>
         <PincodeDisplay pin={pin} maxLength={maxLength} />
       </View>
@@ -103,19 +89,6 @@ const styles = StyleSheet.create({
     marginBottom: 24,
     paddingHorizontal: '15%',
     alignItems: 'center',
-  },
-
-  guidedOnboardingCopy: {
-    ...fontStyles.regular,
-  },
-  guidedOnboardingHeader: {
-    ...fontStyles.h1,
-  },
-  contentContainer: {
-    flexGrow: 1,
-    justifyContent: 'center',
-    marginLeft: 24,
-    marginRight: 24,
   },
 })
 

--- a/src/pincode/PincodeSet.tsx
+++ b/src/pincode/PincodeSet.tsx
@@ -86,12 +86,7 @@ const mapDispatchToProps = {
 export class PincodeSet extends React.Component<Props, State> {
   static navigationOptions = ({ route }: ScreenProps) => {
     const changePin = route.params?.changePin
-    const showGuidedOnboarding = route.params?.showGuidedOnboarding
-    const title = changePin
-      ? i18n.t('pincodeSet.changePIN')
-      : showGuidedOnboarding // this should be during onboarding
-      ? i18n.t('pincodeSet.selectPIN')
-      : i18n.t('pincodeSet.create')
+    const title = changePin ? i18n.t('pincodeSet.changePIN') : i18n.t('pincodeSet.create')
 
     return {
       ...nuxNavigationOptions,

--- a/src/redux/migrations.test.ts
+++ b/src/redux/migrations.test.ts
@@ -33,7 +33,6 @@ import {
   v58Schema,
   v59Schema,
   v62Schema,
-  v74Schema,
   v7Schema,
   v8Schema,
   vNeg1Schema,
@@ -662,16 +661,6 @@ describe('Redux persist migrations', () => {
     expectedSchema.app.superchargeTokenConfigByToken = {}
     delete expectedSchema.app.superchargeTokens
 
-    expect(migratedSchema).toStrictEqual(expectedSchema)
-  })
-
-  it('works for v74 to v75', () => {
-    const oldSchema = v74Schema
-    const migratedSchema = migrations[75](oldSchema)
-
-    const expectedSchema: any = _.cloneDeep(oldSchema)
-    expectedSchema.app.showGuidedOnboardingCopy = false
-    // shall be the default value as configured in REMOTE_CONFIG_VALUES_DEFAULTS
     expect(migratedSchema).toStrictEqual(expectedSchema)
   })
 })

--- a/src/redux/migrations.ts
+++ b/src/redux/migrations.ts
@@ -805,13 +805,6 @@ export const migrations = {
   }),
   75: (state: any) => ({
     ...state,
-    app: {
-      ...state.app,
-      showGuidedOnboardingCopy: REMOTE_CONFIG_VALUES_DEFAULTS.showGuidedOnboardingCopy,
-    },
-  }),
-  76: (state: any) => ({
-    ...state,
     app: _.omit(state.app, 'showRaiseDailyLimitTarget'),
     account: _.omit(state.account, 'dailyLimitRequestStatus', 'dailyLimitCusd'),
   }),

--- a/src/redux/store.test.ts
+++ b/src/redux/store.test.ts
@@ -93,7 +93,7 @@ describe('store state', () => {
       Object {
         "_persist": Object {
           "rehydrated": true,
-          "version": 76,
+          "version": 75,
         },
         "account": Object {
           "acceptedTerms": false,
@@ -166,7 +166,6 @@ describe('store state', () => {
           "sentryTracesSampleRate": 0.2,
           "sessionId": "",
           "shouldShowRecoveryPhraseInSettings": false,
-          "showGuidedOnboardingCopy": false,
           "showPriceChangeIndicatorInBalances": false,
           "showSwapMenuInDrawerMenu": false,
           "skipProfilePicture": false,

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -23,7 +23,7 @@ const persistConfig: PersistConfig<RootState> = {
   key: 'root',
   // default is -1, increment as we make migrations
   // See https://github.com/valora-inc/wallet/tree/main/WALLET.md#redux-state-migration
-  version: 76,
+  version: 75,
   keyPrefix: `reduxStore-`, // the redux-persist default is `persist:` which doesn't work with some file systems.
   storage: FSStorage(),
   blacklist: ['networkInfo', 'alert', 'imports', 'supercharge'],

--- a/test/RootStateSchema.json
+++ b/test/RootStateSchema.json
@@ -2003,9 +2003,6 @@
                 "shouldShowRecoveryPhraseInSettings": {
                     "type": "boolean"
                 },
-                "showGuidedOnboardingCopy": {
-                    "type": "boolean"
-                },
                 "showPriceChangeIndicatorInBalances": {
                     "type": "boolean"
                 },
@@ -2088,7 +2085,6 @@
                 "sentryTracesSampleRate",
                 "sessionId",
                 "shouldShowRecoveryPhraseInSettings",
-                "showGuidedOnboardingCopy",
                 "showPriceChangeIndicatorInBalances",
                 "showSwapMenuInDrawerMenu",
                 "skipProfilePicture",

--- a/test/schemas.ts
+++ b/test/schemas.ts
@@ -1600,22 +1600,10 @@ export const v75Schema = {
     ...v74Schema._persist,
     version: 75,
   },
-  app: {
-    ...v74Schema.app,
-    showGuidedOnboardingCopy: false,
-  },
-}
-
-export const v76Schema = {
-  ...v75Schema,
-  _persist: {
-    ...v75Schema._persist,
-    version: 76,
-  },
-  app: _.omit(v75Schema.app, 'showRaiseDailyLimitTarget'),
-  account: _.omit(v75Schema.account, 'dailyLimitRequestStatus', 'dailyLimitCusd'),
+  app: _.omit(v74Schema.app, 'showRaiseDailyLimitTarget'),
+  account: _.omit(v74Schema.account, 'dailyLimitRequestStatus', 'dailyLimitCusd'),
 }
 
 export function getLatestSchema(): Partial<RootState> {
-  return v76Schema as Partial<RootState>
+  return v75Schema as Partial<RootState>
 }


### PR DESCRIPTION
### Description

Reverts #2817 due to:
- The onboarding text was displayed in non onboarding pin displays.
- Empty Scroll view was causing unexpected shifts to pincode entry layout.

#### Screenshots Before Revert / After Revert
<p align="center">
<img src="https://user-images.githubusercontent.com/26950305/187997831-80c9cdcb-1310-4dbb-9a49-a9e6b8973c42.png" width="48%" height="auto" />
<img src="https://user-images.githubusercontent.com/26950305/187997875-db430061-7c37-405f-90cf-44891a63d6af.png" width="48%" height="auto" />
</p>

### Other changes

N/A

### Tested

Tested locally on iOS

### How others should test

Devs: Please double check my changes to the migrations.

QA: Check that Pin Entry Functions as expected and displays correctly during onboarding, viewing recovery phrase, and on Pin Change.

### Related issues

N/A

### Backwards compatibility

Yes - Devs may need a fresh install due to redux changes.