### PR TITLE
fix: prevent text overlapping the device status bar

### DIFF
--- a/src/components/header/CustomHeader.tsx
+++ b/src/components/header/CustomHeader.tsx
@@ -27,6 +27,7 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'center',
+    overflow: 'hidden',
   },
   buttonContainer: {
     height: '100%',

--- a/src/exchange/ExchangeScreenHeader.tsx
+++ b/src/exchange/ExchangeScreenHeader.tsx
@@ -50,8 +50,10 @@ function ExchangeTradeScreenHeader({ currency, isCeloPurchase, onChangeCurrency 
       titleText = t('tokenBalance', { token: currency })
       title = (
         <View style={styles.titleContainer} testID="HeaderCurrencyPicker">
-          <Text style={headerStyles.headerSubTitle}>{titleText}</Text>
-          <DownArrowIcon color={colors.gray3} />
+          <Text style={headerStyles.headerSubTitle} allowFontScaling={false}>
+            {titleText}
+          </Text>
+          <DownArrowIcon color={colors.gray3} height={16} />
         </View>
       )
     }
@@ -88,6 +90,8 @@ function ExchangeTradeScreenHeader({ currency, isCeloPurchase, onChangeCurrency 
 const styles = StyleSheet.create({
   titleContainer: {
     flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
   },
 })
 

--- a/src/exchange/__snapshots__/ExchangeTradeScreen.test.tsx.snap
+++ b/src/exchange/__snapshots__/ExchangeTradeScreen.test.tsx.snap
@@ -22,6 +22,7 @@ exports[`ExchangeTradeScreen renders correctly 1`] = `
         "flexDirection": "row",
         "height": 56,
         "justifyContent": "space-between",
+        "overflow": "hidden",
         "width": "100%",
       }
     }
@@ -69,6 +70,7 @@ exports[`ExchangeTradeScreen renders correctly 1`] = `
           }
         >
           <Text
+            allowFontScaling={false}
             numberOfLines={1}
             style={
               Object {
@@ -104,6 +106,7 @@ exports[`ExchangeTradeScreen renders correctly 1`] = `
             </Text>
           </Text>
           <Text
+            allowFontScaling={false}
             numberOfLines={1}
             style={
               Object {
@@ -115,12 +118,15 @@ exports[`ExchangeTradeScreen renders correctly 1`] = `
             <View
               style={
                 Object {
+                  "alignItems": "center",
                   "flexDirection": "row",
+                  "justifyContent": "center",
                 }
               }
               testID="HeaderCurrencyPicker"
             >
               <Text
+                allowFontScaling={false}
                 style={
                   Object {
                     "color": "#9CA4A9",

--- a/src/navigator/Headers.tsx
+++ b/src/navigator/Headers.tsx
@@ -214,12 +214,22 @@ export function HeaderTitleWithSubtitle({
   return (
     <View style={styles.header} testID={testID}>
       {title && (
-        <Text testID="HeaderTitle" style={styles.headerTitle} numberOfLines={1}>
+        <Text
+          testID="HeaderTitle"
+          style={styles.headerTitle}
+          numberOfLines={1}
+          allowFontScaling={false}
+        >
           {title}
         </Text>
       )}
       {subTitle && (
-        <Text testID="HeaderSubTitle" style={styles.headerSubTitle} numberOfLines={1}>
+        <Text
+          testID="HeaderSubTitle"
+          style={styles.headerSubTitle}
+          numberOfLines={1}
+          allowFontScaling={false}
+        >
           {subTitle}
         </Text>
       )}

--- a/src/send/SendAmount/SendAmount.test.tsx
+++ b/src/send/SendAmount/SendAmount.test.tsx
@@ -284,24 +284,24 @@ describe('SendAmount', () => {
           },
         },
       })
-      const { queryByTestId } = render(
+      const { queryByText } = render(
         <Provider store={store}>
           <SendAmount {...mockScreenProps()} />
         </Provider>
       )
 
-      expect(queryByTestId('HeaderCurrencyPicker')).toBeFalsy()
+      expect(queryByText('send')).toBeFalsy()
     })
 
     it("allows choosing the currency when there's balance for more than one token", () => {
       const store = createMockStore(storeData)
-      const { queryByTestId } = render(
+      const { getByText } = render(
         <Provider store={store}>
           <SendAmount {...mockScreenProps()} />
         </Provider>
       )
 
-      expect(queryByTestId('HeaderCurrencyPicker')).toBeTruthy()
+      expect(getByText('send')).toBeTruthy()
     })
 
     it('displays the loading spinner when verification status is unknown', () => {

--- a/src/send/SendAmount/SendAmountHeader.tsx
+++ b/src/send/SendAmount/SendAmountHeader.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { StyleSheet, Text, View } from 'react-native'
+import { Text } from 'react-native'
 import { RequestEvents, SendEvents } from 'src/analytics/Events'
 import BackButton from 'src/components/BackButton'
 import CustomHeader from 'src/components/header/CustomHeader'
@@ -59,11 +59,7 @@ function SendAmountHeader({
       title = titleText
     } else {
       titleText = t('send')
-      title = (
-        <View style={styles.titleContainer} testID="HeaderCurrencyPicker">
-          <Text style={headerStyles.headerTitle}>{titleText}</Text>
-        </View>
-      )
+      title = t('send')
     }
     return isOutgoingPaymentRequest ? (
       <Text style={headerStyles.headerTitle}>{titleText}</Text>
@@ -93,11 +89,5 @@ function SendAmountHeader({
     </>
   )
 }
-
-const styles = StyleSheet.create({
-  titleContainer: {
-    flexDirection: 'row',
-  },
-})
 
 export default SendAmountHeader

--- a/src/send/__snapshots__/Send.test.tsx.snap
+++ b/src/send/__snapshots__/Send.test.tsx.snap
@@ -20,6 +20,7 @@ exports[`Send renders correctly with invite rewards disabled 1`] = `
         "flexDirection": "row",
         "height": 56,
         "justifyContent": "space-between",
+        "overflow": "hidden",
         "width": "100%",
       }
     }

--- a/src/send/__snapshots__/SendConfirmation.test.tsx.snap
+++ b/src/send/__snapshots__/SendConfirmation.test.tsx.snap
@@ -16,6 +16,7 @@ exports[`SendConfirmation renders correctly 1`] = `
         "flexDirection": "row",
         "height": 56,
         "justifyContent": "space-between",
+        "overflow": "hidden",
         "width": "100%",
       }
     }

--- a/src/send/__snapshots__/SendConfirmationLegacy.test.tsx.snap
+++ b/src/send/__snapshots__/SendConfirmationLegacy.test.tsx.snap
@@ -16,6 +16,7 @@ exports[`SendConfirmationLegacy renders correctly 1`] = `
         "flexDirection": "row",
         "height": 56,
         "justifyContent": "space-between",
+        "overflow": "hidden",
         "width": "100%",
       }
     }


### PR DESCRIPTION
### Description

Currently the app does not handle large fonts very well. In the CustomHeader component, the title is absolutely positioned and for users with large fonts enabled, the title breaches the device native status bar. This shouldn't be allowed.

Current:
<img width="300" alt="Screenshot 2022-09-14 at 17 00 32" src="https://user-images.githubusercontent.com/20150449/190190989-e5acddf7-9a17-4256-aada-fcebbc935c6c.png">

It's pretty hard to optimise headers with large text and 2 lines. I tested how Apple handles this natively in the Photos app and it appears that they do not allow font scaling in the headers. I took this approach as it seems sensible enough and technically simple, and at a later stage we can revisit this if we want to optimise for large fonts. Open to other ideas about how to handle this scenario.


Updated:
<img width="300" alt="Screenshot 2022-09-14 at 17 01 44" src="https://user-images.githubusercontent.com/20150449/190191300-0f64be81-88cb-4d1c-83ed-2f6c414315f7.png">



### Other changes

N/A

### Tested

Manually

### How others should test

N/A

### Related issues

N/A

### Backwards compatibility

Yes