### PR TITLE
test(e2e): add scroll in secure send

### DIFF
--- a/e2e/src/usecases/SecureSend.js
+++ b/e2e/src/usecases/SecureSend.js
@@ -1,5 +1,5 @@
 import { reloadReactNative } from '../utils/retries'
-import { enterPinUiIfNecessary, inputNumberKeypad, sleep } from '../utils/utils'
+import { enterPinUiIfNecessary, inputNumberKeypad, scrollIntoView, sleep } from '../utils/utils'
 const faker = require('@faker-js/faker')
 
 const PHONE_NUMBER = '+12057368924'
@@ -46,8 +46,8 @@ export default SecureSend = () => {
       await element(by.id(`SingleDigitInput/digit${index}`)).replaceText(character)
     }
 
-    // Tap to dismiss keyboard
-    await element(by.id('ConfirmAccountNumber/Title')).tap()
+    // Scroll to see submit button
+    await scrollIntoView('Submit', 'KeyboardAwareScrollView')
     await element(by.id('ConfirmAccountButton')).tap()
 
     // Write a comment.

--- a/e2e/src/usecases/SecureSend.js
+++ b/e2e/src/usecases/SecureSend.js
@@ -46,6 +46,8 @@ export default SecureSend = () => {
       await element(by.id(`SingleDigitInput/digit${index}`)).replaceText(character)
     }
 
+    // Tap to dismiss keyboard
+    await element(by.id('ConfirmAccountNumber/Title')).tap()
     await element(by.id('ConfirmAccountButton')).tap()
 
     // Write a comment.

--- a/src/components/KeyboardAwareScrollView.tsx
+++ b/src/components/KeyboardAwareScrollView.tsx
@@ -92,6 +92,13 @@ export default class KeyboardAwareScrollView extends React.Component<Props> {
   render() {
     const { hasNavBar, ...other } = this.props
 
-    return <ScrollView ref={this.scrollViewRef} keyboardShouldPersistTaps="handled" {...other} />
+    return (
+      <ScrollView
+        testID="KeyboardAwareScrollView"
+        ref={this.scrollViewRef}
+        keyboardShouldPersistTaps="handled"
+        {...other}
+      />
+    )
   }
 }

--- a/src/components/__snapshots__/ReviewFrame.test.tsx.snap
+++ b/src/components/__snapshots__/ReviewFrame.test.tsx.snap
@@ -19,6 +19,7 @@ exports[`ReviewFrame renders correctly 1`] = `
       }
     }
     keyboardShouldPersistTaps="handled"
+    testID="KeyboardAwareScrollView"
   >
     <View>
       <View

--- a/src/exchange/__snapshots__/ExchangeTradeScreen.test.tsx.snap
+++ b/src/exchange/__snapshots__/ExchangeTradeScreen.test.tsx.snap
@@ -223,6 +223,7 @@ exports[`ExchangeTradeScreen renders correctly 1`] = `
       }
     }
     keyboardShouldPersistTaps="always"
+    testID="KeyboardAwareScrollView"
   >
     <View>
       <View

--- a/src/exchange/__snapshots__/WithdrawCeloScreen.test.tsx.snap
+++ b/src/exchange/__snapshots__/WithdrawCeloScreen.test.tsx.snap
@@ -21,6 +21,7 @@ exports[`WithdrawCeloScreen renders correctly 1`] = `
       }
     }
     keyboardShouldPersistTaps="always"
+    testID="KeyboardAwareScrollView"
   >
     <View>
       <Text

--- a/src/fiatExchanges/__snapshots__/FiatExchangeAmount.test.tsx.snap
+++ b/src/fiatExchanges/__snapshots__/FiatExchangeAmount.test.tsx.snap
@@ -223,6 +223,7 @@ exports[`FiatExchangeAmount cashIn renders correctly with EUR as app currency 1`
       }
     }
     keyboardShouldPersistTaps="always"
+    testID="KeyboardAwareScrollView"
   >
     <View>
       <View
@@ -699,6 +700,7 @@ exports[`FiatExchangeAmount cashIn renders correctly with USD as app currency 1`
       }
     }
     keyboardShouldPersistTaps="always"
+    testID="KeyboardAwareScrollView"
   >
     <View>
       <View

--- a/src/identity/__snapshots__/PhoneNumberLookupQuotaScreen.test.tsx.snap
+++ b/src/identity/__snapshots__/PhoneNumberLookupQuotaScreen.test.tsx.snap
@@ -19,6 +19,7 @@ exports[`PhoneNumberLookupQuotaScreen renders correctly 1`] = `
       }
     }
     keyboardShouldPersistTaps="always"
+    testID="KeyboardAwareScrollView"
   >
     <View>
       <svg

--- a/src/import/__snapshots__/ImportWallet.test.tsx.snap
+++ b/src/import/__snapshots__/ImportWallet.test.tsx.snap
@@ -19,6 +19,7 @@ exports[`ImportWallet renders correctly and is disabled with no text 1`] = `
       ]
     }
     keyboardShouldPersistTaps="always"
+    testID="KeyboardAwareScrollView"
   >
     <View>
       <View

--- a/src/paymentRequest/__snapshots__/PaymentRequestConfirmation.test.tsx.snap
+++ b/src/paymentRequest/__snapshots__/PaymentRequestConfirmation.test.tsx.snap
@@ -32,6 +32,7 @@ exports[`PaymentRequestConfirmation renders correctly for request payment confir
         }
       }
       keyboardShouldPersistTaps="handled"
+      testID="KeyboardAwareScrollView"
     >
       <View>
         <View

--- a/src/paymentRequest/__snapshots__/PaymentRequestConfirmationLegacy.test.tsx.snap
+++ b/src/paymentRequest/__snapshots__/PaymentRequestConfirmationLegacy.test.tsx.snap
@@ -32,6 +32,7 @@ exports[`PaymentRequestConfirmation renders correctly for request payment confir
         }
       }
       keyboardShouldPersistTaps="handled"
+      testID="KeyboardAwareScrollView"
     >
       <View>
         <View

--- a/src/send/ValidateRecipientAccount.tsx
+++ b/src/send/ValidateRecipientAccount.tsx
@@ -278,7 +278,9 @@ export class ValidateRecipientAccount extends React.Component<Props, State> {
           keyboardShouldPersistTaps={'always'}
         >
           <View>
-            <Text style={styles.h2}>{t('confirmAccountNumber.title')}</Text>
+            <Text testID="ConfirmAccountNumber/Title" style={styles.h2}>
+              {t('confirmAccountNumber.title')}
+            </Text>
             <View>{this.renderInstructionsAndInputField()}</View>
             <ErrorMessageInline error={error} />
             <Button

--- a/src/send/__snapshots__/SendConfirmation.test.tsx.snap
+++ b/src/send/__snapshots__/SendConfirmation.test.tsx.snap
@@ -104,6 +104,7 @@ exports[`SendConfirmation renders correctly 1`] = `
         }
       }
       keyboardShouldPersistTaps="handled"
+      testID="KeyboardAwareScrollView"
     >
       <View>
         <View

--- a/src/send/__snapshots__/SendConfirmationLegacy.test.tsx.snap
+++ b/src/send/__snapshots__/SendConfirmationLegacy.test.tsx.snap
@@ -104,6 +104,7 @@ exports[`SendConfirmationLegacy renders correctly 1`] = `
         }
       }
       keyboardShouldPersistTaps="handled"
+      testID="KeyboardAwareScrollView"
     >
       <View>
         <View

--- a/src/send/__snapshots__/ValidateRecipientAccount.test.tsx.snap
+++ b/src/send/__snapshots__/ValidateRecipientAccount.test.tsx.snap
@@ -31,6 +31,7 @@ exports[`ValidateRecipientAccount renders correctly when full validation require
               "paddingVertical": 16,
             }
           }
+          testID="ConfirmAccountNumber/Title"
         >
           confirmAccountNumber.title
         </Text>
@@ -673,6 +674,7 @@ exports[`ValidateRecipientAccount renders correctly when partial validation requ
               "paddingVertical": 16,
             }
           }
+          testID="ConfirmAccountNumber/Title"
         >
           confirmAccountNumber.title
         </Text>

--- a/src/send/__snapshots__/ValidateRecipientAccount.test.tsx.snap
+++ b/src/send/__snapshots__/ValidateRecipientAccount.test.tsx.snap
@@ -18,6 +18,7 @@ exports[`ValidateRecipientAccount renders correctly when full validation require
       }
     }
     keyboardShouldPersistTaps="always"
+    testID="KeyboardAwareScrollView"
   >
     <View>
       <View>
@@ -661,6 +662,7 @@ exports[`ValidateRecipientAccount renders correctly when partial validation requ
       }
     }
     keyboardShouldPersistTaps="always"
+    testID="KeyboardAwareScrollView"
   >
     <View>
       <View>

--- a/src/verify/__snapshots__/VerificationInputScreen.test.tsx.snap
+++ b/src/verify/__snapshots__/VerificationInputScreen.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`VerificationInputScreen renders correctly 1`] = `
         ]
       }
       keyboardShouldPersistTaps="always"
+      testID="KeyboardAwareScrollView"
     >
       <View>
         <RNCSafeAreaView


### PR DESCRIPTION
### Description

- Adds a testID to `KeyboardAwareScrollView`. 
- Uses test util `scrollIntoView` from `e2e/src/utils/utils.js` to scroll the submit button into view.

### Other changes

N/A

### Tested

Tested locally on Android and in CI.

### How others should test

N/A

### Related issues

N/A

### Backwards compatibility

Yes