### PR TITLE
fix: header on initial recovery phrase screen

### DIFF
--- a/src/backup/BackupIntroduction.tsx
+++ b/src/backup/BackupIntroduction.tsx
@@ -2,6 +2,7 @@ import { StackScreenProps } from '@react-navigation/stack'
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import { ScrollView, StyleSheet, Text, View } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
 import { connect } from 'react-redux'
 import { OnboardingEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
@@ -51,16 +52,27 @@ class BackupIntroduction extends React.Component<Props> {
     const { backupCompleted, route } = this.props
     const showDrawerTopBar = route.params?.showDrawerTopBar
 
-    return (
-      <View style={styles.container}>
-        {showDrawerTopBar && <DrawerTopBar testID="BackupIntroduction/DrawerTopBar" />}
-        {backupCompleted ? (
-          <AccountKeyPostSetup />
-        ) : (
-          <AccountKeyIntro onPrimaryPress={this.onPressBackup} />
-        )}
-      </View>
-    )
+    // Conditional rendering for headers
+    if (showDrawerTopBar) {
+      return (
+        <SafeAreaView style={styles.container}>
+          <DrawerTopBar testID="BackupIntroduction/DrawerTopBar" />
+          { backupCompleted
+            ? <AccountKeyPostSetup />
+            : <AccountKeyIntro onPrimaryPress={this.onPressBackup} />
+          }
+        </SafeAreaView>
+      )
+    } else {
+      return (
+        <View style={styles.container}>
+          { backupCompleted
+            ? <AccountKeyPostSetup />
+            : <AccountKeyIntro onPrimaryPress={this.onPressBackup} />
+          }
+        </View>
+      )
+    }
   }
 }
 

--- a/src/backup/BackupIntroduction.tsx
+++ b/src/backup/BackupIntroduction.tsx
@@ -57,19 +57,21 @@ class BackupIntroduction extends React.Component<Props> {
       return (
         <SafeAreaView style={styles.container}>
           <DrawerTopBar testID="BackupIntroduction/DrawerTopBar" />
-          { backupCompleted
-            ? <AccountKeyPostSetup />
-            : <AccountKeyIntro onPrimaryPress={this.onPressBackup} />
-          }
+          {backupCompleted ? (
+            <AccountKeyPostSetup />
+          ) : (
+            <AccountKeyIntro onPrimaryPress={this.onPressBackup} />
+          )}
         </SafeAreaView>
       )
     } else {
       return (
         <View style={styles.container}>
-          { backupCompleted
-            ? <AccountKeyPostSetup />
-            : <AccountKeyIntro onPrimaryPress={this.onPressBackup} />
-          }
+          {backupCompleted ? (
+            <AccountKeyPostSetup />
+          ) : (
+            <AccountKeyIntro onPrimaryPress={this.onPressBackup} />
+          )}
         </View>
       )
     }


### PR DESCRIPTION
### Description

After #3014 the initial header for the recovery phrase the hamburger menu icon was outside of the safe area boundaries boundaries.

#### Screenshot Before / After

<p align="center">
<img src="https://user-images.githubusercontent.com/26950305/198030681-28c8fe32-5ecd-4a9a-886e-e8483d2069ac.png" width="48%" "height="auto" />
<img src="https://user-images.githubusercontent.com/26950305/198030092-0b67ac5f-6165-4dd9-aade-37281b2ac105.png" width="48%" "height="auto" />
</p>


### Other changes

N/A

### Tested

Tested locally on iOS

### How others should test

Prerequisite:  a new wallet
1. Navigate to recovery phrase quiz.
2. Ensure that the menu icon is within the safe area boundaries. 

### Related issues

N/A

### Backwards compatibility

Yes