### PR TITLE
fix(fiatconnect): Fix memory leak warning on Fiat Details screen

### DIFF
--- a/src/fiatconnect/FiatDetailsScreen.tsx
+++ b/src/fiatconnect/FiatDetailsScreen.tsx
@@ -1,5 +1,5 @@
 import { StackScreenProps } from '@react-navigation/stack'
-import React, { useLayoutEffect, useMemo, useRef, useState } from 'react'
+import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ActivityIndicator, Image, StyleSheet, Text, View } from 'react-native'
 import PickerSelect from 'react-native-picker-select'
@@ -245,6 +245,15 @@ function FormField({
   const { t } = useTranslation()
   const [showError, setShowError] = useState(false)
   const typingTimer = useRef<ReturnType<typeof setTimeout>>()
+
+  // Clear timeout on unmount to prevent memory leak warning
+  useEffect(() => {
+    return () => {
+      if (typingTimer?.current) {
+        clearTimeout(typingTimer.current)
+      }
+    }
+  }, [])
 
   const onInputChange = (value: any) => {
     if (!showError) {


### PR DESCRIPTION
### Description

Currently, if a user submits fiat details, and the submission fails, they will be brought back to the Fiat Details screen, and a memory leak warning will be logged:

```
 INFO  [1667838148077] Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in a useEffect cleanup function.
    in FormField (at FiatDetailsScreen.tsx:203)
```

I believe this warning was coming from the fact that it was possible that the `setTimeout` in `FormField` had neither fired nor been cleared by the time that the user had clicked submit. (Our timeout fires after 1.5 seconds atm, so this is very possible.) If the `setTimeout` fires after the user has hit submit, we attempt to update the state on the `FormField` component, which is no longer mounted, causing the error. This fix ensures that the `setTimeout` is cleared when the `FormField` component unmounts, avoiding the warning.

### Other changes

N/A

### Tested

Manually tested, warning no longer fires on failure submitting Fiat Account details.

### How others should test

N/A

### Related issues

N/A

### Backwards compatibility

Yes