### PR TITLE
feat: auto focus on code input for CPV verification

### DIFF
--- a/src/components/CodeInput.tsx
+++ b/src/components/CodeInput.tsx
@@ -41,6 +41,7 @@ export interface Props {
   testID?: string
   style?: StyleProp<ViewStyle>
   shortVerificationCodesEnabled?: boolean
+  autoFocus?: boolean
 }
 
 export default function CodeInput({
@@ -56,6 +57,7 @@ export default function CodeInput({
   testID,
   style,
   shortVerificationCodesEnabled = true,
+  autoFocus,
 }: Props) {
   const [forceShowingPasteIcon, clipboardContent, getFreshClipboardContent] = useClipboard()
 
@@ -159,6 +161,7 @@ export default function CodeInput({
                       : undefined,
                 }}
                 autoCapitalize="none"
+                autoFocus={autoFocus}
                 testID={testID}
               />
             ) : (

--- a/src/verify/VerificationCodeInputScreen.tsx
+++ b/src/verify/VerificationCodeInputScreen.tsx
@@ -120,6 +120,7 @@ function VerificationCodeInputScreen({
           {t('phoneVerificationInput.description', { phoneNumber: route.params.e164Number })}
         </Text>
         <CodeInput
+          autoFocus
           status={codeInputStatus}
           inputValue={code}
           inputPlaceholder={t('phoneVerificationInput.codeInputPlaceholder')}


### PR DESCRIPTION
### Description

As the title

### Other changes

N/A

### Tested

Manually

### How others should test

See that the sms verification code input is automatically focused when going through the CPV flow.

### Related issues

N/A

### Backwards compatibility

Yes