### PR TITLE
fix: invite modal display for android

### DIFF
--- a/src/invite/InviteModal.tsx
+++ b/src/invite/InviteModal.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { Dimensions, Image, StyleSheet, Text, View } from 'react-native'
+import { Image, StyleSheet, Text, View } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import Button, { BtnSizes, BtnTypes } from 'src/components/Button'
 import Touchable from 'src/components/Touchable'
@@ -56,15 +56,13 @@ const InviteModal = ({
     </SafeAreaView>
   )
 }
-const { height, width } = Dimensions.get('window')
 
 const styles = StyleSheet.create({
   container: {
-    height,
-    width,
-    flex: 1,
+    height: variables.height,
+    width: variables.width,
+    flexGrow: 1,
     position: 'absolute',
-    bottom: 0,
     backgroundColor: colors.light,
     padding: Spacing.Thick24,
   },

--- a/src/send/SendAmount/index.tsx
+++ b/src/send/SendAmount/index.tsx
@@ -246,7 +246,7 @@ function SendAmount(props: Props) {
     recipientVerificationStatus === RecipientVerificationStatus.UNKNOWN || reviewButtonPressed
 
   const shouldShowModal =
-    recipientVerificationStatus !== RecipientVerificationStatus.VERIFIED &&
+    recipientVerificationStatus === RecipientVerificationStatus.UNVERIFIED &&
     (inviteMethod === InviteMethodType.ManualShare || inviteMethod === InviteMethodType.ReferralUrl)
 
   return (

--- a/src/send/SendAmount/index.tsx
+++ b/src/send/SendAmount/index.tsx
@@ -245,48 +245,53 @@ function SendAmount(props: Props) {
   const buttonLoading =
     recipientVerificationStatus === RecipientVerificationStatus.UNKNOWN || reviewButtonPressed
 
+  const shouldShowModal =
+    recipientVerificationStatus === RecipientVerificationStatus.UNKNOWN &&
+    (inviteMethod === InviteMethodType.ManualShare || inviteMethod === InviteMethodType.ReferralUrl)
+
   return (
     <SafeAreaView style={styles.container}>
-      <SendAmountHeader
-        tokenAddress={transferTokenAddress}
-        isOutgoingPaymentRequest={!!props.route.params?.isOutgoingPaymentRequest}
-        isInvite={recipientVerificationStatus === RecipientVerificationStatus.UNVERIFIED}
-        onChangeToken={setTransferToken}
-        disallowCurrencyChange={Boolean(forceTokenAddress)}
-      />
-      <DisconnectBanner />
-      <View style={styles.contentContainer}>
-        <SendAmountValue
-          isOutgoingPaymentRequest={!!props.route.params?.isOutgoingPaymentRequest}
-          inputAmount={amount}
-          tokenAmount={tokenAmount}
-          usingLocalAmount={showInputInLocalAmount}
-          tokenAddress={transferTokenAddress}
-          onPressMax={onPressMax}
-          onSwapInput={onSwapInput}
-          tokenHasUsdPrice={tokenHasUsdPrice}
-        />
-        <AmountKeypad
-          amount={amount}
-          maxDecimals={showInputInLocalAmount ? NUMBER_INPUT_MAX_DECIMALS : TOKEN_MAX_DECIMALS}
-          onAmountChange={onAmountChange}
-        />
-      </View>
-      <Button
-        style={styles.nextBtn}
-        size={BtnSizes.FULL}
-        text={t('review')}
-        showLoading={buttonLoading}
-        type={BtnTypes.PRIMARY}
-        onPress={onReviewButtonPressed}
-        disabled={!isAmountValid || buttonLoading}
-        testID="Review"
-      />
-      {recipientVerificationStatus === RecipientVerificationStatus.UNVERIFIED &&
-      (inviteMethod === InviteMethodType.ManualShare ||
-        inviteMethod === InviteMethodType.ReferralUrl) ? (
+      {shouldShowModal ? (
         <InviteOptionsModal recipient={recipient} onClose={navigateBack} />
-      ) : null}
+      ) : (
+        <>
+          <SendAmountHeader
+            tokenAddress={transferTokenAddress}
+            isOutgoingPaymentRequest={!!props.route.params?.isOutgoingPaymentRequest}
+            isInvite={recipientVerificationStatus === RecipientVerificationStatus.UNVERIFIED}
+            onChangeToken={setTransferToken}
+            disallowCurrencyChange={Boolean(forceTokenAddress)}
+          />
+          <DisconnectBanner />
+          <View style={styles.contentContainer}>
+            <SendAmountValue
+              isOutgoingPaymentRequest={!!props.route.params?.isOutgoingPaymentRequest}
+              inputAmount={amount}
+              tokenAmount={tokenAmount}
+              usingLocalAmount={showInputInLocalAmount}
+              tokenAddress={transferTokenAddress}
+              onPressMax={onPressMax}
+              onSwapInput={onSwapInput}
+              tokenHasUsdPrice={tokenHasUsdPrice}
+            />
+            <AmountKeypad
+              amount={amount}
+              maxDecimals={showInputInLocalAmount ? NUMBER_INPUT_MAX_DECIMALS : TOKEN_MAX_DECIMALS}
+              onAmountChange={onAmountChange}
+            />
+          </View>
+          <Button
+            style={styles.nextBtn}
+            size={BtnSizes.FULL}
+            text={t('review')}
+            showLoading={buttonLoading}
+            type={BtnTypes.PRIMARY}
+            onPress={onReviewButtonPressed}
+            disabled={!isAmountValid || buttonLoading}
+            testID="Review"
+          />
+        </>
+      )}
     </SafeAreaView>
   )
 }

--- a/src/send/SendAmount/index.tsx
+++ b/src/send/SendAmount/index.tsx
@@ -246,7 +246,7 @@ function SendAmount(props: Props) {
     recipientVerificationStatus === RecipientVerificationStatus.UNKNOWN || reviewButtonPressed
 
   const shouldShowModal =
-    recipientVerificationStatus === RecipientVerificationStatus.UNKNOWN &&
+    recipientVerificationStatus !== RecipientVerificationStatus.VERIFIED &&
     (inviteMethod === InviteMethodType.ManualShare || inviteMethod === InviteMethodType.ReferralUrl)
 
   return (


### PR DESCRIPTION
### Description

Invite modal display was had incorrect headers for Android devices documented in #3059.

### Other changes

N/A

### Tested

Tested locally on Android

### How others should test

Check that the invite screen from the side menu and send flow render correctly.

### Related issues

- Fixes #3059

### Backwards compatibility

Yes