### PR TITLE
fix(fiatconnect): Fix state warning on `SelectProvider` screen

### DIFF
--- a/src/fiatExchanges/PaymentMethodSection.tsx
+++ b/src/fiatExchanges/PaymentMethodSection.tsx
@@ -44,8 +44,10 @@ export function PaymentMethodSection({
         quoteCount: sectionQuotes.length,
         providers: sectionQuotes.map((quote) => quote.getProviderId()),
       })
+    } else {
+      setNoPaymentMethods(true)
     }
-  }, [])
+  }, [sectionQuotes])
 
   const toggleExpanded = () => {
     if (expanded) {
@@ -62,8 +64,8 @@ export function PaymentMethodSection({
     LayoutAnimation.easeInEaseOut()
     setExpanded(!expanded)
   }
+
   if (!sectionQuotes.length) {
-    setNoPaymentMethods(true)
     return null
   }
 

--- a/src/fiatExchanges/PaymentMethodSection.tsx
+++ b/src/fiatExchanges/PaymentMethodSection.tsx
@@ -47,7 +47,7 @@ export function PaymentMethodSection({
     } else {
       setNoPaymentMethods(true)
     }
-  }, [sectionQuotes])
+  }, [])
 
   const toggleExpanded = () => {
     if (expanded) {


### PR DESCRIPTION
### Description

Previously, we were getting a warning when rendering the `SelectProvider` screen after fetching quotes:

```
 INFO  [1667836533196] Warning: Cannot update a component (`SelectProviderScreen`) while rendering a different component (`PaymentMethodSection`). To locate the bad setState() call inside `PaymentMethodSection`, follow the stack trace as described in https://reactjs.org/link/setstate-in-render
    in PaymentMethodSection (at SelectProvider.tsx:229)
    in RCTScrollContentView (at ScrollView.js:1674)
    in RCTScrollView (at ScrollView.js:1792)
    in ScrollView (at ScrollView.js:1818)
    in ScrollView (at SelectProvider.tsx:228)
    in SelectProviderScreen (at SceneView.tsx:130)
```

This was due to the fact that when rendering the `PaymentMethodSection` component within `SelectProvider` screen, it would call the `setNoPaymentMethods` method of the parent component, triggering a re-render of the parent while attempting to render the child. Moving the `setNoPaymentMethods` call inside the `useEffect` hook fixes this issue and prevents the warning from occuring.

### Other changes

N/A

### Tested

Manually tested, warning is no longer generated.


### How others should test

N/A

### Related issues

N/A

### Backwards compatibility

Yes.