### PR TITLE
feat(fiatconnect): Cache quote parameters when posting KYC to IHL

### DIFF
--- a/src/fiatconnect/saga.test.ts
+++ b/src/fiatconnect/saga.test.ts
@@ -59,6 +59,7 @@ import {
   submitFiatAccount,
   submitFiatAccountCompleted,
   submitFiatAccountKycApproved,
+  cacheQuoteParams,
 } from 'src/fiatconnect/slice'
 import FiatConnectQuote from 'src/fiatExchanges/quotes/FiatConnectQuote'
 import { normalizeFiatConnectQuotes } from 'src/fiatExchanges/quotes/normalizeQuotes'
@@ -891,6 +892,19 @@ describe('Fiatconnect saga', () => {
           [matches.call.fn(getFiatConnectClient), mockFcClient],
           { call: provideDelay },
         ])
+        .put(
+          cacheQuoteParams({
+            providerId: normalizedQuoteKyc.getProviderId(),
+            kycSchema: normalizedQuoteKyc.getKycSchema()!,
+            cachedQuoteParams: {
+              cryptoAmount: normalizedQuoteKyc.getCryptoAmount(),
+              fiatAmount: normalizedQuoteKyc.getFiatAmount(),
+              flow: normalizedQuoteKyc.flow,
+              cryptoType: normalizedQuoteKyc.getCryptoType(),
+              fiatType: normalizedQuoteKyc.getFiatType(),
+            },
+          })
+        )
         .put(selectFiatConnectQuoteCompleted())
         .run()
       expect(navigate).toHaveBeenCalledWith(Screens.KycLanding, {

--- a/src/fiatconnect/saga.ts
+++ b/src/fiatconnect/saga.ts
@@ -59,6 +59,7 @@ import {
   submitFiatAccount,
   submitFiatAccountCompleted,
   submitFiatAccountKycApproved,
+  cacheQuoteParams,
 } from 'src/fiatconnect/slice'
 import FiatConnectQuote from 'src/fiatExchanges/quotes/FiatConnectQuote'
 import { normalizeFiatConnectQuotes } from 'src/fiatExchanges/quotes/normalizeQuotes'
@@ -498,11 +499,26 @@ export function* handleSelectFiatConnectQuote({
       switch (fiatConnectKycStatus) {
         case FiatConnectKycStatus.KycNotCreated:
           if (getKycStatusResponse.persona === PersonaKycStatus.Approved) {
-            // If user has Persona KYC on file, just submit it and continue to account management
+            // If user has Persona KYC on file, just submit it and continue to account management.
+            // We also need to save a user's quote parameters so we can re-fetch if KYC takes a long
+            // time to process.
             yield call(postKyc, {
               providerInfo: quote.quote.provider,
               kycSchema,
             })
+            yield put(
+              cacheQuoteParams({
+                providerId: quote.getProviderId(),
+                kycSchema,
+                cachedQuoteParams: {
+                  cryptoAmount: quote.getCryptoAmount(),
+                  fiatAmount: quote.getFiatAmount(),
+                  flow: quote.flow,
+                  cryptoType: quote.getCryptoType(),
+                  fiatType: quote.getFiatType(),
+                },
+              })
+            )
             break
           } else {
             // If no Persona KYC on file, navigate to Persona

--- a/src/fiatconnect/selectors.ts
+++ b/src/fiatconnect/selectors.ts
@@ -16,3 +16,4 @@ export const fiatConnectProvidersSelector = (state: RootState) => state.fiatConn
 export const sendingFiatAccountStatusSelector = (state: RootState) =>
   state.fiatConnect.sendingFiatAccountStatus
 export const kycTryAgainLoadingSelector = (state: RootState) => state.fiatConnect.kycTryAgainLoading
+export const cachedQuoteParamsSelector = (state: RootState) => state.fiatConnect.cachedQuoteParams

--- a/src/redux/migrations.ts
+++ b/src/redux/migrations.ts
@@ -839,4 +839,11 @@ export const migrations = {
     },
   }),
   81: (state: any) => state,
+  82: (state: any) => ({
+    ...state,
+    fiatConnect: {
+      ...state.fiatConnect,
+      cachedQuoteParams: {},
+    },
+  }),
 }

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -23,7 +23,7 @@ const persistConfig: PersistConfig<RootState> = {
   key: 'root',
   // default is -1, increment as we make migrations
   // See https://github.com/valora-inc/wallet/tree/main/WALLET.md#redux-state-migration
-  version: 81,
+  version: 82,
   keyPrefix: `reduxStore-`, // the redux-persist default is `persist:` which doesn't work with some file systems.
   storage: FSStorage(),
   blacklist: ['networkInfo', 'alert', 'imports', 'supercharge'],

--- a/test/RootStateSchema.json
+++ b/test/RootStateSchema.json
@@ -273,6 +273,34 @@
             ],
             "type": "object"
         },
+        "CachedQuoteParams": {
+            "additionalProperties": false,
+            "properties": {
+                "cryptoAmount": {
+                    "type": "string"
+                },
+                "cryptoType": {
+                    "$ref": "#/definitions/Currency"
+                },
+                "fiatAmount": {
+                    "type": "string"
+                },
+                "fiatType": {
+                    "$ref": "#/definitions/FiatType"
+                },
+                "flow": {
+                    "$ref": "#/definitions/CICOFlow"
+                }
+            },
+            "required": [
+                "cryptoAmount",
+                "cryptoType",
+                "fiatAmount",
+                "fiatType",
+                "flow"
+            ],
+            "type": "object"
+        },
         "CreateAccountCopyTestType": {
             "enum": [
                 "ACCOUNT",
@@ -2883,6 +2911,12 @@
                     },
                     "type": "array"
                 },
+                "cachedQuoteParams": {
+                    "additionalProperties": {
+                        "$ref": "#/definitions/{PersonalDataAndDocuments:CachedQuoteParams;}"
+                    },
+                    "type": "object"
+                },
                 "kycTryAgainLoading": {
                     "type": "boolean"
                 },
@@ -3103,6 +3137,7 @@
             "required": [
                 "attemptReturnUserFlowLoading",
                 "cachedFiatAccountUses",
+                "cachedQuoteParams",
                 "kycTryAgainLoading",
                 "providers",
                 "quotes",
@@ -4068,6 +4103,18 @@
                 "c",
                 "e",
                 "s"
+            ],
+            "type": "object"
+        },
+        "{PersonalDataAndDocuments:CachedQuoteParams;}": {
+            "additionalProperties": false,
+            "properties": {
+                "PersonalDataAndDocuments": {
+                    "$ref": "#/definitions/CachedQuoteParams"
+                }
+            },
+            "required": [
+                "PersonalDataAndDocuments"
             ],
             "type": "object"
         },

--- a/test/schemas.ts
+++ b/test/schemas.ts
@@ -1677,6 +1677,17 @@ export const v81Schema = {
   },
 }
 
+export const v82Schema = {
+  ...v81Schema,
+  _persist: {
+    ...v81Schema._persist,
+    version: 82,
+  },
+  fiatConnect: {
+    ...v81Schema.fiatConnect,
+    cachedQuoteParams: {},
+  },
+}
 export function getLatestSchema(): Partial<RootState> {
-  return v81Schema as Partial<RootState>
+  return v82Schema as Partial<RootState>
 }


### PR DESCRIPTION
### Description
For ACT-473. Caches the parameters used for the current quote when posting KYC to IHL. This sets us up for later on when jumping to the review screen when the user receives a push/homecard alerting them that their KYC has passed, since we'll need to refetch a quote with the same parameters as the quote used when submitting KYC information.

### Other changes

N/A

### Tested

Unit tested.

### How others should test

N/A currently; new redux state is unused.

### Related issues

- Fixes ACT-473.

### Backwards compatibility

N/A