### PR TITLE
chore: remove swapFeeEnabled and swapFeePercentage

### DIFF
--- a/src/app/reducers.ts
+++ b/src/app/reducers.ts
@@ -58,8 +58,6 @@ export interface State {
   shouldShowRecoveryPhraseInSettings: boolean
   createAccountCopyTestType: CreateAccountCopyTestType
   maxSwapSlippagePercentage: number
-  swapFeeEnabled: boolean
-  swapFeePercentage: number
   inviteMethod: InviteMethodType
   centralPhoneVerificationEnabled: boolean
 }
@@ -113,8 +111,6 @@ const initialState = {
     REMOTE_CONFIG_VALUES_DEFAULTS.shouldShowRecoveryPhraseInSettings,
   createAccountCopyTestType: REMOTE_CONFIG_VALUES_DEFAULTS.createAccountCopyTestType,
   maxSwapSlippagePercentage: REMOTE_CONFIG_VALUES_DEFAULTS.maxSwapSlippagePercentage,
-  swapFeeEnabled: REMOTE_CONFIG_VALUES_DEFAULTS.swapFeeEnabled,
-  swapFeePercentage: REMOTE_CONFIG_VALUES_DEFAULTS.swapFeePercentage,
   inviteMethod: REMOTE_CONFIG_VALUES_DEFAULTS.inviteMethod,
   centralPhoneVerificationEnabled: REMOTE_CONFIG_VALUES_DEFAULTS.centralPhoneVerificationEnabled,
 }
@@ -235,8 +231,6 @@ export const appReducer = (
         shouldShowRecoveryPhraseInSettings: action.configValues.shouldShowRecoveryPhraseInSettings,
         createAccountCopyTestType: action.configValues.createAccountCopyTestType,
         maxSwapSlippagePercentage: action.configValues.maxSwapSlippagePercentage,
-        swapFeeEnabled: action.configValues.swapFeeEnabled,
-        swapFeePercentage: action.configValues.swapFeePercentage,
         inviteMethod: action.configValues.inviteMethod,
         showGuidedOnboardingCopy: action.configValues.showGuidedOnboardingCopy,
         centralPhoneVerificationEnabled: action.configValues.centralPhoneVerificationEnabled,

--- a/src/app/saga.ts
+++ b/src/app/saga.ts
@@ -199,8 +199,6 @@ export interface RemoteConfigValues {
   shouldShowRecoveryPhraseInSettings: boolean
   createAccountCopyTestType: CreateAccountCopyTestType
   maxSwapSlippagePercentage: number
-  swapFeeEnabled: boolean
-  swapFeePercentage: number
   inviteMethod: InviteMethodType
   showGuidedOnboardingCopy: boolean
   centralPhoneVerificationEnabled: boolean

--- a/src/app/selectors.ts
+++ b/src/app/selectors.ts
@@ -128,10 +128,6 @@ export const createAccountCopyTestTypeSelector = (state: RootState) =>
 export const maxSwapSlippagePercentageSelector = (state: RootState) =>
   state.app.maxSwapSlippagePercentage
 
-export const swapFeeEnabledSelector = (state: RootState) => state.app.swapFeeEnabled
-
-export const swapFeePercentageSelector = (state: RootState) => state.app.swapFeePercentage
-
 export const inviteMethodSelector = (state: RootState) => state.app.inviteMethod
 
 export const showGuidedOnboardingSelector = (state: RootState) => state.app.showGuidedOnboardingCopy

--- a/src/firebase/firebase.ts
+++ b/src/firebase/firebase.ts
@@ -304,8 +304,6 @@ export async function fetchRemoteConfigValues(): Promise<RemoteConfigValues | nu
     shouldShowRecoveryPhraseInSettings: flags.shouldShowRecoveryPhraseInSettings.asBoolean(),
     createAccountCopyTestType: flags.createAccountCopyTestType.asString() as CreateAccountCopyTestType,
     maxSwapSlippagePercentage: flags.maxSwapSlippagePercentage.asNumber(),
-    swapFeeEnabled: flags.swapFeeEnabled.asBoolean(),
-    swapFeePercentage: flags.swapFeePercentage.asNumber(),
     inviteMethod: flags.inviteMethod.asString() as InviteMethodType,
     showGuidedOnboardingCopy: flags.showGuidedOnboardingCopy.asBoolean(),
     centralPhoneVerificationEnabled: flags.centralPhoneVerificationEnabled.asBoolean(),

--- a/src/firebase/remoteConfigValuesDefaults.e2e.ts
+++ b/src/firebase/remoteConfigValuesDefaults.e2e.ts
@@ -70,8 +70,6 @@ export const REMOTE_CONFIG_VALUES_DEFAULTS: Omit<
   shouldShowRecoveryPhraseInSettings: false,
   createAccountCopyTestType: CreateAccountCopyTestType.Account,
   maxSwapSlippagePercentage: 2,
-  swapFeeEnabled: false,
-  swapFeePercentage: 0.743,
   inviteMethod: InviteMethodType.Escrow,
   showGuidedOnboardingCopy: false,
   centralPhoneVerificationEnabled: false,

--- a/src/firebase/remoteConfigValuesDefaults.ts
+++ b/src/firebase/remoteConfigValuesDefaults.ts
@@ -69,8 +69,6 @@ export const REMOTE_CONFIG_VALUES_DEFAULTS: Omit<
   shouldShowRecoveryPhraseInSettings: false,
   createAccountCopyTestType: CreateAccountCopyTestType.Account,
   maxSwapSlippagePercentage: 2,
-  swapFeeEnabled: false,
-  swapFeePercentage: 0.743,
   inviteMethod: InviteMethodType.Escrow,
   showGuidedOnboardingCopy: false,
   centralPhoneVerificationEnabled: false,

--- a/src/redux/migrations.test.ts
+++ b/src/redux/migrations.test.ts
@@ -38,6 +38,7 @@ import {
   v8Schema,
   vNeg1Schema,
   v81Schema,
+  v84Schema,
 } from 'test/schemas'
 
 describe('Redux persist migrations', () => {
@@ -687,6 +688,16 @@ describe('Redux persist migrations', () => {
       swapUserInput: null,
     }
 
+    expect(migratedSchema).toStrictEqual(expectedSchema)
+  })
+
+  it('works from v84 to v85', () => {
+    const oldSchema = v84Schema
+    const migratedSchema = migrations[85](oldSchema)
+
+    const expectedSchema: any = _.cloneDeep(oldSchema)
+    delete expectedSchema.app.swapFeeEnabled
+    delete expectedSchema.app.swapFeePercentage
     expect(migratedSchema).toStrictEqual(expectedSchema)
   })
 })

--- a/src/redux/migrations.ts
+++ b/src/redux/migrations.ts
@@ -787,8 +787,8 @@ export const migrations = {
     app: {
       ...state.app,
       maxSwapSlippagePercentage: REMOTE_CONFIG_VALUES_DEFAULTS.maxSwapSlippagePercentage,
-      swapFeeEnabled: REMOTE_CONFIG_VALUES_DEFAULTS.swapFeeEnabled,
-      swapFeePercentage: REMOTE_CONFIG_VALUES_DEFAULTS.swapFeePercentage,
+      swapFeeEnabled: false,
+      swapFeePercentage: false,
     },
   }),
   72: (state: any) => ({
@@ -860,5 +860,9 @@ export const migrations = {
       ...state.fiatConnect,
       schemaCountryOverrides: {},
     },
+  }),
+  85: (state: any) => ({
+    ...state,
+    app: _.omit(state.app, 'swapFeeEnabled', 'swapFeePercentage'),
   }),
 }

--- a/src/redux/store.test.ts
+++ b/src/redux/store.test.ts
@@ -93,7 +93,7 @@ describe('store state', () => {
       Object {
         "_persist": Object {
           "rehydrated": true,
-          "version": 84,
+          "version": 85,
         },
         "account": Object {
           "acceptedTerms": false,
@@ -177,8 +177,6 @@ describe('store state', () => {
           "superchargeButtonType": "PILL_REWARDS",
           "superchargeTokenConfigByToken": Object {},
           "supportedBiometryType": null,
-          "swapFeeEnabled": false,
-          "swapFeePercentage": 0.743,
           "visualizeNFTsEnabledInHomeAssetsPage": false,
           "walletConnectV1Enabled": true,
         },

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -23,7 +23,7 @@ const persistConfig: PersistConfig<RootState> = {
   key: 'root',
   // default is -1, increment as we make migrations
   // See https://github.com/valora-inc/wallet/tree/main/WALLET.md#redux-state-migration
-  version: 84,
+  version: 85,
   keyPrefix: `reduxStore-`, // the redux-persist default is `persist:` which doesn't work with some file systems.
   storage: FSStorage(),
   blacklist: ['networkInfo', 'alert', 'imports', 'supercharge', 'swap'],

--- a/test/RootStateSchema.json
+++ b/test/RootStateSchema.json
@@ -2208,12 +2208,6 @@
                         }
                     ]
                 },
-                "swapFeeEnabled": {
-                    "type": "boolean"
-                },
-                "swapFeePercentage": {
-                    "type": "number"
-                },
                 "visualizeNFTsEnabledInHomeAssetsPage": {
                     "type": "boolean"
                 },
@@ -2263,8 +2257,6 @@
                 "superchargeButtonType",
                 "superchargeTokenConfigByToken",
                 "supportedBiometryType",
-                "swapFeeEnabled",
-                "swapFeePercentage",
                 "visualizeNFTsEnabledInHomeAssetsPage",
                 "walletConnectV1Enabled"
             ],

--- a/test/schemas.ts
+++ b/test/schemas.ts
@@ -1714,6 +1714,15 @@ export const v84Schema = {
   },
 }
 
+export const v85Schema = {
+  ...v84Schema,
+  _persist: {
+    ...v84Schema._persist,
+    version: 85,
+  },
+  app: _.omit(v82Schema.app, 'swapFeeEnabled', 'swapFeePercentage'),
+}
+
 export function getLatestSchema(): Partial<RootState> {
-  return v84Schema as Partial<RootState>
+  return v85Schema as Partial<RootState>
 }


### PR DESCRIPTION
### Description

Removes the unused swapFeeEnabled and swapFeePercentage from redux and remote config. A follow up PR to #2977 based on https://github.com/valora-inc/wallet/pull/2977#discussion_r993054558.

### Other changes

N/A

### Tested

Tested in CI.

### How others should test

Ensure that the app loads.

### Related issues

N/A

### Backwards compatibility

Yes