### PR TITLE
fix(deep link): Remove duplicate block handling dynamic links on iOS

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -105,14 +105,6 @@ export class App extends React.Component<Props> {
         this.handleOpenURL({ url })
       )
 
-      if (Platform.OS === 'ios') {
-        const firebaseUrl = await dynamicLinks().getInitialLink()
-
-        if (firebaseUrl) {
-          await this.handleOpenURL({ url: firebaseUrl.url })
-        }
-      }
-
       // On Android, initial deep links are picked up by CleverTap - even if they were created by Firebase DynamicLinks.
       // Breaking out here on Android avoids events being tracked multiple times.
       if (Platform.OS === 'ios') {


### PR DESCRIPTION
### Description

Removes a duplicate block of code for handling Deep Links on iOS. I believe it was added via a bad merge.

When @kathaypacific was testing the analytics around the invite link, I believe she reported seeing some duplicate events. This is likely the cause.

### Other changes

N/A

### Tested

N/A

### How others should test

I would appreciate some help testing on iOS, as I don't have an iOS device to test on.

### Related issues

N/A

### Backwards compatibility

N/A