### PR TITLE
Run E2E Suite on Multiple Android Versions

### DIFF
--- a/.github/workflows/e2e-android.yml
+++ b/.github/workflows/e2e-android.yml
@@ -57,11 +57,11 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v2
         with:
-          name: android-e2e-artifact
+          name: android-${{ inputs.android-api-level }}-e2e-artifact
           path: e2e/artifacts
       - name: 'Upload Android E2E HTML Report'
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: android-e2e-test-report
+          name: android-${{ inputs.android-api-level }}-e2e-test-report
           path: e2e/test-results

--- a/.github/workflows/e2e-android.yml
+++ b/.github/workflows/e2e-android.yml
@@ -1,0 +1,67 @@
+name: E2E - Android
+on:
+  workflow_call:
+    inputs:
+      android-api-level:
+        required: true
+        type: number
+
+jobs:
+  android:
+    env:
+      BASH_ENV: ~/.profile
+    name: Android (SDK ${{ inputs.android-api-level }})
+    runs-on: android-e2e-group
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+          check-latest: true
+      - name: Install package dependencies
+        run: yarn || yarn --network-concurrency 1
+      - name: Fail if someone forgot to commit "yarn.lock"
+        run: git diff --exit-code
+      - name: Check E2E wallet balance
+        run: NODE_OPTIONS='--unhandled-rejections=strict' yarn ts-node ./e2e/scripts/check-e2e-wallet-balance.ts
+      - name: Create Detox Build
+        run: |
+          export CELO_TEST_CONFIG=e2e
+          export ANDROID_SDK_ROOT=$HOME/android-tools
+          yarn detox build -c android.release
+      - name: Run Detox
+        run: >
+          export ANDROID_SDK_ROOT=$HOME/android-tools &&
+          export PATH=$ANDROID_SDK_ROOT/platform-tools:$PATH &&
+          yarn detox test
+          --device-name Pixel_API_${{ inputs.android-api-level }}_AOSP_x86_64
+          --configuration android.release
+          --artifacts-location e2e/artifacts
+          --take-screenshots=failing
+          --record-videos=failing
+          --record-logs=failing
+          --loglevel info
+          --debug-synchronization 10000
+          --workers 3
+          --headless
+          --retries 3
+          --device-boot-args="-snapshot ci_boot"
+        timeout-minutes: 45
+      - name: Publish Android JUnit Report
+        if: always()
+        uses: mikepenz/action-junit-report@v2
+        with:
+          check_name: Android e2e Test Report
+          report_paths: 'e2e/test-results/junit.xml'
+      - name: 'Upload Android E2E Artifacts'
+        if: failure()
+        uses: actions/upload-artifact@v2
+        with:
+          name: android-e2e-artifact
+          path: e2e/artifacts
+      - name: 'Upload Android E2E HTML Report'
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: android-e2e-test-report
+          path: e2e/test-results

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -26,68 +26,16 @@ concurrency:
 
 jobs:
   android:
-    env:
-      BASH_ENV: ~/.profile
     name: Android
     strategy:
       max-parallel: 2
       fail-fast: false
       matrix:
         android-api-level: [29, 30, 31]
-    runs-on: android-e2e-group
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-        with:
-          node-version: '16'
-          check-latest: true
-      - name: Install package dependencies
-        run: yarn || yarn --network-concurrency 1
-      - name: Fail if someone forgot to commit "yarn.lock"
-        run: git diff --exit-code
-      - name: Check E2E wallet balance
-        run: NODE_OPTIONS='--unhandled-rejections=strict' yarn ts-node ./e2e/scripts/check-e2e-wallet-balance.ts
-      - name: Create Detox Build
-        run: |
-          export CELO_TEST_CONFIG=e2e
-          export ANDROID_SDK_ROOT=$HOME/android-tools
-          yarn detox build -c android.release
-      - name: Run Detox
-        run: >
-          export ANDROID_SDK_ROOT=$HOME/android-tools &&
-          export PATH=$ANDROID_SDK_ROOT/platform-tools:$PATH &&
-          yarn detox test
-          --device-name Pixel_API_${{ matrix.android-api-level }}_AOSP_x86_64
-          --configuration android.release
-          --artifacts-location e2e/artifacts
-          --take-screenshots=failing
-          --record-videos=failing
-          --record-logs=failing
-          --loglevel info
-          --debug-synchronization 10000
-          --workers 3
-          --headless
-          --retries 3
-          --device-boot-args="-snapshot ci_boot"
-        timeout-minutes: 45
-      - name: Publish Android JUnit Report
-        if: always()
-        uses: mikepenz/action-junit-report@v2
-        with:
-          check_name: Android e2e Test Report
-          report_paths: 'e2e/test-results/junit.xml'
-      - name: 'Upload Android E2E Artifacts'
-        if: failure()
-        uses: actions/upload-artifact@v2
-        with:
-          name: android-e2e-artifact
-          path: e2e/artifacts
-      - name: 'Upload Android E2E HTML Report'
-        if: always()
-        uses: actions/upload-artifact@v2
-        with:
-          name: android-e2e-test-report
-          path: e2e/test-results
+    uses: ./.github/workflows/e2e-android.yml
+    with:
+      android-api-level: ${{ matrix.android-api-level }}
+    secrets: inherit
   ios:
     env:
       # `if` conditions can't directly access secrets, so we use a workaround

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -29,6 +29,11 @@ jobs:
     env:
       BASH_ENV: ~/.profile
     name: Android
+    strategy:
+      max-parallel: 2
+      fail-fast: false
+      matrix:
+        android-api-level: [29, 30, 31]
     runs-on: android-e2e-group
     steps:
       - uses: actions/checkout@v2
@@ -52,6 +57,7 @@ jobs:
           export ANDROID_SDK_ROOT=$HOME/android-tools &&
           export PATH=$ANDROID_SDK_ROOT/platform-tools:$PATH &&
           yarn detox test
+          --device-name Pixel_API_${{ matrix.android-api-level }}_AOSP_x86_64
           --configuration android.release
           --artifacts-location e2e/artifacts
           --take-screenshots=failing

--- a/.github/workflows/e2e-main.yml
+++ b/.github/workflows/e2e-main.yml
@@ -1,9 +1,6 @@
-name: E2E
+name: E2E - Main
 on:
   push:
-    branches:
-      - main
-  pull_request:
     branches:
       - main
   workflow_dispatch:

--- a/.github/workflows/e2e-pr.yml
+++ b/.github/workflows/e2e-pr.yml
@@ -1,0 +1,99 @@
+name: E2E - PR
+on:
+  pull_request:
+    branches:
+      - main
+
+# Cancel any in progress run of the workflow for a given PR
+# This avoids building outdated code
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+  android:
+    name: Android
+    uses: ./.github/workflows/e2e-android.yml
+    with:
+      android-api-level: 30
+    secrets: inherit
+  ios:
+    env:
+      # `if` conditions can't directly access secrets, so we use a workaround
+      # See https://docs.github.com/en/actions/security-guides/encrypted-secrets#using-encrypted-secrets-in-a-workflow
+      SECRETS_AVAILABLE: ${{ secrets.SECRETS_AVAILABLE }}
+      BASH_ENV: ~/.profile
+    name: iOS
+    runs-on: ios-e2e-group
+    steps:
+      - name: Google Secrets
+        if: ${{ env.SECRETS_AVAILABLE }}
+        id: google-secrets
+        uses: google-github-actions/get-secretmanager-secrets@v0.2.2
+        with:
+          secrets: |-
+            EMERGE_API_TOKEN:projects/1027349420744/secrets/EMERGE_API_TOKEN
+          credentials: ${{ secrets.MAINNET_SERVICE_ACCOUNT_KEY }}
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+          check-latest: true
+      - name: Install package dependencies
+        run: yarn || yarn --network-concurrency 1
+      - name: Fail if someone forgot to commit "yarn.lock"
+        run: git diff --exit-code
+      - name: Install Ruby dependencies
+        run: bundle install --path vendor/bundle
+      - name: Fail if someone forgot to commit "Gemfile.lock"
+        run: git diff --exit-code
+      - name: Install CocoaPods dependencies
+        working-directory: ios
+        run: bundle exec pod install || bundle exec pod install --repo-update
+      - name: Fail if someone forgot to commit "Podfile.lock"
+        run: git diff --exit-code
+      - name: Check E2E wallet balance
+        run: NODE_OPTIONS='--unhandled-rejections=strict' yarn ts-node ./e2e/scripts/check-e2e-wallet-balance.ts
+      - name: Create Detox Build
+        run: |
+          export CELO_TEST_CONFIG=e2e
+          yarn detox build -c ios.release
+      - name: Upload Detox Build to Emerge
+        if: |
+          env.SECRETS_AVAILABLE
+            && (github.event_name == 'pull_request' || github.event_name == 'push')
+        run: yarn ts-node .github/scripts/uploadE2eBuildToEmerge.ts
+        env:
+          EMERGE_API_TOKEN: ${{ steps.google-secrets.outputs.EMERGE_API_TOKEN }}
+          DETOX_CONFIG: ios.release
+      - name: Run Detox
+        run: >
+          yarn detox test
+          --configuration ios.release
+          --artifacts-location e2e/artifacts
+          --take-screenshots=failing
+          --record-videos=failing
+          --record-logs=failing
+          --loglevel info
+          --debug-synchronization 10000
+          --workers 6
+          --retries 3
+        timeout-minutes: 45
+      - name: Publish iOS JUnit Report
+        if: always()
+        uses: mikepenz/action-junit-report@v2
+        with:
+          check_name: iOS e2e Test Report
+          report_paths: 'e2e/test-results/junit.xml'
+      - name: 'Upload iOS E2E Artifacts'
+        if: failure()
+        uses: actions/upload-artifact@v2
+        with:
+          name: ios-e2e-artifact
+          path: e2e/artifacts
+      - name: 'Upload iOS E2E HTML Report'
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: ios-e2e-test-report
+          path: e2e/test-results


### PR DESCRIPTION
### Description

I split `e2e-ci.yml` into three workflows:
1. A re-usable workflow to run Android E2E tests (`e2e-android.yml`).
2. A workflow that runs E2E tests on one device on iOS and one device on Android, whenever a PR into `main` is opened. It utilizes the re-usable Android workflow.
3. A workflow that runs E2E tests on one device on iOS and on multiple devices on Android. This workflow is called whenever a commit is pushed to `main`, the workflow is called manually from the Github UI, and once per day on a schedule. It also utilizes the re-usable Android workflow

Do note, the iOS side of things is still a WIP. My next PR will break out the copied iOS steps into their own reusable workflow, like Android, and will allow running on multiple iOS versions. I'm also looking into getting it working on even more Android versions, but we had some issues with versions <= 28 and >= 32.

### Other changes

N/A

### Tested

I've run these tests many times via Github Actions.

### How others should test

N/A

### Related issues

RET-275

### Backwards compatibility

N/A