### PR TITLE
fix(home): Fix frozen home screen on iOS

### DIFF
--- a/src/home/CashInBottomSheet.tsx
+++ b/src/home/CashInBottomSheet.tsx
@@ -1,4 +1,5 @@
 // import styles from 'src/styles/styles'
+import { delay } from 'lodash'
 import React, { useEffect, useState } from 'react'
 import { useAsync } from 'react-async-hook'
 import { useTranslation } from 'react-i18next'
@@ -86,8 +87,11 @@ function CashInBottomSheet() {
     },
     [],
     {
-      onSuccess: () => setModalVisible(true),
-      onError: () => setModalVisible(true),
+      // The modal can freeze up on iOS if its visibility is quickly changed from false to true
+      // this delay prevents that, and is enough that its not very noticible to the user since
+      // the home page is also loading at this point.
+      onSuccess: () => delay(() => setModalVisible(true), 1000),
+      onError: () => delay(() => setModalVisible(true), 1000),
     }
   )
 


### PR DESCRIPTION
### Description


https://user-images.githubusercontent.com/8432644/198121473-82d2dda3-786b-46f8-b012-3a588af89d99.mp4

Fixes https://valora-app.slack.com/archives/C02N3AR2P2S/p1666741437531239

### Tested

I narrowed down the exact time to use by replacing the entire useAsync function with a `sleep(<time>)` function and adjusted time until the issue consistently didn't reproduce. 1000 was the lowest It could go. 

### How others should test

On an iOS simulator/device on *main build* attempt to onboard all the way to the Home screen. Verify that the screen is not frozen AND the cash in bottom sheet shows up

> you may have to turn on the cash in bottom sheet feature flag to see it

### Related issues

- Fixes https://valora-app.slack.com/archives/C02N3AR2P2S/p1666741437531239
