### PR TITLE
feat: handle number already verified for CPV

### DIFF
--- a/src/verify/VerificationCodeInputScreen.test.tsx
+++ b/src/verify/VerificationCodeInputScreen.test.tsx
@@ -84,7 +84,7 @@ describe('VerificationCodeInputScreen', () => {
   })
 
   it('displays an error if verification code request fails', async () => {
-    mockFetch.mockRejectOnce()
+    mockFetch.mockResponseOnce(JSON.stringify({ message: 'something went wrong' }), { status: 500 })
     renderComponent()
 
     await act(flushMicrotasksQueue)
@@ -122,6 +122,30 @@ describe('VerificationCodeInputScreen', () => {
         '{"phoneNumber":"+31619123456","verificationId":"someId","smsCode":"123456","clientPlatform":"android","clientVersion":"0.0.1"}',
     })
     expect(getByTestId('PhoneVerificationCode/CheckIcon')).toBeTruthy()
+
+    jest.runOnlyPendingTimers()
+    expect(navigate).toHaveBeenCalledWith(Screens.OnboardingSuccessScreen)
+  })
+
+  it('handles when phone number already verified', async () => {
+    mockFetch.mockResponse(JSON.stringify({ message: 'Phone number already verified' }), {
+      status: 400,
+    })
+
+    renderComponent()
+
+    await act(flushMicrotasksQueue)
+
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+    expect(mockFetch).toHaveBeenCalledWith(`${networkConfig.verifyPhoneNumberUrl}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        authorization: 'Valora 0xabc:someSignedMessage',
+      },
+      body:
+        '{"phoneNumber":"+31619123456","clientPlatform":"android","clientVersion":"0.0.1","clientBundleId":"org.celo.mobile.debug","publicDataEncryptionKey":"somePublicKey"}',
+    })
 
     jest.runOnlyPendingTimers()
     expect(navigate).toHaveBeenCalledWith(Screens.OnboardingSuccessScreen)


### PR DESCRIPTION
### Description

Ensure that users who are already verified can restore their accounts and verify again. We can consume the new phone number lookup endpoint, but this PR achieves feature parity for now.

Video: https://linear.app/valora/issue/RET-389#comment-a119f794

### Other changes

N/A

### Tested

Manually, unit test

### How others should test

Verify a phone number against an account. Restore the account, and verify the same phone number. 

### Related issues

- Fixes RET-389
- 
### Backwards compatibility

Yes