### PR TITLE
fix(fiatconnect): Small changes to copy/style/function of kyc status screens

### DIFF
--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -1320,7 +1320,7 @@
       "retryable": {
         "title": "ID verification was not accepted.",
         "description": "Please verify again or try a different way to withdraw funds.",
-        "tryAgain": "Try again"
+        "tryAgain": "Verify again"
       },
       "final": {
         "title": "Verification denied.",
@@ -1330,7 +1330,7 @@
     "expired": {
       "title": "ID verification expired.",
       "description": "Please verify again or try a different way to withdraw funds.",
-      "tryAgain": "Try again",
+      "tryAgain": "Verify again",
       "switch": "Switch withdraw method"
     },
     "tryAgainFailed": "There was an error clearing KYC information. Please try again"

--- a/src/fiatconnect/kyc/KycDenied.tsx
+++ b/src/fiatconnect/kyc/KycDenied.tsx
@@ -131,6 +131,7 @@ const styles = StyleSheet.create({
   },
   switchButton: {
     marginTop: 12,
+    marginBottom: 100,
   },
   activityIndicatorContainer: {
     paddingVertical: variables.contentPadding,

--- a/src/fiatconnect/kyc/KycExpired.tsx
+++ b/src/fiatconnect/kyc/KycExpired.tsx
@@ -114,6 +114,7 @@ const styles = StyleSheet.create({
   },
   switchButton: {
     marginTop: 12,
+    marginBottom: 100,
   },
   activityIndicatorContainer: {
     paddingVertical: variables.contentPadding,

--- a/src/fiatconnect/kyc/KycPending.tsx
+++ b/src/fiatconnect/kyc/KycPending.tsx
@@ -1,21 +1,21 @@
+import { KycStatus as FiatConnectKycStatus } from '@fiatconnect/fiatconnect-types'
+import { StackScreenProps } from '@react-navigation/stack'
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 import { StyleSheet, Text, View } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
-import { StackScreenProps } from '@react-navigation/stack'
-import { StackParamList } from 'src/navigator/types'
-import { Screens } from 'src/navigator/Screens'
-import { navigateHome } from 'src/navigator/NavigationService'
-import { useTranslation } from 'react-i18next'
-import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import { FiatExchangeEvents } from 'src/analytics/Events'
-import { KycStatus as FiatConnectKycStatus } from '@fiatconnect/fiatconnect-types'
-import fontStyles from 'src/styles/fonts'
-import colors from 'src/styles/colors'
+import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import Button, { BtnSizes, BtnTypes } from 'src/components/Button'
-import ClockIcon from 'src/icons/ClockIcon'
-import CircledIcon from 'src/icons/CircledIcon'
-import BankIcon from 'src/icons/BankIcon'
 import getNavigationOptions from 'src/fiatconnect/kyc/getNavigationOptions'
+import BankIcon from 'src/icons/BankIcon'
+import CircledIcon from 'src/icons/CircledIcon'
+import ClockIcon from 'src/icons/ClockIcon'
+import { navigateHome } from 'src/navigator/NavigationService'
+import { Screens } from 'src/navigator/Screens'
+import { StackParamList } from 'src/navigator/types'
+import colors from 'src/styles/colors'
+import fontStyles from 'src/styles/fonts'
 
 type Props = StackScreenProps<StackParamList, Screens.KycPending>
 
@@ -95,6 +95,7 @@ const styles = StyleSheet.create({
   },
   button: {
     marginTop: 12,
+    marginBottom: 100,
   },
 })
 

--- a/src/fiatconnect/kyc/getNavigationOptions.tsx
+++ b/src/fiatconnect/kyc/getNavigationOptions.tsx
@@ -1,18 +1,18 @@
+import { KycStatus as FiatConnectKycStatus } from '@fiatconnect/fiatconnect-types'
 import * as React from 'react'
 import { StyleSheet, View } from 'react-native'
-import FiatConnectQuote from 'src/fiatExchanges/quotes/FiatConnectQuote'
-import TextButton from 'src/components/TextButton'
-import i18n from 'src/i18n'
-import CancelButton from 'src/components/CancelButton'
-import { emptyHeader } from 'src/navigator/Headers'
-import { navigate } from 'src/navigator/NavigationService'
-import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import { FiatExchangeEvents } from 'src/analytics/Events'
-import { KycStatus as FiatConnectKycStatus } from '@fiatconnect/fiatconnect-types'
+import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
+import CancelButton from 'src/components/CancelButton'
+import TextButton from 'src/components/TextButton'
+import FiatConnectQuote from 'src/fiatExchanges/quotes/FiatConnectQuote'
+import i18n from 'src/i18n'
+import { emptyHeader } from 'src/navigator/Headers'
+import { navigate, navigateHome } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
+import colors from 'src/styles/colors'
 import fontStyles from 'src/styles/fonts'
 import { Spacing } from 'src/styles/styles'
-import colors from 'src/styles/colors'
 
 const getNavigationOptions = ({
   fiatConnectKycStatus,
@@ -32,26 +32,23 @@ const getNavigationOptions = ({
     })
   }
 
-  const onPressBack = () => {
+  const onPressCancel = () => {
     ValoraAnalytics.track(FiatExchangeEvents.cico_fc_kyc_status_back, {
       provider: quote.getProviderId(),
       flow: quote.flow,
       fiatConnectKycStatus,
     })
-    navigate(Screens.SelectProvider, {
-      flow: quote.flow,
-      selectedCrypto: quote.getCryptoType(),
-      amount: {
-        crypto: Number(quote.getCryptoAmount()),
-        fiat: Number(quote.getFiatAmount()),
-      },
-    })
+    navigateHome()
   }
   return {
     ...emptyHeader,
     headerLeft: () => (
       <View style={styles.cancelBtnContainer}>
-        <CancelButton buttonType="icon" style={styles.cancelBtnContainer} onCancel={onPressBack} />
+        <CancelButton
+          buttonType="icon"
+          style={styles.cancelBtnContainer}
+          onCancel={onPressCancel}
+        />
       </View>
     ),
     headerRight: () => (


### PR DESCRIPTION
### Description

Talked over all changes w/ Nitya & Laura
1. X button in the top left goes to home now
2. Bring the content up so it looks more centered ([Videos of the old ones where the content looks a little low](https://github.com/valora-inc/wallet/pull/2921))
3. Copy change around Re-try kyc button

### Tested

Manually went through[ KYC flows](https://docs.google.com/document/d/1tVSk6KfJu0_I8fTTFMn1WRb-PCuZr4bKNeIyKpa8DAo/edit#) with the changes

<img width="1870" alt="Screen Shot 2022-10-18 at 2 39 31 PM" src="https://user-images.githubusercontent.com/8432644/196549983-9cffdaa1-456d-4a32-b915-ed5b153ea7a7.png">
