### PR TITLE
feat(fiatconnect): add timeout to fiat connect requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     ]
   },
   "dependencies": {
-    "@badrap/result": "~0.2.12",
+    "@badrap/result": "~0.2.13",
     "@celo/connect": "~1.2.0",
     "@celo/contractkit": "~1.2.0",
     "@celo/identity": "~1.2.0",
@@ -73,7 +73,7 @@
     "@celo/wallet-rpc": "~1.2.0",
     "@coinbase/cbpay-js": "^1.0.2",
     "@crowdin/ota-client": "^0.4.0",
-    "@fiatconnect/fiatconnect-sdk": "^0.4.0",
+    "@fiatconnect/fiatconnect-sdk": "^0.4.1",
     "@fiatconnect/fiatconnect-types": "^8.0.0",
     "@google-cloud/storage": "^5.16.1",
     "@gorhom/bottom-sheet": "^4.3.2",

--- a/src/app/reducers.ts
+++ b/src/app/reducers.ts
@@ -61,6 +61,7 @@ export interface State {
   inviteMethod: InviteMethodType
   centralPhoneVerificationEnabled: boolean
   inviterAddress: string | null
+  networkTimeoutSeconds: number
 }
 
 const initialState = {
@@ -115,6 +116,7 @@ const initialState = {
   inviteMethod: REMOTE_CONFIG_VALUES_DEFAULTS.inviteMethod,
   centralPhoneVerificationEnabled: REMOTE_CONFIG_VALUES_DEFAULTS.centralPhoneVerificationEnabled,
   inviterAddress: null,
+  networkTimeoutSeconds: REMOTE_CONFIG_VALUES_DEFAULTS.networkTimeoutSeconds,
 }
 
 export const appReducer = (
@@ -236,6 +238,7 @@ export const appReducer = (
         inviteMethod: action.configValues.inviteMethod,
         showGuidedOnboardingCopy: action.configValues.showGuidedOnboardingCopy,
         centralPhoneVerificationEnabled: action.configValues.centralPhoneVerificationEnabled,
+        networkTimeoutSeconds: action.configValues.networkTimeoutSeconds,
       }
     case Actions.TOGGLE_INVITE_MODAL:
       return {

--- a/src/app/saga.ts
+++ b/src/app/saga.ts
@@ -212,6 +212,7 @@ export interface RemoteConfigValues {
   fiatConnectCashInEnabled: boolean
   fiatConnectCashOutEnabled: boolean
   fiatAccountSchemaCountryOverrides: FiatAccountSchemaCountryOverrides
+  fiatConnectTimeoutSeconds: number
   dappConnectInfo: DappConnectInfo
   visualizeNFTsEnabledInHomeAssetsPage: boolean
   coinbasePayEnabled: boolean

--- a/src/app/saga.ts
+++ b/src/app/saga.ts
@@ -212,7 +212,6 @@ export interface RemoteConfigValues {
   fiatConnectCashInEnabled: boolean
   fiatConnectCashOutEnabled: boolean
   fiatAccountSchemaCountryOverrides: FiatAccountSchemaCountryOverrides
-  fiatConnectTimeoutSeconds: number
   dappConnectInfo: DappConnectInfo
   visualizeNFTsEnabledInHomeAssetsPage: boolean
   coinbasePayEnabled: boolean
@@ -223,6 +222,7 @@ export interface RemoteConfigValues {
   inviteMethod: InviteMethodType
   showGuidedOnboardingCopy: boolean
   centralPhoneVerificationEnabled: boolean
+  networkTimeoutSeconds: number
 }
 
 export function* appRemoteFeatureFlagSaga() {

--- a/src/app/selectors.ts
+++ b/src/app/selectors.ts
@@ -262,3 +262,5 @@ export const shouldRunVerificationMigrationSelector = createSelector(
 )
 
 export const inviterAddressSelector = (state: RootState) => state.app.inviterAddress
+
+export const networkTimeoutSecondsSelector = (state: RootState) => state.app.networkTimeoutSeconds

--- a/src/fiatconnect/clients.test.tsx
+++ b/src/fiatconnect/clients.test.tsx
@@ -1,5 +1,6 @@
 import { FiatConnectClient } from '@fiatconnect/fiatconnect-sdk'
 import { getFiatConnectClient, getSiweSigningFunction } from 'src/fiatconnect/clients'
+import { REMOTE_CONFIG_VALUES_DEFAULTS } from 'src/firebase/remoteConfigValuesDefaults'
 import { getPassword } from 'src/pincode/authentication'
 import { getWalletAsync } from 'src/web3/contracts'
 import { KeychainWallet } from 'src/web3/KeychainWallet'
@@ -50,6 +51,10 @@ describe('getFiatConnectClient', () => {
     const fcClient = await getFiatConnectClient('provider1', 'https://provider1.url')
     expect(getWalletAsync).toHaveBeenCalled()
     expect(fcClient).toBeInstanceOf(FiatConnectClient)
+    expect(fcClient).toHaveProperty(
+      'config.timeout',
+      REMOTE_CONFIG_VALUES_DEFAULTS.fiatConnectTimeoutSeconds * 1000
+    )
   })
 
   it('returns an already existing client', async () => {

--- a/src/fiatconnect/clients.test.tsx
+++ b/src/fiatconnect/clients.test.tsx
@@ -53,7 +53,7 @@ describe('getFiatConnectClient', () => {
     expect(fcClient).toBeInstanceOf(FiatConnectClient)
     expect(fcClient).toHaveProperty(
       'config.timeout',
-      REMOTE_CONFIG_VALUES_DEFAULTS.fiatConnectTimeoutSeconds * 1000
+      REMOTE_CONFIG_VALUES_DEFAULTS.networkTimeoutSeconds * 1000
     )
   })
 

--- a/src/fiatconnect/clients.ts
+++ b/src/fiatconnect/clients.ts
@@ -2,7 +2,9 @@ import { ensureLeading0x } from '@celo/utils/lib/address'
 import { UnlockableWallet } from '@celo/wallet-base'
 import { FiatConnectApiClient, FiatConnectClient } from '@fiatconnect/fiatconnect-sdk'
 import { FIATCONNECT_NETWORK } from 'src/config'
+import { timeoutSecondsSelector } from 'src/fiatconnect/selectors'
 import { getPassword } from 'src/pincode/authentication'
+import { store } from 'src/redux/store'
 import { UNLOCK_DURATION } from 'src/web3/consts'
 import { getWalletAsync } from 'src/web3/contracts'
 
@@ -39,6 +41,11 @@ export async function getFiatConnectClient(
     fiatConnectClients[providerId].url !== providerBaseUrl ||
     fiatConnectClients[providerId].apiKey !== providerApiKey
   ) {
+    console.log(
+      'creating fc client with timeout: ',
+      timeoutSecondsSelector(store.getState()),
+      providerId
+    )
     const wallet = (await getWalletAsync()) as UnlockableWallet
     const [account] = wallet.getAccounts()
     fiatConnectClients[providerId] = {
@@ -50,6 +57,7 @@ export async function getFiatConnectClient(
           network: FIATCONNECT_NETWORK,
           accountAddress: account,
           apiKey: providerApiKey,
+          timeout: timeoutSecondsSelector(store.getState()) * 1000,
         },
         getSiweSigningFunction(wallet)
       ),

--- a/src/fiatconnect/clients.ts
+++ b/src/fiatconnect/clients.ts
@@ -1,8 +1,8 @@
 import { ensureLeading0x } from '@celo/utils/lib/address'
 import { UnlockableWallet } from '@celo/wallet-base'
 import { FiatConnectApiClient, FiatConnectClient } from '@fiatconnect/fiatconnect-sdk'
+import { networkTimeoutSecondsSelector } from 'src/app/selectors'
 import { FIATCONNECT_NETWORK } from 'src/config'
-import { timeoutSecondsSelector } from 'src/fiatconnect/selectors'
 import { getPassword } from 'src/pincode/authentication'
 import { store } from 'src/redux/store'
 import { UNLOCK_DURATION } from 'src/web3/consts'
@@ -52,7 +52,7 @@ export async function getFiatConnectClient(
           network: FIATCONNECT_NETWORK,
           accountAddress: account,
           apiKey: providerApiKey,
-          timeout: timeoutSecondsSelector(store.getState()) * 1000,
+          timeout: networkTimeoutSecondsSelector(store.getState()) * 1000,
         },
         getSiweSigningFunction(wallet)
       ),

--- a/src/fiatconnect/clients.ts
+++ b/src/fiatconnect/clients.ts
@@ -41,11 +41,6 @@ export async function getFiatConnectClient(
     fiatConnectClients[providerId].url !== providerBaseUrl ||
     fiatConnectClients[providerId].apiKey !== providerApiKey
   ) {
-    console.log(
-      'creating fc client with timeout: ',
-      timeoutSecondsSelector(store.getState()),
-      providerId
-    )
     const wallet = (await getWalletAsync()) as UnlockableWallet
     const [account] = wallet.getAccounts()
     fiatConnectClients[providerId] = {

--- a/src/fiatconnect/selectors.ts
+++ b/src/fiatconnect/selectors.ts
@@ -19,3 +19,4 @@ export const kycTryAgainLoadingSelector = (state: RootState) => state.fiatConnec
 export const cachedQuoteParamsSelector = (state: RootState) => state.fiatConnect.cachedQuoteParams
 export const schemaCountryOverridesSelector = (state: RootState) =>
   state.fiatConnect.schemaCountryOverrides
+export const timeoutSecondsSelector = (state: RootState) => state.fiatConnect.timeoutSeconds

--- a/src/fiatconnect/selectors.ts
+++ b/src/fiatconnect/selectors.ts
@@ -19,4 +19,3 @@ export const kycTryAgainLoadingSelector = (state: RootState) => state.fiatConnec
 export const cachedQuoteParamsSelector = (state: RootState) => state.fiatConnect.cachedQuoteParams
 export const schemaCountryOverridesSelector = (state: RootState) =>
   state.fiatConnect.schemaCountryOverrides
-export const timeoutSecondsSelector = (state: RootState) => state.fiatConnect.timeoutSeconds

--- a/src/fiatconnect/slice.ts
+++ b/src/fiatconnect/slice.ts
@@ -1,9 +1,9 @@
 import {
+  FiatAccountSchema,
   FiatAccountType,
   FiatType,
   KycSchema,
   ObfuscatedFiatAccountData,
-  FiatAccountSchema,
 } from '@fiatconnect/fiatconnect-types'
 import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 import { isEqual } from 'lodash'
@@ -16,6 +16,7 @@ import {
 import { FiatAccountSchemaCountryOverrides } from 'src/fiatconnect/types'
 import FiatConnectQuote from 'src/fiatExchanges/quotes/FiatConnectQuote'
 import { CICOFlow } from 'src/fiatExchanges/utils'
+import { REMOTE_CONFIG_VALUES_DEFAULTS } from 'src/firebase/remoteConfigValuesDefaults'
 import { getRehydratePayload, REHYDRATE, RehydrateAction } from 'src/redux/persist-helper'
 import { CiCoCurrency, Currency } from 'src/utils/currencies'
 
@@ -58,6 +59,7 @@ export interface State {
     }
   }
   schemaCountryOverrides: FiatAccountSchemaCountryOverrides
+  timeoutSeconds: number
 }
 
 const initialState: State = {
@@ -73,6 +75,7 @@ const initialState: State = {
   kycTryAgainLoading: false,
   cachedQuoteParams: {},
   schemaCountryOverrides: {},
+  timeoutSeconds: REMOTE_CONFIG_VALUES_DEFAULTS.fiatConnectTimeoutSeconds,
 }
 
 export type FiatAccount = ObfuscatedFiatAccountData & {
@@ -285,6 +288,7 @@ export const slice = createSlice({
         AppActions.UPDATE_REMOTE_CONFIG_VALUES,
         (state, action: UpdateConfigValuesAction) => {
           state.schemaCountryOverrides = action.configValues.fiatAccountSchemaCountryOverrides
+          state.timeoutSeconds = action.configValues.fiatConnectTimeoutSeconds
         }
       )
       .addCase(REHYDRATE, (state, action: RehydrateAction) => ({

--- a/src/fiatconnect/slice.ts
+++ b/src/fiatconnect/slice.ts
@@ -16,7 +16,6 @@ import {
 import { FiatAccountSchemaCountryOverrides } from 'src/fiatconnect/types'
 import FiatConnectQuote from 'src/fiatExchanges/quotes/FiatConnectQuote'
 import { CICOFlow } from 'src/fiatExchanges/utils'
-import { REMOTE_CONFIG_VALUES_DEFAULTS } from 'src/firebase/remoteConfigValuesDefaults'
 import { getRehydratePayload, REHYDRATE, RehydrateAction } from 'src/redux/persist-helper'
 import { CiCoCurrency, Currency } from 'src/utils/currencies'
 
@@ -59,7 +58,6 @@ export interface State {
     }
   }
   schemaCountryOverrides: FiatAccountSchemaCountryOverrides
-  timeoutSeconds: number
 }
 
 const initialState: State = {
@@ -75,7 +73,6 @@ const initialState: State = {
   kycTryAgainLoading: false,
   cachedQuoteParams: {},
   schemaCountryOverrides: {},
-  timeoutSeconds: REMOTE_CONFIG_VALUES_DEFAULTS.fiatConnectTimeoutSeconds,
 }
 
 export type FiatAccount = ObfuscatedFiatAccountData & {
@@ -288,7 +285,6 @@ export const slice = createSlice({
         AppActions.UPDATE_REMOTE_CONFIG_VALUES,
         (state, action: UpdateConfigValuesAction) => {
           state.schemaCountryOverrides = action.configValues.fiatAccountSchemaCountryOverrides
-          state.timeoutSeconds = action.configValues.fiatConnectTimeoutSeconds
         }
       )
       .addCase(REHYDRATE, (state, action: RehydrateAction) => ({

--- a/src/firebase/firebase.ts
+++ b/src/firebase/firebase.ts
@@ -297,7 +297,6 @@ export async function fetchRemoteConfigValues(): Promise<RemoteConfigValues | nu
     fiatAccountSchemaCountryOverrides: fiatAccountSchemaCountryOverrides
       ? JSON.parse(fiatAccountSchemaCountryOverrides)
       : {},
-    fiatConnectTimeoutSeconds: flags.fiatConnectTimeoutSeconds.asNumber(),
     dappConnectInfo: flags.dappConnectInfo.asString() as DappConnectInfo,
     visualizeNFTsEnabledInHomeAssetsPage: flags.visualizeNFTsEnabledInHomeAssetsPage.asBoolean(),
     coinbasePayEnabled: flags.coinbasePayEnabled.asBoolean(),
@@ -309,6 +308,7 @@ export async function fetchRemoteConfigValues(): Promise<RemoteConfigValues | nu
     inviteMethod: flags.inviteMethod.asString() as InviteMethodType,
     showGuidedOnboardingCopy: flags.showGuidedOnboardingCopy.asBoolean(),
     centralPhoneVerificationEnabled: flags.centralPhoneVerificationEnabled.asBoolean(),
+    networkTimeoutSeconds: flags.networkTimeoutSeconds.asNumber(),
   }
 }
 

--- a/src/firebase/firebase.ts
+++ b/src/firebase/firebase.ts
@@ -297,6 +297,7 @@ export async function fetchRemoteConfigValues(): Promise<RemoteConfigValues | nu
     fiatAccountSchemaCountryOverrides: fiatAccountSchemaCountryOverrides
       ? JSON.parse(fiatAccountSchemaCountryOverrides)
       : {},
+    fiatConnectTimeoutSeconds: flags.fiatConnectTimeoutSeconds.asNumber(),
     dappConnectInfo: flags.dappConnectInfo.asString() as DappConnectInfo,
     visualizeNFTsEnabledInHomeAssetsPage: flags.visualizeNFTsEnabledInHomeAssetsPage.asBoolean(),
     coinbasePayEnabled: flags.coinbasePayEnabled.asBoolean(),

--- a/src/firebase/remoteConfigValuesDefaults.e2e.ts
+++ b/src/firebase/remoteConfigValuesDefaults.e2e.ts
@@ -63,7 +63,6 @@ export const REMOTE_CONFIG_VALUES_DEFAULTS: Omit<
   celoWithdrawalEnabledInExchange: true,
   fiatConnectCashInEnabled: false,
   fiatConnectCashOutEnabled: true,
-  fiatConnectTimeoutSeconds: 30,
   dappConnectInfo: DappConnectInfo.Basic,
   visualizeNFTsEnabledInHomeAssetsPage: false,
   coinbasePayEnabled: false,
@@ -74,4 +73,5 @@ export const REMOTE_CONFIG_VALUES_DEFAULTS: Omit<
   inviteMethod: InviteMethodType.Escrow,
   showGuidedOnboardingCopy: false,
   centralPhoneVerificationEnabled: false,
+  networkTimeoutSeconds: 30,
 }

--- a/src/firebase/remoteConfigValuesDefaults.e2e.ts
+++ b/src/firebase/remoteConfigValuesDefaults.e2e.ts
@@ -63,6 +63,7 @@ export const REMOTE_CONFIG_VALUES_DEFAULTS: Omit<
   celoWithdrawalEnabledInExchange: true,
   fiatConnectCashInEnabled: false,
   fiatConnectCashOutEnabled: true,
+  fiatConnectTimeoutSeconds: 30,
   dappConnectInfo: DappConnectInfo.Basic,
   visualizeNFTsEnabledInHomeAssetsPage: false,
   coinbasePayEnabled: false,

--- a/src/firebase/remoteConfigValuesDefaults.ts
+++ b/src/firebase/remoteConfigValuesDefaults.ts
@@ -62,7 +62,6 @@ export const REMOTE_CONFIG_VALUES_DEFAULTS: Omit<
   celoWithdrawalEnabledInExchange: true,
   fiatConnectCashInEnabled: false,
   fiatConnectCashOutEnabled: false,
-  fiatConnectTimeoutSeconds: 30,
   dappConnectInfo: DappConnectInfo.Default,
   visualizeNFTsEnabledInHomeAssetsPage: false,
   coinbasePayEnabled: false,
@@ -73,4 +72,5 @@ export const REMOTE_CONFIG_VALUES_DEFAULTS: Omit<
   inviteMethod: InviteMethodType.Escrow,
   showGuidedOnboardingCopy: false,
   centralPhoneVerificationEnabled: false,
+  networkTimeoutSeconds: 30,
 }

--- a/src/firebase/remoteConfigValuesDefaults.ts
+++ b/src/firebase/remoteConfigValuesDefaults.ts
@@ -62,6 +62,7 @@ export const REMOTE_CONFIG_VALUES_DEFAULTS: Omit<
   celoWithdrawalEnabledInExchange: true,
   fiatConnectCashInEnabled: false,
   fiatConnectCashOutEnabled: false,
+  fiatConnectTimeoutSeconds: 30,
   dappConnectInfo: DappConnectInfo.Default,
   visualizeNFTsEnabledInHomeAssetsPage: false,
   coinbasePayEnabled: false,

--- a/src/in-house-liquidity/client.test.ts
+++ b/src/in-house-liquidity/client.test.ts
@@ -1,4 +1,5 @@
 import { SiweClient } from '@fiatconnect/fiatconnect-sdk'
+import { REMOTE_CONFIG_VALUES_DEFAULTS } from 'src/firebase/remoteConfigValuesDefaults'
 import { getClient } from 'src/in-house-liquidity/client'
 import { getWalletAsync } from 'src/web3/contracts'
 
@@ -19,6 +20,10 @@ describe('getClient', () => {
     const ihlClient = await getClient()
     expect(getWalletAsync).toHaveBeenCalled()
     expect(ihlClient).toBeInstanceOf(SiweClient)
+    expect(ihlClient).toHaveProperty(
+      'config.timeout',
+      REMOTE_CONFIG_VALUES_DEFAULTS.fiatConnectTimeoutSeconds * 1000
+    )
   })
 
   it('returns an already existing client', async () => {

--- a/src/in-house-liquidity/client.test.ts
+++ b/src/in-house-liquidity/client.test.ts
@@ -22,7 +22,7 @@ describe('getClient', () => {
     expect(ihlClient).toBeInstanceOf(SiweClient)
     expect(ihlClient).toHaveProperty(
       'config.timeout',
-      REMOTE_CONFIG_VALUES_DEFAULTS.fiatConnectTimeoutSeconds * 1000
+      REMOTE_CONFIG_VALUES_DEFAULTS.networkTimeoutSeconds * 1000
     )
   })
 

--- a/src/in-house-liquidity/client.ts
+++ b/src/in-house-liquidity/client.ts
@@ -1,5 +1,7 @@
 import { SiweApiClient, SiweClient } from '@fiatconnect/fiatconnect-sdk'
 import { getSiweSigningFunction } from 'src/fiatconnect/clients'
+import { timeoutSecondsSelector } from 'src/fiatconnect/selectors'
+import { store } from 'src/redux/store'
 import { getWalletAsync } from 'src/web3/contracts'
 import networkConfig from 'src/web3/networkConfig'
 
@@ -22,6 +24,7 @@ export const getClient = async (): Promise<SiweApiClient> => {
         sessionDurationMs: SESSION_DURATION_MS,
         loginUrl: `${networkConfig.inHouseLiquidityURL}/auth/login`,
         clockUrl: `${networkConfig.inHouseLiquidityURL}/clock`,
+        timeout: timeoutSecondsSelector(store.getState()) * 1000,
       },
       getSiweSigningFunction(wallet)
     )

--- a/src/in-house-liquidity/client.ts
+++ b/src/in-house-liquidity/client.ts
@@ -1,6 +1,6 @@
 import { SiweApiClient, SiweClient } from '@fiatconnect/fiatconnect-sdk'
+import { networkTimeoutSecondsSelector } from 'src/app/selectors'
 import { getSiweSigningFunction } from 'src/fiatconnect/clients'
-import { timeoutSecondsSelector } from 'src/fiatconnect/selectors'
 import { store } from 'src/redux/store'
 import { getWalletAsync } from 'src/web3/contracts'
 import networkConfig from 'src/web3/networkConfig'
@@ -24,7 +24,7 @@ export const getClient = async (): Promise<SiweApiClient> => {
         sessionDurationMs: SESSION_DURATION_MS,
         loginUrl: `${networkConfig.inHouseLiquidityURL}/auth/login`,
         clockUrl: `${networkConfig.inHouseLiquidityURL}/clock`,
-        timeout: timeoutSecondsSelector(store.getState()) * 1000,
+        timeout: networkTimeoutSecondsSelector(store.getState()) * 1000,
       },
       getSiweSigningFunction(wallet)
     )

--- a/src/redux/migrations.ts
+++ b/src/redux/migrations.ts
@@ -868,4 +868,11 @@ export const migrations = {
     },
   }),
   87: (state: any) => state,
+  88: (state: any) => ({
+    ...state,
+    fiatConnect: {
+      ...state.fiatConnect,
+      timeoutSeconds: REMOTE_CONFIG_VALUES_DEFAULTS.fiatConnectTimeoutSeconds,
+    },
+  }),
 }

--- a/src/redux/migrations.ts
+++ b/src/redux/migrations.ts
@@ -870,9 +870,9 @@ export const migrations = {
   87: (state: any) => state,
   88: (state: any) => ({
     ...state,
-    fiatConnect: {
-      ...state.fiatConnect,
-      timeoutSeconds: REMOTE_CONFIG_VALUES_DEFAULTS.fiatConnectTimeoutSeconds,
+    app: {
+      ...state.app,
+      networkTimeoutSeconds: REMOTE_CONFIG_VALUES_DEFAULTS.networkTimeoutSeconds,
     },
   }),
 }

--- a/src/redux/store.test.ts
+++ b/src/redux/store.test.ts
@@ -149,6 +149,7 @@ describe('store state', () => {
           "loggedIn": false,
           "maxSwapSlippagePercentage": 2,
           "minVersion": null,
+          "networkTimeoutSeconds": 30,
           "numberVerified": false,
           "paymentDeepLinkHandler": "",
           "phoneNumberVerified": false,
@@ -224,7 +225,6 @@ describe('store state', () => {
           "schemaCountryOverrides": Object {},
           "selectFiatConnectQuoteLoading": false,
           "sendingFiatAccountStatus": "NotSending",
-          "timeoutSeconds": 30,
           "transfer": null,
         },
         "fiatExchanges": Object {

--- a/src/redux/store.test.ts
+++ b/src/redux/store.test.ts
@@ -93,7 +93,7 @@ describe('store state', () => {
       Object {
         "_persist": Object {
           "rehydrated": true,
-          "version": 87,
+          "version": 88,
         },
         "account": Object {
           "acceptedTerms": false,
@@ -224,6 +224,7 @@ describe('store state', () => {
           "schemaCountryOverrides": Object {},
           "selectFiatConnectQuoteLoading": false,
           "sendingFiatAccountStatus": "NotSending",
+          "timeoutSeconds": 30,
           "transfer": null,
         },
         "fiatExchanges": Object {

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -23,7 +23,7 @@ const persistConfig: PersistConfig<RootState> = {
   key: 'root',
   // default is -1, increment as we make migrations
   // See https://github.com/valora-inc/wallet/tree/main/WALLET.md#redux-state-migration
-  version: 87,
+  version: 88,
   keyPrefix: `reduxStore-`, // the redux-persist default is `persist:` which doesn't work with some file systems.
   storage: FSStorage(),
   blacklist: ['networkInfo', 'alert', 'imports', 'supercharge', 'swap'],

--- a/test/RootStateSchema.json
+++ b/test/RootStateSchema.json
@@ -3293,6 +3293,9 @@
                 "sendingFiatAccountStatus": {
                     "$ref": "#/definitions/SendingFiatAccountStatus"
                 },
+                "timeoutSeconds": {
+                    "type": "number"
+                },
                 "transfer": {
                     "anyOf": [
                         {
@@ -3316,6 +3319,7 @@
                 "schemaCountryOverrides",
                 "selectFiatConnectQuoteLoading",
                 "sendingFiatAccountStatus",
+                "timeoutSeconds",
                 "transfer"
             ],
             "type": "object"

--- a/test/RootStateSchema.json
+++ b/test/RootStateSchema.json
@@ -2133,6 +2133,9 @@
                         "string"
                     ]
                 },
+                "networkTimeoutSeconds": {
+                    "type": "number"
+                },
                 "numberVerified": {
                     "type": "boolean"
                 },
@@ -2250,6 +2253,7 @@
                 "loggedIn",
                 "maxSwapSlippagePercentage",
                 "minVersion",
+                "networkTimeoutSeconds",
                 "numberVerified",
                 "paymentDeepLinkHandler",
                 "phoneNumberVerified",
@@ -3293,9 +3297,6 @@
                 "sendingFiatAccountStatus": {
                     "$ref": "#/definitions/SendingFiatAccountStatus"
                 },
-                "timeoutSeconds": {
-                    "type": "number"
-                },
                 "transfer": {
                     "anyOf": [
                         {
@@ -3319,7 +3320,6 @@
                 "schemaCountryOverrides",
                 "selectFiatConnectQuoteLoading",
                 "sendingFiatAccountStatus",
-                "timeoutSeconds",
                 "transfer"
             ],
             "type": "object"

--- a/test/schemas.ts
+++ b/test/schemas.ts
@@ -1743,6 +1743,18 @@ export const v87Schema = {
   },
 }
 
+export const v88Schema = {
+  ...v87Schema,
+  _persist: {
+    ...v87Schema._persist,
+    version: 88,
+  },
+  fiatConnect: {
+    ...v87Schema.fiatConnect,
+    timeoutSeconds: 30,
+  },
+}
+
 export function getLatestSchema(): Partial<RootState> {
-  return v87Schema as Partial<RootState>
+  return v88Schema as Partial<RootState>
 }

--- a/test/schemas.ts
+++ b/test/schemas.ts
@@ -1749,9 +1749,9 @@ export const v88Schema = {
     ...v87Schema._persist,
     version: 88,
   },
-  fiatConnect: {
-    ...v87Schema.fiatConnect,
-    timeoutSeconds: 30,
+  app: {
+    ...v87Schema.app,
+    networkTimeoutSeconds: 30,
   },
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2294,10 +2294,10 @@
     lodash "^4.17.19"
     to-fast-properties "^2.0.0"
 
-"@badrap/result@^0.2.12", "@badrap/result@~0.2.12":
-  version "0.2.12"
-  resolved "https://registry.yarnpkg.com/@badrap/result/-/result-0.2.12.tgz#ab5690ae04ee474ef6c912210b4126c56e7a0a9d"
-  integrity sha512-tSFeaiqM9p/2AtB0XNiTaZ0l+8icGxNTmF+v6sYBeV+JrFgoxhGn4BaM/SfP54Hc0eM3d8TwY0Q2k5AdSRaHIw==
+"@badrap/result@^0.2.13", "@badrap/result@~0.2.13":
+  version "0.2.13"
+  resolved "https://registry.yarnpkg.com/@badrap/result/-/result-0.2.13.tgz#3c23f39f7e861cfa8ac3a65726ac17b1ee364927"
+  integrity sha512-Qvyzz0dmGY0h8pwvBFo1BznAKf5Y5NXIDiqhPALWtfU7oHbAToCtPu4FlYQ3uysskSWLx8GUiyhe0nv0nDd/7Q==
 
 "@bcoe/v8-coverage@^0.2.3":
   version "0.2.3"
@@ -3262,15 +3262,15 @@
   resolved "https://registry.yarnpkg.com/@faker-js/faker/-/faker-5.5.3.tgz#18e3af6b8eae7984072bbeb0c0858474d7c4cefe"
   integrity sha512-R11tGE6yIFwqpaIqcfkcg7AICXzFg14+5h5v0TfF/9+RMDL6jhzCy/pxHVOfbALGdtVYdt6JdR21tuxEgl34dw==
 
-"@fiatconnect/fiatconnect-sdk@^0.4.0":
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/@fiatconnect/fiatconnect-sdk/-/fiatconnect-sdk-0.4.0.tgz#dd5c79cc4c84ded86b42fa9aa52f75ef5f02714f"
-  integrity sha512-Es/rl2pGNs2G5tviRcz7WmBdtFqAyVom77jIHvqMXdCqsTNK/IifxcHQ78jmxY/IO6Mbstaar9p9kmMe6Qg7bw==
+"@fiatconnect/fiatconnect-sdk@^0.4.1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@fiatconnect/fiatconnect-sdk/-/fiatconnect-sdk-0.4.1.tgz#1c19da1eaee65ac0a020340f188c65e54d11f35b"
+  integrity sha512-TMcavOdhRE1JaM9gLcr8LkISTpx1mUecqRLXBt40S3jdOVPGJo07ocaxSnPMyBGmat0F2vVBdm0JNbZkII3DyA==
   dependencies:
-    "@badrap/result" "^0.2.12"
+    "@badrap/result" "^0.2.13"
     "@fiatconnect/fiatconnect-types" "^8.0.0"
     cross-fetch "^3.1.5"
-    ethers "^5.7.1"
+    ethers "^5.7.2"
     fetch-cookie "^2.0.3"
     siwe "^1.1.6"
     tough-cookie "^4.0.0"
@@ -9808,7 +9808,7 @@ ethereumjs-util@^7.0.8, ethereumjs-util@^7.1.0, ethereumjs-util@^7.1.3:
     ethereum-cryptography "^0.1.3"
     rlp "^2.2.4"
 
-ethers@5.0.5, ethers@^5.0.13, ethers@^5.5.4, ethers@^5.7.1:
+ethers@5.0.5, ethers@^5.0.13, ethers@^5.5.4, ethers@^5.7.2:
   version "5.0.5"
   resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.0.5.tgz#09b37c27d3b7d93c084af7ec4cad72ca8cfa5b7a"
   integrity sha512-hkVI7fi16ADWTctYMEfamU39hoR+JpkdEI7LH8PC7Bhl0Dp8y8dqFJ948pSEuuPJI5NR/L4+V6y2Alvyu+zROw==


### PR DESCRIPTION
### Description

react-native's fetch implementation doesn't have a default timeout option and requests can hang for a long time. This PR uses the latest fiatconnect-sdk (which supports timeouts) to set a timeout on all fiatConnect and IHL requests. The timeout is configurable through firebase remote config

### Other changes

N/A

### Tested

Unit tests, manually by setting a low value for timeout (500ms) and checking if selecting a quote for a provider, which should trigger a login with the provider, errors out with an AbortError .


### How others should test

N/A

### Related issues

- Fixes ACT-499

### Backwards compatibility

Yes