### PR TITLE
feat: use centralised phone number lookup in send flow

### DIFF
--- a/src/components/CodeRow.tsx
+++ b/src/components/CodeRow.tsx
@@ -24,6 +24,7 @@ export interface CodeRowProps {
   inputPlaceholder: string
   onInputChange: (value: string) => void
   shouldShowClipboard: (value: string) => boolean
+  testID?: string
 }
 
 type Props = CodeRowProps & WithTranslation
@@ -35,6 +36,7 @@ function CodeRow({
   onInputChange,
   shouldShowClipboard,
   t,
+  testID,
 }: Props) {
   if (status === CodeRowStatus.DISABLED) {
     return (
@@ -52,6 +54,7 @@ function CodeRow({
         shouldShowClipboard={shouldShowClipboard}
         onChangeText={onInputChange}
         style={styles.codeInput}
+        testID={testID}
       />
     )
   }

--- a/src/identity/contactMapping.ts
+++ b/src/identity/contactMapping.ts
@@ -298,9 +298,13 @@ function* fetchWalletAddresses(e164Number: string) {
         ]),
       ]
     } else {
-      throw new Error(
-        `Received response from lookupPhoneNumber service ${centralisedLookupResponse.text()}`
+      Logger.debug(
+        `${TAG}/fetchWalletAddresses`,
+        `lookupPhoneNumber service failed with status ${centralisedLookupResponse.status}`
       )
+      // in the case that the user failed to migrate to CPV, the centralised
+      // service will throw an error so we can only return the decentralised mapping
+      return addressesFromDecentralizedMapping
     }
   } catch (error) {
     Logger.debug(`${TAG}/fetchWalletAddresses`, 'Unable to look up phone number', error)

--- a/src/identity/contactMapping.ts
+++ b/src/identity/contactMapping.ts
@@ -221,7 +221,7 @@ function* getAccountAddresses(e164Number: string) {
   return yield call(filterNonVerifiedAddresses, accountAddresses, phoneHash)
 }
 
-function* fetchWalletAddressesDecentralised(e164Number: string) {
+export function* fetchWalletAddressesDecentralised(e164Number: string) {
   const contractKit = yield call(getContractKit)
   const accountsWrapper: AccountsWrapper = yield call([
     contractKit.contracts,
@@ -277,6 +277,11 @@ function* fetchWalletAddresses(e164Number: string) {
 
     if (response.ok) {
       const { addresses } = yield call([response, 'json'])
+      if (addresses.length === 0) {
+        // check decentralised mapping if non exists on the centralised mapping,
+        // in case this user has not migrated yet
+        return yield call(fetchWalletAddressesDecentralised, e164Number)
+      }
       return addresses
     } else {
       throw new Error(`Received response from lookupPhoneNumber service ${response.text()}`)

--- a/src/identity/contactMapping.ts
+++ b/src/identity/contactMapping.ts
@@ -5,7 +5,9 @@ import { PhoneNumberHashDetails } from '@celo/identity/lib/odis/phone-number-ide
 import { isValidAddress, normalizeAddressWith0x } from '@celo/utils/lib/address'
 import { isAccountConsideredVerified } from '@celo/utils/lib/attestations'
 import BigNumber from 'bignumber.js'
+import { Platform } from 'react-native'
 import { MinimalContact } from 'react-native-contacts'
+import DeviceInfo from 'react-native-device-info'
 import { all, call, delay, put, race, select, take } from 'redux-saga/effects'
 import { setUserContactDetails } from 'src/account/actions'
 import { defaultCountryCodeSelector, e164NumberSelector } from 'src/account/selectors'
@@ -13,6 +15,7 @@ import { showErrorOrFallback } from 'src/alert/actions'
 import { IdentityEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import { ErrorMessages } from 'src/app/ErrorMessages'
+import { centralPhoneVerificationEnabledSelector } from 'src/app/selectors'
 import { fetchLostAccounts } from 'src/firebase/firebase'
 import {
   Actions,
@@ -38,6 +41,7 @@ import {
   secureSendPhoneNumberMappingSelector,
 } from 'src/identity/selectors'
 import { ImportContactsStatus } from 'src/identity/types'
+import { retrieveSignedMessage } from 'src/pincode/authentication'
 import { contactsToRecipients, NumberToRecipient } from 'src/recipients/recipient'
 import { setPhoneRecipientCache } from 'src/recipients/reducer'
 import { SentryTransactionHub } from 'src/sentry/SentryTransactionHub'
@@ -46,8 +50,9 @@ import { getAllContacts } from 'src/utils/contacts'
 import Logger from 'src/utils/Logger'
 import { checkContactsPermission } from 'src/utils/permissions'
 import { getContractKit } from 'src/web3/contracts'
+import networkConfig from 'src/web3/networkConfig'
 import { getConnectedAccount } from 'src/web3/saga'
-import { currentAccountSelector } from 'src/web3/selectors'
+import { walletAddressSelector } from 'src/web3/selectors'
 
 const TAG = 'identity/contactMapping'
 export const IMPORT_CONTACTS_TIMEOUT = 1 * 60 * 1000 // 1 minute
@@ -170,7 +175,7 @@ export function* fetchAddressesAndValidateSaga({
       walletAddresses.map((a) => (addressToE164NumberUpdates[a] = e164Number))
     }
 
-    const userAddress = yield select(currentAccountSelector)
+    const userAddress = yield select(walletAddressSelector)
     const secureSendPossibleAddresses = [...walletAddresses]
     const secureSendPhoneNumberMapping = yield select(secureSendPhoneNumberMappingSelector)
     // If fetch is being done as part of a payment request from an unverified address,
@@ -195,7 +200,7 @@ export function* fetchAddressesAndValidateSaga({
     yield put(endFetchingAddresses(e164Number, true))
     ValoraAnalytics.track(IdentityEvents.phone_number_lookup_complete)
   } catch (error) {
-    Logger.error(TAG + '@fetchAddressesAndValidate', `Error fetching addresses`, error)
+    Logger.debug(TAG + '@fetchAddressesAndValidate', `Error fetching addresses`, error)
     yield put(showErrorOrFallback(error, ErrorMessages.ADDRESS_LOOKUP_FAILURE))
     yield put(endFetchingAddresses(e164Number, false))
     ValoraAnalytics.track(IdentityEvents.phone_number_lookup_error, {
@@ -216,7 +221,7 @@ function* getAccountAddresses(e164Number: string) {
   return yield call(filterNonVerifiedAddresses, accountAddresses, phoneHash)
 }
 
-function* fetchWalletAddresses(e164Number: string) {
+function* fetchWalletAddressesDecentralised(e164Number: string) {
   const contractKit = yield call(getContractKit)
   const accountsWrapper: AccountsWrapper = yield call([
     contractKit.contracts,
@@ -245,6 +250,41 @@ function* fetchWalletAddresses(e164Number: string) {
   }
   yield put(updateWalletToAccountAddress(walletToAccountAddress))
   return Array.from(possibleUserAddresses)
+}
+
+function* fetchWalletAddresses(e164Number: string) {
+  const centralPhoneVerificationEnabled = yield select(centralPhoneVerificationEnabledSelector)
+  if (!centralPhoneVerificationEnabled) {
+    return yield call(fetchWalletAddressesDecentralised, e164Number)
+  }
+
+  try {
+    const address = yield select(walletAddressSelector)
+    const signedMessage = yield call(retrieveSignedMessage)
+
+    const response: Response = yield call(fetch, networkConfig.lookupPhoneNumberUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        authorization: `Valora ${address}:${signedMessage}`,
+      },
+      body: JSON.stringify({
+        phoneNumber: e164Number,
+        clientPlatform: Platform.OS,
+        clientVersion: DeviceInfo.getVersion(),
+      }),
+    })
+
+    if (response.ok) {
+      const { addresses } = yield call([response, 'json'])
+      return addresses
+    } else {
+      throw new Error(`Received response from lookupPhoneNumber service ${response.text()}`)
+    }
+  } catch (error) {
+    Logger.debug(`${TAG}/fetchWalletAddresses`, 'Unable to look up phone number', error)
+    throw new Error('Unable to fetch wallet address for this phone number')
+  }
 }
 
 // Returns a list of account addresses for the identifier received.

--- a/src/identity/contactMapping.ts
+++ b/src/identity/contactMapping.ts
@@ -253,14 +253,14 @@ export function* fetchWalletAddressesDecentralized(e164Number: string) {
 }
 
 function* fetchWalletAddresses(e164Number: string) {
-  const addressesFromDecentralisedMapping: string[] = yield call(
+  const addressesFromDecentralizedMapping: string[] = yield call(
     fetchWalletAddressesDecentralized,
     e164Number
   )
   const centralPhoneVerificationEnabled = yield select(centralPhoneVerificationEnabledSelector)
 
   if (!centralPhoneVerificationEnabled) {
-    return addressesFromDecentralisedMapping
+    return addressesFromDecentralizedMapping
   }
 
   try {
@@ -283,12 +283,12 @@ function* fetchWalletAddresses(e164Number: string) {
     if (response.ok) {
       const { addresses }: { addresses: string[] } = yield call([response, 'json'])
 
-      // combine with addresses found in decentralised mapping to maintain
+      // combine with addresses found in decentralized mapping to maintain
       // backwards compatibilty with accounts that have not migrated to CPV
       return [
         ...new Set([
           ...addresses.map((address) => address.toLowerCase()),
-          ...addressesFromDecentralisedMapping.map((address) => address.toLowerCase()),
+          ...addressesFromDecentralizedMapping.map((address) => address.toLowerCase()),
         ]),
       ]
     } else {

--- a/src/identity/saga.ts
+++ b/src/identity/saga.ts
@@ -97,7 +97,7 @@ function* watchVerification() {
 
 function* watchContactMapping() {
   yield takeLeading(Actions.IMPORT_CONTACTS, doImportContactsWrapper)
-  yield takeEvery(Actions.FETCH_ADDRESSES_AND_VALIDATION_STATUS, fetchAddressesAndValidateSaga)
+  yield takeLatest(Actions.FETCH_ADDRESSES_AND_VALIDATION_STATUS, fetchAddressesAndValidateSaga)
 }
 
 export function* watchValidateRecipientAddress() {

--- a/src/send/ValidateRecipientAccount.test.tsx
+++ b/src/send/ValidateRecipientAccount.test.tsx
@@ -67,6 +67,28 @@ describe('ValidateRecipientAccount', () => {
     expect(tree.getByTestId('ConfirmAccountButton')).not.toBeDisabled()
   })
 
+  it('enables submit button for full validation', () => {
+    const store = createMockStore()
+    const tree = render(
+      <Provider store={store}>
+        <ValidateRecipientAccount
+          {...getMockStackScreenProps(Screens.ValidateRecipientAccount, {
+            transactionData: mockTransactionData,
+            addressValidationType: AddressValidationType.FULL,
+            origin: SendOrigin.AppSendFlow,
+          })}
+        />
+      </Provider>
+    )
+
+    expect(tree.getByTestId('ConfirmAccountButton')).toBeDisabled()
+    fireEvent.changeText(
+      tree.getByTestId('ValidateRecipientAccount/TextInput'),
+      mockCusdAddress[38]
+    )
+    expect(tree.getByTestId('ConfirmAccountButton')).not.toBeDisabled()
+  })
+
   it('navigates to send confirmation when validation successful for send flow', () => {
     const store = createMockStore({
       identity: {

--- a/src/send/ValidateRecipientAccount.tsx
+++ b/src/send/ValidateRecipientAccount.tsx
@@ -263,11 +263,13 @@ export class ValidateRecipientAccount extends React.Component<Props, State> {
   }
 
   render = () => {
-    const { t, recipient, error } = this.props
-    const { singleDigitInputValueArr } = this.state
+    const { t, recipient, error, addressValidationType } = this.props
+    const { singleDigitInputValueArr, inputValue } = this.state
     const displayName = getDisplayName(recipient, t)
     const isFilled =
-      singleDigitInputValueArr.filter((entry) => /[a-f0-9]/gi.test(entry)).length === 4
+      addressValidationType === AddressValidationType.FULL
+        ? inputValue.length > 0
+        : singleDigitInputValueArr.filter((entry) => /[a-f0-9]/gi.test(entry)).length === 4
 
     return (
       <SafeAreaView style={styles.container}>

--- a/src/send/ValidateRecipientAccount.tsx
+++ b/src/send/ValidateRecipientAccount.tsx
@@ -230,6 +230,7 @@ export class ValidateRecipientAccount extends React.Component<Props, State> {
             inputPlaceholder={FULL_ADDRESS_PLACEHOLDER}
             onInputChange={this.onInputChange}
             shouldShowClipboard={this.shouldShowClipboard}
+            testID="ValidateRecipientAccount/TextInput"
           />
         </View>
       )

--- a/src/send/__snapshots__/ValidateRecipientAccount.test.tsx.snap
+++ b/src/send/__snapshots__/ValidateRecipientAccount.test.tsx.snap
@@ -117,6 +117,7 @@ exports[`ValidateRecipientAccount renders correctly when full validation require
                     undefined,
                   ]
                 }
+                testID="ValidateRecipientAccount/TextInput"
                 value=""
               />
             </View>

--- a/src/web3/networkConfig.ts
+++ b/src/web3/networkConfig.ts
@@ -37,6 +37,7 @@ interface NetworkConfig {
   executeSwapUrl: string
   verifyPhoneNumberUrl: string
   verifySmsCodeUrl: string
+  lookupPhoneNumberUrl: string
 }
 
 const KOMENCI_URL_MAINNET = 'https://mainnet-komenci.azurefd.net'
@@ -87,6 +88,9 @@ const VERIFY_PHONE_NUMBER_MAINNET = `${CLOUD_FUNCTIONS_MAINNET}/verifyPhoneNumbe
 const VERIFY_SMS_CODE_ALFAJORES = `${CLOUD_FUNCTIONS_STAGING}/verifySmsCode`
 const VERIFY_SMS_CODE_MAINNET = `${CLOUD_FUNCTIONS_MAINNET}/verifySmsCode`
 
+const LOOKUP_PHONE_NUMBER_ALFAJORES = `${CLOUD_FUNCTIONS_STAGING}/lookupPhoneNumber`
+const LOOKUP_PHONE_NUMBER_MAINNET = `${CLOUD_FUNCTIONS_MAINNET}/lookupPhoneNumber`
+
 const CELO_EXPLORER_BASE_TX_URL_ALFAJORES = 'https://alfajores-blockscout.celo-testnet.org/tx/'
 const CELO_EXPLORER_BASE_TX_URL_MAINNET = 'https://explorer.celo.org/tx/'
 
@@ -125,6 +129,7 @@ const networkConfigs: { [testnet: string]: NetworkConfig } = {
     executeSwapUrl: EXECUTE_SWAP_URL,
     verifyPhoneNumberUrl: VERIFY_PHONE_NUMBER_ALFAJORES,
     verifySmsCodeUrl: VERIFY_SMS_CODE_ALFAJORES,
+    lookupPhoneNumberUrl: LOOKUP_PHONE_NUMBER_ALFAJORES,
   },
   [Testnets.mainnet]: {
     networkId: '42220',
@@ -154,6 +159,7 @@ const networkConfigs: { [testnet: string]: NetworkConfig } = {
     executeSwapUrl: EXECUTE_SWAP_URL,
     verifyPhoneNumberUrl: VERIFY_PHONE_NUMBER_MAINNET,
     verifySmsCodeUrl: VERIFY_SMS_CODE_MAINNET,
+    lookupPhoneNumberUrl: LOOKUP_PHONE_NUMBER_MAINNET,
   },
 }
 


### PR DESCRIPTION
### Description

As the title, this PR updates only the send flow to work with CPV.

If no addresses are found with the lookupPhoneNumbers endpoint, then the decentralised mapping is used to maintain backwards compatibility while users are still migrating.

### Other changes

N/A

### Tested

Manually, unit tests

### How others should test

In Alfajores, sending to phone numbers should work as before. Including the secure send flow when sending to a phone number that has multiple addresses

### Related issues

Fixes RET-389

### Backwards compatibility

Yes