### PR TITLE
chore(ci): Use node 16 for the licenses check

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -83,7 +83,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: '12'
+          node-version: '16'
           check-latest: true
       # https://github.com/actions/cache/blob/main/examples.md#node---lerna
       - uses: actions/cache@v2


### PR DESCRIPTION
### Description

It looks like this one was just missed when we originally switched all the checks to node 16 in https://github.com/valora-inc/wallet/pull/2474/files
