### PR TITLE
chore: add device brand and model to contact support log information

### DIFF
--- a/__mocks__/react-native-device-info.ts
+++ b/__mocks__/react-native-device-info.ts
@@ -4,5 +4,8 @@ mockRNDeviceInfo.getBundleId.mockImplementation(() => 'org.celo.mobile.debug')
 mockRNDeviceInfo.getVersion.mockImplementation(() => '0.0.1')
 mockRNDeviceInfo.getBuildNumber.mockImplementation(() => '1')
 mockRNDeviceInfo.getUniqueId.mockImplementation(() => 'abc-def-123')
+mockRNDeviceInfo.getDeviceId.mockImplementation(() => 'someDeviceId')
+mockRNDeviceInfo.getBrand.mockImplementation(() => 'someBrand')
+mockRNDeviceInfo.getModel.mockImplementation(() => 'someModel')
 
 export default mockRNDeviceInfo

--- a/src/account/SupportContact.test.tsx
+++ b/src/account/SupportContact.test.tsx
@@ -54,7 +54,7 @@ describe('Contact', () => {
       expect.objectContaining({
         isHTML: true,
         body:
-          'Test Message<br/><br/><b>{"version":"0.0.1","buildNumber":"1","apiLevel":-1,"deviceId":"unknown","address":"0x0000000000000000000000000000000000007e57","sessionId":"","numberVerifiedDecentralized":false,"numberVerifiedCentralized":false,"network":"alfajores"}</b><br/><br/><b>Support logs are attached...</b>',
+          'Test Message<br/><br/><b>{"version":"0.0.1","buildNumber":"1","apiLevel":-1,"deviceId":"someDeviceId","deviceBrand":"someBrand","deviceModel":"someModel","address":"0x0000000000000000000000000000000000007e57","sessionId":"","numberVerifiedDecentralized":false,"numberVerifiedCentralized":false,"network":"alfajores"}</b><br/><br/><b>Support logs are attached...</b>',
         recipients: [CELO_SUPPORT_EMAIL_ADDRESS],
         subject: i18n.t('supportEmailSubject', { appName: APP_NAME, user: '+1415555XXXX' }),
         attachments: logAttachments,

--- a/src/account/SupportContact.tsx
+++ b/src/account/SupportContact.tsx
@@ -60,6 +60,8 @@ function SupportContact({ route }: Props) {
       buildNumber: DeviceInfo.getBuildNumber(),
       apiLevel: DeviceInfo.getApiLevelSync(),
       deviceId: DeviceInfo.getDeviceId(),
+      deviceBrand: DeviceInfo.getBrand(),
+      deviceModel: DeviceInfo.getModel(),
       address: currentAccount,
       sessionId,
       numberVerifiedDecentralized,

--- a/src/app/__snapshots__/Debug.test.tsx.snap
+++ b/src/app/__snapshots__/Debug.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`Debug renders correctly 1`] = `
       }
     }
   >
-    Device Id: unknown | Phone Number: +14155556666
+    Device Id: someDeviceId | Phone Number: +14155556666
   </Text>
   <Text
     onPress={[Function]}


### PR DESCRIPTION
### Description

This was a request from the support team, this can be helpful for debugging.  e.g. in RET-445.

### Other changes

N/A

### Tested

Manually

### How others should test

Shake to contact support. When the email appears, see that the expect values of device brand and model are present in the email body.

### Related issues

N/A

### Backwards compatibility

N/A