### PR TITLE
fix(fiatconnect): pass address to getQuotes

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@celo/wallet-rpc": "~1.2.0",
     "@coinbase/cbpay-js": "^1.0.2",
     "@crowdin/ota-client": "^0.4.0",
-    "@fiatconnect/fiatconnect-sdk": "^0.3.9",
+    "@fiatconnect/fiatconnect-sdk": "^0.4.0",
     "@fiatconnect/fiatconnect-types": "^8.0.0",
     "@google-cloud/storage": "^5.16.1",
     "@gorhom/bottom-sheet": "^4.3.2",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@coinbase/cbpay-js": "^1.0.2",
     "@crowdin/ota-client": "^0.4.0",
     "@fiatconnect/fiatconnect-sdk": "^0.3.9",
-    "@fiatconnect/fiatconnect-types": "^7.0.3",
+    "@fiatconnect/fiatconnect-types": "^8.0.0",
     "@google-cloud/storage": "^5.16.1",
     "@gorhom/bottom-sheet": "^4.3.2",
     "@komenci/contracts": "1.1.0",

--- a/src/fiatconnect/index.test.ts
+++ b/src/fiatconnect/index.test.ts
@@ -131,6 +131,7 @@ describe('FiatConnect helpers', () => {
       cryptoAmount: 100,
       country: 'US',
       fiatConnectProviders: mockFiatConnectProviderInfo,
+      address: '0xabc',
     }
     it('returns an empty array if fiatType is not supported', async () => {
       const quotes = await getFiatConnectQuotes({

--- a/src/fiatconnect/index.test.ts
+++ b/src/fiatconnect/index.test.ts
@@ -112,6 +112,7 @@ describe('FiatConnect helpers', () => {
           termsAndConditionsUrl: 'https://fake-provider.valoraapp.com/terms',
         },
       ],
+      address: '0xabc',
     }
     it('returns an empty array if fiatConnectCashInEnabled is false with cash in', async () => {
       const quotes = await fetchQuotes(fetchQuotesInput)

--- a/src/fiatconnect/index.ts
+++ b/src/fiatconnect/index.ts
@@ -106,6 +106,7 @@ export type QuotesInput = {
   digitalAsset: CiCoCurrency
   cryptoAmount: number
   country: string
+  address: string
 }
 
 export type GetFiatConnectQuotesResponse = {
@@ -127,7 +128,15 @@ export type FiatConnectQuoteSuccess = {
 export async function getFiatConnectQuotes(
   params: QuotesInput
 ): Promise<(FiatConnectQuoteSuccess | FiatConnectQuoteError)[]> {
-  const { fiatConnectProviders, localCurrency, digitalAsset, cryptoAmount, country, flow } = params
+  const {
+    fiatConnectProviders,
+    localCurrency,
+    digitalAsset,
+    cryptoAmount,
+    country,
+    flow,
+    address,
+  } = params
   const fiatType = convertToFiatConnectFiatCurrency(localCurrency)
   if (!fiatType) return []
   const cryptoType = convertToFiatConnectCryptoCurrency(digitalAsset)
@@ -136,6 +145,7 @@ export async function getFiatConnectQuotes(
     cryptoType,
     cryptoAmount: cryptoAmount.toString(),
     country,
+    address,
   }
   const providers = fiatConnectProviders.map((provider) => provider.id).join(',')
   const queryParams = new URLSearchParams({

--- a/yarn.lock
+++ b/yarn.lock
@@ -3262,24 +3262,19 @@
   resolved "https://registry.yarnpkg.com/@faker-js/faker/-/faker-5.5.3.tgz#18e3af6b8eae7984072bbeb0c0858474d7c4cefe"
   integrity sha512-R11tGE6yIFwqpaIqcfkcg7AICXzFg14+5h5v0TfF/9+RMDL6jhzCy/pxHVOfbALGdtVYdt6JdR21tuxEgl34dw==
 
-"@fiatconnect/fiatconnect-sdk@^0.3.9":
-  version "0.3.9"
-  resolved "https://registry.yarnpkg.com/@fiatconnect/fiatconnect-sdk/-/fiatconnect-sdk-0.3.9.tgz#ce7f9ea373251428c4bad1ac6208e424dcff5cb9"
-  integrity sha512-29vDo+cUPNEewDaeUCJUecZV6rwDPT10JoGkKt3FVAGEGUIsyb1Ad6SBYon0wjoj8suLjH6X3JA+LV/TnvR3RA==
+"@fiatconnect/fiatconnect-sdk@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@fiatconnect/fiatconnect-sdk/-/fiatconnect-sdk-0.4.0.tgz#dd5c79cc4c84ded86b42fa9aa52f75ef5f02714f"
+  integrity sha512-Es/rl2pGNs2G5tviRcz7WmBdtFqAyVom77jIHvqMXdCqsTNK/IifxcHQ78jmxY/IO6Mbstaar9p9kmMe6Qg7bw==
   dependencies:
     "@badrap/result" "^0.2.12"
-    "@fiatconnect/fiatconnect-types" "^7.0.3"
+    "@fiatconnect/fiatconnect-types" "^8.0.0"
     cross-fetch "^3.1.5"
     ethers "^5.7.1"
     fetch-cookie "^2.0.3"
     siwe "^1.1.6"
     tough-cookie "^4.0.0"
     tslib "^2.4.0"
-
-"@fiatconnect/fiatconnect-types@^7.0.3":
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/@fiatconnect/fiatconnect-types/-/fiatconnect-types-7.0.3.tgz#1fa8b840fd21f56b861af985d50c2b32847f7242"
-  integrity sha512-q5OIHatju8jMjghMoC68u+ZkSPL8GYpZv+FgQvFVCBRxXMy3SoBlAU6PGO2Cm6OMJRZG299rBPkq07zObm0gWQ==
 
 "@fiatconnect/fiatconnect-types@^8.0.0":
   version "8.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3281,6 +3281,11 @@
   resolved "https://registry.yarnpkg.com/@fiatconnect/fiatconnect-types/-/fiatconnect-types-7.0.3.tgz#1fa8b840fd21f56b861af985d50c2b32847f7242"
   integrity sha512-q5OIHatju8jMjghMoC68u+ZkSPL8GYpZv+FgQvFVCBRxXMy3SoBlAU6PGO2Cm6OMJRZG299rBPkq07zObm0gWQ==
 
+"@fiatconnect/fiatconnect-types@^8.0.0":
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/@fiatconnect/fiatconnect-types/-/fiatconnect-types-8.0.0.tgz#35c539e409495777670c4e56eebfeacb25143b2c"
+  integrity sha512-Hvy/SXSWMlgiO69Uu/5v2pKDckPt+ZZHlMcahBtQh4pon5Ic7QgFVr70S8s8iAqRMpbC/Jksg9lo80qJuhXuOA==
+
 "@google-cloud/common@^3.8.1":
   version "3.8.1"
   resolved "https://registry.yarnpkg.com/@google-cloud/common/-/common-3.8.1.tgz#1313c55bb66df88f69bf7c828135fae25fbd2036"


### PR DESCRIPTION
### Description

Related to https://github.com/valora-inc/valora-rest-api/pull/183. 

### Other changes

Changed deprecated currentAccountSelector to walletAddressSelector in fiatconnect/saga.ts

### Tested

Unit tests, manual by running the app and checking the request includes address on flipper


### How others should test

1. Navigate to Add or Withdraw
2. Select withdraw funds
3. Choose any currency and enter any amount
4. Ensure "Bank Account" shows up in the Select Provider screen

### Related issues

N/A

### Backwards compatibility

N/A