### PR TITLE
chore: skip ASv1 CPV migration for users who have no signed message

### DIFF
--- a/src/app/saga.test.ts
+++ b/src/app/saga.test.ts
@@ -490,6 +490,25 @@ describe('runCentralPhoneVerificationMigration', () => {
     expect(mockFetch).not.toHaveBeenCalled()
   })
 
+  // this is true for users who created accounts before app version 1.32 and
+  // have never unlocked their account to generate the signed message
+  it('should not run if migration conditions there is no signed message', async () => {
+    await expectSaga(runCentralPhoneVerificationMigration)
+      .provide([
+        [select(dataEncryptionKeySelector), 'someDEK'],
+        [select(shouldRunVerificationMigrationSelector), true],
+        [select(inviterAddressSelector), undefined],
+        [select(mtwAddressSelector), undefined],
+        [select(walletAddressSelector), '0xabc'],
+        [select(e164NumberSelector), '+31619777888'],
+        [call(retrieveSignedMessage), null],
+      ])
+      .not.put(phoneNumberVerificationMigrated())
+      .run()
+
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
   it('should not run if no DEK can be found', async () => {
     await expectSaga(runCentralPhoneVerificationMigration)
       .provide([

--- a/src/app/saga.ts
+++ b/src/app/saga.ts
@@ -408,11 +408,6 @@ export function* runCentralPhoneVerificationMigration() {
     return
   }
 
-  Logger.debug(
-    `${TAG}@runCentralPhoneVerificationMigration`,
-    'Starting to run central phone verification migration'
-  )
-
   const address = yield select(walletAddressSelector)
   const mtwAddress = yield select(mtwAddressSelector)
   const phoneNumber = yield select(e164NumberSelector)
@@ -420,6 +415,19 @@ export function* runCentralPhoneVerificationMigration() {
 
   try {
     const signedMessage = yield call(retrieveSignedMessage)
+    if (!signedMessage) {
+      Logger.warn(
+        `${TAG}@runCentralPhoneVerificationMigration`,
+        'No signed message was found for this user. Skipping CPV migration.'
+      )
+      return
+    }
+
+    Logger.debug(
+      `${TAG}@runCentralPhoneVerificationMigration`,
+      'Starting to run central phone verification migration'
+    )
+
     const phoneHashDetails: PhoneNumberHashDetails = yield call(fetchPhoneHashPrivate, phoneNumber)
     const inviterAddress = yield select(inviterAddressSelector)
 


### PR DESCRIPTION
### Description

For users who created their accounts before app version 1.32 and have never entered their pincode, they will not have a signed message to use for authentication. This PR skips the CPV migration for these users, since it will always fail.

### Other changes

N/A

### Tested

Unit tests

### How others should test

N/A

### Related issues

Fixes RET-490

### Backwards compatibility

Yes