### PR TITLE
chore(e2e): use xcode 13.1 for iOS

### DIFF
--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -26,6 +26,8 @@ concurrency:
 
 jobs:
   android:
+    env:
+      BASH_ENV: /Users/administrator/.profile
     name: Android
     runs-on: android-e2e-group
     steps:
@@ -41,9 +43,7 @@ jobs:
       - name: Check E2E wallet balance
         run: NODE_OPTIONS='--unhandled-rejections=strict' yarn ts-node ./e2e/scripts/check-e2e-wallet-balance.ts
       - name: Create Detox Build
-        # TODO: remove source once we get default version to be java 11
         run: |
-          source ~/.profile
           export CELO_TEST_CONFIG=e2e
           export ANDROID_SDK_ROOT=$HOME/android-tools
           yarn detox build -c android.release
@@ -87,8 +87,10 @@ jobs:
       # `if` conditions can't directly access secrets, so we use a workaround
       # See https://docs.github.com/en/actions/security-guides/encrypted-secrets#using-encrypted-secrets-in-a-workflow
       SECRETS_AVAILABLE: ${{ secrets.SECRETS_AVAILABLE }}
+      BASH_ENV: /Users/administrator/.profile
     name: iOS
-    runs-on: ios-e2e-group
+    # TODO: revert below line once all machines have xcode 13.1
+    runs-on: ios-e2e-group-xcode-13
     steps:
       - name: Google Secrets
         if: ${{ env.SECRETS_AVAILABLE }}

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -26,8 +26,6 @@ concurrency:
 
 jobs:
   android:
-    env:
-      BASH_ENV: /Users/administrator/.profile
     name: Android
     runs-on: android-e2e-group
     steps:
@@ -43,7 +41,9 @@ jobs:
       - name: Check E2E wallet balance
         run: NODE_OPTIONS='--unhandled-rejections=strict' yarn ts-node ./e2e/scripts/check-e2e-wallet-balance.ts
       - name: Create Detox Build
+        # TODO: remove source once we get default version to be java 11
         run: |
+          source ~/.profile
           export CELO_TEST_CONFIG=e2e
           export ANDROID_SDK_ROOT=$HOME/android-tools
           yarn detox build -c android.release

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -89,8 +89,7 @@ jobs:
       SECRETS_AVAILABLE: ${{ secrets.SECRETS_AVAILABLE }}
       BASH_ENV: ~/.profile
     name: iOS
-    # TODO: revert below line once all machines have xcode 13.1
-    runs-on: ios-e2e-group-xcode-13
+    runs-on: ios-e2e-group
     steps:
       - name: Google Secrets
         if: ${{ env.SECRETS_AVAILABLE }}

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -87,7 +87,7 @@ jobs:
       # `if` conditions can't directly access secrets, so we use a workaround
       # See https://docs.github.com/en/actions/security-guides/encrypted-secrets#using-encrypted-secrets-in-a-workflow
       SECRETS_AVAILABLE: ${{ secrets.SECRETS_AVAILABLE }}
-      BASH_ENV: /Users/administrator/.profile
+      BASH_ENV: ~/.profile
     name: iOS
     # TODO: revert below line once all machines have xcode 13.1
     runs-on: ios-e2e-group-xcode-13


### PR DESCRIPTION
### Description

Sets BASH_ENV, which source's the ~/.profile file to pick the correct ruby version that works with xcode 13.1. This is required for #2855 

### Other changes

N/A

### Tested

CI

### How others should test

N/A

### Related issues

N/A

### Backwards compatibility

Yes