### PR TITLE
fix(fiatconnect): Get quotes using the value the user inputs

### DIFF
--- a/src/fiatExchanges/FiatExchangeAmount.tsx
+++ b/src/fiatExchanges/FiatExchangeAmount.tsx
@@ -48,7 +48,7 @@ import colors from 'src/styles/colors'
 import fontStyles from 'src/styles/fonts'
 import variables from 'src/styles/variables'
 import { useTokenInfoBySymbol } from 'src/tokens/hooks'
-import { Currency } from 'src/utils/currencies'
+import { CiCoCurrency, Currency } from 'src/utils/currencies'
 import { roundUp } from 'src/utils/formatting'
 import Logger from 'src/utils/Logger'
 import { CICOFlow } from './utils'
@@ -65,6 +65,9 @@ const oneUnitAmount = (currency: Currency) => ({
   value: new BigNumber('1'),
   currencyCode: currency,
 })
+
+export const isUserInputCrypto = (flow: CICOFlow, currency: Currency | CiCoCurrency): boolean =>
+  flow === CICOFlow.CashOut || currency === Currency.Celo || currency === CiCoCurrency.CELO
 
 function FiatExchangeAmount({ route }: Props) {
   const { t } = useTranslation()
@@ -88,7 +91,7 @@ function FiatExchangeAmount({ route }: Props) {
   const cryptoSymbol = currency === Currency.Celo ? 'CELO' : currency
   const localCurrencySymbol = LocalCurrencySymbol[localCurrencyCode]
 
-  const inputIsCrypto = flow === CICOFlow.CashOut || currency === Currency.Celo
+  const inputIsCrypto = isUserInputCrypto(flow, currency)
 
   const inputCryptoAmount = inputIsCrypto ? parsedInputAmount : inputConvertedToCrypto
   const inputLocalCurrencyAmount = inputIsCrypto ? inputConvertedToLocalCurrency : parsedInputAmount
@@ -301,7 +304,7 @@ FiatExchangeAmount.navOptions = ({
   route: RouteProp<StackParamList, Screens.FiatExchangeAmount>
 }) => {
   const { currency, flow } = route.params
-  const inputIsCrypto = flow === CICOFlow.CashOut || currency === Currency.Celo
+  const inputIsCrypto = isUserInputCrypto(flow, currency)
   return {
     ...emptyHeader,
     headerLeft: () => <BackButton eventName={FiatExchangeEvents.cico_amount_back} />,

--- a/src/fiatExchanges/SelectProvider.tsx
+++ b/src/fiatExchanges/SelectProvider.tsx
@@ -94,6 +94,7 @@ export default function SelectProviderScreen({ route, navigation }: Props) {
         flow,
         digitalAsset,
         cryptoAmount: route.params.amount.crypto,
+        fiatAmount: route.params.amount.fiat,
       })
     )
   }, [flow, digitalAsset, route.params.amount.crypto, fiatConnectProviders])

--- a/src/fiatconnect/RefetchQuoteScreen.test.tsx
+++ b/src/fiatconnect/RefetchQuoteScreen.test.tsx
@@ -1,14 +1,14 @@
-import { createMockStore, getMockStackScreenProps } from 'test/utils'
-import { Provider } from 'react-redux'
-import * as React from 'react'
-import FiatConnectRefetchQuoteScreen from 'src/fiatconnect/RefetchQuoteScreen'
-import { Screens } from 'src/navigator/Screens'
-import { KycSchema, FiatType } from '@fiatconnect/fiatconnect-types'
+import { FiatType, KycSchema } from '@fiatconnect/fiatconnect-types'
 import { render } from '@testing-library/react-native'
-import { navigate } from 'src/navigator/NavigationService'
+import * as React from 'react'
+import { Provider } from 'react-redux'
+import FiatConnectRefetchQuoteScreen from 'src/fiatconnect/RefetchQuoteScreen'
 import { refetchQuote } from 'src/fiatconnect/slice'
 import { CICOFlow } from 'src/fiatExchanges/utils'
+import { navigate } from 'src/navigator/NavigationService'
+import { Screens } from 'src/navigator/Screens'
 import { Currency } from 'src/utils/currencies'
+import { createMockStore, getMockStackScreenProps } from 'test/utils'
 
 const store = createMockStore()
 
@@ -69,6 +69,7 @@ describe('RefetchQuoteScreen', () => {
         flow: CICOFlow.CashOut,
         cryptoType: Currency.Dollar,
         cryptoAmount: '10',
+        fiatAmount: '10',
         providerId: 'some-provider',
       })
     )
@@ -107,6 +108,7 @@ describe('RefetchQuoteScreen', () => {
         flow: CICOFlow.CashOut,
         cryptoType: Currency.Dollar,
         cryptoAmount: '10',
+        fiatAmount: '10',
         providerId: 'some-provider',
       })
     )

--- a/src/fiatconnect/RefetchQuoteScreen.tsx
+++ b/src/fiatconnect/RefetchQuoteScreen.tsx
@@ -1,17 +1,17 @@
-import React, { useEffect } from 'react'
-import { Screens } from 'src/navigator/Screens'
 import { StackScreenProps } from '@react-navigation/stack'
-import { StackParamList } from 'src/navigator/types'
-import { useSelector, useDispatch } from 'react-redux'
-import { StyleSheet, ActivityIndicator, View } from 'react-native'
-import colors from 'src/styles/colors'
+import React, { useEffect } from 'react'
+import { ActivityIndicator, StyleSheet, View } from 'react-native'
+import { useDispatch, useSelector } from 'react-redux'
 import {
-  fiatConnectQuotesErrorSelector,
   cachedQuoteParamsSelector,
+  fiatConnectQuotesErrorSelector,
 } from 'src/fiatconnect/selectors'
-import variables from 'src/styles/variables'
 import { refetchQuote } from 'src/fiatconnect/slice'
 import { navigate } from 'src/navigator/NavigationService'
+import { Screens } from 'src/navigator/Screens'
+import { StackParamList } from 'src/navigator/types'
+import colors from 'src/styles/colors'
+import variables from 'src/styles/variables'
 
 type Props = StackScreenProps<StackParamList, Screens.FiatConnectRefetchQuote>
 
@@ -32,6 +32,7 @@ export default function FiatConnectRefetchQuoteScreen({ route }: Props) {
           flow: cachedQuoteParams.flow,
           cryptoType: cachedQuoteParams.cryptoType,
           cryptoAmount: cachedQuoteParams.cryptoAmount,
+          fiatAmount: cachedQuoteParams.fiatAmount,
           providerId,
         })
       )

--- a/src/fiatconnect/ReviewScreen.test.tsx
+++ b/src/fiatconnect/ReviewScreen.test.tsx
@@ -5,7 +5,7 @@ import * as React from 'react'
 import { Provider } from 'react-redux'
 import { FiatConnectQuoteSuccess } from 'src/fiatconnect'
 import FiatConnectReviewScreen from 'src/fiatconnect/ReviewScreen'
-import { createFiatConnectTransfer, refetchQuote, FiatAccount } from 'src/fiatconnect/slice'
+import { createFiatConnectTransfer, FiatAccount, refetchQuote } from 'src/fiatconnect/slice'
 import FiatConnectQuote from 'src/fiatExchanges/quotes/FiatConnectQuote'
 import { CICOFlow } from 'src/fiatExchanges/utils'
 import { navigate } from 'src/navigator/NavigationService'
@@ -102,6 +102,7 @@ describe('ReviewScreen', () => {
           flow: CICOFlow.CashOut,
           cryptoType: props.route.params.normalizedQuote.getCryptoType(),
           cryptoAmount: props.route.params.normalizedQuote.getCryptoAmount(),
+          fiatAmount: props.route.params.normalizedQuote.getFiatAmount(),
           providerId: props.route.params.normalizedQuote.getProviderId(),
           fiatAccount: props.route.params.fiatAccount,
         })
@@ -125,6 +126,7 @@ describe('ReviewScreen', () => {
           flow: CICOFlow.CashOut,
           cryptoType: props.route.params.normalizedQuote.getCryptoType(),
           cryptoAmount: props.route.params.normalizedQuote.getCryptoAmount(),
+          fiatAmount: props.route.params.normalizedQuote.getFiatAmount(),
           providerId: props.route.params.normalizedQuote.getProviderId(),
           fiatAccount: props.route.params.fiatAccount,
         })
@@ -136,6 +138,7 @@ describe('ReviewScreen', () => {
           flow: CICOFlow.CashOut,
           cryptoType: props.route.params.normalizedQuote.getCryptoType(),
           cryptoAmount: props.route.params.normalizedQuote.getCryptoAmount(),
+          fiatAmount: props.route.params.normalizedQuote.getFiatAmount(),
           providerId: props.route.params.normalizedQuote.getProviderId(),
           fiatAccount: props.route.params.fiatAccount,
         })
@@ -190,6 +193,7 @@ describe('ReviewScreen', () => {
           flow: CICOFlow.CashOut,
           cryptoType: props.route.params.normalizedQuote.getCryptoType(),
           cryptoAmount: props.route.params.normalizedQuote.getCryptoAmount(),
+          fiatAmount: props.route.params.normalizedQuote.getFiatAmount(),
           providerId: props.route.params.normalizedQuote.getProviderId(),
           fiatAccount: props.route.params.fiatAccount,
         })

--- a/src/fiatconnect/ReviewScreen.tsx
+++ b/src/fiatconnect/ReviewScreen.tsx
@@ -52,6 +52,7 @@ export default function FiatConnectReviewScreen({ route, navigation }: Props) {
           flow,
           cryptoType: normalizedQuote.getCryptoType(),
           cryptoAmount: normalizedQuote.getCryptoAmount(),
+          fiatAmount: normalizedQuote.getFiatAmount(),
           providerId: normalizedQuote.getProviderId(),
           fiatAccount,
         })
@@ -122,6 +123,7 @@ export default function FiatConnectReviewScreen({ route, navigation }: Props) {
         flow,
         cryptoType: normalizedQuote.getCryptoType(),
         cryptoAmount: normalizedQuote.getCryptoAmount(),
+        fiatAmount: normalizedQuote.getFiatAmount(),
         providerId: normalizedQuote.getProviderId(),
         fiatAccount,
       })
@@ -176,6 +178,7 @@ export default function FiatConnectReviewScreen({ route, navigation }: Props) {
               flow,
               cryptoType: normalizedQuote.getCryptoType(),
               cryptoAmount: normalizedQuote.getCryptoAmount(),
+              fiatAmount: normalizedQuote.getFiatAmount(),
               providerId: normalizedQuote.getProviderId(),
               fiatAccount,
             })

--- a/src/fiatconnect/index.test.ts
+++ b/src/fiatconnect/index.test.ts
@@ -98,6 +98,7 @@ describe('FiatConnect helpers', () => {
       localCurrency: LocalCurrencyCode.USD,
       digitalAsset: CiCoCurrency.CUSD,
       cryptoAmount: 100,
+      fiatAmount: 100,
       country: 'US',
       fiatConnectProviders: [
         {
@@ -130,6 +131,7 @@ describe('FiatConnect helpers', () => {
       localCurrency: LocalCurrencyCode.USD,
       digitalAsset: CiCoCurrency.CUSD,
       cryptoAmount: 100,
+      fiatAmount: 100,
       country: 'US',
       fiatConnectProviders: mockFiatConnectProviderInfo,
       address: '0xabc',
@@ -154,6 +156,31 @@ describe('FiatConnect helpers', () => {
       const quotes = await getFiatConnectQuotes(getQuotesInput)
       expect(quotes).toEqual([mockFiatConnectQuotes[1], mockFiatConnectQuotes[0]])
       expect(Logger.error).not.toHaveBeenCalled()
+    })
+    it('calls with cryptoAmount for cash out', async () => {
+      mockFetch.mockResponseOnce(JSON.stringify({ quotes: mockGetFiatConnectQuotesResponse }), {
+        status: 200,
+      })
+      await getFiatConnectQuotes({ ...getQuotesInput, flow: CICOFlow.CashOut })
+      expect(mockFetch).toHaveBeenCalledWith(expect.stringContaining('cryptoAmount=100'))
+      expect(mockFetch).toHaveBeenCalledWith(expect.not.stringContaining('fiatAmount=100'))
+      expect(Logger.error).not.toHaveBeenCalled()
+    })
+    it('calls with fiatAmount for cash in', async () => {
+      mockFetch.mockResponseOnce(JSON.stringify({ quotes: mockGetFiatConnectQuotesResponse }), {
+        status: 200,
+      })
+      await getFiatConnectQuotes(getQuotesInput)
+      expect(mockFetch).toHaveBeenCalledWith(expect.stringContaining('fiatAmount=100'))
+      expect(mockFetch).toHaveBeenCalledWith(expect.not.stringContaining('cryptoAmount=100'))
+    })
+    it('calls with cryptoAmount for cash in when crypto is CELO', async () => {
+      mockFetch.mockResponseOnce(JSON.stringify({ quotes: mockGetFiatConnectQuotesResponse }), {
+        status: 200,
+      })
+      await getFiatConnectQuotes({ ...getQuotesInput, digitalAsset: CiCoCurrency.CELO })
+      expect(mockFetch).toHaveBeenCalledWith(expect.stringContaining('cryptoAmount=100'))
+      expect(mockFetch).toHaveBeenCalledWith(expect.not.stringContaining('fiatAmount=100'))
     })
   })
   describe('loginWithFiatConnectProvider', () => {

--- a/src/fiatconnect/index.ts
+++ b/src/fiatconnect/index.ts
@@ -6,6 +6,7 @@ import {
   QuoteErrorResponse,
   QuoteResponse,
 } from '@fiatconnect/fiatconnect-types'
+import { isUserInputCrypto } from 'src/fiatExchanges/FiatExchangeAmount'
 import { CICOFlow } from 'src/fiatExchanges/utils'
 import { LocalCurrencyCode } from 'src/localCurrency/consts'
 import { getPassword } from 'src/pincode/authentication'
@@ -104,6 +105,7 @@ export type QuotesInput = {
   localCurrency: LocalCurrencyCode
   digitalAsset: CiCoCurrency
   cryptoAmount: number
+  fiatAmount: number
   country: string
   address: string
 }
@@ -132,6 +134,7 @@ export async function getFiatConnectQuotes(
     localCurrency,
     digitalAsset,
     cryptoAmount,
+    fiatAmount,
     country,
     flow,
     address,
@@ -142,7 +145,8 @@ export async function getFiatConnectQuotes(
   const quoteParams: CreateQuoteParams = {
     fiatType,
     cryptoType,
-    cryptoAmount: cryptoAmount.toString(),
+    ...(isUserInputCrypto(flow, digitalAsset) && { cryptoAmount: cryptoAmount.toString() }),
+    ...(!isUserInputCrypto(flow, digitalAsset) && { fiatAmount: fiatAmount.toString() }),
     country,
     address,
   }

--- a/src/fiatconnect/saga.test.ts
+++ b/src/fiatconnect/saga.test.ts
@@ -622,6 +622,7 @@ describe('Fiatconnect saga', () => {
           flow: CICOFlow.CashIn,
           digitalAsset: CiCoCurrency.CELO,
           cryptoAmount: 3,
+          fiatAmount: 2,
           providerIds: ['provider-one'],
         })
       )
@@ -639,6 +640,7 @@ describe('Fiatconnect saga', () => {
       expect(fetchQuotes).toHaveBeenCalledWith({
         country: 'MX',
         cryptoAmount: 3,
+        fiatAmount: 2,
         digitalAsset: 'CELO',
         fiatConnectCashInEnabled: false,
         fiatConnectCashOutEnabled: true,
@@ -657,6 +659,7 @@ describe('Fiatconnect saga', () => {
           flow: CICOFlow.CashIn,
           digitalAsset: CiCoCurrency.CELO,
           cryptoAmount: 3,
+          fiatAmount: 2,
         })
       )
         .provide([
@@ -673,6 +676,7 @@ describe('Fiatconnect saga', () => {
       expect(fetchQuotes).toHaveBeenCalledWith({
         country: 'MX',
         cryptoAmount: 3,
+        fiatAmount: 2,
         digitalAsset: 'CELO',
         fiatConnectCashInEnabled: false,
         fiatConnectCashOutEnabled: true,
@@ -690,6 +694,7 @@ describe('Fiatconnect saga', () => {
           flow: CICOFlow.CashIn,
           digitalAsset: CiCoCurrency.CELO,
           cryptoAmount: 3,
+          fiatAmount: 2,
         })
       )
         .provide([
@@ -1075,6 +1080,7 @@ describe('Fiatconnect saga', () => {
       flow: CICOFlow.CashOut,
       cryptoType: quote.getCryptoType(),
       cryptoAmount: quote.getCryptoAmount(),
+      fiatAmount: quote.getFiatAmount(),
       providerId: quote.getProviderId(),
       fiatAccount,
     })
@@ -1083,6 +1089,7 @@ describe('Fiatconnect saga', () => {
         flow: CICOFlow.CashOut,
         cryptoType: quote.getCryptoType(),
         cryptoAmount: quote.getCryptoAmount(),
+        fiatAmount: quote.getFiatAmount(),
         providerId: quote.getProviderId(),
       })
       await expectSaga(handleRefetchQuote, paramsWithoutFiatAccount)
@@ -1092,6 +1099,7 @@ describe('Fiatconnect saga', () => {
               flow: params.payload.flow,
               digitalAsset: CiCoCurrency.CUSD,
               cryptoAmount: 100,
+              fiatAmount: 100,
               providerId: params.payload.providerId,
               fiatAccount: undefined,
             }),
@@ -1117,6 +1125,7 @@ describe('Fiatconnect saga', () => {
             call(_getSpecificQuote, {
               digitalAsset: CiCoCurrency.CUSD,
               cryptoAmount: 100,
+              fiatAmount: 100,
               flow: params.payload.flow,
               providerId: params.payload.providerId,
               fiatAccount,
@@ -1135,6 +1144,7 @@ describe('Fiatconnect saga', () => {
               flow: params.payload.flow,
               digitalAsset: CiCoCurrency.CUSD,
               cryptoAmount: 100,
+              fiatAmount: 100,
               providerId: params.payload.providerId,
               fiatAccount,
             }),
@@ -1206,6 +1216,7 @@ describe('Fiatconnect saga', () => {
             call(_getSpecificQuote, {
               digitalAsset: CiCoCurrency.CUSD,
               cryptoAmount: 2,
+              fiatAmount: 2,
               flow: params.payload.flow,
               providerId: params.payload.providerId,
               fiatAccount,
@@ -1230,6 +1241,7 @@ describe('Fiatconnect saga', () => {
             call(_getSpecificQuote, {
               digitalAsset: CiCoCurrency.CUSD,
               cryptoAmount: 2,
+              fiatAmount: 2,
               flow: params.payload.flow,
               providerId: params.payload.providerId,
               fiatAccount,
@@ -1266,6 +1278,7 @@ describe('Fiatconnect saga', () => {
             call(_getSpecificQuote, {
               digitalAsset: CiCoCurrency.CUSD,
               cryptoAmount: 2,
+              fiatAmount: 2,
               flow: params.payload.flow,
               providerId: params.payload.providerId,
               fiatAccount,
@@ -1301,6 +1314,7 @@ describe('Fiatconnect saga', () => {
             call(_getSpecificQuote, {
               digitalAsset: CiCoCurrency.CUSD,
               cryptoAmount: 2,
+              fiatAmount: 2,
               flow: paramsKyc.payload.flow,
               providerId: paramsKyc.payload.providerId,
               fiatAccount: fiatAccountKyc,
@@ -1344,6 +1358,7 @@ describe('Fiatconnect saga', () => {
             call(_getSpecificQuote, {
               digitalAsset: CiCoCurrency.CUSD,
               cryptoAmount: 2,
+              fiatAmount: 2,
               flow: paramsKyc.payload.flow,
               providerId: paramsKyc.payload.providerId,
               fiatAccount: fiatAccountKyc,
@@ -1386,6 +1401,7 @@ describe('Fiatconnect saga', () => {
             call(_getSpecificQuote, {
               digitalAsset: CiCoCurrency.CUSD,
               cryptoAmount: 2,
+              fiatAmount: 2,
               flow: paramsKyc.payload.flow,
               providerId: paramsKyc.payload.providerId,
               fiatAccount: fiatAccountKyc,
@@ -1427,6 +1443,7 @@ describe('Fiatconnect saga', () => {
             call(_getSpecificQuote, {
               digitalAsset: CiCoCurrency.CUSD,
               cryptoAmount: 2,
+              fiatAmount: 2,
               flow: paramsKyc.payload.flow,
               providerId: paramsKyc.payload.providerId,
               fiatAccount: fiatAccountKyc,
@@ -1468,6 +1485,7 @@ describe('Fiatconnect saga', () => {
             call(_getSpecificQuote, {
               digitalAsset: CiCoCurrency.CUSD,
               cryptoAmount: 2,
+              fiatAmount: 2,
               flow: paramsKyc.payload.flow,
               providerId: paramsKyc.payload.providerId,
               fiatAccount: fiatAccountKyc,
@@ -1995,6 +2013,7 @@ describe('Fiatconnect saga', () => {
       await expectSaga(_getSpecificQuote, {
         digitalAsset: CiCoCurrency.CUSD,
         cryptoAmount: 2,
+        fiatAmount: 2,
         flow: CICOFlow.CashOut,
         providerId: 'provider-two',
       })
@@ -2004,6 +2023,7 @@ describe('Fiatconnect saga', () => {
               flow: CICOFlow.CashOut,
               digitalAsset: CiCoCurrency.CUSD,
               cryptoAmount: 2,
+              fiatAmount: 2,
               providerIds: ['provider-two'],
             }),
             [mockFiatConnectQuotes[1]],
@@ -2031,6 +2051,7 @@ describe('Fiatconnect saga', () => {
           await expectSaga(_getSpecificQuote, {
             digitalAsset: CiCoCurrency.CUSD,
             cryptoAmount: 2,
+            fiatAmount: 2,
             flow: CICOFlow.CashOut,
             providerId: 'provider-two',
           })
@@ -2040,6 +2061,7 @@ describe('Fiatconnect saga', () => {
                   flow: CICOFlow.CashOut,
                   digitalAsset: CiCoCurrency.CUSD,
                   cryptoAmount: 2,
+                  fiatAmount: 2,
                   providerIds: ['provider-two'],
                 }),
                 [mockFiatConnectQuotes[1]],
@@ -2069,6 +2091,7 @@ describe('Fiatconnect saga', () => {
               flow: CICOFlow.CashOut,
               digitalAsset: CiCoCurrency.CUSD,
               cryptoAmount: 2,
+              fiatAmount: 2,
               providerIds: ['provider-two'],
             }),
             [mockFiatConnectQuotes[1]],
@@ -2099,6 +2122,7 @@ describe('Fiatconnect saga', () => {
                   flow: CICOFlow.CashOut,
                   digitalAsset: CiCoCurrency.CUSD,
                   cryptoAmount: 2,
+                  fiatAmount: 2,
                   providerIds: ['provider-two'],
                 }),
                 [mockFiatConnectQuotes[1]],

--- a/src/fiatconnect/saga.ts
+++ b/src/fiatconnect/saga.ts
@@ -89,12 +89,13 @@ const KYC_WAIT_TIME_MILLIS = 3000
 export function* handleFetchFiatConnectQuotes({
   payload: params,
 }: ReturnType<typeof fetchFiatConnectQuotes>) {
-  const { flow, digitalAsset, cryptoAmount, providerIds } = params
+  const { flow, digitalAsset, cryptoAmount, fiatAmount, providerIds } = params
   try {
     const quotes: (FiatConnectQuoteSuccess | FiatConnectQuoteError)[] = yield call(_getQuotes, {
       flow,
       digitalAsset,
       cryptoAmount,
+      fiatAmount,
       providerIds,
     })
     yield put(fetchFiatConnectQuotesCompleted({ quotes }))
@@ -108,7 +109,7 @@ export function* handleFetchFiatConnectQuotes({
  * Handles Refetching a single quote for the Review Screen.
  */
 export function* handleRefetchQuote({ payload: params }: ReturnType<typeof refetchQuote>) {
-  const { flow, cryptoType, cryptoAmount, providerId, fiatAccount } = params
+  const { flow, cryptoType, cryptoAmount, fiatAmount, providerId, fiatAccount } = params
   try {
     const {
       normalizedQuote,
@@ -120,6 +121,7 @@ export function* handleRefetchQuote({ payload: params }: ReturnType<typeof refet
       flow,
       digitalAsset: resolveCICOCurrency(cryptoType),
       cryptoAmount: parseFloat(cryptoAmount),
+      fiatAmount: parseFloat(fiatAmount),
       providerId: providerId,
       fiatAccount: fiatAccount,
     })
@@ -324,6 +326,7 @@ export function* handleAttemptReturnUserFlow({
       {
         digitalAsset,
         cryptoAmount: amount.crypto,
+        fiatAmount: amount.fiat,
         flow,
         providerId,
         fiatAccount: fiatAccount,
@@ -401,11 +404,13 @@ export function* handleAttemptReturnUserFlow({
 export function* _getQuotes({
   digitalAsset,
   cryptoAmount,
+  fiatAmount,
   flow,
   providerIds,
 }: {
   digitalAsset: CiCoCurrency
   cryptoAmount: number
+  fiatAmount: number
   flow: CICOFlow
   providerIds?: string[]
 }) {
@@ -428,6 +433,7 @@ export function* _getQuotes({
     localCurrency,
     digitalAsset,
     cryptoAmount,
+    fiatAmount,
     country: userLocation?.countryCodeAlpha2 || 'US',
     flow,
     fiatConnectCashInEnabled,
@@ -515,12 +521,14 @@ export function* _selectQuoteAndFiatAccount({
 export function* _getSpecificQuote({
   digitalAsset,
   cryptoAmount,
+  fiatAmount,
   flow,
   providerId,
   fiatAccount,
 }: {
   digitalAsset: CiCoCurrency
   cryptoAmount: number
+  fiatAmount: number
   flow: CICOFlow
   providerId: string
   fiatAccount?: FiatAccount
@@ -531,6 +539,7 @@ export function* _getSpecificQuote({
     flow,
     digitalAsset,
     cryptoAmount,
+    fiatAmount,
     providerIds: [providerId],
   })
   const normalizedQuotes = normalizeFiatConnectQuotes(flow, quotes)

--- a/src/fiatconnect/slice.ts
+++ b/src/fiatconnect/slice.ts
@@ -93,6 +93,7 @@ export interface FetchQuotesAction {
   flow: CICOFlow
   digitalAsset: CiCoCurrency
   cryptoAmount: number
+  fiatAmount: number
   providerIds?: string[]
 }
 
@@ -141,6 +142,7 @@ interface RefetchQuoteAction {
   flow: CICOFlow
   cryptoType: Currency
   cryptoAmount: string
+  fiatAmount: string
   providerId: string
   fiatAccount?: FiatAccount
 }


### PR DESCRIPTION
### Description

This change calls fiatconnect getQuotes using fiatAmount or cryptoAmount depending on which one the user originally inputed when trying to Add/Withdraw.

### Tested

Added unit tests. Saw logs where correct amount was being sent to valora-rest-api

### How others should test

N/A, only changes cash-in and its not ready yet.

### Related issues

https://linear.app/valora/issue/ACT-403/update-selectproviders-screen-for-transfers-in
