### PR TITLE
feat: restore phone verification status when restoring wallet

### DIFF
--- a/src/account/saga.test.ts
+++ b/src/account/saga.test.ts
@@ -1,23 +1,39 @@
+import * as DEK from '@celo/utils/lib/dataEncryptionKey'
+import { FetchMock } from 'jest-fetch-mock/types'
 import * as Keychain from 'react-native-keychain'
 import { expectSaga } from 'redux-saga-test-plan'
 import * as matchers from 'redux-saga-test-plan/matchers'
 import { throwError } from 'redux-saga-test-plan/providers'
 import { call, select } from 'redux-saga/effects'
-import { generateSignedMessage, handleUpdateAccountRegistration } from 'src/account/saga'
+import {
+  generateSignedMessage,
+  handleUpdateAccountRegistration,
+  initializeAccountSaga,
+} from 'src/account/saga'
+import { choseToRestoreAccountSelector } from 'src/account/selectors'
 import { updateAccountRegistration } from 'src/account/updateAccountRegistration'
+import { Actions as AccountActions, phoneNumberVerificationCompleted } from 'src/app/actions'
+import { centralPhoneVerificationEnabledSelector } from 'src/app/selectors'
 import { currentLanguageSelector } from 'src/i18n/selectors'
 import { userLocationDataSelector } from 'src/networkInfo/selectors'
 import { retrieveSignedMessage, storeSignedMessage } from 'src/pincode/authentication'
 import Logger from 'src/utils/Logger'
 import { getContractKit, getWallet } from 'src/web3/contracts'
-import { unlockAccount, UnlockResult } from 'src/web3/saga'
+import networkConfig from 'src/web3/networkConfig'
+import { getOrCreateAccount, unlockAccount, UnlockResult } from 'src/web3/saga'
 import { walletAddressSelector } from 'src/web3/selectors'
 import { mockWallet } from 'test/values'
 import { mocked } from 'ts-jest/utils'
-import { saveSignedMessage } from './actions'
+import { initializeAccountSuccess, saveSignedMessage } from './actions'
 
 const loggerErrorSpy = jest.spyOn(Logger, 'error')
 const mockedKeychain = mocked(Keychain)
+
+const mockedDEK = mocked(DEK)
+mockedDEK.compressedPubKey = jest.fn().mockReturnValue('publicKeyForUser')
+
+const mockFetch = fetch as FetchMock
+jest.unmock('src/pincode/authentication')
 
 jest.mock('@react-native-firebase/app', () => ({
   app: jest.fn(() => ({
@@ -119,5 +135,80 @@ describe('generateSignedMessage', () => {
         .not.call(storeSignedMessage)
         .run()
     ).rejects.toThrowError('could not generate signature')
+  })
+})
+
+describe('initializeAccount', () => {
+  beforeEach(() => {
+    mockFetch.resetMocks()
+  })
+
+  it('should handle the last previously verified phone number', async () => {
+    mockFetch.mockResponse(
+      JSON.stringify({ data: { phoneNumbers: ['+1302123456', '+31619123456'] } })
+    )
+
+    await expectSaga(initializeAccountSaga)
+      .provide([
+        [call(getOrCreateAccount), undefined],
+        [call(generateSignedMessage), undefined],
+        [select(choseToRestoreAccountSelector), true],
+        [select(centralPhoneVerificationEnabledSelector), true],
+        [call(retrieveSignedMessage), 'some signed message'],
+        [select(walletAddressSelector), '0xabc'],
+      ])
+      .put(initializeAccountSuccess())
+      .put(phoneNumberVerificationCompleted('+31619123456', '+31'))
+      .run()
+
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+    expect(mockFetch).toHaveBeenCalledWith(
+      `${networkConfig.lookupAddressUrl}?clientPlatform=android&clientVersion=0.0.1`,
+      {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+          authorization: `Valora 0xabc:some signed message`,
+        },
+      }
+    )
+  })
+
+  it('should handle if there is no previously verified phone number', async () => {
+    mockFetch.mockResponse(JSON.stringify({ data: { phoneNumbers: [] } }))
+
+    await expectSaga(initializeAccountSaga)
+      .provide([
+        [call(getOrCreateAccount), undefined],
+        [call(generateSignedMessage), undefined],
+        [select(choseToRestoreAccountSelector), true],
+        [select(centralPhoneVerificationEnabledSelector), true],
+        [call(retrieveSignedMessage), 'some signed message'],
+        [select(walletAddressSelector), '0xabc'],
+      ])
+      .put(initializeAccountSuccess())
+      .not.put.actionType(AccountActions.PHONE_NUMBER_VERIFICATION_COMPLETED)
+      .run()
+
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('should still initialize account if lookup address fails', async () => {
+    mockFetch.mockResponse(JSON.stringify({ message: 'something went wrong' }), { status: 500 })
+
+    await expectSaga(initializeAccountSaga)
+      .provide([
+        [call(getOrCreateAccount), undefined],
+        [call(generateSignedMessage), undefined],
+        [select(choseToRestoreAccountSelector), true],
+        [select(centralPhoneVerificationEnabledSelector), true],
+        [call(retrieveSignedMessage), 'some signed message'],
+        [select(walletAddressSelector), '0xabc'],
+      ])
+      .put(initializeAccountSuccess())
+      .not.put.actionType(AccountActions.PHONE_NUMBER_VERIFICATION_COMPLETED)
+      .run()
+
+    expect(mockFetch).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/account/saga.ts
+++ b/src/account/saga.ts
@@ -125,7 +125,7 @@ function* handlePreviouslyVerifiedPhoneNumber() {
           yield put(
             phoneNumberVerificationCompleted(
               phoneDetails.e164Number,
-              phoneDetails.countryCodeAlpha2
+              phoneDetails.countryCode ? `+${phoneDetails.countryCode}` : null
             )
           )
         } else {

--- a/src/account/saga.ts
+++ b/src/account/saga.ts
@@ -1,7 +1,9 @@
 import { ContractKit } from '@celo/contractkit'
+import { parsePhoneNumber } from '@celo/utils/lib/phoneNumbers'
 import { EIP712TypedData } from '@celo/utils/lib/sign-typed-data-utils'
 import { UnlockableWallet } from '@celo/wallet-base'
 import firebase from '@react-native-firebase/app'
+import { Platform } from 'react-native'
 import DeviceInfo from 'react-native-device-info'
 import { call, put, select, spawn, take, takeLeading } from 'redux-saga/effects'
 import {
@@ -10,11 +12,14 @@ import {
   initializeAccountSuccess,
   saveSignedMessage,
 } from 'src/account/actions'
+import { choseToRestoreAccountSelector } from 'src/account/selectors'
 import { updateAccountRegistration } from 'src/account/updateAccountRegistration'
 import { showError } from 'src/alert/actions'
 import { OnboardingEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
+import { phoneNumberVerificationCompleted } from 'src/app/actions'
 import { ErrorMessages } from 'src/app/ErrorMessages'
+import { centralPhoneVerificationEnabledSelector } from 'src/app/selectors'
 import { clearStoredMnemonic } from 'src/backup/utils'
 import { FIREBASE_ENABLED } from 'src/config'
 import { firebaseSignOut } from 'src/firebase/firebase'
@@ -34,6 +39,7 @@ import Logger from 'src/utils/Logger'
 import { getContractKit, getWallet } from 'src/web3/contracts'
 import { registerAccountDek } from 'src/web3/dataEncryptionKey'
 import { clearStoredAccounts } from 'src/web3/KeychainSigner'
+import networkConfig from 'src/web3/networkConfig'
 import { getOrCreateAccount, unlockAccount } from 'src/web3/saga'
 import { walletAddressSelector } from 'src/web3/selectors'
 
@@ -67,20 +73,74 @@ function* clearStoredAccountSaga({ account, onlyReduxState }: ClearStoredAccount
   }
 }
 
-function* initializeAccount() {
-  Logger.debug(TAG + '@initializeAccount', 'Creating account')
+export function* initializeAccountSaga() {
+  Logger.debug(TAG + '@initializeAccountSaga', 'Creating account')
   try {
     ValoraAnalytics.track(OnboardingEvents.initialize_account_start)
     yield call(getOrCreateAccount)
     yield call(generateSignedMessage)
     yield put(refreshAllBalances())
-    Logger.debug(TAG + '@initializeAccount', 'Account creation success')
+
+    const choseToRestoreAccount = yield select(choseToRestoreAccountSelector)
+    const centralPhoneVerificationEnabled = yield select(centralPhoneVerificationEnabledSelector)
+    if (centralPhoneVerificationEnabled && choseToRestoreAccount) {
+      yield call(handlePreviouslyVerifiedPhoneNumber)
+    }
+
+    Logger.debug(TAG + '@initializeAccountSaga', 'Account creation success')
     ValoraAnalytics.track(OnboardingEvents.initialize_account_complete)
     yield put(initializeAccountSuccess())
   } catch (e) {
     Logger.error(TAG, 'Failed to initialize account', e)
     ValoraAnalytics.track(OnboardingEvents.initialize_account_error, { error: e.message })
     navigateClearingStack(Screens.AccounSetupFailureScreen)
+  }
+}
+
+function* handlePreviouslyVerifiedPhoneNumber() {
+  const address = yield select(walletAddressSelector)
+
+  try {
+    const signedMessage = yield call(retrieveSignedMessage)
+    const queryParams = new URLSearchParams({
+      clientPlatform: Platform.OS,
+      clientVersion: DeviceInfo.getVersion(),
+    }).toString()
+
+    const response = yield call(fetch, `${networkConfig.lookupAddressUrl}?${queryParams}`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        authorization: `Valora ${address}:${signedMessage}`,
+      },
+    })
+
+    const result = yield call([response, 'json'])
+    if (response.ok && result.data?.phoneNumbers) {
+      // if phoneNumbers length is 0, there are no verified numbers so do nothing
+      if (result.data.phoneNumbers.length > 0) {
+        const lastVerifiedNumber = result.data.phoneNumbers[result.data.phoneNumbers.length - 1]
+        const phoneDetails = yield call(parsePhoneNumber, lastVerifiedNumber)
+        if (phoneDetails) {
+          yield put(
+            phoneNumberVerificationCompleted(
+              phoneDetails.e164Number,
+              phoneDetails.countryCodeAlpha2
+            )
+          )
+        } else {
+          throw new Error('Could not parse verified phone number')
+        }
+      }
+    } else {
+      throw new Error(yield call([response, 'text']))
+    }
+  } catch (error) {
+    Logger.debug(
+      `${TAG}@importBackupPhraseSaga`,
+      `Failed to lookup and store verified phone numbers for this wallet address`,
+      error
+    )
   }
 }
 
@@ -167,7 +227,7 @@ export function* watchClearStoredAccount() {
 }
 
 export function* watchInitializeAccount() {
-  yield takeLeading(Actions.INITIALIZE_ACCOUNT, initializeAccount)
+  yield takeLeading(Actions.INITIALIZE_ACCOUNT, initializeAccountSaga)
 }
 
 export function* watchSignedMessage() {

--- a/src/account/saga.ts
+++ b/src/account/saga.ts
@@ -136,7 +136,7 @@ function* handlePreviouslyVerifiedPhoneNumber() {
       throw new Error(yield call([response, 'text']))
     }
   } catch (error) {
-    Logger.debug(
+    Logger.warn(
       `${TAG}@importBackupPhraseSaga`,
       `Failed to lookup and store verified phone numbers for this wallet address`,
       error

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -139,7 +139,7 @@ export interface AndroidMobileServicesAvailabilityChecked {
 export interface PhoneNumberVerificationCompleted {
   type: Actions.PHONE_NUMBER_VERIFICATION_COMPLETED
   e164PhoneNumber: string
-  countryCode: string
+  countryCode: string | null
 }
 
 export type ActionTypes =
@@ -284,7 +284,7 @@ export const androidMobileServicesAvailabilityChecked = (
 
 export const phoneNumberVerificationCompleted = (
   e164PhoneNumber: string,
-  countryCode: string
+  countryCode: string | null
 ): PhoneNumberVerificationCompleted => {
   return {
     type: Actions.PHONE_NUMBER_VERIFICATION_COMPLETED,

--- a/src/web3/networkConfig.ts
+++ b/src/web3/networkConfig.ts
@@ -38,6 +38,7 @@ interface NetworkConfig {
   verifyPhoneNumberUrl: string
   verifySmsCodeUrl: string
   lookupPhoneNumberUrl: string
+  lookupAddressUrl: string
 }
 
 const KOMENCI_URL_MAINNET = 'https://mainnet-komenci.azurefd.net'
@@ -91,6 +92,9 @@ const VERIFY_SMS_CODE_MAINNET = `${CLOUD_FUNCTIONS_MAINNET}/verifySmsCode`
 const LOOKUP_PHONE_NUMBER_ALFAJORES = `${CLOUD_FUNCTIONS_STAGING}/lookupPhoneNumber`
 const LOOKUP_PHONE_NUMBER_MAINNET = `${CLOUD_FUNCTIONS_MAINNET}/lookupPhoneNumber`
 
+const LOOKUP_ADDRESS_ALFAJORES = `${CLOUD_FUNCTIONS_STAGING}/lookupAddress`
+const LOOKUP_ADDRESS_MAINNET = `${CLOUD_FUNCTIONS_MAINNET}/lookupAddress`
+
 const CELO_EXPLORER_BASE_TX_URL_ALFAJORES = 'https://alfajores-blockscout.celo-testnet.org/tx/'
 const CELO_EXPLORER_BASE_TX_URL_MAINNET = 'https://explorer.celo.org/mainnet/tx/'
 
@@ -130,6 +134,7 @@ const networkConfigs: { [testnet: string]: NetworkConfig } = {
     verifyPhoneNumberUrl: VERIFY_PHONE_NUMBER_ALFAJORES,
     verifySmsCodeUrl: VERIFY_SMS_CODE_ALFAJORES,
     lookupPhoneNumberUrl: LOOKUP_PHONE_NUMBER_ALFAJORES,
+    lookupAddressUrl: LOOKUP_ADDRESS_ALFAJORES,
   },
   [Testnets.mainnet]: {
     networkId: '42220',
@@ -160,6 +165,7 @@ const networkConfigs: { [testnet: string]: NetworkConfig } = {
     verifyPhoneNumberUrl: VERIFY_PHONE_NUMBER_MAINNET,
     verifySmsCodeUrl: VERIFY_SMS_CODE_MAINNET,
     lookupPhoneNumberUrl: LOOKUP_PHONE_NUMBER_MAINNET,
+    lookupAddressUrl: LOOKUP_ADDRESS_MAINNET,
   },
 }
 


### PR DESCRIPTION
### Description

When initialising (restoring) wallet, check if there is a phone number already verified for this wallet. If so, store the verified phone number in redux so that the user correctly displays as verified in the app.

Note that the signed message is required for making the address lookup query, and this is generated potentially after the restore saga finishes so that's why it's in the initializeAccount saga now... 

### Other changes

N/A

### Tested

Manually + unit tests.

### How others should test

Verify a phone number against an address. Reinstall the app and restore this account - the app should know that your number is verified.

### Related issues

- Fixes RET-451

### Backwards compatibility

Yes