### PR TITLE
fix: crowdin automerge job sometimes leaves incorrect reviews

### DIFF
--- a/.github/scripts/automergeCrowdinPr.js
+++ b/.github/scripts/automergeCrowdinPr.js
@@ -12,8 +12,13 @@
 const CROWDIN_BRANCH = 'l10n/main'
 const CROWDIN_PR_USER = 'valora-bot-crowdin'
 
-const ALLOWED_UPDATED_FILE_MATCHER = new RegExp(`locales\/.*\/translation\.json`)
-const DISALLOWED_UPDATED_FILE = 'locales/base/translation.json'
+const ALLOWED_UPDATED_FILE_MATCHER = new RegExp(
+  `locales\/.*\/translation\.json|ios/celo\/.*\/InfoPlist.strings`
+)
+const DISALLOWED_UPDATED_FILES = [
+  'locales/base/translation.json',
+  'ios/celo/Base.lproj/InfoPlist.strings',
+]
 const enableAutomergeQuery = `mutation ($pullRequestId: ID!, $mergeMethod: PullRequestMergeMethod!) {
   enablePullRequestAutoMerge(input: {
     pullRequestId: $pullRequestId,
@@ -88,7 +93,7 @@ module.exports = async ({ github, context }) => {
     })
     const unexpectedFiles = listFiles.data.filter(
       ({ filename }) =>
-        filename === DISALLOWED_UPDATED_FILE || !filename.match(ALLOWED_UPDATED_FILE_MATCHER)
+        DISALLOWED_UPDATED_FILES.includes(filename) || !filename.match(ALLOWED_UPDATED_FILE_MATCHER)
     )
     if (unexpectedFiles.length > 0) {
       console.log(

--- a/.github/scripts/automergeCrowdinPr.js
+++ b/.github/scripts/automergeCrowdinPr.js
@@ -76,6 +76,10 @@ module.exports = async ({ github, context }) => {
   if (isApproved) {
     console.log('Already approved')
   } else {
+    // wait some seconds before proceeding, or else the checks will be done
+    // before the branch is properly updated from main
+    await new Promise((resolve) => setTimeout(resolve, 5000))
+
     console.log(`Verifying that only expected files are modified for PR #${pr.number}`)
     const listFiles = await github.rest.pulls.listFiles({
       owner,
@@ -88,7 +92,9 @@ module.exports = async ({ github, context }) => {
     )
     if (unexpectedFiles.length > 0) {
       console.log(
-        `Files updated in PR #${pr.number} do not match the expectation, please check manually`
+        `The following files updated do not match the expectation: 
+        ${unexpectedFiles.map((file) => file.filename).join(', ')}.
+        Please check manually.`
       )
       await github.rest.pulls.createReview({
         owner,

--- a/.github/scripts/automergeCrowdinPr.js
+++ b/.github/scripts/automergeCrowdinPr.js
@@ -76,8 +76,8 @@ module.exports = async ({ github, context }) => {
   if (isApproved) {
     console.log('Already approved')
   } else {
-    // wait some seconds before proceeding, or else the checks will be done
-    // before the branch is properly updated from main
+    // wait some seconds before proceeding, to ensure that the checks are done
+    // after the branch is updated with main
     await new Promise((resolve) => setTimeout(resolve, 5000))
 
     console.log(`Verifying that only expected files are modified for PR #${pr.number}`)

--- a/.github/scripts/automergeCrowdinPr.js
+++ b/.github/scripts/automergeCrowdinPr.js
@@ -81,8 +81,7 @@ module.exports = async ({ github, context }) => {
   if (isApproved) {
     console.log('Already approved')
   } else {
-    // wait some seconds before proceeding, to ensure that the checks are done
-    // after the branch is updated with main
+    // wait until the branch is properly updated
     await new Promise((resolve) => setTimeout(resolve, 5000))
 
     console.log(`Verifying that only expected files are modified for PR #${pr.number}`)
@@ -98,7 +97,7 @@ module.exports = async ({ github, context }) => {
     if (unexpectedFiles.length > 0) {
       console.log(
         `The following files updated do not match the expectation: 
-        ${unexpectedFiles.map((file) => file.filename).join(', ')}.
+        ${unexpectedFiles.map((file) => file.filename).join('\n')}.
         Please check manually.`
       )
       await github.rest.pulls.createReview({

--- a/.github/workflows/automerge-crowdin.yml
+++ b/.github/workflows/automerge-crowdin.yml
@@ -7,6 +7,9 @@ on:
   # 1 hour before the nightly build
   schedule:
     - cron: '0 2 * * *'
+  push:
+    branches:
+      - kathy/fix-crowdin-automerge-race
 
 jobs:
   automerge-crowdin-pr:

--- a/.github/workflows/automerge-crowdin.yml
+++ b/.github/workflows/automerge-crowdin.yml
@@ -7,9 +7,6 @@ on:
   # 1 hour before the nightly build
   schedule:
     - cron: '0 2 * * *'
-  push:
-    branches:
-      - kathy/fix-crowdin-automerge-race
 
 jobs:
   automerge-crowdin-pr:


### PR DESCRIPTION
### Description

I found the automerge job sometimes leaves the "changes requested" review when the Crowdin PR does not contain any unexpected changes. I suspect that it is because the review is done before the branch is properly updated. e.g. https://github.com/valora-inc/wallet/pull/2982

In this PR
- wait for a few seconds after updating the branch, to do the review
- make the logging more explicit so that we can see which files are causing the incorrect review

### Other changes

N/A

### Tested

Tested https://github.com/valora-inc/wallet/actions/runs/3243609016/jobs/5318572378

### How others should test

N/A

### Related issues

N/A

### Backwards compatibility

Yes