### PR TITLE
refactor(fiatconnect): Refactor fiat account submission to saga

### DIFF
--- a/src/fiatconnect/FiatDetailsScreen.test.tsx
+++ b/src/fiatconnect/FiatDetailsScreen.test.tsx
@@ -1,34 +1,21 @@
 import { Result } from '@badrap/result'
-import {
-  FiatConnectApiClient,
-  FiatConnectClient,
-  ResponseError,
-} from '@fiatconnect/fiatconnect-sdk'
-import {
-  FiatAccountSchema,
-  FiatAccountType,
-  FiatConnectError,
-  Network,
-} from '@fiatconnect/fiatconnect-types'
+import { FiatConnectApiClient, FiatConnectClient } from '@fiatconnect/fiatconnect-sdk'
+import { FiatAccountSchema, FiatAccountType, Network } from '@fiatconnect/fiatconnect-types'
 import { fireEvent, render } from '@testing-library/react-native'
 import _ from 'lodash'
 import * as React from 'react'
 import { Provider } from 'react-redux'
-import { showError, showMessage } from 'src/alert/actions'
 import { FiatExchangeEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import { FiatConnectQuoteSuccess } from 'src/fiatconnect'
-import { getFiatConnectClient } from 'src/fiatconnect/clients'
 import FiatConnectQuote from 'src/fiatExchanges/quotes/FiatConnectQuote'
 import { CICOFlow } from 'src/fiatExchanges/utils'
-import i18n from 'src/i18n'
 import { navigate, navigateBack } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
-import Logger from 'src/utils/Logger'
 import { createMockStore, getMockStackScreenProps } from 'test/utils'
 import { mockFiatConnectProviderIcon, mockFiatConnectQuotes, mockNavigation } from 'test/values'
-import { mocked } from 'ts-jest/utils'
-import FiatDetailsScreen, { TAG } from './FiatDetailsScreen'
+import FiatDetailsScreen from './FiatDetailsScreen'
+import { submitFiatAccount } from 'src/fiatconnect/slice'
 
 jest.mock('src/alert/actions')
 jest.mock('src/analytics/ValoraAnalytics')
@@ -111,7 +98,6 @@ describe('FiatDetailsScreen', () => {
       (msg: string) => Promise.resolve(msg)
     )
     store.dispatch = jest.fn()
-    mocked(getFiatConnectClient).mockResolvedValue(fiatConnectClient)
   })
   afterEach(() => {
     jest.clearAllMocks()
@@ -265,7 +251,7 @@ describe('FiatDetailsScreen', () => {
     expect(queryByText('fiatAccountSchema.accountNumber.errorMessage')).toBeTruthy()
     expect(queryByTestId('submitButton')).toBeDisabled()
   })
-  it('sends a successful request to add new fiat account after pressing the next button [Schema: AccountName]', async () => {
+  it('dispatches to saga when validation passes after pressing submit', async () => {
     const { getByTestId } = render(
       <Provider store={store}>
         <FiatDetailsScreen {...mockScreenProps} />
@@ -275,48 +261,7 @@ describe('FiatDetailsScreen', () => {
     fireEvent.changeText(getByTestId('input-institutionName'), fakeInstitutionName)
     fireEvent.changeText(getByTestId('input-accountNumber'), fakeAccountNumber)
 
-    const expectedBody = {
-      accountName: 'CapitalTwo Bank (...7890)',
-      institutionName: fakeInstitutionName,
-      accountNumber: fakeAccountNumber,
-      country: 'US',
-      fiatAccountType: 'BankAccount',
-    }
-    await fireEvent.press(getByTestId('submitButton'))
-
-    expect(getFiatConnectClient).toHaveBeenCalledWith(
-      quote.getProviderId(),
-      quote.getProviderBaseUrl(),
-      quote.getProviderApiKey()
-    )
-    expect(fiatConnectClient.addFiatAccount).toHaveBeenCalledWith({
-      fiatAccountSchema: 'AccountNumber',
-      data: expectedBody,
-    })
-    expect(showMessage).toHaveBeenCalledWith(
-      i18n.t('fiatDetailsScreen.addFiatAccountSuccess', { provider: quote.getProviderName() })
-    )
-    expect(navigate).toHaveBeenCalledWith(Screens.FiatConnectReview, {
-      flow: CICOFlow.CashIn,
-      normalizedQuote: quote,
-      fiatAccount: mockResult.isOk && mockResult.value,
-    })
-  })
-  it('does not navigate to next page when account already exists', async () => {
-    const { getByTestId } = render(
-      <Provider store={store}>
-        <FiatDetailsScreen {...mockScreenProps} />
-      </Provider>
-    )
-    mockResult = Result.err(
-      new ResponseError('some message', { error: FiatConnectError.ResourceExists })
-    )
-    const fakeInstitutionName = 'CapitalTwo Bank'
-    const fakeAccountNumber = '1234567890'
-    fireEvent.changeText(getByTestId('input-institutionName'), fakeInstitutionName)
-    fireEvent.changeText(getByTestId('input-accountNumber'), fakeAccountNumber)
-
-    const expectedBody = {
+    const mockFiatAccountData = {
       accountName: 'CapitalTwo Bank (...7890)',
       institutionName: fakeInstitutionName,
       accountNumber: fakeAccountNumber,
@@ -326,61 +271,12 @@ describe('FiatDetailsScreen', () => {
 
     await fireEvent.press(getByTestId('submitButton'))
 
-    expect(getFiatConnectClient).toHaveBeenCalledWith(
-      quote.getProviderId(),
-      quote.getProviderBaseUrl(),
-      quote.getProviderApiKey()
+    expect(store.dispatch).toHaveBeenCalledWith(
+      submitFiatAccount({
+        flow: CICOFlow.CashIn,
+        quote,
+        fiatAccountData: mockFiatAccountData,
+      })
     )
-    expect(fiatConnectClient.addFiatAccount).toHaveBeenCalledWith({
-      fiatAccountSchema: 'AccountNumber',
-      data: expectedBody,
-    })
-
-    expect(Logger.error).toHaveBeenCalledWith(
-      TAG,
-      `Error adding fiat account: ${FiatConnectError.ResourceExists}`
-    )
-    expect(showError).toHaveBeenCalledWith(
-      i18n.t('fiatDetailsScreen.addFiatAccountResourceExist', { provider: quote.getProviderName() })
-    )
-    expect(navigate).not.toHaveBeenCalled()
-  })
-  it('does not navigate to next page when experiencing a general error', async () => {
-    const { getByTestId } = render(
-      <Provider store={store}>
-        <FiatDetailsScreen {...mockScreenProps} />
-      </Provider>
-    )
-    mockResult = Result.err(new ResponseError('some message'))
-    const fakeInstitutionName = 'CapitalTwo Bank'
-    const fakeAccountNumber = '1234567890'
-    fireEvent.changeText(getByTestId('input-institutionName'), fakeInstitutionName)
-    fireEvent.changeText(getByTestId('input-accountNumber'), fakeAccountNumber)
-
-    const expectedBody = {
-      accountName: 'CapitalTwo Bank (...7890)',
-      institutionName: fakeInstitutionName,
-      accountNumber: fakeAccountNumber,
-      country: 'US',
-      fiatAccountType: 'BankAccount',
-    }
-
-    await fireEvent.press(getByTestId('submitButton'))
-
-    expect(getFiatConnectClient).toHaveBeenCalledWith(
-      quote.getProviderId(),
-      quote.getProviderBaseUrl(),
-      quote.getProviderApiKey()
-    )
-    expect(fiatConnectClient.addFiatAccount).toHaveBeenCalledWith({
-      fiatAccountSchema: 'AccountNumber',
-      data: expectedBody,
-    })
-
-    expect(Logger.error).toHaveBeenCalledWith(TAG, `Error adding fiat account: some message`)
-    expect(showError).toHaveBeenCalledWith(
-      i18n.t('fiatDetailsScreen.addFiatAccountFailed', { provider: quote.getProviderName() })
-    )
-    expect(navigate).not.toHaveBeenCalled()
   })
 })

--- a/src/fiatconnect/FiatDetailsScreen.test.tsx
+++ b/src/fiatconnect/FiatDetailsScreen.test.tsx
@@ -1,6 +1,5 @@
 import { Result } from '@badrap/result'
-import { FiatConnectApiClient, FiatConnectClient } from '@fiatconnect/fiatconnect-sdk'
-import { FiatAccountSchema, FiatAccountType, Network } from '@fiatconnect/fiatconnect-types'
+import { FiatAccountSchema, FiatAccountType } from '@fiatconnect/fiatconnect-types'
 import { fireEvent, render } from '@testing-library/react-native'
 import _ from 'lodash'
 import * as React from 'react'
@@ -80,8 +79,6 @@ const mockScreenProps = getMockStackScreenProps(Screens.FiatDetailsScreen, {
 })
 
 describe('FiatDetailsScreen', () => {
-  let fiatConnectClient: FiatConnectApiClient
-
   beforeEach(() => {
     mockResult = Result.ok({
       fiatAccountId: '1234',
@@ -89,14 +86,6 @@ describe('FiatDetailsScreen', () => {
       institutionName: fakeInstitutionName,
       fiatAccountType: FiatAccountType.BankAccount,
     })
-    fiatConnectClient = new FiatConnectClient(
-      {
-        baseUrl: 'some-url',
-        network: Network.Alfajores,
-        accountAddress: 'some-address',
-      },
-      (msg: string) => Promise.resolve(msg)
-    )
     store.dispatch = jest.fn()
   })
   afterEach(() => {

--- a/src/fiatconnect/saga.test.ts
+++ b/src/fiatconnect/saga.test.ts
@@ -193,7 +193,6 @@ describe('Fiatconnect saga', () => {
           )
         )
         .run()
-      expect(ValoraAnalytics.track).toHaveBeenCalledTimes(1)
       expect(ValoraAnalytics.track).toHaveBeenCalledWith(
         FiatExchangeEvents.cico_fiat_details_error,
         {
@@ -226,7 +225,6 @@ describe('Fiatconnect saga', () => {
           )
         )
         .run()
-      expect(ValoraAnalytics.track).toHaveBeenCalledTimes(1)
       expect(ValoraAnalytics.track).toHaveBeenCalledWith(
         FiatExchangeEvents.cico_fiat_details_error,
         {

--- a/src/fiatconnect/saga.ts
+++ b/src/fiatconnect/saga.ts
@@ -189,7 +189,7 @@ export function* handleSubmitFiatAccount({
       error: postFiatAccountResponse.error.message,
     })
     if (postFiatAccountResponse.error.fiatConnectError === FiatConnectError.ResourceExists) {
-      put(
+      yield put(
         showError(
           i18n.t('fiatDetailsScreen.addFiatAccountResourceExist', {
             provider: quote.getProviderName(),
@@ -197,7 +197,7 @@ export function* handleSubmitFiatAccount({
         )
       )
     } else {
-      put(
+      yield put(
         showError(
           i18n.t('fiatDetailsScreen.addFiatAccountFailed', { provider: quote.getProviderName() })
         )

--- a/src/fiatconnect/selectors.ts
+++ b/src/fiatconnect/selectors.ts
@@ -13,3 +13,4 @@ export const selectFiatConnectQuoteLoadingSelector = (state: RootState) =>
   state.fiatConnect.selectFiatConnectQuoteLoading
 export const fiatConnectTransferSelector = (state: RootState) => state.fiatConnect.transfer
 export const fiatConnectProvidersSelector = (state: RootState) => state.fiatConnect.providers
+export const sendingFiatAccountSelector = (state: RootState) => state.fiatConnect.sendingFiatAccount

--- a/src/fiatconnect/slice.ts
+++ b/src/fiatconnect/slice.ts
@@ -2,7 +2,6 @@ import {
   FiatAccountType,
   FiatType,
   ObfuscatedFiatAccountData,
-  FiatAccountSchemas,
 } from '@fiatconnect/fiatconnect-types'
 import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 import { isEqual } from 'lodash'

--- a/src/fiatconnect/slice.ts
+++ b/src/fiatconnect/slice.ts
@@ -193,7 +193,6 @@ export const slice = createSlice({
     ) => {
       state.transfer = {
         quoteId: action.payload.quoteId,
-
         flow: action.payload.flow,
         isSending: false,
         failed: true,

--- a/src/fiatconnect/slice.ts
+++ b/src/fiatconnect/slice.ts
@@ -2,6 +2,7 @@ import {
   FiatAccountType,
   FiatType,
   ObfuscatedFiatAccountData,
+  FiatAccountSchemas,
 } from '@fiatconnect/fiatconnect-types'
 import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 import { isEqual } from 'lodash'
@@ -31,6 +32,7 @@ export interface State {
   cachedFiatAccountUses: CachedFiatAccountUse[]
   attemptReturnUserFlowLoading: boolean
   selectFiatConnectQuoteLoading: boolean
+  sendingFiatAccount: boolean
 }
 
 const initialState: State = {
@@ -42,6 +44,7 @@ const initialState: State = {
   cachedFiatAccountUses: [],
   attemptReturnUserFlowLoading: false,
   selectFiatConnectQuoteLoading: false,
+  sendingFiatAccount: false,
 }
 
 export type FiatAccount = ObfuscatedFiatAccountData & {
@@ -111,10 +114,22 @@ interface RefetchQuoteAction {
   fiatAccount: ObfuscatedFiatAccountData
 }
 
+interface SubmitFiatAccountAction {
+  flow: CICOFlow
+  quote: FiatConnectQuote
+  fiatAccountData: Record<string, any>
+}
+
 export const slice = createSlice({
   name: 'fiatConnect',
   initialState,
   reducers: {
+    submitFiatAccount: (state, action: PayloadAction<SubmitFiatAccountAction>) => {
+      state.sendingFiatAccount = true
+    },
+    submitFiatAccountCompleted: (state) => {
+      state.sendingFiatAccount = false
+    },
     fetchFiatConnectQuotes: (state, action: PayloadAction<FetchQuotesAction>) => {
       state.quotesLoading = true
       state.quotesError = null
@@ -178,6 +193,7 @@ export const slice = createSlice({
     ) => {
       state.transfer = {
         quoteId: action.payload.quoteId,
+
         flow: action.payload.flow,
         isSending: false,
         failed: true,
@@ -237,6 +253,8 @@ export const {
   createFiatConnectTransferCompleted,
   fetchFiatConnectProviders,
   fetchFiatConnectProvidersCompleted,
+  submitFiatAccount,
+  submitFiatAccountCompleted,
 } = slice.actions
 
 export default slice.reducer

--- a/src/redux/migrations.ts
+++ b/src/redux/migrations.ts
@@ -815,4 +815,11 @@ export const migrations = {
       showGuidedOnboardingCopy: REMOTE_CONFIG_VALUES_DEFAULTS.showGuidedOnboardingCopy,
     },
   }),
+  77: (state: any) => ({
+    ...state,
+    fiatConnect: {
+      ...state.fiatConnect,
+      sendingFiatAccount: false,
+    },
+  }),
 }

--- a/src/redux/store.test.ts
+++ b/src/redux/store.test.ts
@@ -93,7 +93,7 @@ describe('store state', () => {
       Object {
         "_persist": Object {
           "rehydrated": true,
-          "version": 77,
+          "version": 78,
         },
         "account": Object {
           "acceptedTerms": false,
@@ -220,6 +220,7 @@ describe('store state', () => {
           "quotesError": null,
           "quotesLoading": false,
           "selectFiatConnectQuoteLoading": false,
+          "sendingFiatAccount": false,
           "transfer": null,
         },
         "fiatExchanges": Object {

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -23,7 +23,7 @@ const persistConfig: PersistConfig<RootState> = {
   key: 'root',
   // default is -1, increment as we make migrations
   // See https://github.com/valora-inc/wallet/tree/main/WALLET.md#redux-state-migration
-  version: 76,
+  version: 77,
   keyPrefix: `reduxStore-`, // the redux-persist default is `persist:` which doesn't work with some file systems.
   storage: FSStorage(),
   blacklist: ['networkInfo', 'alert', 'imports', 'supercharge'],

--- a/test/RootStateSchema.json
+++ b/test/RootStateSchema.json
@@ -3056,6 +3056,9 @@
                 "selectFiatConnectQuoteLoading": {
                     "type": "boolean"
                 },
+                "sendingFiatAccount": {
+                    "type": "boolean"
+                },
                 "transfer": {
                     "anyOf": [
                         {
@@ -3075,6 +3078,7 @@
                 "quotesError",
                 "quotesLoading",
                 "selectFiatConnectQuoteLoading",
+                "sendingFiatAccount",
                 "transfer"
             ],
             "type": "object"

--- a/test/schemas.ts
+++ b/test/schemas.ts
@@ -1616,6 +1616,18 @@ export const v76Schema = {
   },
 }
 
+export const v77Schema = {
+  ...v76Schema,
+  _persist: {
+    ...v76Schema._persist,
+    version: 76,
+  },
+  fiatConnect: {
+    ...v76Schema.fiatConnect,
+    sendingFiatAccount: false,
+  },
+}
+
 export function getLatestSchema(): Partial<RootState> {
-  return v76Schema as Partial<RootState>
+  return v77Schema as Partial<RootState>
 }


### PR DESCRIPTION
### Description
While working on checking KYC after submitting a Fiat Account, the FiatDetails screen was becoming really cluttered, and figured it would be a good idea to take care of the TODO there to pull the logic out to a saga. No new functionality here, just porting the logic over to a saga. KYC stuff will come in a subsequent PR for ease of review.

_A few sentences describing the overall effects and goals of the pull request's commits.
What is the current behavior, and what is the updated/expected behavior with this PR?_

### Other changes

_Describe any minor or "drive-by" changes here._

### Tested

_An explanation of how the changes were tested or an explanation as to why they don't need to be._


### How others should test

_Does this need to be tested by QA in the next release cycle? If so please give a brief explanation of how to test these changes._

### Related issues

- Fixes #[issue number here]

### Backwards compatibility

_Brief explanation of why these changes are/are not backwards compatible._