### PR TITLE
feat(fiatconnect): re-use existing fiatAccounts between cash-in and cash-out

### DIFF
--- a/src/fiatExchanges/FiatExchangeAmount.test.tsx
+++ b/src/fiatExchanges/FiatExchangeAmount.test.tsx
@@ -294,7 +294,7 @@ describe('FiatExchangeAmount cashOut', () => {
       },
     })
   })
-  it('calls diapatch attemptReturnUserFlow when there is a previously linked fiatconnect account', () => {
+  it('calls dispatch attemptReturnUserFlow when there is a previously linked fiatconnect account', () => {
     const store = createMockStore({
       stableToken: {
         balances: { [Currency.Dollar]: '1000.00', [Currency.Euro]: '500.00' },
@@ -314,6 +314,61 @@ describe('FiatExchangeAmount cashOut', () => {
             fiatAccountId: '123',
             fiatAccountType: FiatAccountType.BankAccount,
             flow: CICOFlow.CashOut,
+            cryptoType: Currency.Dollar,
+            fiatType: FiatType.USD,
+            fiatAccountSchema: FiatAccountSchema.AccountNumber,
+          },
+        ],
+      },
+    })
+    store.dispatch = jest.fn()
+    const screenProps = getMockStackScreenProps(Screens.FiatExchangeAmount, {
+      currency: Currency.Dollar,
+      flow: CICOFlow.CashOut,
+    })
+    const tree = render(
+      <Provider store={store}>
+        <FiatExchangeAmount {...screenProps} />
+      </Provider>
+    )
+
+    fireEvent.changeText(tree.getByTestId('FiatExchangeInput'), '750')
+    fireEvent.press(tree.getByTestId('FiatExchangeNextButton'))
+    expect(store.dispatch).toHaveBeenLastCalledWith(
+      attemptReturnUserFlow({
+        flow: CICOFlow.CashOut,
+        selectedCrypto: Currency.Dollar,
+        amount: {
+          crypto: 750,
+          fiat: 750,
+        },
+        providerId: 'provider-two',
+        fiatAccountId: '123',
+        fiatAccountType: FiatAccountType.BankAccount,
+        fiatAccountSchema: FiatAccountSchema.AccountNumber,
+      })
+    )
+  })
+  it('calls dispatch attemptReturnUserFlow when there is a previously linked fiatconnect account that used a different flow', () => {
+    const store = createMockStore({
+      stableToken: {
+        balances: { [Currency.Dollar]: '1000.00', [Currency.Euro]: '500.00' },
+      },
+      goldToken: {
+        balance: '5.5',
+      },
+      localCurrency: {
+        fetchedCurrencyCode: LocalCurrencyCode.USD,
+        preferredCurrencyCode: LocalCurrencyCode.USD,
+        exchangeRates: usdExchangeRates,
+      },
+      fiatConnect: {
+        cachedFiatAccountUses: [
+          {
+            providerId: 'provider-two',
+            fiatAccountId: '123',
+            fiatAccountType: FiatAccountType.BankAccount,
+            flow: CICOFlow.CashIn,
             cryptoType: Currency.Dollar,
             fiatType: FiatType.USD,
             fiatAccountSchema: FiatAccountSchema.AccountNumber,

--- a/src/fiatExchanges/FiatExchangeAmount.tsx
+++ b/src/fiatExchanges/FiatExchangeAmount.tsx
@@ -160,8 +160,7 @@ function FiatExchangeAmount({ route }: Props) {
     const previousFiatAccount = cachedFiatAccountUses.find(
       (account) =>
         account.cryptoType === currency &&
-        account.fiatType === convertToFiatConnectFiatCurrency(localCurrencyCode) &&
-        account.flow === flow
+        account.fiatType === convertToFiatConnectFiatCurrency(localCurrencyCode)
     )
     if (previousFiatAccount) {
       // This will attempt to navigate to the Review Screen if the proper quote and fiatAccount are found


### PR DESCRIPTION
### Description

Pretty short and sweet. We used to check that the cashed fiat account use matches on flow, but now we do not.

### Tested

Additional unit tests

### How others should test

N/a

### Related issues

https://linear.app/valora/issue/ACT-401/re-use-fiat-accounts-between-cash-in-and-cash-out
