### PR TITLE
chore(copy): change "zero fees" to "low fees" for ramp cash-in bottom…

### DIFF
--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -1114,7 +1114,7 @@
     "subtitle": "Your account is currently empty",
     "addFunds": "Add Funds",
     "titleRamp": "Add {{currency}} to start using Valora",
-    "subtitleRamp": "Add funds with zero fees through one of our trusted external providers."
+    "subtitleRamp": "Add funds with low fees through one of our trusted external providers."
   },
   "balances": "Assets",
   "totalBalanceWithLocalCurrencySymbol": "{{localCurrencySymbol}}{{totalBalance}} Total",


### PR DESCRIPTION
… sheet

### Description

Ramp doesn't have zero fees anymore, so we should say "low fees"

### Other changes

na

### Tested

ran locally and checked that the new copy appears where I expected it to

![Screen Shot 2022-09-12 at 4 02 43 PM](https://user-images.githubusercontent.com/7979215/189773213-65f5b1c3-af11-4983-afc0-05c346b63e12.png)


### How others should test

na

### Related issues

na

### Backwards compatibility

na