### PR TITLE
feat: add iban as supported fiat account schema

### DIFF
--- a/src/fiatExchanges/quotes/FiatConnectQuote.test.ts
+++ b/src/fiatExchanges/quotes/FiatConnectQuote.test.ts
@@ -28,310 +28,362 @@ const mockExchangeRates = {
   cEUR: '2',
 }
 
-describe('FiatConnectQuote', () => {
-  describe('constructor', () => {
-    it('throws an error if fiatAccountType is not supported', () => {
-      expect(
-        () =>
-          new FiatConnectQuote({
-            flow: CICOFlow.CashIn,
-            quote: mockFiatConnectQuotes[1] as FiatConnectQuoteSuccess,
-            fiatAccountType: 'Foo' as FiatAccountType,
-          })
-      ).toThrow()
-    })
-    it('throws an error if at least one fiatAccountSchema is not supported', () => {
-      const quoteData = {
-        ...mockFiatConnectQuotes[1],
-        fiatAccount: {
-          BankAccount: {
-            fiatAccountSchemas: [
-              {
-                fiatAccountSchema: 'SomethingUnsupported' as FiatAccountSchema,
-                allowedValues: {},
-              },
-            ],
-          },
+const getQuote = (baseFcQuote: FiatConnectQuoteSuccess, fiatAccountSchema: FiatAccountSchema) => {
+  const quoteCopy = _.cloneDeep(baseFcQuote)
+  quoteCopy.fiatAccount.BankAccount = {
+    ...quoteCopy.fiatAccount.BankAccount,
+    fiatAccountSchemas: [
+      {
+        fiatAccountSchema: fiatAccountSchema,
+        allowedValues: {
+          institutionName: ['Bank A', 'Bank B'],
         },
-      }
-      expect(
-        () =>
-          new FiatConnectQuote({
-            flow: CICOFlow.CashIn,
-            quote: quoteData as FiatConnectQuoteSuccess,
-            fiatAccountType: FiatAccountType.BankAccount,
-          })
-      ).toThrow()
-    })
-    it('throws an error if KYC is required but not one of the supported schemas', () => {
-      expect(
-        () =>
-          new FiatConnectQuote({
-            flow: CICOFlow.CashIn,
-            quote: mockFiatConnectQuotes[2] as FiatConnectQuoteSuccess,
-            fiatAccountType: 'Foo' as FiatAccountType,
-          })
-      ).toThrow()
-    })
-  })
-  describe('.getPaymentMethod', () => {
-    it('returns Bank for BankAccount', () => {
-      const quote = new FiatConnectQuote({
-        flow: CICOFlow.CashIn,
-        quote: mockFiatConnectQuotes[1] as FiatConnectQuoteSuccess,
-        fiatAccountType: FiatAccountType.BankAccount,
-      })
-      expect(quote.getPaymentMethod()).toEqual(PaymentMethod.Bank)
-    })
-  })
+      },
+    ],
+  }
+  return quoteCopy
+}
 
-  describe('.getFeeInCrypto', () => {
-    it('returns null if there is no fee', () => {
-      const quoteData = _.cloneDeep(mockFiatConnectQuotes[1]) as FiatConnectQuoteSuccess
-      delete quoteData.quote.fee
-      const quote = new FiatConnectQuote({
-        flow: CICOFlow.CashIn,
-        quote: quoteData,
-        fiatAccountType: FiatAccountType.BankAccount,
-      })
-      expect(quote.getFeeInCrypto(mockExchangeRates)).toBeNull()
-    })
-    it('returns fee directly for cash out', () => {
-      const quote = new FiatConnectQuote({
-        flow: CICOFlow.CashOut,
-        quote: mockFiatConnectQuotes[1] as FiatConnectQuoteSuccess,
-        fiatAccountType: FiatAccountType.BankAccount,
-      })
-      expect(quote.getFeeInCrypto(mockExchangeRates)).toEqual(new BigNumber(0.53))
-    })
-    it('returns converted fee for cash in', () => {
-      const quote = new FiatConnectQuote({
-        flow: CICOFlow.CashIn,
-        quote: mockFiatConnectQuotes[1] as FiatConnectQuoteSuccess,
-        fiatAccountType: FiatAccountType.BankAccount,
-      })
-      expect(quote.getFeeInCrypto(mockExchangeRates)).toEqual(new BigNumber(0.265))
-    })
-  })
+const baseFcQuote = mockFiatConnectQuotes[1] as FiatConnectQuoteSuccess
 
-  describe('.getFeeInFiat', () => {
-    it('returns null if there is no fee', () => {
-      const quoteData = _.cloneDeep(mockFiatConnectQuotes[1]) as FiatConnectQuoteSuccess
-      delete quoteData.quote.fee
-      const quote = new FiatConnectQuote({
-        flow: CICOFlow.CashIn,
-        quote: quoteData,
-        fiatAccountType: FiatAccountType.BankAccount,
-      })
-      expect(quote.getFeeInFiat(mockExchangeRates)).toBeNull()
-    })
-    it('returns fee directly for cash in', () => {
-      const quote = new FiatConnectQuote({
-        flow: CICOFlow.CashIn,
-        quote: mockFiatConnectQuotes[1] as FiatConnectQuoteSuccess,
-        fiatAccountType: FiatAccountType.BankAccount,
-      })
-      expect(quote.getFeeInFiat(mockExchangeRates)).toEqual(new BigNumber(0.53))
-    })
-    it('returns converted fee for cash out', () => {
-      const quote = new FiatConnectQuote({
-        flow: CICOFlow.CashOut,
-        quote: mockFiatConnectQuotes[1] as FiatConnectQuoteSuccess,
-        fiatAccountType: FiatAccountType.BankAccount,
-      })
-      expect(quote.getFeeInFiat(mockExchangeRates)).toEqual(new BigNumber(1.06))
-    })
-  })
+const accountNumberQuote = getQuote(baseFcQuote, FiatAccountSchema.AccountNumber)
+const ibanQuote = getQuote(baseFcQuote, FiatAccountSchema.IBANNumber)
 
-  describe('.getKycInfo', () => {
-    it('returns null if there is no kyc', () => {
-      const quote = new FiatConnectQuote({
-        flow: CICOFlow.CashIn,
-        quote: mockFiatConnectQuotes[1] as FiatConnectQuoteSuccess,
-        fiatAccountType: FiatAccountType.BankAccount,
+describe('FiatConnectQuote', () => {
+  describe.each([
+    [
+      'AccountNumber',
+      {
+        fiatAccountSchema: FiatAccountSchema.AccountNumber,
+        schemaQuoteData: accountNumberQuote,
+      },
+    ],
+    [
+      'IbanNumber',
+      {
+        fiatAccountSchema: FiatAccountSchema.IBANNumber,
+        schemaQuoteData: ibanQuote,
+      },
+    ],
+  ])('%s test', (_title, { fiatAccountSchema, schemaQuoteData }) => {
+    describe('constructor', () => {
+      it('throws an error if fiatAccountType is not supported', () => {
+        expect(
+          () =>
+            new FiatConnectQuote({
+              flow: CICOFlow.CashIn,
+              quote: schemaQuoteData,
+              fiatAccountType: 'Foo' as FiatAccountType,
+            })
+        ).toThrow()
       })
-      expect(quote.getKycInfo()).toBeNull()
+      it('throws an error if at least one fiatAccountSchema is not supported', () => {
+        const quoteData = {
+          ...schemaQuoteData,
+          fiatAccount: {
+            BankAccount: {
+              fiatAccountSchemas: [
+                {
+                  fiatAccountSchema: 'SomethingUnsupported' as FiatAccountSchema,
+                  allowedValues: {},
+                },
+              ],
+            },
+          },
+        }
+        expect(
+          () =>
+            new FiatConnectQuote({
+              flow: CICOFlow.CashIn,
+              quote: quoteData as FiatConnectQuoteSuccess,
+              fiatAccountType: FiatAccountType.BankAccount,
+            })
+        ).toThrow()
+      })
+      it('throws an error if KYC is required but not one of the supported schemas', () => {
+        const quoteData = {
+          ...schemaQuoteData,
+          kyc: {
+            kycRequired: true,
+            kycSchemas: [{ kycSchema: 'fake-schema' as KycSchema, allowedValues: {} }],
+          },
+        }
+        expect(
+          () =>
+            new FiatConnectQuote({
+              flow: CICOFlow.CashIn,
+              quote: quoteData,
+              fiatAccountType: 'Foo' as FiatAccountType,
+            })
+        ).toThrow()
+      })
     })
-  })
+    describe('.getPaymentMethod', () => {
+      it('returns Bank for BankAccount', () => {
+        const quote = new FiatConnectQuote({
+          flow: CICOFlow.CashIn,
+          quote: schemaQuoteData,
+          fiatAccountType: FiatAccountType.BankAccount,
+        })
+        expect(quote.getPaymentMethod()).toEqual(PaymentMethod.Bank)
+      })
+    })
 
-  describe('.getTimeEstimation', () => {
-    it('returns numDays', () => {
-      const quote = new FiatConnectQuote({
-        flow: CICOFlow.CashIn,
-        quote: mockFiatConnectQuotes[1] as FiatConnectQuoteSuccess,
-        fiatAccountType: FiatAccountType.BankAccount,
+    describe('.getFeeInCrypto', () => {
+      it('returns null if there is no fee', () => {
+        const quoteData = _.cloneDeep(schemaQuoteData) as FiatConnectQuoteSuccess
+        delete quoteData.quote.fee
+        const quote = new FiatConnectQuote({
+          flow: CICOFlow.CashIn,
+          quote: quoteData,
+          fiatAccountType: FiatAccountType.BankAccount,
+        })
+        expect(quote.getFeeInCrypto(mockExchangeRates)).toBeNull()
       })
-      expect(quote.getTimeEstimation()).toEqual('selectProviderScreen.numDays')
+      it('returns fee directly for cash out', () => {
+        const quote = new FiatConnectQuote({
+          flow: CICOFlow.CashOut,
+          quote: schemaQuoteData,
+          fiatAccountType: FiatAccountType.BankAccount,
+        })
+        expect(quote.getFeeInCrypto(mockExchangeRates)).toEqual(new BigNumber(0.53))
+      })
+      it('returns converted fee for cash in', () => {
+        const quote = new FiatConnectQuote({
+          flow: CICOFlow.CashIn,
+          quote: schemaQuoteData,
+          fiatAccountType: FiatAccountType.BankAccount,
+        })
+        expect(quote.getFeeInCrypto(mockExchangeRates)).toEqual(new BigNumber(0.265))
+      })
     })
-  })
 
-  describe('.onPress', () => {
-    it('returns a function that calls ValoraAnalytics', () => {
-      const quote = new FiatConnectQuote({
-        flow: CICOFlow.CashIn,
-        quote: mockFiatConnectQuotes[1] as FiatConnectQuoteSuccess,
-        fiatAccountType: FiatAccountType.BankAccount,
+    describe('.getFeeInFiat', () => {
+      it('returns null if there is no fee', () => {
+        const quoteData = _.cloneDeep(schemaQuoteData) as FiatConnectQuoteSuccess
+        delete quoteData.quote.fee
+        const quote = new FiatConnectQuote({
+          flow: CICOFlow.CashIn,
+          quote: quoteData,
+          fiatAccountType: FiatAccountType.BankAccount,
+        })
+        expect(quote.getFeeInFiat(mockExchangeRates)).toBeNull()
       })
-      quote.onPress(CICOFlow.CashIn, createMockStore().dispatch)()
-      expect(ValoraAnalytics.track).toHaveBeenCalled()
+      it('returns fee directly for cash in', () => {
+        const quote = new FiatConnectQuote({
+          flow: CICOFlow.CashIn,
+          quote: schemaQuoteData,
+          fiatAccountType: FiatAccountType.BankAccount,
+        })
+        expect(quote.getFeeInFiat(mockExchangeRates)).toEqual(new BigNumber(0.53))
+      })
+      it('returns converted fee for cash out', () => {
+        const quote = new FiatConnectQuote({
+          flow: CICOFlow.CashOut,
+          quote: schemaQuoteData,
+          fiatAccountType: FiatAccountType.BankAccount,
+        })
+        expect(quote.getFeeInFiat(mockExchangeRates)).toEqual(new BigNumber(1.06))
+      })
     })
-  })
 
-  describe('.navigate', () => {
-    const store = createMockStore()
-    store.dispatch = jest.fn()
-    it('calls dispatch', () => {
-      const quote = new FiatConnectQuote({
-        flow: CICOFlow.CashIn,
-        quote: mockFiatConnectQuotes[1] as FiatConnectQuoteSuccess,
-        fiatAccountType: FiatAccountType.BankAccount,
+    describe('.getKycInfo', () => {
+      it('returns null if there is no kyc', () => {
+        const quote = new FiatConnectQuote({
+          flow: CICOFlow.CashIn,
+          quote: schemaQuoteData,
+          fiatAccountType: FiatAccountType.BankAccount,
+        })
+        expect(quote.getKycInfo()).toBeNull()
       })
-      quote.navigate(store.dispatch)
-      expect(store.dispatch).toHaveBeenCalledWith(selectFiatConnectQuote({ quote }))
     })
-  })
 
-  describe('.getProviderInfo', () => {
-    it('returns provider info', () => {
-      const quote = new FiatConnectQuote({
-        flow: CICOFlow.CashIn,
-        quote: mockFiatConnectQuotes[1] as FiatConnectQuoteSuccess,
-        fiatAccountType: FiatAccountType.BankAccount,
+    describe('.getTimeEstimation', () => {
+      it('returns numDays', () => {
+        const quote = new FiatConnectQuote({
+          flow: CICOFlow.CashIn,
+          quote: schemaQuoteData,
+          fiatAccountType: FiatAccountType.BankAccount,
+        })
+        expect(quote.getTimeEstimation()).toEqual('selectProviderScreen.numDays')
       })
-      expect(quote.getProviderInfo()).toEqual(mockFiatConnectProviderInfo[0])
     })
-  })
 
-  describe('.getProviderName', () => {
-    it('returns provider name', () => {
-      const quote = new FiatConnectQuote({
-        flow: CICOFlow.CashIn,
-        quote: mockFiatConnectQuotes[1] as FiatConnectQuoteSuccess,
-        fiatAccountType: FiatAccountType.BankAccount,
+    describe('.onPress', () => {
+      it('returns a function that calls ValoraAnalytics', () => {
+        const quote = new FiatConnectQuote({
+          flow: CICOFlow.CashIn,
+          quote: schemaQuoteData,
+          fiatAccountType: FiatAccountType.BankAccount,
+        })
+        quote.onPress(CICOFlow.CashIn, createMockStore().dispatch)()
+        expect(ValoraAnalytics.track).toHaveBeenCalled()
       })
-      expect(quote.getProviderName()).toEqual('Provider Two')
     })
-  })
 
-  describe('.getProviderLogo', () => {
-    it('returns provider logo', () => {
-      const quote = new FiatConnectQuote({
-        flow: CICOFlow.CashIn,
-        quote: mockFiatConnectQuotes[1] as FiatConnectQuoteSuccess,
-        fiatAccountType: FiatAccountType.BankAccount,
+    describe('.navigate', () => {
+      const store = createMockStore()
+      store.dispatch = jest.fn()
+      it('calls dispatch', () => {
+        const quote = new FiatConnectQuote({
+          flow: CICOFlow.CashIn,
+          quote: schemaQuoteData,
+          fiatAccountType: FiatAccountType.BankAccount,
+        })
+        quote.navigate(store.dispatch)
+        expect(store.dispatch).toHaveBeenCalledWith(selectFiatConnectQuote({ quote }))
       })
-      expect(quote.getProviderLogo()).toEqual(
-        'https://firebasestorage.googleapis.com/v0/b/celo-mobile-mainnet.appspot.com/o/images%2Fsimplex.jpg?alt=media'
-      )
     })
-  })
 
-  describe('.getProviderId', () => {
-    it('returns provider id', () => {
-      const quote = new FiatConnectQuote({
-        flow: CICOFlow.CashIn,
-        quote: mockFiatConnectQuotes[1] as FiatConnectQuoteSuccess,
-        fiatAccountType: FiatAccountType.BankAccount,
+    describe('.getProviderInfo', () => {
+      it('returns provider info', () => {
+        const quote = new FiatConnectQuote({
+          flow: CICOFlow.CashIn,
+          quote: schemaQuoteData,
+          fiatAccountType: FiatAccountType.BankAccount,
+        })
+        expect(quote.getProviderInfo()).toEqual(mockFiatConnectProviderInfo[0])
       })
-      expect(quote.getProviderId()).toEqual('provider-two')
     })
-  })
 
-  describe('.getProviderApiKey', () => {
-    it('returns provider api key', () => {
-      const quote = new FiatConnectQuote({
-        flow: CICOFlow.CashIn,
-        quote: mockFiatConnectQuotes[1] as FiatConnectQuoteSuccess,
-        fiatAccountType: FiatAccountType.BankAccount,
+    describe('.getProviderName', () => {
+      it('returns provider name', () => {
+        const quote = new FiatConnectQuote({
+          flow: CICOFlow.CashIn,
+          quote: schemaQuoteData,
+          fiatAccountType: FiatAccountType.BankAccount,
+        })
+        expect(quote.getProviderName()).toEqual('Provider Two')
       })
-      expect(quote.getProviderApiKey()).toEqual('fake-api-key')
     })
-  })
 
-  describe('.getFiatAmount', () => {
-    it('returns fiat amount', () => {
-      const quote = new FiatConnectQuote({
-        flow: CICOFlow.CashIn,
-        quote: mockFiatConnectQuotes[1] as FiatConnectQuoteSuccess,
-        fiatAccountType: FiatAccountType.BankAccount,
+    describe('.getProviderLogo', () => {
+      it('returns provider logo', () => {
+        const quote = new FiatConnectQuote({
+          flow: CICOFlow.CashIn,
+          quote: schemaQuoteData,
+          fiatAccountType: FiatAccountType.BankAccount,
+        })
+        expect(quote.getProviderLogo()).toEqual(
+          'https://firebasestorage.googleapis.com/v0/b/celo-mobile-mainnet.appspot.com/o/images%2Fsimplex.jpg?alt=media'
+        )
       })
-      expect(quote.getFiatAmount()).toEqual('100')
     })
-  })
 
-  describe('.getFiatType', () => {
-    it('returns fiat type', () => {
-      const quote = new FiatConnectQuote({
-        flow: CICOFlow.CashIn,
-        quote: mockFiatConnectQuotes[1] as FiatConnectQuoteSuccess,
-        fiatAccountType: FiatAccountType.BankAccount,
+    describe('.getProviderId', () => {
+      it('returns provider id', () => {
+        const quote = new FiatConnectQuote({
+          flow: CICOFlow.CashIn,
+          quote: schemaQuoteData,
+          fiatAccountType: FiatAccountType.BankAccount,
+        })
+        expect(quote.getProviderId()).toEqual('provider-two')
       })
-      expect(quote.getFiatType()).toEqual(FiatType.USD)
     })
-  })
 
-  describe('.getCryptoAmount', () => {
-    it('returns crypto amount', () => {
-      const quote = new FiatConnectQuote({
-        flow: CICOFlow.CashIn,
-        quote: mockFiatConnectQuotes[1] as FiatConnectQuoteSuccess,
-        fiatAccountType: FiatAccountType.BankAccount,
+    describe('.getProviderApiKey', () => {
+      it('returns provider api key', () => {
+        const quote = new FiatConnectQuote({
+          flow: CICOFlow.CashIn,
+          quote: schemaQuoteData,
+          fiatAccountType: FiatAccountType.BankAccount,
+        })
+        expect(quote.getProviderApiKey()).toEqual('fake-api-key')
       })
-      expect(quote.getCryptoAmount()).toEqual('100')
     })
-  })
 
-  describe('.getCryptoType', () => {
-    it('returns crypto type', () => {
-      const quote = new FiatConnectQuote({
-        flow: CICOFlow.CashIn,
-        quote: mockFiatConnectQuotes[1] as FiatConnectQuoteSuccess,
-        fiatAccountType: FiatAccountType.BankAccount,
+    describe('.getFiatAmount', () => {
+      it('returns fiat amount', () => {
+        const quote = new FiatConnectQuote({
+          flow: CICOFlow.CashIn,
+          quote: schemaQuoteData,
+          fiatAccountType: FiatAccountType.BankAccount,
+        })
+        expect(quote.getFiatAmount()).toEqual('100')
       })
-      expect(quote.getCryptoType()).toEqual(Currency.Dollar)
     })
-  })
 
-  describe('.getFiatAccountSchema', () => {
-    it('returns fiat account schema', () => {
-      const quote = new FiatConnectQuote({
-        flow: CICOFlow.CashIn,
-        quote: mockFiatConnectQuotes[1] as FiatConnectQuoteSuccess,
-        fiatAccountType: FiatAccountType.BankAccount,
+    describe('.getFiatType', () => {
+      it('returns fiat type', () => {
+        const quote = new FiatConnectQuote({
+          flow: CICOFlow.CashIn,
+          quote: schemaQuoteData,
+          fiatAccountType: FiatAccountType.BankAccount,
+        })
+        expect(quote.getFiatType()).toEqual(FiatType.USD)
       })
-      expect(quote.getFiatAccountSchema()).toEqual(FiatAccountSchema.AccountNumber)
     })
-  })
 
-  describe('.getFiatAccountSchemaAllowedValues', () => {
-    it('returns allowed values', () => {
-      const quote = new FiatConnectQuote({
-        flow: CICOFlow.CashIn,
-        quote: mockFiatConnectQuotes[1] as FiatConnectQuoteSuccess,
-        fiatAccountType: FiatAccountType.BankAccount,
-      })
-      expect(quote.getFiatAccountSchemaAllowedValues()).toEqual({
-        institutionName: ['Bank A', 'Bank B'],
+    describe('.getCryptoAmount', () => {
+      it('returns crypto amount', () => {
+        const quote = new FiatConnectQuote({
+          flow: CICOFlow.CashIn,
+          quote: schemaQuoteData,
+          fiatAccountType: FiatAccountType.BankAccount,
+        })
+        expect(quote.getCryptoAmount()).toEqual('100')
       })
     })
-  })
 
-  describe('.getKycSchema', () => {
-    it('returns required KYC schema when one exists', () => {
-      const quote = new FiatConnectQuote({
-        flow: CICOFlow.CashOut,
-        quote: mockFiatConnectQuotes[3] as FiatConnectQuoteSuccess,
-        fiatAccountType: FiatAccountType.BankAccount,
+    describe('.getCryptoType', () => {
+      it('returns crypto type', () => {
+        const quote = new FiatConnectQuote({
+          flow: CICOFlow.CashIn,
+          quote: schemaQuoteData,
+          fiatAccountType: FiatAccountType.BankAccount,
+        })
+        expect(quote.getCryptoType()).toEqual(Currency.Dollar)
       })
-      expect(quote.getKycSchema()).toEqual(KycSchema.PersonalDataAndDocuments)
     })
-    it('returns nothing when KYC is not required', () => {
-      const quote = new FiatConnectQuote({
-        flow: CICOFlow.CashIn,
-        quote: mockFiatConnectQuotes[1] as FiatConnectQuoteSuccess,
-        fiatAccountType: FiatAccountType.BankAccount,
+
+    describe('.getFiatAccountSchema', () => {
+      it('returns fiat account schema', () => {
+        const quote = new FiatConnectQuote({
+          flow: CICOFlow.CashIn,
+          quote: schemaQuoteData,
+          fiatAccountType: FiatAccountType.BankAccount,
+        })
+        expect(quote.getFiatAccountSchema()).toEqual(fiatAccountSchema)
       })
-      expect(quote.getKycSchema()).toBeUndefined()
+    })
+
+    describe('.getFiatAccountSchemaAllowedValues', () => {
+      it('returns allowed values', () => {
+        const quote = new FiatConnectQuote({
+          flow: CICOFlow.CashIn,
+          quote: schemaQuoteData,
+          fiatAccountType: FiatAccountType.BankAccount,
+        })
+        expect(quote.getFiatAccountSchemaAllowedValues()).toEqual({
+          institutionName: ['Bank A', 'Bank B'],
+        })
+      })
+    })
+
+    describe('.getKycSchema', () => {
+      it('returns required KYC schema when one exists', () => {
+        const quoteData = {
+          ...schemaQuoteData,
+          kyc: {
+            kycRequired: true,
+            kycSchemas: [{ kycSchema: KycSchema.PersonalDataAndDocuments, allowedValues: {} }],
+          },
+        }
+        const quote = new FiatConnectQuote({
+          flow: CICOFlow.CashOut,
+          quote: quoteData,
+          fiatAccountType: FiatAccountType.BankAccount,
+        })
+        expect(quote.getKycSchema()).toEqual(KycSchema.PersonalDataAndDocuments)
+      })
+      it('returns nothing when KYC is not required', () => {
+        const quote = new FiatConnectQuote({
+          flow: CICOFlow.CashIn,
+          quote: schemaQuoteData,
+          fiatAccountType: FiatAccountType.BankAccount,
+        })
+        expect(quote.getKycSchema()).toBeUndefined()
+      })
     })
   })
 })

--- a/src/fiatExchanges/quotes/FiatConnectQuote.ts
+++ b/src/fiatExchanges/quotes/FiatConnectQuote.ts
@@ -30,7 +30,10 @@ const kycStrings = {
 
 // TODO: When we add support for more types be sure to add more unit tests to the FiatConnectQuotes class
 const SUPPORTED_FIAT_ACCOUNT_TYPES = new Set<FiatAccountType>([FiatAccountType.BankAccount])
-const SUPPORTED_FIAT_ACCOUNT_SCHEMAS = new Set<FiatAccountSchema>([FiatAccountSchema.AccountNumber])
+const SUPPORTED_FIAT_ACCOUNT_SCHEMAS = new Set<FiatAccountSchema>([
+  FiatAccountSchema.AccountNumber,
+  FiatAccountSchema.IBANNumber,
+])
 const SUPPORTED_KYC_SCHEMAS = new Set<KycSchema>([KycSchema.PersonalDataAndDocuments])
 
 export default class FiatConnectQuote extends NormalizedQuote {


### PR DESCRIPTION
### Description

Currently, FiatConnect only supports the `AccountNumber` schema type. This PR adds `IBANNumber` as a supported schema type. Changes are mostly made to the testing file, ensuring that quotes with an `IBANNumber` fiat account schema work as expected.

### Other changes

N/A

### Tested

Updated unit tests.

### How others should test

N/A

### Related issues

- [ACT-484](https://linear.app/valora/issue/ACT-484/support-ibannumber-fiataccountschema)

### Backwards compatibility

N/A