### PR TITLE
fix: ensure CPV start button is disabled when signed message unavailable

### DIFF
--- a/src/verify/VerificationStartScreen.test.tsx
+++ b/src/verify/VerificationStartScreen.test.tsx
@@ -65,7 +65,11 @@ describe('VerificationStartScreen', () => {
     mockedKeychain.getGenericPassword.mockResolvedValue(false)
     const { queryByText, getByTestId } = renderComponent()
 
-    jest.advanceTimersByTime(500)
+    act(() => {
+      jest.advanceTimersByTime(5000)
+      // enter a valid phone number
+      fireEvent.changeText(getByTestId('PhoneNumberField'), '619123456')
+    })
 
     expect(getByTestId('PhoneVerificationContinue')).toBeDisabled()
     expect(getByTestId('Button/Loading')).toBeTruthy()

--- a/src/verify/VerificationStartScreen.tsx
+++ b/src/verify/VerificationStartScreen.tsx
@@ -214,7 +214,7 @@ function VerificationStartScreen({
           type={BtnTypes.ONBOARDING}
           showLoading={!signedMessageCreated}
           style={styles.startButton}
-          disabled={!phoneNumberInfo.isValidNumber}
+          disabled={!phoneNumberInfo.isValidNumber || !signedMessageCreated}
           testID="PhoneVerificationContinue"
         />
       </KeyboardAwareScrollView>


### PR DESCRIPTION
### Description

As the title - perhaps fixes this error https://valora-app.slack.com/archives/C044B8ULVC0/p1668449338531799

### Other changes

N/A

### Tested

Unit tests

### How others should test

N/A

### Related issues

N/A

### Backwards compatibility

Yes