### PR TITLE
refactor: abstract InviteModal component so that it can be reused

### DIFF
--- a/src/components/InviteOptionsModal.tsx
+++ b/src/components/InviteOptionsModal.tsx
@@ -1,21 +1,12 @@
 import { getPhoneHash } from '@celo/utils/lib/phoneNumbers'
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
-import { Dimensions, Image, Share, StyleSheet, Text, View } from 'react-native'
-import { SafeAreaView } from 'react-native-safe-area-context'
+import { Share } from 'react-native'
 import { InviteEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
-import Button, { BtnSizes, BtnTypes } from 'src/components/Button'
-import Touchable from 'src/components/Touchable'
 import { DYNAMIC_DOWNLOAD_LINK } from 'src/config'
-import ShareIcon from 'src/icons/Share'
-import Times from 'src/icons/Times'
-import { inviteModal } from 'src/images/Images'
+import InviteModal from 'src/invite/InviteModal'
 import { getDisplayName, Recipient } from 'src/recipients/recipient'
-import colors from 'src/styles/colors'
-import fontStyles from 'src/styles/fonts'
-import { Spacing } from 'src/styles/styles'
-import variables from 'src/styles/variables'
 
 interface Props {
   recipient: Recipient
@@ -41,54 +32,15 @@ const InviteOptionsModal = ({ recipient, onClose }: Props) => {
   }
 
   return (
-    <SafeAreaView style={styles.container}>
-      <Touchable onPress={handleClose} borderless={true} hitSlop={variables.iconHitslop}>
-        <Times />
-      </Touchable>
-      <View style={styles.contentContainer}>
-        <Image style={styles.imageContainer} source={inviteModal} resizeMode="contain" />
-        <Text style={[fontStyles.h2, styles.text]}>
-          {t('inviteModal.title', { contactName: getDisplayName(recipient, t) })}
-        </Text>
-        <Text style={[fontStyles.regular, styles.text]}>{t('inviteModal.body')}</Text>
-        <Button
-          icon={<ShareIcon color={colors.light} height={24} />}
-          iconPositionLeft={false}
-          size={BtnSizes.SMALL}
-          text={t('inviteModal.sendInviteButtonLabel')}
-          type={BtnTypes.PRIMARY}
-          onPress={handleShareInvite}
-        />
-      </View>
-    </SafeAreaView>
+    <InviteModal
+      title={t('inviteModal.title', { contactName: getDisplayName(recipient, t) })}
+      description={t('inviteModal.body')}
+      buttonLabel={t('inviteModal.sendInviteButtonLabel')}
+      disabled={false}
+      onClose={handleClose}
+      onShareInvite={handleShareInvite}
+    />
   )
 }
-const { height, width } = Dimensions.get('window')
-
-const styles = StyleSheet.create({
-  container: {
-    height,
-    width,
-    flex: 1,
-    position: 'absolute',
-    bottom: 0,
-    backgroundColor: colors.light,
-    padding: Spacing.Thick24,
-  },
-  contentContainer: {
-    flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  imageContainer: {
-    marginBottom: Spacing.Regular16,
-    width: 120,
-    height: 120,
-  },
-  text: {
-    textAlign: 'center',
-    marginBottom: Spacing.Regular16,
-  },
-})
 
 export default InviteOptionsModal

--- a/src/invite/InviteModal.test.tsx
+++ b/src/invite/InviteModal.test.tsx
@@ -1,0 +1,44 @@
+import { fireEvent, render } from '@testing-library/react-native'
+import * as React from 'react'
+import InviteModal from 'src/invite/InviteModal'
+
+describe('InviteModal', () => {
+  it('renders the correctly elements', () => {
+    const { getByText } = render(
+      <InviteModal
+        title="some title"
+        description="some description"
+        buttonLabel="some button label"
+        disabled
+        onClose={jest.fn()}
+        onShareInvite={jest.fn()}
+      />
+    )
+
+    expect(getByText('some title')).toBeTruthy()
+    expect(getByText('some description')).toBeTruthy()
+    expect(getByText('some button label')).toBeDisabled()
+  })
+
+  it('fires the correct callbacks', () => {
+    const onCloseSpy = jest.fn()
+    const onShareInviteSpy = jest.fn()
+
+    const { getByText, getByTestId } = render(
+      <InviteModal
+        title="some title"
+        description="some description"
+        buttonLabel="some button label"
+        disabled={false}
+        onClose={jest.fn()}
+        onShareInvite={jest.fn()}
+      />
+    )
+
+    fireEvent.press(getByText('someButtonLabel'))
+    fireEvent.press(getByTestId('InviteModalCloseButton'))
+
+    expect(onShareInviteSpy).toHaveBeenCalledTimes(1)
+    expect(onCloseSpy).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/invite/InviteModal.test.tsx
+++ b/src/invite/InviteModal.test.tsx
@@ -30,12 +30,12 @@ describe('InviteModal', () => {
         description="some description"
         buttonLabel="some button label"
         disabled={false}
-        onClose={jest.fn()}
-        onShareInvite={jest.fn()}
+        onClose={onCloseSpy}
+        onShareInvite={onShareInviteSpy}
       />
     )
 
-    fireEvent.press(getByText('someButtonLabel'))
+    fireEvent.press(getByText('some button label'))
     fireEvent.press(getByTestId('InviteModalCloseButton'))
 
     expect(onShareInviteSpy).toHaveBeenCalledTimes(1)

--- a/src/invite/InviteModal.test.tsx
+++ b/src/invite/InviteModal.test.tsx
@@ -3,7 +3,7 @@ import * as React from 'react'
 import InviteModal from 'src/invite/InviteModal'
 
 describe('InviteModal', () => {
-  it('renders the correctly elements', () => {
+  it('renders correctly', () => {
     const { getByText } = render(
       <InviteModal
         title="some title"

--- a/src/invite/InviteModal.tsx
+++ b/src/invite/InviteModal.tsx
@@ -1,0 +1,86 @@
+import * as React from 'react'
+import { Dimensions, Image, StyleSheet, Text, View } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
+import Button, { BtnSizes, BtnTypes } from 'src/components/Button'
+import Touchable from 'src/components/Touchable'
+import ShareIcon from 'src/icons/Share'
+import Times from 'src/icons/Times'
+import { inviteModal } from 'src/images/Images'
+import colors from 'src/styles/colors'
+import fontStyles from 'src/styles/fonts'
+import { Spacing } from 'src/styles/styles'
+import variables from 'src/styles/variables'
+
+interface Props {
+  title: string
+  description: string
+  buttonLabel: string
+  disabled: boolean
+  onClose(): void
+  onShareInvite(): void
+}
+
+const InviteModal = ({
+  title,
+  description,
+  buttonLabel,
+  disabled,
+  onClose,
+  onShareInvite,
+}: Props) => {
+  return (
+    <SafeAreaView style={styles.container}>
+      <Touchable
+        onPress={onClose}
+        borderless={true}
+        hitSlop={variables.iconHitslop}
+        testID="InviteModalCloseButton"
+      >
+        <Times />
+      </Touchable>
+      <View style={styles.contentContainer}>
+        <Image style={styles.imageContainer} source={inviteModal} resizeMode="contain" />
+        <Text style={[fontStyles.h2, styles.text]}>{title}</Text>
+        <Text style={[fontStyles.regular, styles.text]}>{description}</Text>
+        <Button
+          icon={<ShareIcon color={colors.light} height={24} />}
+          iconPositionLeft={false}
+          size={BtnSizes.SMALL}
+          text={buttonLabel}
+          type={BtnTypes.PRIMARY}
+          disabled={disabled}
+          onPress={onShareInvite}
+        />
+      </View>
+    </SafeAreaView>
+  )
+}
+const { height, width } = Dimensions.get('window')
+
+const styles = StyleSheet.create({
+  container: {
+    height,
+    width,
+    flex: 1,
+    position: 'absolute',
+    bottom: 0,
+    backgroundColor: colors.light,
+    padding: Spacing.Thick24,
+  },
+  contentContainer: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  imageContainer: {
+    marginBottom: Spacing.Regular16,
+    width: 120,
+    height: 120,
+  },
+  text: {
+    textAlign: 'center',
+    marginBottom: Spacing.Regular16,
+  },
+})
+
+export default InviteModal


### PR DESCRIPTION
### Description

As the title, this component can be reused by both variants of the invite experiment

### Other changes

N/A

### Tested

Unit tests and manually

### How others should test

N/A

### Related issues

N/A

### Backwards compatibility

Yes