### PR TITLE
test(FiatDetailsScreen): use getBy* over queryBy*

### DIFF
--- a/src/fiatconnect/FiatDetailsScreen.test.tsx
+++ b/src/fiatconnect/FiatDetailsScreen.test.tsx
@@ -104,24 +104,24 @@ describe('FiatDetailsScreen', () => {
   })
 
   it('can view a list of bank fields', () => {
-    const { queryByText, queryByTestId } = render(
+    const { getByText, getByTestId, queryByTestId } = render(
       <Provider store={store}>
         <FiatDetailsScreen {...mockScreenPropsWithAllowedValues} />
       </Provider>
     )
 
-    expect(queryByText('fiatAccountSchema.institutionName.label')).toBeTruthy()
+    expect(getByText('fiatAccountSchema.institutionName.label')).toBeTruthy()
     // checks presence of picker, testID is hardcoded and not customizable
-    expect(queryByTestId('android_touchable_wrapper')).toBeTruthy()
+    expect(getByTestId('android_touchable_wrapper')).toBeTruthy()
 
-    expect(queryByText('fiatAccountSchema.accountNumber.label')).toBeTruthy()
-    expect(queryByTestId('input-accountNumber')).toBeTruthy()
+    expect(getByText('fiatAccountSchema.accountNumber.label')).toBeTruthy()
+    expect(getByTestId('input-accountNumber')).toBeTruthy()
 
     expect(queryByTestId(/errorMessage-.+/)).toBeFalsy()
 
-    expect(queryByTestId('submitButton')).toBeTruthy()
-    expect(queryByTestId('submitButton')).toBeDisabled()
-    expect(queryByText('fiatDetailsScreen.submitAndContinue')).toBeTruthy()
+    expect(getByTestId('submitButton')).toBeTruthy()
+    expect(getByTestId('submitButton')).toBeDisabled()
+    expect(getByText('fiatDetailsScreen.submitAndContinue')).toBeTruthy()
   })
   it('renders header with provider image', () => {
     let headerTitle: React.ReactNode
@@ -135,15 +135,11 @@ describe('FiatDetailsScreen', () => {
       </Provider>
     )
 
-    const { queryByTestId, getByTestId, queryByText } = render(
-      <Provider store={store}>{headerTitle}</Provider>
-    )
+    const { getByTestId, getByText } = render(<Provider store={store}>{headerTitle}</Provider>)
 
-    expect(queryByText('fiatDetailsScreen.header')).toBeTruthy()
-    expect(
-      queryByText('fiatDetailsScreen.headerSubTitle, {"provider":"Provider Two"}')
-    ).toBeTruthy()
-    expect(queryByTestId('headerProviderIcon')).toBeTruthy()
+    expect(getByText('fiatDetailsScreen.header')).toBeTruthy()
+    expect(getByText('fiatDetailsScreen.headerSubTitle, {"provider":"Provider Two"}')).toBeTruthy()
+    expect(getByTestId('headerProviderIcon')).toBeTruthy()
     expect(getByTestId('headerProviderIcon').props.source.uri).toEqual(mockFiatConnectProviderIcon)
   })
   it('cancel button navigates to fiat exchange screen and fires analytics event', () => {
@@ -158,9 +154,8 @@ describe('FiatDetailsScreen', () => {
       </Provider>
     )
 
-    const { getByText, queryByText } = render(<Provider store={store}>{headerRight}</Provider>)
+    const { getByText } = render(<Provider store={store}>{headerRight}</Provider>)
 
-    expect(queryByText('cancel')).toBeTruthy()
     fireEvent.press(getByText('cancel'))
     expect(navigate).toHaveBeenCalledWith(Screens.FiatExchange)
     expect(ValoraAnalytics.track).toHaveBeenCalledWith(
@@ -184,9 +179,9 @@ describe('FiatDetailsScreen', () => {
       </Provider>
     )
 
-    const { getByTestId, queryByTestId } = render(<Provider store={store}>{headerLeft}</Provider>)
+    const { getByTestId } = render(<Provider store={store}>{headerLeft}</Provider>)
 
-    expect(queryByTestId('backButton')).toBeTruthy()
+    expect(getByTestId('backButton')).toBeTruthy()
     fireEvent.press(getByTestId('backButton'))
     expect(navigateBack).toHaveBeenCalledWith()
     expect(ValoraAnalytics.track).toHaveBeenCalledWith(FiatExchangeEvents.cico_fiat_details_back, {
@@ -196,29 +191,29 @@ describe('FiatDetailsScreen', () => {
     })
   })
   it('button remains disabled if required input field is empty', () => {
-    const { queryByText, getByTestId, queryByTestId } = render(
+    const { getByText, getByTestId, queryByTestId } = render(
       <Provider store={store}>
         <FiatDetailsScreen {...mockScreenPropsWithAllowedValues} />
       </Provider>
     )
 
-    expect(queryByText('fiatAccountSchema.institutionName.label')).toBeTruthy()
-    expect(queryByText('fiatAccountSchema.accountNumber.label')).toBeTruthy()
+    expect(getByText('fiatAccountSchema.institutionName.label')).toBeTruthy()
+    expect(getByText('fiatAccountSchema.accountNumber.label')).toBeTruthy()
     expect(queryByTestId(/errorMessage-.+/)).toBeFalsy()
 
     fireEvent.changeText(getByTestId('input-accountNumber'), fakeAccountNumber)
 
-    expect(queryByTestId('submitButton')).toBeDisabled()
+    expect(getByTestId('submitButton')).toBeDisabled()
   })
   it('shows validation error if the input field does not fulfill the requirement after delay', () => {
-    const { queryByText, getByTestId, queryByTestId } = render(
+    const { getByText, getByTestId, queryByTestId } = render(
       <Provider store={store}>
         <FiatDetailsScreen {...mockScreenPropsWithAllowedValues} />
       </Provider>
     )
 
-    expect(queryByText('fiatAccountSchema.institutionName.label')).toBeTruthy()
-    expect(queryByText('fiatAccountSchema.accountNumber.label')).toBeTruthy()
+    expect(getByText('fiatAccountSchema.institutionName.label')).toBeTruthy()
+    expect(getByText('fiatAccountSchema.accountNumber.label')).toBeTruthy()
     expect(queryByTestId(/errorMessage-.+/)).toBeFalsy()
 
     fireEvent.changeText(getByTestId('input-accountNumber'), '12dtfa')
@@ -227,19 +222,19 @@ describe('FiatDetailsScreen', () => {
     // after delay
     expect(queryByTestId(/errorMessage-.+/)).toBeFalsy()
     jest.advanceTimersByTime(1500)
-    expect(queryByTestId('errorMessage-accountNumber')).toBeTruthy()
-    expect(queryByText('fiatAccountSchema.accountNumber.errorMessageDigit')).toBeTruthy()
-    expect(queryByTestId('submitButton')).toBeDisabled()
+    expect(getByTestId('errorMessage-accountNumber')).toBeTruthy()
+    expect(getByText('fiatAccountSchema.accountNumber.errorMessageDigit')).toBeTruthy()
+    expect(getByTestId('submitButton')).toBeDisabled()
   })
   it('shows validation error if the input field does not fulfill the requirement immediately on blur', () => {
-    const { queryByText, getByTestId, queryByTestId } = render(
+    const { getByText, getByTestId, queryByTestId } = render(
       <Provider store={store}>
         <FiatDetailsScreen {...mockScreenProps} />
       </Provider>
     )
 
-    expect(queryByText('fiatAccountSchema.institutionName.label')).toBeTruthy()
-    expect(queryByText('fiatAccountSchema.accountNumber.label')).toBeTruthy()
+    expect(getByText('fiatAccountSchema.institutionName.label')).toBeTruthy()
+    expect(getByText('fiatAccountSchema.accountNumber.label')).toBeTruthy()
     expect(queryByTestId(/errorMessage-.+/)).toBeFalsy()
 
     fireEvent.changeText(getByTestId('input-accountNumber'), '12dtfa')
@@ -247,23 +242,23 @@ describe('FiatDetailsScreen', () => {
 
     // Should see an error message saying the account number field is invalid
     // immediately since the field loses focus
-    expect(queryByTestId('errorMessage-accountNumber')).toBeTruthy()
-    expect(queryByText('fiatAccountSchema.accountNumber.errorMessageDigit')).toBeTruthy()
-    expect(queryByTestId('submitButton')).toBeDisabled()
+    expect(getByTestId('errorMessage-accountNumber')).toBeTruthy()
+    expect(getByText('fiatAccountSchema.accountNumber.errorMessageDigit')).toBeTruthy()
+    expect(getByTestId('submitButton')).toBeDisabled()
   })
   it('shows country specific validation error using overrides', () => {
     const mockStore = createMockStore({
       fiatConnect: { schemaCountryOverrides },
       networkInfo: { userLocationData: { countryCodeAlpha2: 'NG' } },
     })
-    const { queryByText, getByTestId, queryByTestId } = render(
+    const { getByText, getByTestId, queryByTestId } = render(
       <Provider store={mockStore}>
         <FiatDetailsScreen {...mockScreenProps} />
       </Provider>
     )
 
-    expect(queryByText('fiatAccountSchema.institutionName.label')).toBeTruthy()
-    expect(queryByText('fiatAccountSchema.accountNumber.label')).toBeTruthy()
+    expect(getByText('fiatAccountSchema.institutionName.label')).toBeTruthy()
+    expect(getByText('fiatAccountSchema.accountNumber.label')).toBeTruthy()
     expect(queryByTestId(/errorMessage-.+/)).toBeFalsy()
 
     fireEvent.changeText(getByTestId('input-accountNumber'), '123456')
@@ -271,9 +266,9 @@ describe('FiatDetailsScreen', () => {
 
     // Should see an error message saying the account number field is invalid
     // immediately since the field loses focus
-    expect(queryByTestId('errorMessage-accountNumber')).toBeTruthy()
-    expect(queryByText('fiatAccountSchema.accountNumber.errorMessageDigitLength')).toBeTruthy()
-    expect(queryByTestId('submitButton')).toBeDisabled()
+    expect(getByTestId('errorMessage-accountNumber')).toBeTruthy()
+    expect(getByText('fiatAccountSchema.accountNumber.errorMessageDigitLength')).toBeTruthy()
+    expect(getByTestId('submitButton')).toBeDisabled()
   })
   it('dispatches to saga when validation passes after pressing submit', async () => {
     const { getByTestId } = render(
@@ -310,12 +305,12 @@ describe('FiatDetailsScreen', () => {
         schemaCountryOverrides,
       },
     })
-    const { queryByTestId } = render(
+    const { getByTestId } = render(
       <Provider store={mockStore}>
         <FiatDetailsScreen {...mockScreenProps} />
       </Provider>
     )
-    expect(queryByTestId('spinner')).toBeTruthy()
+    expect(getByTestId('spinner')).toBeTruthy()
   })
   it('shows checkmark if fiat account and KYC have been approved', () => {
     const mockStore = createMockStore({
@@ -324,11 +319,11 @@ describe('FiatDetailsScreen', () => {
         schemaCountryOverrides,
       },
     })
-    const { queryByTestId } = render(
+    const { getByTestId } = render(
       <Provider store={mockStore}>
         <FiatDetailsScreen {...mockScreenProps} />
       </Provider>
     )
-    expect(queryByTestId('checkmark')).toBeTruthy()
+    expect(getByTestId('checkmark')).toBeTruthy()
   })
 })


### PR DESCRIPTION
### Description

For https://github.com/valora-inc/wallet/pull/2979#discussion_r993412171

### Other changes

N/A

### Tested

unit tests


### How others should test

N/A

### Related issues

N/A

### Backwards compatibility

N/A