### PR TITLE
fix(fiatconnect): check fiatAccountSchema in return user flow

### DIFF
--- a/src/fiatExchanges/FiatExchangeAmount.test.tsx
+++ b/src/fiatExchanges/FiatExchangeAmount.test.tsx
@@ -1,4 +1,4 @@
-import { FiatAccountType, FiatType } from '@fiatconnect/fiatconnect-types'
+import { FiatAccountSchema, FiatAccountType, FiatType } from '@fiatconnect/fiatconnect-types'
 import { fireEvent, render } from '@testing-library/react-native'
 import * as React from 'react'
 import { Provider } from 'react-redux'
@@ -316,6 +316,7 @@ describe('FiatExchangeAmount cashOut', () => {
             flow: CICOFlow.CashOut,
             cryptoType: Currency.Dollar,
             fiatType: FiatType.USD,
+            fiatAccountSchema: FiatAccountSchema.AccountNumber,
           },
         ],
       },
@@ -344,6 +345,7 @@ describe('FiatExchangeAmount cashOut', () => {
         providerId: 'provider-two',
         fiatAccountId: '123',
         fiatAccountType: FiatAccountType.BankAccount,
+        fiatAccountSchema: FiatAccountSchema.AccountNumber,
       })
     )
   })

--- a/src/fiatExchanges/FiatExchangeAmount.tsx
+++ b/src/fiatExchanges/FiatExchangeAmount.tsx
@@ -166,7 +166,7 @@ function FiatExchangeAmount({ route }: Props) {
     if (previousFiatAccount) {
       // This will attempt to navigate to the Review Screen if the proper quote and fiatAccount are found
       // If not, then the user will be navigated to the SelectProvider screen as normal
-      const { providerId, fiatAccountId, fiatAccountType } = previousFiatAccount
+      const { providerId, fiatAccountId, fiatAccountType, fiatAccountSchema } = previousFiatAccount
       dispatch(
         attemptReturnUserFlow({
           flow,
@@ -175,6 +175,7 @@ function FiatExchangeAmount({ route }: Props) {
           providerId,
           fiatAccountId,
           fiatAccountType,
+          fiatAccountSchema,
         })
       )
     } else {

--- a/src/fiatconnect/saga.test.ts
+++ b/src/fiatconnect/saga.test.ts
@@ -1169,12 +1169,14 @@ describe('Fiatconnect saga', () => {
       providerId: 'provider-two',
       fiatAccountId: '123',
       fiatAccountType: FiatAccountType.BankAccount,
+      fiatAccountSchema: FiatAccountSchema.AccountNumber,
     })
     const paramsKyc = attemptReturnUserFlow({
       ...selectProviderParams,
       providerId: 'provider-three',
       fiatAccountId: '123',
       fiatAccountType: FiatAccountType.BankAccount,
+      fiatAccountSchema: FiatAccountSchema.AccountNumber,
     })
     const fiatAccount = {
       fiatAccountId: '123',

--- a/src/fiatconnect/saga.ts
+++ b/src/fiatconnect/saga.ts
@@ -299,7 +299,15 @@ export function* handleSubmitFiatAccount({
 export function* handleAttemptReturnUserFlow({
   payload: params,
 }: ReturnType<typeof attemptReturnUserFlow>): any {
-  const { amount, flow, selectedCrypto, providerId, fiatAccountId, fiatAccountType } = params
+  const {
+    amount,
+    flow,
+    selectedCrypto,
+    providerId,
+    fiatAccountId,
+    fiatAccountType,
+    fiatAccountSchema,
+  } = params
   const digitalAsset = {
     [Currency.Celo]: CiCoCurrency.CELO,
     [Currency.Dollar]: CiCoCurrency.CUSD,
@@ -315,6 +323,7 @@ export function* handleAttemptReturnUserFlow({
       providerId,
       fiatAccountId,
       fiatAccountType,
+      fiatAccountSchema,
     })
     if (!fiatAccount) {
       throw new Error('Could not find fiat account')

--- a/src/fiatconnect/slice.ts
+++ b/src/fiatconnect/slice.ts
@@ -106,6 +106,7 @@ export interface AttemptReturnUserFlowAction {
   providerId: string
   fiatAccountId: string
   fiatAccountType: FiatAccountType
+  fiatAccountSchema: FiatAccountSchema
 }
 
 export interface FetchFiatConnectQuotesCompletedAction {


### PR DESCRIPTION
### Description

* Check that fiatAccountSchema for the account on file matches the fiatAccountSchema for the cached quote in the return user flow.

This work was mostly already done by @jophish in https://github.com/valora-inc/wallet/pull/3040 . This is just connecting part of what he already built.

### Tested

Unit tests

### How others should test
N/A

### Related issues

https://linear.app/valora/issue/ACT-402/ensure-that-fiat-account-schema-is-eligible-in-return-user-flow

### Backwards compatibility

Previous incompatible cached accounts were handled in joe's previous pr