### PR TITLE
fix: invite modal display on android not taking up whole screen height

### DIFF
--- a/src/components/InviteOptionsModal.tsx
+++ b/src/components/InviteOptionsModal.tsx
@@ -1,7 +1,7 @@
 import { getPhoneHash } from '@celo/utils/lib/phoneNumbers'
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
-import { Image, Share, StyleSheet, Text, View } from 'react-native'
+import { Dimensions, Image, Share, StyleSheet, Text, View } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { InviteEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
@@ -63,13 +63,15 @@ const InviteOptionsModal = ({ recipient, onClose }: Props) => {
     </SafeAreaView>
   )
 }
+const { height, width } = Dimensions.get('window')
 
 const styles = StyleSheet.create({
   container: {
-    height: variables.height,
-    width: variables.width,
+    height,
+    width,
     flex: 1,
     position: 'absolute',
+    bottom: 0,
     backgroundColor: colors.light,
     padding: Spacing.Thick24,
   },

--- a/src/tokens/TokenBalances.tsx
+++ b/src/tokens/TokenBalances.tsx
@@ -205,6 +205,7 @@ const styles = StyleSheet.create({
   },
   bannerContainer: {
     paddingHorizontal: Spacing.Thick24,
+    paddingVertical: 4,
     justifyContent: 'space-between',
     flexWrap: 'wrap',
     width: '100%',


### PR DESCRIPTION
### Description

As the title says

### Other changes

Vertical padding on the NFT banner. Before -> after

![Simulator Screen Shot - iPhone 11 - 2022-09-12 at 15 50 55](https://user-images.githubusercontent.com/20150449/189671458-1dbec8ab-bb41-4f84-8a1d-09cd9f524c15.png)


![Simulator Screen Shot - iPhone 11 - 2022-09-12 at 15 49 46](https://user-images.githubusercontent.com/20150449/189671397-1b018e52-4858-44bf-ad64-63e0b1243636.png)


### Tested
Manually
### How others should test

Verify that https://github.com/valora-inc/wallet/issues/2852 cannot be reproduced.

### Related issues

- Fixes #2852 

### Backwards compatibility

Yes