### PR TITLE
fix: use view instead of nested SafeAreaView to prevent extra top space

### DIFF
--- a/src/send/ValidateRecipientAccount.tsx
+++ b/src/send/ValidateRecipientAccount.tsx
@@ -2,7 +2,6 @@ import { StackScreenProps } from '@react-navigation/stack'
 import * as React from 'react'
 import { WithTranslation } from 'react-i18next'
 import { StyleSheet, Text, View } from 'react-native'
-import { SafeAreaView } from 'react-native-safe-area-context'
 import { connect } from 'react-redux'
 import { SendEvents } from 'src/analytics/Events'
 import { SendOrigin } from 'src/analytics/types'
@@ -270,7 +269,7 @@ export class ValidateRecipientAccount extends React.Component<Props, State> {
       singleDigitInputValueArr.filter((entry) => /[a-f0-9]/gi.test(entry)).length === 4
 
     return (
-      <SafeAreaView style={styles.container}>
+      <View style={styles.container}>
         <KeyboardAwareScrollView
           contentContainerStyle={styles.scrollContainer}
           keyboardShouldPersistTaps={'always'}
@@ -314,7 +313,7 @@ export class ValidateRecipientAccount extends React.Component<Props, State> {
             <TextButton onPress={this.toggleModal}>{t('dismiss')}</TextButton>
           </View>
         </Modal>
-      </SafeAreaView>
+      </View>
     )
   }
 }

--- a/src/send/ValidateRecipientAccount.tsx
+++ b/src/send/ValidateRecipientAccount.tsx
@@ -325,7 +325,7 @@ const styles = StyleSheet.create({
   },
   scrollContainer: {
     flexGrow: 1,
-    padding: 16,
+    paddingHorizontal: 16,
     justifyContent: 'space-between',
   },
   singleDigitInputContainer: {

--- a/src/send/__snapshots__/ValidateRecipientAccount.test.tsx.snap
+++ b/src/send/__snapshots__/ValidateRecipientAccount.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ValidateRecipientAccount renders correctly when full validation required 1`] = `
-<RNCSafeAreaView
+<View
   style={
     Object {
       "flex": 1,
@@ -14,7 +14,7 @@ exports[`ValidateRecipientAccount renders correctly when full validation require
       Object {
         "flexGrow": 1,
         "justifyContent": "space-between",
-        "padding": 16,
+        "paddingHorizontal": 16,
       }
     }
     keyboardShouldPersistTaps="always"
@@ -638,11 +638,11 @@ exports[`ValidateRecipientAccount renders correctly when full validation require
       </RNCSafeAreaView>
     </View>
   </Modal>
-</RNCSafeAreaView>
+</View>
 `;
 
 exports[`ValidateRecipientAccount renders correctly when partial validation required 1`] = `
-<RNCSafeAreaView
+<View
   style={
     Object {
       "flex": 1,
@@ -655,7 +655,7 @@ exports[`ValidateRecipientAccount renders correctly when partial validation requ
       Object {
         "flexGrow": 1,
         "justifyContent": "space-between",
-        "padding": 16,
+        "paddingHorizontal": 16,
       }
     }
     keyboardShouldPersistTaps="always"
@@ -1465,5 +1465,5 @@ exports[`ValidateRecipientAccount renders correctly when partial validation requ
       </RNCSafeAreaView>
     </View>
   </Modal>
-</RNCSafeAreaView>
+</View>
 `;


### PR DESCRIPTION
### Description

Removes the nested SafeAreaView and replaces it with a View to avoid adding an extra margin on top of the nested view.
Removes vertical padding on View element.

#### Video

https://user-images.githubusercontent.com/26950305/194951320-9dbb00a8-0524-4901-952e-529e4b903c85.mov

### Other changes

N/A

### Tested

Tested locally on Android

### How others should test

1. On Alfajores Send to attempt to send to `12057368924`.
2. Enter amount and tap 'Confirm Account Address'
3. Observe padding at the top matches other screens.
4. Observe button not hidden behind keyboard.

### Related issues

N/A

### Backwards compatibility

Yes