### PR TITLE
feat(fiatconnect): Sort fiat account schemas in quote constructor

### DIFF
--- a/src/fiatExchanges/quotes/FiatConnectQuote.test.ts
+++ b/src/fiatExchanges/quotes/FiatConnectQuote.test.ts
@@ -63,6 +63,52 @@ describe('FiatConnectQuote', () => {
           })
       ).toThrow()
     })
+    it('chooses the same fiat account schema regardless of ordering', () => {
+      const quoteData1 = {
+        ...mockFiatConnectQuotes[1],
+        fiatAccount: {
+          BankAccount: {
+            fiatAccountSchemas: [
+              {
+                fiatAccountSchema: FiatAccountSchema.AccountNumber,
+              },
+              {
+                fiatAccountSchema: FiatAccountSchema.IBANNumber,
+              },
+            ],
+          },
+        },
+      }
+      const quoteData2 = {
+        ...mockFiatConnectQuotes[1],
+        fiatAccount: {
+          BankAccount: {
+            fiatAccountSchemas: [
+              {
+                fiatAccountSchema: FiatAccountSchema.IBANNumber,
+              },
+              {
+                fiatAccountSchema: FiatAccountSchema.AccountNumber,
+              },
+            ],
+          },
+        },
+      }
+
+      const fiatConnectQuote1 = new FiatConnectQuote({
+        flow: CICOFlow.CashIn,
+        quote: quoteData1 as FiatConnectQuoteSuccess,
+        fiatAccountType: FiatAccountType.BankAccount,
+      })
+      const fiatConnectQuote2 = new FiatConnectQuote({
+        flow: CICOFlow.CashIn,
+        quote: quoteData2 as FiatConnectQuoteSuccess,
+        fiatAccountType: FiatAccountType.BankAccount,
+      })
+
+      expect(fiatConnectQuote1.getFiatAccountSchema()).toEqual(FiatAccountSchema.AccountNumber)
+      expect(fiatConnectQuote2.getFiatAccountSchema()).toEqual(FiatAccountSchema.AccountNumber)
+    })
     it.each([FiatAccountSchema.AccountNumber, FiatAccountSchema.IBANNumber])(
       'does not throw an error if at least one fiatAccountSchema is supported',
       (fiatAccountSchema) => {

--- a/src/fiatExchanges/quotes/FiatConnectQuote.ts
+++ b/src/fiatExchanges/quotes/FiatConnectQuote.ts
@@ -62,10 +62,14 @@ export default class FiatConnectQuote extends NormalizedQuote {
         `Error: ${quote.provider.id}. FiatAccountType: ${fiatAccountType} is not supported in the app`
       )
     }
+
     // Find a supported FiatAccountSchema
-    const quoteResponseFiatAccountSchema = quote.fiatAccount[
-      fiatAccountType
-    ]?.fiatAccountSchemas.find((schema) =>
+    // In case there are multiple schemas present, we sort them first so that the same schema is
+    // consistently chosen.
+    const sortedFiatAccountSchemas = (quote.fiatAccount[fiatAccountType]?.fiatAccountSchemas || [])
+      .slice()
+      .sort((schema1, schema2) => (schema1.fiatAccountSchema < schema2.fiatAccountSchema ? -1 : 1))
+    const quoteResponseFiatAccountSchema = sortedFiatAccountSchemas.find((schema) =>
       SUPPORTED_FIAT_ACCOUNT_SCHEMAS.has(schema.fiatAccountSchema)
     )
     if (!quoteResponseFiatAccountSchema) {


### PR DESCRIPTION
### Description

Currently, we generate one quote object per fiat account type. If multiple fiat account _schemas_ are available to use for that account type, we pick the first one we encounter in the list of available schemas. The ordering of allowed schemas is not guaranteed, which means that we could potentially pick a _different_ schema for some account type across multiple runs if several are available. This PR sorts the schemas before picking one, in order to avoid this problem.

### Other changes

N/A

### Tested

Unit tested.

### How others should test

N/A

### Related issues

N/A

### Backwards compatibility

Yes.