### PR TITLE
chore: update blockscout/explorer alfajores url to avoid redirect

### DIFF
--- a/src/web3/networkConfig.ts
+++ b/src/web3/networkConfig.ts
@@ -103,7 +103,7 @@ const LOOKUP_ADDRESS_MAINNET = `${CLOUD_FUNCTIONS_MAINNET}/lookupAddress`
 const REVOKE_PHONE_NUMBER_ALFAJORES = `${CLOUD_FUNCTIONS_STAGING}/revokePhoneNumber`
 const REVOKE_PHONE_NUMBER_MAINNET = `${CLOUD_FUNCTIONS_MAINNET}/revokePhoneNumber`
 
-const CELO_EXPLORER_BASE_TX_URL_ALFAJORES = 'https://alfajores-blockscout.celo-testnet.org/tx/'
+const CELO_EXPLORER_BASE_TX_URL_ALFAJORES = 'https://explorer.celo.org/alfajores/tx/'
 const CELO_EXPLORER_BASE_TX_URL_MAINNET = 'https://explorer.celo.org/mainnet/tx/'
 
 const NFTS_VALORA_APP_URL = 'https://nfts.valoraapp.com/'


### PR DESCRIPTION
### Description

Title says it all.

### Tested

On Valora alfajores, tapping on "View on CeloExplorer" from a swap detail screen should open the explorer showing the transaction details.

### How others should test

See above.

### Related issues

- RET-440

### Backwards compatibility

Yes