### PR TITLE
fix: recovery phrase display

### DIFF
--- a/src/backup/BackupIntroduction.tsx
+++ b/src/backup/BackupIntroduction.tsx
@@ -2,7 +2,6 @@ import { StackScreenProps } from '@react-navigation/stack'
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import { ScrollView, StyleSheet, Text, View } from 'react-native'
-import { SafeAreaView } from 'react-native-safe-area-context'
 import { connect } from 'react-redux'
 import { OnboardingEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
@@ -53,14 +52,14 @@ class BackupIntroduction extends React.Component<Props> {
     const showDrawerTopBar = route.params?.showDrawerTopBar
 
     return (
-      <SafeAreaView style={styles.container}>
+      <View style={styles.container}>
         {showDrawerTopBar && <DrawerTopBar testID="BackupIntroduction/DrawerTopBar" />}
         {backupCompleted ? (
           <AccountKeyPostSetup />
         ) : (
           <AccountKeyIntro onPrimaryPress={this.onPressBackup} />
         )}
-      </SafeAreaView>
+      </View>
     )
   }
 }

--- a/src/backup/BackupPhrase.tsx
+++ b/src/backup/BackupPhrase.tsx
@@ -15,8 +15,10 @@ import CancelConfirm from 'src/backup/CancelConfirm'
 import { getStoredMnemonic, onGetMnemonicFail } from 'src/backup/utils'
 import Button, { BtnSizes, BtnTypes } from 'src/components/Button'
 import CancelButton from 'src/components/CancelButton'
+import CustomHeader from 'src/components/header/CustomHeader'
 import Switch from 'src/components/Switch'
 import { withTranslation } from 'src/i18n'
+import { noHeader } from 'src/navigator/Headers'
 import { navigate, pushToStack } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import { TopBarTextButton } from 'src/navigator/TopBarButton'
@@ -24,6 +26,7 @@ import { StackParamList } from 'src/navigator/types'
 import { RootState } from 'src/redux/reducers'
 import colors from 'src/styles/colors'
 import fontStyles from 'src/styles/fonts'
+import variables from 'src/styles/variables'
 import { currentAccountSelector } from 'src/web3/selectors'
 
 const TAG = 'backup/BackupPhrase'
@@ -52,22 +55,6 @@ const mapStateToProps = (state: RootState): StateProps => {
   return {
     account: currentAccountSelector(state),
     backupCompleted: state.account.backupCompleted,
-  }
-}
-
-export const navOptionsForBackupPhrase = ({
-  route,
-}: StackScreenProps<StackParamList, Screens.BackupPhrase>) => {
-  const navigatedFromSettings = route.params?.navigatedFromSettings
-  return {
-    headerLeft: () => {
-      return navigatedFromSettings ? (
-        <CancelButton style={styles.cancelButton} />
-      ) : (
-        <CancelConfirm screen={TAG} />
-      )
-    },
-    headerRight: () => <HeaderRight />,
   }
 }
 
@@ -123,6 +110,16 @@ class BackupPhrase extends React.Component<Props, State> {
     const navigatedFromSettings = this.navigatedFromSettings()
     return (
       <SafeAreaView style={styles.container}>
+        <CustomHeader
+          left={
+            navigatedFromSettings ? (
+              <CancelButton style={styles.cancelButton} />
+            ) : (
+              <CancelConfirm screen={TAG} />
+            )
+          }
+          right={<HeaderRight />}
+        />
         <ScrollView contentContainerStyle={styles.scrollContainer}>
           <BackupPhraseContainer
             value={mnemonic}
@@ -150,12 +147,17 @@ class BackupPhrase extends React.Component<Props, State> {
               size={BtnSizes.FULL}
               type={BtnTypes.SECONDARY}
               testID="backupKeyContinue"
+              style={styles.continueButton}
             />
           </>
         )}
       </SafeAreaView>
     )
   }
+}
+
+export const navOptionsForBackupPhrase = {
+  ...noHeader,
 }
 
 function HeaderRight() {
@@ -171,11 +173,12 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     justifyContent: 'space-between',
-    padding: 16,
   },
   scrollContainer: {
     flexGrow: 1,
     paddingBottom: 16,
+    justifyContent: 'space-between',
+    padding: variables.contentPadding,
   },
   body: {
     ...fontStyles.regular,
@@ -185,6 +188,7 @@ const styles = StyleSheet.create({
     marginVertical: 16,
     flexDirection: 'row',
     alignItems: 'center',
+    paddingHorizontal: variables.contentPadding,
   },
   confirmationSwitchLabel: {
     flex: 1,
@@ -193,6 +197,9 @@ const styles = StyleSheet.create({
   },
   cancelButton: {
     color: colors.gray4,
+  },
+  continueButton: {
+    paddingHorizontal: variables.contentPadding,
   },
 })
 

--- a/src/backup/__snapshots__/BackupPhrase.test.tsx.snap
+++ b/src/backup/__snapshots__/BackupPhrase.test.tsx.snap
@@ -6,14 +6,389 @@ exports[`renders correctly with backup completed 1`] = `
     Object {
       "flex": 1,
       "justifyContent": "space-between",
-      "padding": 16,
     }
   }
 >
+  <View
+    style={
+      Object {
+        "alignItems": "center",
+        "flexDirection": "row",
+        "height": 56,
+        "justifyContent": "space-between",
+        "overflow": "hidden",
+        "width": "100%",
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "alignItems": "center",
+          "height": "100%",
+          "justifyContent": "center",
+        }
+      }
+    >
+      <Modal
+        animationType="none"
+        deviceHeight={null}
+        deviceWidth={null}
+        hardwareAccelerated={false}
+        hideModalContentWhileAnimating={false}
+        onBackdropPress={[Function]}
+        onModalHide={[Function]}
+        onModalWillHide={[Function]}
+        onModalWillShow={[Function]}
+        onRequestClose={[Function]}
+        panResponderThreshold={4}
+        scrollHorizontal={false}
+        scrollOffset={0}
+        scrollOffsetMax={0}
+        scrollTo={null}
+        statusBarTranslucent={true}
+        supportedOrientations={
+          Array [
+            "portrait",
+            "landscape",
+          ]
+        }
+        swipeThreshold={100}
+        transparent={true}
+        visible={false}
+      >
+        <View
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          forwardedRef={[Function]}
+          nativeID="animatedComponent"
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "backgroundColor": "black",
+              "bottom": 0,
+              "height": 1334,
+              "left": 0,
+              "opacity": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+              "width": 750,
+            }
+          }
+        />
+        <View
+          collapsable={false}
+          deviceHeight={null}
+          deviceWidth={null}
+          forwardedRef={[Function]}
+          hideModalContentWhileAnimating={false}
+          nativeID="animatedComponent"
+          onBackdropPress={[Function]}
+          onModalHide={[Function]}
+          onModalWillHide={[Function]}
+          onModalWillShow={[Function]}
+          panResponderThreshold={4}
+          pointerEvents="box-none"
+          scrollHorizontal={false}
+          scrollOffset={0}
+          scrollOffsetMax={0}
+          scrollTo={null}
+          statusBarTranslucent={true}
+          style={
+            Object {
+              "flex": 1,
+              "justifyContent": "center",
+              "margin": 37.5,
+              "transform": Array [
+                Object {
+                  "translateY": 0,
+                },
+              ],
+            }
+          }
+          supportedOrientations={
+            Array [
+              "portrait",
+              "landscape",
+            ]
+          }
+          swipeThreshold={100}
+        >
+          <RNCSafeAreaView>
+            <View
+              style={
+                Array [
+                  Object {
+                    "backgroundColor": "#FFFFFF",
+                    "padding": 16,
+                  },
+                  Object {
+                    "borderRadius": 8,
+                  },
+                  Object {
+                    "elevation": 12,
+                    "shadowColor": "rgba(156, 164, 169, 0.4)",
+                    "shadowOffset": Object {
+                      "height": 2,
+                      "width": 0,
+                    },
+                    "shadowOpacity": 1,
+                    "shadowRadius": 12,
+                  },
+                  Array [
+                    Object {
+                      "backgroundColor": "#FFFFFF",
+                      "maxHeight": "100%",
+                      "padding": 24,
+                    },
+                    undefined,
+                  ],
+                ]
+              }
+            >
+              <RCTScrollView
+                contentContainerStyle={
+                  Object {
+                    "alignItems": "center",
+                  }
+                }
+              >
+                <View>
+                  <Text
+                    style={
+                      Object {
+                        "color": "#2E3338",
+                        "fontFamily": "Jost-Medium",
+                        "fontSize": 22,
+                        "lineHeight": 28,
+                        "marginBottom": 12,
+                        "textAlign": "center",
+                      }
+                    }
+                  >
+                    cancelDialog.title
+                  </Text>
+                  <Text
+                    style={
+                      Object {
+                        "color": "#2E3338",
+                        "fontFamily": "Inter-Regular",
+                        "fontSize": 16,
+                        "lineHeight": 22,
+                        "marginBottom": 24,
+                        "textAlign": "center",
+                      }
+                    }
+                  >
+                    cancelDialog.body
+                  </Text>
+                </View>
+              </RCTScrollView>
+              <View
+                style={
+                  Object {
+                    "flexDirection": "row",
+                    "flexWrap": "wrap",
+                    "justifyContent": "space-around",
+                    "maxWidth": "100%",
+                  }
+                }
+              >
+                <View
+                  accessible={true}
+                  focusable={true}
+                  nativeBackgroundAndroid={
+                    Object {
+                      "attribute": "selectableItemBackgroundBorderless",
+                      "rippleRadius": undefined,
+                      "type": "ThemeAttrAndroid",
+                    }
+                  }
+                  onClick={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                >
+                  <Text
+                    style={
+                      Array [
+                        Object {
+                          "color": "#1AB775",
+                          "fontFamily": "Inter-SemiBold",
+                          "fontSize": 16,
+                          "lineHeight": 22,
+                        },
+                        Object {
+                          "color": "#9CA4A9",
+                          "paddingTop": 16,
+                        },
+                      ]
+                    }
+                  >
+                    cancelDialog.secondary
+                  </Text>
+                </View>
+                <View
+                  accessible={true}
+                  focusable={true}
+                  nativeBackgroundAndroid={
+                    Object {
+                      "attribute": "selectableItemBackgroundBorderless",
+                      "rippleRadius": undefined,
+                      "type": "ThemeAttrAndroid",
+                    }
+                  }
+                  onClick={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                >
+                  <Text
+                    style={
+                      Array [
+                        Object {
+                          "color": "#1AB775",
+                          "fontFamily": "Inter-SemiBold",
+                          "fontSize": 16,
+                          "lineHeight": 22,
+                        },
+                        Object {
+                          "paddingTop": 16,
+                        },
+                      ]
+                    }
+                  >
+                    cancelDialog.action
+                  </Text>
+                </View>
+              </View>
+            </View>
+          </RNCSafeAreaView>
+        </View>
+      </Modal>
+      <View
+        accessible={true}
+        focusable={true}
+        hitSlop={
+          Object {
+            "bottom": 10,
+            "left": 10,
+            "right": 10,
+            "top": 10,
+          }
+        }
+        nativeBackgroundAndroid={
+          Object {
+            "attribute": "selectableItemBackgroundBorderless",
+            "rippleRadius": undefined,
+            "type": "ThemeAttrAndroid",
+          }
+        }
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        testID="CancelButton"
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "#1AB775",
+                "fontFamily": "Inter-Regular",
+                "fontSize": 16,
+                "lineHeight": 22,
+                "paddingHorizontal": 24,
+              },
+              Array [
+                Object {
+                  "color": "#2E3338",
+                },
+                Object {
+                  "color": "#9CA4A9",
+                },
+              ],
+            ]
+          }
+        >
+          cancel
+        </Text>
+      </View>
+    </View>
+    <View
+      style={
+        Object {
+          "alignItems": "center",
+          "height": "100%",
+          "justifyContent": "center",
+        }
+      }
+    >
+      <View
+        accessible={true}
+        focusable={true}
+        hitSlop={
+          Object {
+            "bottom": 10,
+            "left": 10,
+            "right": 10,
+            "top": 10,
+          }
+        }
+        nativeBackgroundAndroid={
+          Object {
+            "attribute": "selectableItemBackgroundBorderless",
+            "rippleRadius": undefined,
+            "type": "ThemeAttrAndroid",
+          }
+        }
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+      >
+        <Text
+          style={
+            Object {
+              "color": "#1AB775",
+              "fontFamily": "Inter-Regular",
+              "fontSize": 16,
+              "lineHeight": 22,
+              "paddingHorizontal": 24,
+            }
+          }
+        >
+          moreInfo
+        </Text>
+      </View>
+    </View>
+  </View>
   <RCTScrollView
     contentContainerStyle={
       Object {
         "flexGrow": 1,
+        "justifyContent": "space-between",
+        "padding": 16,
         "paddingBottom": 16,
       }
     }
@@ -102,14 +477,389 @@ exports[`renders correctly with backup not completed 1`] = `
     Object {
       "flex": 1,
       "justifyContent": "space-between",
-      "padding": 16,
     }
   }
 >
+  <View
+    style={
+      Object {
+        "alignItems": "center",
+        "flexDirection": "row",
+        "height": 56,
+        "justifyContent": "space-between",
+        "overflow": "hidden",
+        "width": "100%",
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "alignItems": "center",
+          "height": "100%",
+          "justifyContent": "center",
+        }
+      }
+    >
+      <Modal
+        animationType="none"
+        deviceHeight={null}
+        deviceWidth={null}
+        hardwareAccelerated={false}
+        hideModalContentWhileAnimating={false}
+        onBackdropPress={[Function]}
+        onModalHide={[Function]}
+        onModalWillHide={[Function]}
+        onModalWillShow={[Function]}
+        onRequestClose={[Function]}
+        panResponderThreshold={4}
+        scrollHorizontal={false}
+        scrollOffset={0}
+        scrollOffsetMax={0}
+        scrollTo={null}
+        statusBarTranslucent={true}
+        supportedOrientations={
+          Array [
+            "portrait",
+            "landscape",
+          ]
+        }
+        swipeThreshold={100}
+        transparent={true}
+        visible={false}
+      >
+        <View
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          forwardedRef={[Function]}
+          nativeID="animatedComponent"
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "backgroundColor": "black",
+              "bottom": 0,
+              "height": 1334,
+              "left": 0,
+              "opacity": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+              "width": 750,
+            }
+          }
+        />
+        <View
+          collapsable={false}
+          deviceHeight={null}
+          deviceWidth={null}
+          forwardedRef={[Function]}
+          hideModalContentWhileAnimating={false}
+          nativeID="animatedComponent"
+          onBackdropPress={[Function]}
+          onModalHide={[Function]}
+          onModalWillHide={[Function]}
+          onModalWillShow={[Function]}
+          panResponderThreshold={4}
+          pointerEvents="box-none"
+          scrollHorizontal={false}
+          scrollOffset={0}
+          scrollOffsetMax={0}
+          scrollTo={null}
+          statusBarTranslucent={true}
+          style={
+            Object {
+              "flex": 1,
+              "justifyContent": "center",
+              "margin": 37.5,
+              "transform": Array [
+                Object {
+                  "translateY": 0,
+                },
+              ],
+            }
+          }
+          supportedOrientations={
+            Array [
+              "portrait",
+              "landscape",
+            ]
+          }
+          swipeThreshold={100}
+        >
+          <RNCSafeAreaView>
+            <View
+              style={
+                Array [
+                  Object {
+                    "backgroundColor": "#FFFFFF",
+                    "padding": 16,
+                  },
+                  Object {
+                    "borderRadius": 8,
+                  },
+                  Object {
+                    "elevation": 12,
+                    "shadowColor": "rgba(156, 164, 169, 0.4)",
+                    "shadowOffset": Object {
+                      "height": 2,
+                      "width": 0,
+                    },
+                    "shadowOpacity": 1,
+                    "shadowRadius": 12,
+                  },
+                  Array [
+                    Object {
+                      "backgroundColor": "#FFFFFF",
+                      "maxHeight": "100%",
+                      "padding": 24,
+                    },
+                    undefined,
+                  ],
+                ]
+              }
+            >
+              <RCTScrollView
+                contentContainerStyle={
+                  Object {
+                    "alignItems": "center",
+                  }
+                }
+              >
+                <View>
+                  <Text
+                    style={
+                      Object {
+                        "color": "#2E3338",
+                        "fontFamily": "Jost-Medium",
+                        "fontSize": 22,
+                        "lineHeight": 28,
+                        "marginBottom": 12,
+                        "textAlign": "center",
+                      }
+                    }
+                  >
+                    cancelDialog.title
+                  </Text>
+                  <Text
+                    style={
+                      Object {
+                        "color": "#2E3338",
+                        "fontFamily": "Inter-Regular",
+                        "fontSize": 16,
+                        "lineHeight": 22,
+                        "marginBottom": 24,
+                        "textAlign": "center",
+                      }
+                    }
+                  >
+                    cancelDialog.body
+                  </Text>
+                </View>
+              </RCTScrollView>
+              <View
+                style={
+                  Object {
+                    "flexDirection": "row",
+                    "flexWrap": "wrap",
+                    "justifyContent": "space-around",
+                    "maxWidth": "100%",
+                  }
+                }
+              >
+                <View
+                  accessible={true}
+                  focusable={true}
+                  nativeBackgroundAndroid={
+                    Object {
+                      "attribute": "selectableItemBackgroundBorderless",
+                      "rippleRadius": undefined,
+                      "type": "ThemeAttrAndroid",
+                    }
+                  }
+                  onClick={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                >
+                  <Text
+                    style={
+                      Array [
+                        Object {
+                          "color": "#1AB775",
+                          "fontFamily": "Inter-SemiBold",
+                          "fontSize": 16,
+                          "lineHeight": 22,
+                        },
+                        Object {
+                          "color": "#9CA4A9",
+                          "paddingTop": 16,
+                        },
+                      ]
+                    }
+                  >
+                    cancelDialog.secondary
+                  </Text>
+                </View>
+                <View
+                  accessible={true}
+                  focusable={true}
+                  nativeBackgroundAndroid={
+                    Object {
+                      "attribute": "selectableItemBackgroundBorderless",
+                      "rippleRadius": undefined,
+                      "type": "ThemeAttrAndroid",
+                    }
+                  }
+                  onClick={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                >
+                  <Text
+                    style={
+                      Array [
+                        Object {
+                          "color": "#1AB775",
+                          "fontFamily": "Inter-SemiBold",
+                          "fontSize": 16,
+                          "lineHeight": 22,
+                        },
+                        Object {
+                          "paddingTop": 16,
+                        },
+                      ]
+                    }
+                  >
+                    cancelDialog.action
+                  </Text>
+                </View>
+              </View>
+            </View>
+          </RNCSafeAreaView>
+        </View>
+      </Modal>
+      <View
+        accessible={true}
+        focusable={true}
+        hitSlop={
+          Object {
+            "bottom": 10,
+            "left": 10,
+            "right": 10,
+            "top": 10,
+          }
+        }
+        nativeBackgroundAndroid={
+          Object {
+            "attribute": "selectableItemBackgroundBorderless",
+            "rippleRadius": undefined,
+            "type": "ThemeAttrAndroid",
+          }
+        }
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        testID="CancelButton"
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "#1AB775",
+                "fontFamily": "Inter-Regular",
+                "fontSize": 16,
+                "lineHeight": 22,
+                "paddingHorizontal": 24,
+              },
+              Array [
+                Object {
+                  "color": "#2E3338",
+                },
+                Object {
+                  "color": "#9CA4A9",
+                },
+              ],
+            ]
+          }
+        >
+          cancel
+        </Text>
+      </View>
+    </View>
+    <View
+      style={
+        Object {
+          "alignItems": "center",
+          "height": "100%",
+          "justifyContent": "center",
+        }
+      }
+    >
+      <View
+        accessible={true}
+        focusable={true}
+        hitSlop={
+          Object {
+            "bottom": 10,
+            "left": 10,
+            "right": 10,
+            "top": 10,
+          }
+        }
+        nativeBackgroundAndroid={
+          Object {
+            "attribute": "selectableItemBackgroundBorderless",
+            "rippleRadius": undefined,
+            "type": "ThemeAttrAndroid",
+          }
+        }
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+      >
+        <Text
+          style={
+            Object {
+              "color": "#1AB775",
+              "fontFamily": "Inter-Regular",
+              "fontSize": 16,
+              "lineHeight": 22,
+              "paddingHorizontal": 24,
+            }
+          }
+        >
+          moreInfo
+        </Text>
+      </View>
+    </View>
+  </View>
   <RCTScrollView
     contentContainerStyle={
       Object {
         "flexGrow": 1,
+        "justifyContent": "space-between",
+        "padding": 16,
         "paddingBottom": 16,
       }
     }
@@ -195,6 +945,7 @@ exports[`renders correctly with backup not completed 1`] = `
         "alignItems": "center",
         "flexDirection": "row",
         "marginVertical": 16,
+        "paddingHorizontal": 16,
       }
     }
   >
@@ -233,7 +984,9 @@ exports[`renders correctly with backup not completed 1`] = `
         Object {
           "flexDirection": "column",
         },
-        undefined,
+        Object {
+          "paddingHorizontal": 16,
+        },
       ]
     }
   >
@@ -313,14 +1066,389 @@ exports[`still renders when mnemonic doesnt show up 1`] = `
     Object {
       "flex": 1,
       "justifyContent": "space-between",
-      "padding": 16,
     }
   }
 >
+  <View
+    style={
+      Object {
+        "alignItems": "center",
+        "flexDirection": "row",
+        "height": 56,
+        "justifyContent": "space-between",
+        "overflow": "hidden",
+        "width": "100%",
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "alignItems": "center",
+          "height": "100%",
+          "justifyContent": "center",
+        }
+      }
+    >
+      <Modal
+        animationType="none"
+        deviceHeight={null}
+        deviceWidth={null}
+        hardwareAccelerated={false}
+        hideModalContentWhileAnimating={false}
+        onBackdropPress={[Function]}
+        onModalHide={[Function]}
+        onModalWillHide={[Function]}
+        onModalWillShow={[Function]}
+        onRequestClose={[Function]}
+        panResponderThreshold={4}
+        scrollHorizontal={false}
+        scrollOffset={0}
+        scrollOffsetMax={0}
+        scrollTo={null}
+        statusBarTranslucent={true}
+        supportedOrientations={
+          Array [
+            "portrait",
+            "landscape",
+          ]
+        }
+        swipeThreshold={100}
+        transparent={true}
+        visible={false}
+      >
+        <View
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          forwardedRef={[Function]}
+          nativeID="animatedComponent"
+          onClick={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "backgroundColor": "black",
+              "bottom": 0,
+              "height": 1334,
+              "left": 0,
+              "opacity": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+              "width": 750,
+            }
+          }
+        />
+        <View
+          collapsable={false}
+          deviceHeight={null}
+          deviceWidth={null}
+          forwardedRef={[Function]}
+          hideModalContentWhileAnimating={false}
+          nativeID="animatedComponent"
+          onBackdropPress={[Function]}
+          onModalHide={[Function]}
+          onModalWillHide={[Function]}
+          onModalWillShow={[Function]}
+          panResponderThreshold={4}
+          pointerEvents="box-none"
+          scrollHorizontal={false}
+          scrollOffset={0}
+          scrollOffsetMax={0}
+          scrollTo={null}
+          statusBarTranslucent={true}
+          style={
+            Object {
+              "flex": 1,
+              "justifyContent": "center",
+              "margin": 37.5,
+              "transform": Array [
+                Object {
+                  "translateY": 0,
+                },
+              ],
+            }
+          }
+          supportedOrientations={
+            Array [
+              "portrait",
+              "landscape",
+            ]
+          }
+          swipeThreshold={100}
+        >
+          <RNCSafeAreaView>
+            <View
+              style={
+                Array [
+                  Object {
+                    "backgroundColor": "#FFFFFF",
+                    "padding": 16,
+                  },
+                  Object {
+                    "borderRadius": 8,
+                  },
+                  Object {
+                    "elevation": 12,
+                    "shadowColor": "rgba(156, 164, 169, 0.4)",
+                    "shadowOffset": Object {
+                      "height": 2,
+                      "width": 0,
+                    },
+                    "shadowOpacity": 1,
+                    "shadowRadius": 12,
+                  },
+                  Array [
+                    Object {
+                      "backgroundColor": "#FFFFFF",
+                      "maxHeight": "100%",
+                      "padding": 24,
+                    },
+                    undefined,
+                  ],
+                ]
+              }
+            >
+              <RCTScrollView
+                contentContainerStyle={
+                  Object {
+                    "alignItems": "center",
+                  }
+                }
+              >
+                <View>
+                  <Text
+                    style={
+                      Object {
+                        "color": "#2E3338",
+                        "fontFamily": "Jost-Medium",
+                        "fontSize": 22,
+                        "lineHeight": 28,
+                        "marginBottom": 12,
+                        "textAlign": "center",
+                      }
+                    }
+                  >
+                    cancelDialog.title
+                  </Text>
+                  <Text
+                    style={
+                      Object {
+                        "color": "#2E3338",
+                        "fontFamily": "Inter-Regular",
+                        "fontSize": 16,
+                        "lineHeight": 22,
+                        "marginBottom": 24,
+                        "textAlign": "center",
+                      }
+                    }
+                  >
+                    cancelDialog.body
+                  </Text>
+                </View>
+              </RCTScrollView>
+              <View
+                style={
+                  Object {
+                    "flexDirection": "row",
+                    "flexWrap": "wrap",
+                    "justifyContent": "space-around",
+                    "maxWidth": "100%",
+                  }
+                }
+              >
+                <View
+                  accessible={true}
+                  focusable={true}
+                  nativeBackgroundAndroid={
+                    Object {
+                      "attribute": "selectableItemBackgroundBorderless",
+                      "rippleRadius": undefined,
+                      "type": "ThemeAttrAndroid",
+                    }
+                  }
+                  onClick={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                >
+                  <Text
+                    style={
+                      Array [
+                        Object {
+                          "color": "#1AB775",
+                          "fontFamily": "Inter-SemiBold",
+                          "fontSize": 16,
+                          "lineHeight": 22,
+                        },
+                        Object {
+                          "color": "#9CA4A9",
+                          "paddingTop": 16,
+                        },
+                      ]
+                    }
+                  >
+                    cancelDialog.secondary
+                  </Text>
+                </View>
+                <View
+                  accessible={true}
+                  focusable={true}
+                  nativeBackgroundAndroid={
+                    Object {
+                      "attribute": "selectableItemBackgroundBorderless",
+                      "rippleRadius": undefined,
+                      "type": "ThemeAttrAndroid",
+                    }
+                  }
+                  onClick={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                >
+                  <Text
+                    style={
+                      Array [
+                        Object {
+                          "color": "#1AB775",
+                          "fontFamily": "Inter-SemiBold",
+                          "fontSize": 16,
+                          "lineHeight": 22,
+                        },
+                        Object {
+                          "paddingTop": 16,
+                        },
+                      ]
+                    }
+                  >
+                    cancelDialog.action
+                  </Text>
+                </View>
+              </View>
+            </View>
+          </RNCSafeAreaView>
+        </View>
+      </Modal>
+      <View
+        accessible={true}
+        focusable={true}
+        hitSlop={
+          Object {
+            "bottom": 10,
+            "left": 10,
+            "right": 10,
+            "top": 10,
+          }
+        }
+        nativeBackgroundAndroid={
+          Object {
+            "attribute": "selectableItemBackgroundBorderless",
+            "rippleRadius": undefined,
+            "type": "ThemeAttrAndroid",
+          }
+        }
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        testID="CancelButton"
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "#1AB775",
+                "fontFamily": "Inter-Regular",
+                "fontSize": 16,
+                "lineHeight": 22,
+                "paddingHorizontal": 24,
+              },
+              Array [
+                Object {
+                  "color": "#2E3338",
+                },
+                Object {
+                  "color": "#9CA4A9",
+                },
+              ],
+            ]
+          }
+        >
+          cancel
+        </Text>
+      </View>
+    </View>
+    <View
+      style={
+        Object {
+          "alignItems": "center",
+          "height": "100%",
+          "justifyContent": "center",
+        }
+      }
+    >
+      <View
+        accessible={true}
+        focusable={true}
+        hitSlop={
+          Object {
+            "bottom": 10,
+            "left": 10,
+            "right": 10,
+            "top": 10,
+          }
+        }
+        nativeBackgroundAndroid={
+          Object {
+            "attribute": "selectableItemBackgroundBorderless",
+            "rippleRadius": undefined,
+            "type": "ThemeAttrAndroid",
+          }
+        }
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+      >
+        <Text
+          style={
+            Object {
+              "color": "#1AB775",
+              "fontFamily": "Inter-Regular",
+              "fontSize": 16,
+              "lineHeight": 22,
+              "paddingHorizontal": 24,
+            }
+          }
+        >
+          moreInfo
+        </Text>
+      </View>
+    </View>
+  </View>
   <RCTScrollView
     contentContainerStyle={
       Object {
         "flexGrow": 1,
+        "justifyContent": "space-between",
+        "padding": 16,
         "paddingBottom": 16,
       }
     }


### PR DESCRIPTION
### Description
Header was double height - less visible in the screenshots, but on smaller screens it was evident. Most of the lines are from a new snapshot.
Fixes the header display for the recovery phrase quiz.
Fixes the header display for the recovery phrase display.

#### Screenshots Before
<p align="center">
<img src="https://user-images.githubusercontent.com/26950305/196828751-9838cc8c-f740-46b4-90ee-f73a61d008dd.png" width="48%" height="auto" />
<img src="https://user-images.githubusercontent.com/26950305/196828774-d105e1cb-6083-4f53-8253-970993dd56b7.png" width="48%" height="auto" />
</p>


#### Screenshots After
<p align="center">
<img src="https://user-images.githubusercontent.com/26950305/196828699-1669e7b2-7cd7-443a-bc4e-041013841c7f.png" width="48%" height="auto" />
<img src="https://user-images.githubusercontent.com/26950305/196828684-5a665946-a245-46e2-9a26-af276400918c.png" width="48%" height="auto" />
</p>

### Other changes

Snapshots updated.

### Tested

Tested locally in iOS and Android

### How others should test

1. Navigate to Recovery Phrase Quiz - either from reset or from onboarding.
2. Check Headers and layout.
3. Complete quiz.
4. After completing the Recovery Phrase Quiz check the headers and layout.

### Related issues

N/A

### Backwards compatibility

Yes