### PR TITLE
feat(notifications): handle kyc approved notification

### DIFF
--- a/src/firebase/notifications.test.ts
+++ b/src/firebase/notifications.test.ts
@@ -185,7 +185,7 @@ describe(handleNotification, () => {
     const message = {
       notification: { title: 'KYC', body: 'Kyc Approved' },
       data: {
-        type: NotificationTypes.KYC_APPROVED,
+        type: NotificationTypes.FIAT_CONNECT_KYC_APPROVED,
         kycSchema: KycSchema.PersonalDataAndDocuments,
         providerId: 'test-provider',
       },
@@ -207,7 +207,7 @@ describe(handleNotification, () => {
       expect(navigate).toHaveBeenCalledWith(Screens.FiatConnectReviewWrapper, {
         kycSchema: KycSchema.PersonalDataAndDocuments,
         providerId: 'test-provider',
-        type: NotificationTypes.KYC_APPROVED,
+        type: NotificationTypes.FIAT_CONNECT_KYC_APPROVED,
       })
     })
   })

--- a/src/firebase/notifications.test.ts
+++ b/src/firebase/notifications.test.ts
@@ -199,7 +199,7 @@ describe(handleNotification, () => {
       expect(navigate).not.toHaveBeenCalled()
     })
 
-    it('navigates to the send confirmation screen if the app is not already in the foreground', async () => {
+    it('navigates to the review screen if the app is not already in the foreground', async () => {
       await expectSaga(handleNotification, message, NotificationReceiveState.AppColdStart)
         .provide([[select(recipientInfoSelector), mockRecipientInfo]])
         .run()

--- a/src/firebase/notifications.test.ts
+++ b/src/firebase/notifications.test.ts
@@ -1,3 +1,4 @@
+import { KycSchema } from '@fiatconnect/fiatconnect-types'
 import { FirebaseMessagingTypes } from '@react-native-firebase/messaging'
 import BigNumber from 'bignumber.js'
 import { expectSaga } from 'redux-saga-test-plan'
@@ -176,6 +177,37 @@ describe(handleNotification, () => {
           recipient: { address: '0xTEST' },
           type: 'PAY_REQUEST',
         },
+      })
+    })
+  })
+
+  describe('with a kyc approved notification', () => {
+    const message = {
+      notification: { title: 'KYC', body: 'Kyc Approved' },
+      data: {
+        type: NotificationTypes.KYC_APPROVED,
+        kycSchema: KycSchema.PersonalDataAndDocuments,
+        providerId: 'test-provider',
+      },
+    }
+
+    it('shows the in-app message when the app is already in the foreground', async () => {
+      await expectSaga(handleNotification, message, NotificationReceiveState.AppAlreadyOpen)
+        .put(showMessage('Kyc Approved', undefined, null, null, 'KYC'))
+        .run()
+
+      expect(navigate).not.toHaveBeenCalled()
+    })
+
+    it('navigates to the send confirmation screen if the app is not already in the foreground', async () => {
+      await expectSaga(handleNotification, message, NotificationReceiveState.AppColdStart)
+        .provide([[select(recipientInfoSelector), mockRecipientInfo]])
+        .run()
+
+      expect(navigate).toHaveBeenCalledWith(Screens.FiatConnectReviewWrapper, {
+        kycSchema: KycSchema.PersonalDataAndDocuments,
+        providerId: 'test-provider',
+        type: NotificationTypes.KYC_APPROVED,
       })
     })
   })

--- a/src/firebase/notifications.test.ts
+++ b/src/firebase/notifications.test.ts
@@ -204,7 +204,7 @@ describe(handleNotification, () => {
         .provide([[select(recipientInfoSelector), mockRecipientInfo]])
         .run()
 
-      expect(navigate).toHaveBeenCalledWith(Screens.FiatConnectReviewWrapper, {
+      expect(navigate).toHaveBeenCalledWith(Screens.FiatConnectRefetchQuote, {
         kycSchema: KycSchema.PersonalDataAndDocuments,
         providerId: 'test-provider',
         type: NotificationTypes.FIAT_CONNECT_KYC_APPROVED,

--- a/src/firebase/notifications.ts
+++ b/src/firebase/notifications.ts
@@ -13,7 +13,7 @@ import {
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import {
-  KycApprovedData,
+  FiatConnectKycApprovedData,
   NotificationReceiveState,
   NotificationTypes,
   TransferNotificationData,
@@ -114,7 +114,10 @@ export function* handleNotification(
       break
 
     case NotificationTypes.FIAT_CONNECT_KYC_APPROVED:
-      navigate(Screens.FiatConnectReviewWrapper, message.data as unknown as KycApprovedData)
+      navigate(
+        Screens.FiatConnectReviewWrapper,
+        message.data as unknown as FiatConnectKycApprovedData
+      )
       break
 
     default:

--- a/src/firebase/notifications.ts
+++ b/src/firebase/notifications.ts
@@ -115,7 +115,7 @@ export function* handleNotification(
 
     case NotificationTypes.FIAT_CONNECT_KYC_APPROVED:
       navigate(
-        Screens.FiatConnectReviewWrapper,
+        Screens.FiatConnectRefetchQuote,
         message.data as unknown as FiatConnectKycApprovedData
       )
       break

--- a/src/firebase/notifications.ts
+++ b/src/firebase/notifications.ts
@@ -95,13 +95,13 @@ export function* handleNotification(
       yield put(showMessage(body || title, undefined, null, openUrlAction, body ? title : null))
     }
     return
-  } else {
-    // Notification was received while app wasn't already open (i.e. tapped to act on it)
-    // So directly handle the action if any
-    if (openUrlAction) {
-      yield put(openUrlAction)
-      return
-    }
+  }
+
+  // Notification was received while app wasn't already open (i.e. tapped to act on it)
+  // So directly handle the action if any
+  if (openUrlAction) {
+    yield put(openUrlAction)
+    return
   }
 
   switch (message.data?.type) {

--- a/src/firebase/notifications.ts
+++ b/src/firebase/notifications.ts
@@ -113,7 +113,7 @@ export function* handleNotification(
       yield call(handlePaymentReceived, message.data as unknown as TransferNotificationData)
       break
 
-    case NotificationTypes.KYC_APPROVED:
+    case NotificationTypes.FIAT_CONNECT_KYC_APPROVED:
       navigate(Screens.FiatConnectReviewWrapper, message.data as unknown as KycApprovedData)
       break
 

--- a/src/notifications/types.ts
+++ b/src/notifications/types.ts
@@ -20,7 +20,7 @@ export interface TransferNotificationData {
   imageUrl?: string
 }
 
-export interface KycApprovedData {
+export interface FiatConnectKycApprovedData {
   kycSchema: KycSchema
   providerId: string
   type: NotificationTypes.FIAT_CONNECT_KYC_APPROVED

--- a/src/notifications/types.ts
+++ b/src/notifications/types.ts
@@ -1,6 +1,9 @@
+import { KycSchema } from '@fiatconnect/fiatconnect-types'
+
 export enum NotificationTypes {
   PAYMENT_RECEIVED = 'PAYMENT_RECEIVED',
   PAYMENT_REQUESTED = 'PAYMENT_REQUESTED',
+  KYC_APPROVED = 'KYC_APPROVED',
 }
 
 export interface TransferNotificationData {
@@ -15,6 +18,12 @@ export interface TransferNotificationData {
   type?: NotificationTypes.PAYMENT_RECEIVED
   name?: string
   imageUrl?: string
+}
+
+export interface KycApprovedData {
+  kycSchema: KycSchema
+  providerId: string
+  type: NotificationTypes.KYC_APPROVED
 }
 
 export enum NotificationReceiveState {

--- a/src/notifications/types.ts
+++ b/src/notifications/types.ts
@@ -3,7 +3,7 @@ import { KycSchema } from '@fiatconnect/fiatconnect-types'
 export enum NotificationTypes {
   PAYMENT_RECEIVED = 'PAYMENT_RECEIVED',
   PAYMENT_REQUESTED = 'PAYMENT_REQUESTED',
-  KYC_APPROVED = 'KYC_APPROVED',
+  FIAT_CONNECT_KYC_APPROVED = 'FIAT_CONNECT_KYC_APPROVED',
 }
 
 export interface TransferNotificationData {
@@ -23,7 +23,7 @@ export interface TransferNotificationData {
 export interface KycApprovedData {
   kycSchema: KycSchema
   providerId: string
-  type: NotificationTypes.KYC_APPROVED
+  type: NotificationTypes.FIAT_CONNECT_KYC_APPROVED
 }
 
 export enum NotificationReceiveState {


### PR DESCRIPTION
### Description

Navigates to ReviewScreenWrapper on KycApproved notification. Builds on #3036 

### Other changes

Refactored handling `AppAlreadyOpen` at a more generic place instead of every handler

### Tested

Unit tests and manually by sending a notification. Could only test app opened state, since notifications are not showing up on the emulator. Will test app closed state once this is merged and available on the nightly build.

### How others should test

Not ready for testing

### Related issues

- Fixes ACT-491

### Backwards compatibility

Yes