### PR TITLE
test(e2e): android test group

### DIFF
--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -28,7 +28,7 @@ jobs:
   android:
     name: Android
     # TODO: change the group back to main once all machines are upgraded to java 11
-    runs-on: android-e2e-group-test
+    runs-on: android-e2e-group
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -27,7 +27,6 @@ concurrency:
 jobs:
   android:
     name: Android
-    # TODO: change the group back to main once all machines are upgraded to java 11
     runs-on: android-e2e-group
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
### Description

Adjust the worker group that Android E2E tests run on. [A planned change back](https://github.com/valora-inc/wallet/pull/2834/files#diff-3def5e5f7860c0ac8aa24d252fe222524431c9cbac2ba536e1a2185a9dd2be81R30-R31) as the CI machines have been update to use Java 11.

### Other changes

N/A

### Tested

Tested in CI by first switching all the machines over to the test group.

### How others should test

No need for QA - Reviewers should double check that the Android E2E tests are passing.

### Related issues

N/A

### Backwards compatibility

Yes