### PR TITLE
fix(persona): create a new account when kycStatus is NotCreated

### DIFF
--- a/src/account/Persona.test.tsx
+++ b/src/account/Persona.test.tsx
@@ -84,6 +84,23 @@ describe('Persona', () => {
     expect(createPersonaAccount).toHaveBeenCalledTimes(1)
   })
 
+  it('calls IHL to create a persona account if persona account not created', async () => {
+    const personaProps: Props = {
+      kycStatus: KycStatus.NotCreated,
+      disabled: false,
+    }
+    const { getByTestId } = render(
+      <Provider store={store}>
+        <Persona {...personaProps} />
+      </Provider>
+    )
+    // Should be disabled to start because we don't know if they have an account until the IHL call happens
+    expect(getByTestId('PersonaButton')).toBeDisabled()
+
+    await waitFor(() => expect(getByTestId('PersonaButton')).not.toBeDisabled())
+    expect(createPersonaAccount).toHaveBeenCalledTimes(1)
+  })
+
   it('disables the button when the disabled prop is true', async () => {
     const personaProps: Props = {
       kycStatus: KycStatus.Created,

--- a/src/account/Persona.tsx
+++ b/src/account/Persona.tsx
@@ -37,7 +37,9 @@ enum Status {
 
 const Persona = ({ kycStatus, text, onCanceled, onError, onPress, onSuccess, disabled }: Props) => {
   const { t } = useTranslation()
-  const [personaAccountCreated, setPersonaAccountCreated] = useState(!!kycStatus)
+  const [personaAccountCreated, setPersonaAccountCreated] = useState(
+    kycStatus !== undefined && kycStatus !== KycStatus.NotCreated
+  )
 
   const walletAddress = useSelector(walletAddressSelector)
 


### PR DESCRIPTION
### Description

The NotCreated state was implemented after the original Persona code was written and this part was missed when it was added.

### Tested

added regression test

### How others should test

n/a
