### PR TITLE
feat: Add share URL flow

### DIFF
--- a/android/app/src/debug/AndroidManifest.xml
+++ b/android/app/src/debug/AndroidManifest.xml
@@ -5,6 +5,11 @@
   <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
 
   <application android:usesCleartextTraffic="true" tools:ignore="GoogleAppIndexingWarning" android:networkSecurityConfig="@xml/network_security_config" >
-     <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" android:exported="false" />
+     <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" android:exported="false">
+      <intent-filter android:autoVerify="true">
+        <data android:scheme="https" android:host="valoraapp.com" />
+        <data android:scheme="https" android:host="vlra.app" />
+      </intent-filter>
+    </activity>
   </application>
 </manifest>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -34,6 +34,7 @@
         <category android:name="android.intent.category.DEFAULT" />
         <category android:name="android.intent.category.BROWSABLE" />
         <data android:scheme="https" android:host="valoraapp.com" />
+        <data android:scheme="https" android:host="vlra.app" />
         <data android:pathPrefix="/wc" />
         <data android:path="/plaid-oauth-redirect" />
         <data android:scheme="http" />

--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -577,6 +577,11 @@
     "title": "Send crypto to invite a friend",
     "body": "Once they set up their {{appName}} wallet and connect their number, you’ll each get an exclusive NFT. <0>Earn up to 3 NFTs</0>"
   },
+  "inviteWithUrl": {
+    "title": "Invite a friend",
+    "body": "Connect and share value with your friends and family on {{appName}}.",
+    "button": "Share Invite"
+  },
   "getReward": "Get ${{reward}}",
   "welcomeCelo": "Welcome to {{appName}}",
   "chooseCountryCode": "Country Code",

--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -580,7 +580,8 @@
   "inviteWithUrl": {
     "title": "Invite a friend",
     "body": "Connect and share value with your friends and family on {{appName}}.",
-    "button": "Share Invite"
+    "button": "Share Invite",
+    "share": "Hi! I’ve been using {{appName}} as my crypto wallet. It’s easy to try and I want to invite you to check it out with this link: {{shareUrl}}"
   },
   "getReward": "Get ${{reward}}",
   "welcomeCelo": "Welcome to {{appName}}",

--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -581,6 +581,7 @@
     "title": "Invite a friend",
     "body": "Connect and share value with your friends and family on {{appName}}.",
     "button": "Share Invite",
+    "error": "There was issue an creating a sharable link",
     "share": "Hi! I’ve been using {{appName}} as my crypto wallet. It’s easy to try and I want to invite you to check it out with this link: {{shareUrl}}"
   },
   "getReward": "Get ${{reward}}",

--- a/src/analytics/Events.tsx
+++ b/src/analytics/Events.tsx
@@ -261,6 +261,8 @@ export enum InviteEvents {
   invite_banner_impression = 'invite_banner_impression',
   invite_with_share = 'invite_with_share',
   invite_with_share_dismiss = 'invite_with_share_dismiss',
+  invite_with_referral_url = 'invite_with_referral_url',
+  opened_via_invite_url = 'opened_via_invite_url',
 }
 
 export enum EscrowEvents {

--- a/src/analytics/Properties.tsx
+++ b/src/analytics/Properties.tsx
@@ -592,6 +592,13 @@ interface InviteEventsProperties {
     phoneNumberHash: string | null
   }
   [InviteEvents.invite_with_share_dismiss]: undefined
+  [InviteEvents.invite_with_referral_url]: {
+    action: 'sharedAction' | 'dismissedAction'
+    activityType?: string | undefined
+  }
+  [InviteEvents.opened_via_invite_url]: {
+    inviterAddress: string
+  }
 }
 
 interface EscrowEventsProperties {

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -16,7 +16,7 @@ import { apolloClient } from 'src/apollo/index'
 import { appMounted, appUnmounted, openDeepLink } from 'src/app/actions'
 import AppLoading from 'src/app/AppLoading'
 import ErrorBoundary from 'src/app/ErrorBoundary'
-import { isE2EEnv } from 'src/config'
+import { FIREBASE_ENABLED, isE2EEnv } from 'src/config'
 import i18n from 'src/i18n'
 import I18nGate from 'src/i18n/I18nGate'
 import NavigatorWrapper from 'src/navigator/NavigatorWrapper'
@@ -100,31 +100,33 @@ export class App extends React.Component<Props> {
 
     Linking.addEventListener('url', this.handleOpenURL)
 
-    this.dynamicLinksRemoveListener = dynamicLinks().onLink(({ url }) =>
-      this.handleOpenURL({ url })
-    )
+    if (FIREBASE_ENABLED) {
+      this.dynamicLinksRemoveListener = dynamicLinks().onLink(({ url }) =>
+        this.handleOpenURL({ url })
+      )
 
-    // On Android, initial deep links are picked up by CleverTap - even if they were created by Firebase DynamicLinks.
-    // Breaking out here on Android avoids events being tracked multiple times.
-    if (Platform.OS === 'ios') {
-      const firebaseUrl = await dynamicLinks().getInitialLink()
+      if (Platform.OS === 'ios') {
+        const firebaseUrl = await dynamicLinks().getInitialLink()
 
-      if (firebaseUrl) {
-        await this.handleOpenURL({ url: firebaseUrl.url })
+        if (firebaseUrl) {
+          await this.handleOpenURL({ url: firebaseUrl.url })
+        }
+      }
+
+      // On Android, initial deep links are picked up by CleverTap - even if they were created by Firebase DynamicLinks.
+      // Breaking out here on Android avoids events being tracked multiple times.
+      if (Platform.OS === 'ios') {
+        const firebaseUrl = await dynamicLinks().getInitialLink()
+
+        if (firebaseUrl) {
+          await this.handleOpenURL({ url: firebaseUrl.url })
+        }
       }
     }
 
     const url = await Linking.getInitialURL()
     if (url) {
       await this.handleOpenURL({ url })
-    }
-
-    if (Platform.OS === 'ios') {
-      const firebaseUrl = await dynamicLinks().getInitialLink()
-
-      if (firebaseUrl) {
-        await this.handleOpenURL({ url: firebaseUrl.url })
-      }
     }
 
     this.logAppLoadTime()

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -76,6 +76,7 @@ export class App extends React.Component<Props> {
     await ValoraAnalytics.init()
 
     // Handles opening Clevertap deeplinks when app is closed / in background
+    // Also handles Firebase DynamcicLinks on Android
     CleverTap.getInitialUrl(async (err: any, url) => {
       if (err) {
         if (/CleverTap initialUrl is (nil|null)/gi.test(err)) {
@@ -99,23 +100,39 @@ export class App extends React.Component<Props> {
 
     Linking.addEventListener('url', this.handleOpenURL)
 
-    dynamicLinks().onLink(({ url }) => this.handleOpenURL(url))
+    this.dynamicLinksRemoveListener = dynamicLinks().onLink(({ url }) =>
+      this.handleOpenURL({ url })
+    )
+
+    // On Android, initial deep links are picked up by CleverTap - even if they were created by Firebase DynamicLinks.
+    // Breaking out here on Android avoids events being tracked multiple times.
+    if (Platform.OS === 'ios') {
+      const firebaseUrl = await dynamicLinks().getInitialLink()
+
+      if (firebaseUrl) {
+        await this.handleOpenURL({ url: firebaseUrl.url })
+      }
+    }
 
     const url = await Linking.getInitialURL()
     if (url) {
       await this.handleOpenURL({ url })
     }
 
-    const firebaseUrl = await dynamicLinks().getInitialLink()
+    if (Platform.OS === 'ios') {
+      const firebaseUrl = await dynamicLinks().getInitialLink()
 
-    if (firebaseUrl) {
-      await this.handleOpenURL({ url: firebaseUrl.url })
+      if (firebaseUrl) {
+        await this.handleOpenURL({ url: firebaseUrl.url })
+      }
     }
 
     this.logAppLoadTime()
 
     store.dispatch(appMounted())
   }
+
+  dynamicLinksRemoveListener: (() => void) | undefined
 
   logAppLoadTime() {
     const { appStartedMillis } = this.props
@@ -139,6 +156,7 @@ export class App extends React.Component<Props> {
   componentWillUnmount() {
     CleverTap.removeListener('CleverTapPushNotificationClicked')
     Linking.removeEventListener('url', this.handleOpenURL)
+    this.dynamicLinksRemoveListener?.()
     store.dispatch(appUnmounted())
   }
 

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,3 +1,4 @@
+import dynamicLinks from '@react-native-firebase/dynamic-links'
 import * as Sentry from '@sentry/react-native'
 import BigNumber from 'bignumber.js'
 import CleverTap from 'clevertap-react-native'
@@ -98,9 +99,17 @@ export class App extends React.Component<Props> {
 
     Linking.addEventListener('url', this.handleOpenURL)
 
+    dynamicLinks().onLink(({ url }) => this.handleOpenURL(url))
+
     const url = await Linking.getInitialURL()
     if (url) {
       await this.handleOpenURL({ url })
+    }
+
+    const firebaseUrl = await dynamicLinks().getInitialLink()
+
+    if (firebaseUrl) {
+      await this.handleOpenURL({ url: firebaseUrl.url })
     }
 
     this.logAppLoadTime()

--- a/src/app/saga.test.ts
+++ b/src/app/saga.test.ts
@@ -107,6 +107,21 @@ describe('App saga', () => {
     expect(navigate).not.toHaveBeenCalled()
   })
 
+  it('Handles share deep link', async () => {
+    const deepLink = 'https://vlra.app/share/abc123'
+    await expectSaga(handleDeepLink, openDeepLink(deepLink)).run()
+
+    expect(MockedAnalytics.track).toHaveBeenCalledTimes(1)
+    expect(MockedAnalytics.track.mock.calls[0]).toMatchInlineSnapshot(`
+      Array [
+        "opened_via_invite_url",
+        Object {
+          "inviterAddress": "abc123",
+        },
+      ]
+    `)
+  })
+
   describe('WalletConnect deeplinks', () => {
     const connectionString = encodeURIComponent(
       'wc:79a02f869d0f921e435a5e0643304548ebfa4a0430f9c66fe8b1a9254db7ef77@1?controller=false&publicKey=f661b0a9316a4ce0b6892bdce42bea0f45037f2c1bee9e118a3a4bc868a32a39&relay={"protocol":"waku"}'

--- a/src/app/saga.ts
+++ b/src/app/saga.ts
@@ -15,7 +15,7 @@ import {
   takeEvery,
   takeLatest,
 } from 'redux-saga/effects'
-import { AppEvents } from 'src/analytics/Events'
+import { AppEvents, InviteEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import {
   Actions,
@@ -265,6 +265,7 @@ export function* handleDeepLink(action: OpenDeepLink) {
 
   const rawParams = parse(deepLink)
   if (rawParams.path) {
+    const pathParts = rawParams.path.split('/')
     if (rawParams.path.startsWith('/v/')) {
       yield put(receiveAttestationMessage(rawParams.path.substr(3), CodeInputType.DEEP_LINK))
     } else if (rawParams.path.startsWith('/payment')) {
@@ -291,6 +292,10 @@ export function* handleDeepLink(action: OpenDeepLink) {
       // of our own notifications for security reasons.
       const params = convertQueryToScreenParams(rawParams.query)
       navigate(params.screen as keyof StackParamList, params)
+    } else if (pathParts.length === 3 && pathParts[1] === 'share') {
+      ValoraAnalytics.track(InviteEvents.opened_via_invite_url, {
+        inviterAddress: pathParts[2],
+      })
     }
   }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -125,6 +125,7 @@ export const CASH_IN_FAILURE_DEEPLINK = 'celo://wallet/cash-in-failure'
 
 export const APP_STORE_ID = Config.APP_STORE_ID
 export const DYNAMIC_DOWNLOAD_LINK = Config.DYNAMIC_DOWNLOAD_LINK
+export const DYNAMIC_LINK_DOMAIN_URI_PREFIX = 'https://vlra.app'
 export const CROWDIN_DISTRIBUTION_HASH = 'e-f9f6869461793b9d1a353b2v7c'
 export const OTA_TRANSLATIONS_FILEPATH = `file://${CachesDirectoryPath}/translations`
 

--- a/src/invite/Invite.test.tsx
+++ b/src/invite/Invite.test.tsx
@@ -1,0 +1,94 @@
+import { fireEvent, render, waitFor } from '@testing-library/react-native'
+import { noop } from 'lodash'
+import React from 'react'
+import { Share } from 'react-native'
+import { Provider } from 'react-redux'
+import { mocked } from 'ts-jest/utils'
+
+import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
+import { createMockStore } from 'test/utils'
+
+import Invite from './Invite'
+import { createDynamicLink } from './utils'
+
+jest.mock('./utils', () => ({
+  createDynamicLink: jest.fn(),
+}))
+
+const { press } = fireEvent
+const mockedCreateDynamicLink = mocked(createDynamicLink)
+
+describe('Invite', () => {
+  beforeAll(() => {
+    jest.useRealTimers()
+  })
+
+  beforeEach(() => jest.clearAllMocks())
+
+  const getWrapper = () =>
+    render(
+      <Provider
+        store={createMockStore({
+          web3: {
+            account: '0xabc123',
+          },
+        })}
+      >
+        <Invite />
+      </Provider>
+    )
+
+  it('should disable button while loading share URL', () => {
+    mockedCreateDynamicLink.mockReturnValue(new Promise(noop))
+    const { getByTestId } = getWrapper()
+    expect(getByTestId('InviteModalShareButton')).toBeDisabled()
+  })
+
+  it('should enable button when share URL is loaded', async () => {
+    mockedCreateDynamicLink.mockResolvedValue('https://vlra.app/abc123')
+
+    const { getByTestId } = getWrapper()
+
+    await waitFor(() => true) // Wait one tick for the createDynamicLink promise to resolve
+
+    expect(getByTestId('InviteModalShareButton')).not.toBeDisabled()
+  })
+
+  it('should share when button is pressed', async () => {
+    mockedCreateDynamicLink.mockResolvedValue('https://vlra.app/abc123')
+
+    jest.spyOn(Share, 'share')
+    ;(Share.share as jest.Mock).mockResolvedValue({
+      action: Share.sharedAction,
+      activityType: 'clipboard',
+    })
+
+    jest.spyOn(ValoraAnalytics, 'track')
+
+    const { getByTestId } = getWrapper()
+
+    await waitFor(() => true) // Wait one tick for the createDynamicLink promise to resolve
+
+    await press(getByTestId('InviteModalShareButton'))
+
+    expect(Share.share).toHaveBeenCalledTimes(1)
+    expect((Share.share as jest.Mock).mock.calls[0]).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "message": "inviteWithUrl.share, {\\"shareUrl\\":\\"https://vlra.app/abc123\\"}",
+        },
+      ]
+    `)
+
+    expect(ValoraAnalytics.track).toHaveBeenCalledTimes(1)
+    expect((ValoraAnalytics.track as jest.Mock).mock.calls[0]).toMatchInlineSnapshot(`
+      Array [
+        "invite_with_referral_url",
+        Object {
+          "action": "sharedAction",
+          "activityType": "clipboard",
+        },
+      ]
+    `)
+  })
+})

--- a/src/invite/Invite.tsx
+++ b/src/invite/Invite.tsx
@@ -1,102 +1,27 @@
-import { noop } from 'lodash'
+import { isNil, noop } from 'lodash'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
-import { Image, ScrollView, StyleSheet, Text, View } from 'react-native'
-import { SafeAreaView } from 'react-native-safe-area-context'
 
-import Button, { BtnSizes } from 'src/components/Button'
-import Touchable from 'src/components/Touchable'
-import ShareIcon from 'src/icons/Share'
-import Times from 'src/icons/Times'
-import { inviteModal } from 'src/images/Images'
 import { noHeader } from 'src/navigator/Headers'
 import { navigateBack } from 'src/navigator/NavigationService'
-import fontStyles from 'src/styles/fonts'
-import { Spacing } from 'src/styles/styles'
-import variables from 'src/styles/variables'
 
-function Header() {
-  return (
-    <View style={styles.headerContainer}>
-      <Touchable onPress={navigateBack} borderless={true} hitSlop={variables.iconHitslop}>
-        <Times />
-      </Touchable>
-    </View>
-  )
-}
-
-function Content() {
-  const { t } = useTranslation()
-  return (
-    <View style={styles.outerContentContainer}>
-      <View style={styles.innerContentContainer}>
-        <Image style={styles.art} source={inviteModal} />
-        <Text style={styles.title}>{t('inviteWithUrl.title')}</Text>
-        <Text style={styles.body}>{t('inviteWithUrl.body')}</Text>
-        <Button
-          iconPositionLeft={false}
-          icon={<ShareIcon height={24} color="white" />}
-          text={t('inviteWithUrl.button')}
-          size={BtnSizes.SMALL}
-          onPress={noop}
-        />
-      </View>
-    </View>
-  )
-}
+import { useShareUrl } from './hooks'
+import InviteModal from './InviteModal'
 
 export default function Invite() {
+  const { t } = useTranslation()
+  const shareUrl = useShareUrl()
+
   return (
-    <SafeAreaView style={styles.container}>
-      <ScrollView contentContainerStyle={styles.scrollView}>
-        <Header />
-        <Content />
-      </ScrollView>
-    </SafeAreaView>
+    <InviteModal
+      title={t('inviteWithUrl.title')}
+      description={t('inviteWithUrl.body')}
+      buttonLabel={t('inviteWithUrl.button')}
+      disabled={isNil(shareUrl)}
+      onClose={navigateBack}
+      onShareInvite={shareUrl ?? noop}
+    />
   )
 }
 
 Invite.navOptions = noHeader
-
-const styles = StyleSheet.create({
-  art: {
-    width: 136,
-    height: 120,
-  },
-  outerContentContainer: {
-    flex: 1,
-    justifyContent: 'center',
-    paddingBottom: Spacing.Smallest8 * 14,
-  },
-  innerContentContainer: {
-    height: 280,
-    width: 312,
-    display: 'flex',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-  },
-  container: {
-    flex: 1,
-    justifyContent: 'space-between',
-  },
-  title: {
-    ...fontStyles.h2,
-  },
-  body: {
-    ...fontStyles.regular,
-    textAlign: 'center',
-  },
-  scrollView: {
-    alignItems: 'center',
-    marginHorizontal: Spacing.Thick24,
-    flex: 1,
-  },
-  headerContainer: {
-    height: Spacing.Smallest8 * 7,
-    width: '100%',
-    marginTop: Spacing.Small12,
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-  },
-})

--- a/src/invite/Invite.tsx
+++ b/src/invite/Invite.tsx
@@ -1,0 +1,102 @@
+import { noop } from 'lodash'
+import React from 'react'
+import { useTranslation } from 'react-i18next'
+import { Image, ScrollView, StyleSheet, Text, View } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
+
+import Button, { BtnSizes } from 'src/components/Button'
+import Touchable from 'src/components/Touchable'
+import ShareIcon from 'src/icons/Share'
+import Times from 'src/icons/Times'
+import { inviteModal } from 'src/images/Images'
+import { noHeader } from 'src/navigator/Headers'
+import { navigateBack } from 'src/navigator/NavigationService'
+import fontStyles from 'src/styles/fonts'
+import { Spacing } from 'src/styles/styles'
+import variables from 'src/styles/variables'
+
+function Header() {
+  return (
+    <View style={styles.headerContainer}>
+      <Touchable onPress={navigateBack} borderless={true} hitSlop={variables.iconHitslop}>
+        <Times />
+      </Touchable>
+    </View>
+  )
+}
+
+function Content() {
+  const { t } = useTranslation()
+  return (
+    <View style={styles.outerContentContainer}>
+      <View style={styles.innerContentContainer}>
+        <Image style={styles.art} source={inviteModal} />
+        <Text style={styles.title}>{t('inviteWithUrl.title')}</Text>
+        <Text style={styles.body}>{t('inviteWithUrl.body')}</Text>
+        <Button
+          iconPositionLeft={false}
+          icon={<ShareIcon height={24} color="white" />}
+          text={t('inviteWithUrl.button')}
+          size={BtnSizes.SMALL}
+          onPress={noop}
+        />
+      </View>
+    </View>
+  )
+}
+
+export default function Invite() {
+  return (
+    <SafeAreaView style={styles.container}>
+      <ScrollView contentContainerStyle={styles.scrollView}>
+        <Header />
+        <Content />
+      </ScrollView>
+    </SafeAreaView>
+  )
+}
+
+Invite.navOptions = noHeader
+
+const styles = StyleSheet.create({
+  art: {
+    width: 136,
+    height: 120,
+  },
+  outerContentContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    paddingBottom: Spacing.Smallest8 * 14,
+  },
+  innerContentContainer: {
+    height: 280,
+    width: 312,
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  container: {
+    flex: 1,
+    justifyContent: 'space-between',
+  },
+  title: {
+    ...fontStyles.h2,
+  },
+  body: {
+    ...fontStyles.regular,
+    textAlign: 'center',
+  },
+  scrollView: {
+    alignItems: 'center',
+    marginHorizontal: Spacing.Thick24,
+    flex: 1,
+  },
+  headerContainer: {
+    height: Spacing.Smallest8 * 7,
+    width: '100%',
+    marginTop: Spacing.Small12,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+})

--- a/src/invite/InviteModal.tsx
+++ b/src/invite/InviteModal.tsx
@@ -43,6 +43,7 @@ const InviteModal = ({
         <Text style={[fontStyles.h2, styles.text]}>{title}</Text>
         <Text style={[fontStyles.regular, styles.text]}>{description}</Text>
         <Button
+          testID="InviteModalShareButton"
           icon={<ShareIcon color={colors.light} height={24} />}
           iconPositionLeft={false}
           size={BtnSizes.SMALL}

--- a/src/invite/hooks.tsx
+++ b/src/invite/hooks.tsx
@@ -6,6 +6,7 @@ import { Share } from 'react-native'
 import { useSelector } from 'react-redux'
 import { InviteEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
+import { FIREBASE_ENABLED } from 'src/config'
 
 import { walletAddressSelector } from 'src/web3/selectors'
 
@@ -20,7 +21,7 @@ export function useShareUrl() {
   const message = isNil(shareUrl) ? null : t('inviteWithUrl.share', { shareUrl })
 
   useAsync(async () => {
-    if (isNil(address)) return
+    if (isNil(address) || !FIREBASE_ENABLED) return
     const url = await createDynamicLink(address)
     setShareUrl(url)
   }, [address])

--- a/src/invite/hooks.tsx
+++ b/src/invite/hooks.tsx
@@ -3,27 +3,40 @@ import { useState } from 'react'
 import { useAsync } from 'react-async-hook'
 import { useTranslation } from 'react-i18next'
 import { Share } from 'react-native'
-import { useSelector } from 'react-redux'
+import { useDispatch, useSelector } from 'react-redux'
+import { showError } from 'src/alert/actions'
 import { InviteEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
-import { FIREBASE_ENABLED } from 'src/config'
+import Logger from 'src/utils/Logger'
 
+import { FIREBASE_ENABLED } from 'src/config'
 import { walletAddressSelector } from 'src/web3/selectors'
 
 import { createDynamicLink } from './utils'
+
+const TAG = 'InviteWithReferralURL'
 
 export function useShareUrl() {
   const [shareUrl, setShareUrl] = useState<string | null>(null)
 
   const address = useSelector(walletAddressSelector)
   const { t } = useTranslation()
+  const dispatch = useDispatch()
 
   const message = isNil(shareUrl) ? null : t('inviteWithUrl.share', { shareUrl })
 
   useAsync(async () => {
-    if (isNil(address) || !FIREBASE_ENABLED) return
-    const url = await createDynamicLink(address)
-    setShareUrl(url)
+    try {
+      if (isNil(address) || !FIREBASE_ENABLED) {
+        return
+      } else {
+        const url = await createDynamicLink(address)
+        setShareUrl(url)
+      }
+    } catch (e) {
+      Logger.debug(TAG, 'Error while creating a dynamic link', e)
+      dispatch(showError(t('inviteWithUrl.error')))
+    }
   }, [address])
 
   return isNil(message)

--- a/src/invite/hooks.tsx
+++ b/src/invite/hooks.tsx
@@ -1,0 +1,27 @@
+import { isNil } from 'lodash'
+import { useState } from 'react'
+import { useAsync } from 'react-async-hook'
+import { useTranslation } from 'react-i18next'
+import { Share } from 'react-native'
+import { useSelector } from 'react-redux'
+
+import { walletAddressSelector } from 'src/web3/selectors'
+
+import { createDynamicLink } from './utils'
+
+export function useShareUrl() {
+  const [shareUrl, setShareUrl] = useState<string | null>(null)
+
+  const address = useSelector(walletAddressSelector)
+  const { t } = useTranslation()
+
+  const message = isNil(shareUrl) ? null : t('inviteWithUrl.share', { shareUrl })
+
+  useAsync(async () => {
+    if (isNil(address)) return
+    const url = await createDynamicLink(address)
+    setShareUrl(url)
+  }, [address])
+
+  return isNil(message) ? null : () => Share.share({ message })
+}

--- a/src/invite/hooks.tsx
+++ b/src/invite/hooks.tsx
@@ -4,6 +4,8 @@ import { useAsync } from 'react-async-hook'
 import { useTranslation } from 'react-i18next'
 import { Share } from 'react-native'
 import { useSelector } from 'react-redux'
+import { InviteEvents } from 'src/analytics/Events'
+import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 
 import { walletAddressSelector } from 'src/web3/selectors'
 
@@ -23,5 +25,10 @@ export function useShareUrl() {
     setShareUrl(url)
   }, [address])
 
-  return isNil(message) ? null : () => Share.share({ message })
+  return isNil(message)
+    ? null
+    : async () => {
+        const result = await Share.share({ message })
+        ValoraAnalytics.track(InviteEvents.invite_with_referral_url, result)
+      }
 }

--- a/src/invite/utils.ts
+++ b/src/invite/utils.ts
@@ -78,3 +78,10 @@ export const extractValuesFromDeepLink = async (): Promise<ExtractedInviteCodeAn
   }
   return null
 }
+
+export async function createDynamicLink(address: string) {
+  return dynamicLinks().buildLink({
+    link: `https://vlra.app/share/${address}`,
+    domainUriPrefix: 'https://vlra.app',
+  })
+}

--- a/src/invite/utils.ts
+++ b/src/invite/utils.ts
@@ -4,6 +4,12 @@ import dynamicLinks from '@react-native-firebase/dynamic-links'
 import URLSearchParamsReal from '@ungap/url-search-params'
 import url from 'url'
 
+import {
+  APP_BUNDLE_ID as bundleId,
+  APP_STORE_ID as appStoreId,
+  DYNAMIC_LINK_DOMAIN_URI_PREFIX as baseURI,
+} from 'src/config'
+
 export type ExtractedInviteCodeAndPrivateKey = null | {
   inviteCode: string
   privateKey: string
@@ -81,7 +87,14 @@ export const extractValuesFromDeepLink = async (): Promise<ExtractedInviteCodeAn
 
 export async function createDynamicLink(address: string) {
   return dynamicLinks().buildLink({
-    link: `https://vlra.app/share/${address}`,
-    domainUriPrefix: 'https://vlra.app',
+    link: `${baseURI}/share/${address}`,
+    domainUriPrefix: baseURI,
+    ios: {
+      appStoreId,
+      bundleId,
+    },
+    android: {
+      packageName: bundleId,
+    },
   })
 }

--- a/src/navigator/DrawerNavigator.tsx
+++ b/src/navigator/DrawerNavigator.tsx
@@ -35,8 +35,12 @@ import Support from 'src/account/Support'
 import { HomeEvents, RewardsEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import { toggleInviteModal } from 'src/app/actions'
-import { rewardsEnabledSelector, superchargeButtonTypeSelector } from 'src/app/selectors'
-import { SuperchargeButtonType } from 'src/app/types'
+import {
+  inviteMethodSelector,
+  rewardsEnabledSelector,
+  superchargeButtonTypeSelector,
+} from 'src/app/selectors'
+import { InviteMethodType, SuperchargeButtonType } from 'src/app/types'
 import BackupIntroduction from 'src/backup/BackupIntroduction'
 import AccountNumber from 'src/components/AccountNumber'
 import ContactCircleSelf from 'src/components/ContactCircleSelf'
@@ -47,7 +51,6 @@ import { dappsListApiUrlSelector } from 'src/dapps/selectors'
 import DAppsExplorerScreen from 'src/dappsExplorer/DAppsExplorerScreen'
 import { fetchExchangeRate } from 'src/exchange/actions'
 import ExchangeHomeScreen from 'src/exchange/ExchangeHomeScreen'
-import { features } from 'src/flags'
 import WalletHome from 'src/home/WalletHome'
 import { Home } from 'src/icons/Home'
 import { AccountKey } from 'src/icons/navigator/AccountKey'
@@ -199,6 +202,7 @@ export default function DrawerNavigator() {
   const { t } = useTranslation()
   const isCeloEducationComplete = useSelector((state) => state.goldToken.educationCompleted)
   const dappsListUrl = useSelector(dappsListApiUrlSelector)
+  const inviteMethod = useSelector(inviteMethodSelector)
 
   const rewardsEnabled = useSelector(rewardsEnabledSelector)
   const superchargeButtonType = useSelector(superchargeButtonTypeSelector)
@@ -305,7 +309,7 @@ export default function DrawerNavigator() {
         component={FiatExchange}
         options={{ title: t('addAndWithdraw'), drawerIcon: AddWithdraw }}
       />
-      {features.SHOW_INVITE_MENU_ITEM && (
+      {inviteMethod === InviteMethodType.ReferralUrl && (
         <Drawer.Screen
           name={'InviteModal'}
           component={InviteFriendModal}

--- a/src/navigator/DrawerNavigator.tsx
+++ b/src/navigator/DrawerNavigator.tsx
@@ -34,7 +34,6 @@ import SettingsScreen from 'src/account/Settings'
 import Support from 'src/account/Support'
 import { HomeEvents, RewardsEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
-import { toggleInviteModal } from 'src/app/actions'
 import {
   inviteMethodSelector,
   rewardsEnabledSelector,
@@ -58,12 +57,12 @@ import { AddWithdraw } from 'src/icons/navigator/AddWithdraw'
 import { DappsExplorer } from 'src/icons/navigator/DappsExplorer'
 import { Gold } from 'src/icons/navigator/Gold'
 import { Help } from 'src/icons/navigator/Help'
-import { Invite } from 'src/icons/navigator/Invite'
+import { Invite as InviteIcon } from 'src/icons/navigator/Invite'
 import { MenuRings } from 'src/icons/navigator/MenuRings'
 import { MenuSupercharge } from 'src/icons/navigator/MenuSupercharge'
 import { Settings } from 'src/icons/navigator/Settings'
 import { Swap } from 'src/icons/navigator/Swap'
-import InviteFriendModal from 'src/invite/InviteFriendModal'
+import Invite from 'src/invite/Invite'
 import DrawerItem from 'src/navigator/DrawerItem'
 import { ensurePincode } from 'src/navigator/NavigationService'
 import { getActiveRouteName } from 'src/navigator/NavigatorWrapper'
@@ -203,10 +202,8 @@ export default function DrawerNavigator() {
   const isCeloEducationComplete = useSelector((state) => state.goldToken.educationCompleted)
   const dappsListUrl = useSelector(dappsListApiUrlSelector)
   const inviteMethod = useSelector(inviteMethodSelector)
-
   const rewardsEnabled = useSelector(rewardsEnabledSelector)
   const superchargeButtonType = useSelector(superchargeButtonTypeSelector)
-  const dispatch = useDispatch()
 
   const shouldShowRecoveryPhraseInSettings = useSelector(shouldShowRecoveryPhraseInSettingsSelector)
   const backupCompleted = useSelector(backupCompletedSelector)
@@ -311,12 +308,9 @@ export default function DrawerNavigator() {
       />
       {inviteMethod === InviteMethodType.ReferralUrl && (
         <Drawer.Screen
-          name={'InviteModal'}
-          component={InviteFriendModal}
-          initialParams={{
-            onPress: () => dispatch(toggleInviteModal(true)),
-          }}
-          options={{ title: t('invite'), drawerIcon: Invite }}
+          name={'Invite'}
+          component={Invite}
+          options={{ title: t('invite'), drawerIcon: InviteIcon }}
         />
       )}
       {shouldShowSwapMenuInDrawerMenu && (


### PR DESCRIPTION
### Description

This PR adds a new drawer navigation item "Invite". Users can open the Invite screen to get a deep link directing other users to the app.

### Other changes

 - Grabbing the share link kicks off an analytics event and on iOS, the results of the share (if it was abandoned, or what app was used for the sure) are attached as properties. On Android the results are not available.
 - Users opening the app via the invite link also kicks off an analytics event, with the inviter's wallet address as a property.

### Tested

These steps were followed on each platform:

Link creation:
1. Click the `Invite` link in the drawer navigator
2. The `Invite` button should initially be disabled, as the link is being created
3. When the `Invite` button is enabled, click it.
4. The native share drawer should appear, with a short message including the share link.

Clicking the link:
 - If on a mobile device and the app is not installed, should open valoraapp.com
 - If on a desktop, should open valoraapp.com
 - If on a mobile device and the app is installed, should open the app

### How others should test

I imagine we'll want to add this to QA test steps.

### Related issues

- Fixes EA-300

### Backwards compatibility

This PR should be backwards compatible. Link creation hinges off a remote config variable.


### Relevant UI:

https://user-images.githubusercontent.com/8698364/192322143-74af2dd9-80b8-44d4-98df-0f5c3077f697.mp4


https://user-images.githubusercontent.com/8698364/192322151-bb9bac8a-d2c6-49a7-8388-c7b83c15fadf.mp4

