### PR TITLE
fix: failed CPV during onboarding due to missing signed message

### DIFF
--- a/src/verify/VerificationStartScreen.test.tsx
+++ b/src/verify/VerificationStartScreen.test.tsx
@@ -87,7 +87,7 @@ describe('VerificationStartScreen', () => {
     expect(within(LearnMoreDialog).getByText('phoneVerificationScreen.learnMore.body')).toBeTruthy()
   })
 
-  it.only('shows the skip dialog', () => {
+  it('shows the skip dialog', () => {
     const { getByText, getByTestId } = renderComponent({ hideOnboardingStep: false })
 
     act(() => {

--- a/src/verify/VerificationStartScreen.test.tsx
+++ b/src/verify/VerificationStartScreen.test.tsx
@@ -1,5 +1,6 @@
-import { act, fireEvent, render, within } from '@testing-library/react-native'
+import { act, fireEvent, render, waitFor, within } from '@testing-library/react-native'
 import React from 'react'
+import * as Keychain from 'react-native-keychain'
 import { Provider } from 'react-redux'
 import { navigate, navigateHome } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
@@ -7,6 +8,9 @@ import { StackParamList } from 'src/navigator/types'
 import VerificationEducationScreen from 'src/verify/VerificationEducationScreen'
 import MockedNavigator from 'test/MockedNavigator'
 import { createMockStore } from 'test/utils'
+import { mocked } from 'ts-jest/utils'
+
+const mockedKeychain = mocked(Keychain)
 
 const renderComponent = (navParams?: StackParamList[Screens.VerificationEducationScreen]) =>
   render(
@@ -34,23 +38,44 @@ describe('VerificationStartScreen', () => {
     jest.clearAllMocks()
   })
 
-  it('displays the correct components on mount', () => {
+  it('displays the correct components on mount', async () => {
+    mockedKeychain.getGenericPassword.mockResolvedValue({
+      password: 'some signed message',
+      username: 'username',
+      service: 'service',
+      storage: 'storage',
+    })
     const { getByText, getByTestId } = renderComponent()
 
+    act(() => {
+      jest.advanceTimersByTime(5000)
+    })
+
+    await waitFor(() => expect(getByText('phoneVerificationScreen.startButtonLabel')).toBeTruthy())
     expect(getByText('phoneVerificationScreen.title')).toBeTruthy()
     expect(getByText('phoneVerificationScreen.description')).toBeTruthy()
     expect(getByTestId('CountrySelectionButton')).toBeTruthy()
     expect(getByTestId('PhoneNumberField')).toBeTruthy()
-    expect(getByText('phoneVerificationScreen.startButtonLabel')).toBeTruthy()
     expect(getByText('phoneVerificationScreen.learnMore.buttonLabel')).toBeTruthy()
     expect(getByTestId('PhoneVerificationLearnMoreDialog').props.visible).toBe(false)
     expect(getByTestId('PhoneVerificationSkipDialog').props.visible).toBe(false)
   })
 
-  it('shows the learn more dialog', async () => {
+  it('does not allow starting CPV when signed message is not yet available', () => {
+    mockedKeychain.getGenericPassword.mockResolvedValue(false)
+    const { queryByText, getByTestId } = renderComponent()
+
+    jest.advanceTimersByTime(500)
+
+    expect(getByTestId('PhoneVerificationContinue')).toBeDisabled()
+    expect(getByTestId('Button/Loading')).toBeTruthy()
+    expect(queryByText('phoneVerificationScreen.startButtonLabel')).toBeFalsy()
+  })
+
+  it('shows the learn more dialog', () => {
     const { getByTestId, getByText } = renderComponent()
 
-    await act(() => {
+    act(() => {
       fireEvent.press(getByText('phoneVerificationScreen.learnMore.buttonLabel'))
     })
 
@@ -62,10 +87,10 @@ describe('VerificationStartScreen', () => {
     expect(within(LearnMoreDialog).getByText('phoneVerificationScreen.learnMore.body')).toBeTruthy()
   })
 
-  it('shows the skip dialog', async () => {
+  it.only('shows the skip dialog', () => {
     const { getByText, getByTestId } = renderComponent({ hideOnboardingStep: false })
 
-    await act(() => {
+    act(() => {
       fireEvent.press(getByText('skip'))
     })
 
@@ -74,7 +99,7 @@ describe('VerificationStartScreen', () => {
     expect(within(SkipDialog).getByText('phoneVerificationScreen.skip.title')).toBeTruthy()
     expect(within(SkipDialog).getByText('phoneVerificationScreen.skip.body')).toBeTruthy()
 
-    await act(() => {
+    act(() => {
       fireEvent.press(getByText('phoneVerificationScreen.skip.confirm'))
     })
 
@@ -82,12 +107,20 @@ describe('VerificationStartScreen', () => {
   })
 
   it('proceeds to the next verification step', async () => {
+    mockedKeychain.getGenericPassword.mockResolvedValue({
+      password: 'some signed message',
+      username: 'username',
+      service: 'service',
+      storage: 'storage',
+    })
     const { getByText, getByTestId } = renderComponent({ hideOnboardingStep: false })
 
-    await act(() => {
+    act(() => {
+      jest.advanceTimersByTime(5000)
       fireEvent.changeText(getByTestId('PhoneNumberField'), '619123456')
     })
 
+    await waitFor(() => expect(getByText('phoneVerificationScreen.startButtonLabel')).toBeTruthy())
     fireEvent.press(getByText('phoneVerificationScreen.startButtonLabel'))
 
     expect(navigate).toHaveBeenCalledTimes(1)

--- a/src/verify/VerificationStartScreen.tsx
+++ b/src/verify/VerificationStartScreen.tsx
@@ -256,6 +256,7 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: colors.onboardingBackground,
+    justifyContent: 'center',
   },
   scrollContainer: {
     flex: 1,

--- a/src/verify/VerificationStartScreen.tsx
+++ b/src/verify/VerificationStartScreen.tsx
@@ -26,6 +26,7 @@ import { navigate, navigateHome } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import { TopBarTextButton } from 'src/navigator/TopBarButton'
 import { StackParamList } from 'src/navigator/types'
+import { retrieveSignedMessage } from 'src/pincode/authentication'
 import { waitUntilSagasFinishLoading } from 'src/redux/sagas'
 import colors from 'src/styles/colors'
 import fontStyles from 'src/styles/fonts'
@@ -46,6 +47,7 @@ function VerificationStartScreen({
       route.params?.selectedCountryCodeAlpha2 || RNLocalize.getCountry()
     )
   )
+  const [signedMessageCreated, setSignedMessageCreated] = useState(false)
 
   const { t } = useTranslation()
   const dispatch = useDispatch()
@@ -140,6 +142,17 @@ function VerificationStartScreen({
     }
   }, [route.params?.selectedCountryCodeAlpha2])
 
+  useEffect(() => {
+    const thing = setInterval(async () => {
+      if (!signedMessageCreated) {
+        const signedMessage = await retrieveSignedMessage()
+        setSignedMessageCreated(!!signedMessage)
+      }
+    }, 500)
+
+    return () => clearInterval(thing)
+  }, [])
+
   useAsync(async () => {
     await waitUntilSagasFinishLoading()
     if (walletAddress === null) {
@@ -197,6 +210,7 @@ function VerificationStartScreen({
           text={t('phoneVerificationScreen.startButtonLabel')}
           onPress={onPressStart}
           type={BtnTypes.ONBOARDING}
+          showLoading={!signedMessageCreated}
           style={styles.startButton}
           disabled={!phoneNumberInfo.isValidNumber}
           testID="PhoneVerificationContinue"

--- a/src/verify/VerificationStartScreen.tsx
+++ b/src/verify/VerificationStartScreen.tsx
@@ -143,14 +143,14 @@ function VerificationStartScreen({
   }, [route.params?.selectedCountryCodeAlpha2])
 
   useEffect(() => {
-    const thing = setInterval(async () => {
+    const interval = setInterval(async () => {
       if (!signedMessageCreated) {
         const signedMessage = await retrieveSignedMessage()
         setSignedMessageCreated(!!signedMessage)
       }
     }, 500)
 
-    return () => clearInterval(thing)
+    return () => clearInterval(interval)
   }, [])
 
   useAsync(async () => {


### PR DESCRIPTION
### Description

Context: https://valora-app.slack.com/archives/C044B8ULVC0/p1667413326982599

This PR introduces a loading state to the phone verification start button while the signed message is not available. Previously on android this can fail: 
- during onboarding the "initialise account" action is dispatched on this screen load
- the signed message is only generated after the account has been generated, but this is an asynchronous action
- if the user navigates to the next CPV step before the previous step is complete, there is no signed message for authentication with CPV, so the verification will always fail here.


### Other changes
N/A

### Tested

Manually + unit tests. 

### How others should test

On android device:
- create a new account + verify phone number. it should succeed

### Related issues

N/A

### Backwards compatibility

Yes