### PR TITLE
fix(deps): make @react-native-firebase/app API level 31 compatible

### DIFF
--- a/patches/@react-native-firebase+app+11.5.0.patch
+++ b/patches/@react-native-firebase+app+11.5.0.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/@react-native-firebase/app/package.json b/node_modules/@react-native-firebase/app/package.json
+index 2255702..eae331f 100644
+--- a/node_modules/@react-native-firebase/app/package.json
++++ b/node_modules/@react-native-firebase/app/package.json
+@@ -70,7 +70,7 @@
+       "compileSdk": 30,
+       "buildTools": "30.0.2",
+       "firebase": "26.8.0",
+-      "playServicesAuth": "19.0.0"
++      "playServicesAuth": "20.2.0"
+     }
+   },
+   "gitHead": "0217bff5cbbf233d7915efb4dbbdfe00e82dff23"


### PR DESCRIPTION
### Description

Fixes crash on Connect Phone Number screen. https://valora-app.slack.com/archives/C018VLA3YAK/p1662991289862839

The latest `@react-native-firebase/app` package fixes this, but upgrading it has pods conflict on iOS between segment and firebase packages. This patches `@react-native-firebase/app` to just bump `play-services-auth` version that fixes this issue.
An alternative fix is to just include the `play-services-auth` in build.gradle, but opted for this as it is easier to cleanup when we eventually upgrade `@react-native-firebase/*` packages

### Other changes

N/A

### Tested

Manually

### How others should test

- Launch app on Android version 12 with an account without a connected phone number
- Navigate to settings -> Connect phone number (or supercharge -> Connect phone number)
- App should not crash on the phone number screen

### Related issues


### Backwards compatibility

Yes