### PR TITLE
test(e2e): show recovery phrase only in settings after quiz completion

### DIFF
--- a/e2e/src/usecases/NewAccountOnboarding.js
+++ b/e2e/src/usecases/NewAccountOnboarding.js
@@ -82,4 +82,17 @@ export default NewAccountOnboarding = () => {
       .toBeVisible()
       .withTimeout(10 * 1000)
   })
+
+  // After quiz completion recovery phrase should only be shown in settings
+  it('Recovery phrase only shown in settings', async () => {
+    await waitForElementId('Hamburger')
+    await element(by.id('Hamburger')).tap()
+    await expect(element(by.id('DrawerItem/Recovery Phrase'))).not.toExist()
+    await waitForElementId('DrawerItem/Settings')
+    await element(by.id('DrawerItem/Settings')).tap()
+    await waitForElementId('RecoveryPhrase')
+    await element(by.id('RecoveryPhrase')).tap()
+    await enterPinUi()
+    await waitForElementId('AccountKeyWords')
+  })
 }

--- a/src/firebase/remoteConfigValuesDefaults.e2e.ts
+++ b/src/firebase/remoteConfigValuesDefaults.e2e.ts
@@ -64,7 +64,7 @@ export const REMOTE_CONFIG_VALUES_DEFAULTS: Omit<
   visualizeNFTsEnabledInHomeAssetsPage: false,
   coinbasePayEnabled: false,
   showSwapMenuInDrawerMenu: false,
-  shouldShowRecoveryPhraseInSettings: false,
+  shouldShowRecoveryPhraseInSettings: true,
   createAccountCopyTestType: CreateAccountCopyTestType.Account,
   maxSwapSlippagePercentage: 2,
   inviteMethod: InviteMethodType.Escrow,


### PR DESCRIPTION
### Description

Adds an e2e test to check that the recovery phrase is shown only in settings after completion of the backup quiz.

### Other changes

N/A

### Tested

Tested locally on iOS

### How others should test

N/A - CI should be sufficient.

### Related issues

- RET-420

### Backwards compatibility

Yes