### PR TITLE
Kathy/fix swap android cursor

### DIFF
--- a/src/swap/SwapAmountInput.tsx
+++ b/src/swap/SwapAmountInput.tsx
@@ -47,16 +47,10 @@ const SwapAmountInput = ({
   const { t } = useTranslation()
 
   // the startPosition and textInputRef variables exist to ensure TextInput
-  // displays the start of the value for long values on Android
+  // displays the start of the value for long values on Android when out of focus
   // https://github.com/facebook/react-native/issues/14845
-  const [startPosition, setStartPosition] = useState<number | undefined>(0)
+  const [isFocused, setIsFocused] = useState(!!autoFocus)
   const textInputRef = useRef<RNTextInput | null>(null)
-
-  const handleSetStartPosition = (value?: number) => {
-    if (Platform.OS === 'android') {
-      setStartPosition(value)
-    }
-  }
 
   const showInputLoader = loading && !inputValue
 
@@ -67,7 +61,6 @@ const SwapAmountInput = ({
         <TextInput
           forwardedRef={textInputRef}
           onChangeText={(value) => {
-            handleSetStartPosition(undefined)
             onInputChange(value)
           }}
           value={inputValue || undefined}
@@ -85,16 +78,12 @@ const SwapAmountInput = ({
           ]}
           testID="SwapAmountInput/Input"
           onBlur={() => {
-            handleSetStartPosition(0)
+            setIsFocused(false)
           }}
           onFocus={() => {
-            handleSetStartPosition(inputValue?.length ?? 0)
+            setIsFocused(true)
           }}
-          selection={
-            Platform.OS === 'android' && typeof startPosition === 'number'
-              ? { start: startPosition }
-              : undefined
-          }
+          selection={Platform.OS === 'android' && !isFocused ? { start: 0 } : undefined}
         />
         {showInputLoader && (
           <View style={styles.loadingContainer}>

--- a/src/swap/SwapAmountInput.tsx
+++ b/src/swap/SwapAmountInput.tsx
@@ -47,10 +47,16 @@ const SwapAmountInput = ({
   const { t } = useTranslation()
 
   // the startPosition and textInputRef variables exist to ensure TextInput
-  // displays the start of the value for long values on Android when out of focus
+  // displays the start of the value for long values on Android
   // https://github.com/facebook/react-native/issues/14845
-  const [isFocused, setIsFocused] = useState(!!autoFocus)
+  const [startPosition, setStartPosition] = useState<number | undefined>(0)
   const textInputRef = useRef<RNTextInput | null>(null)
+
+  const handleSetStartPosition = (value?: number) => {
+    if (Platform.OS === 'android') {
+      setStartPosition(value)
+    }
+  }
 
   const showInputLoader = loading && !inputValue
 
@@ -61,6 +67,7 @@ const SwapAmountInput = ({
         <TextInput
           forwardedRef={textInputRef}
           onChangeText={(value) => {
+            handleSetStartPosition(undefined)
             onInputChange(value)
           }}
           value={inputValue || undefined}
@@ -78,12 +85,19 @@ const SwapAmountInput = ({
           ]}
           testID="SwapAmountInput/Input"
           onBlur={() => {
-            setIsFocused(false)
+            handleSetStartPosition(0)
           }}
           onFocus={() => {
-            setIsFocused(true)
+            handleSetStartPosition(inputValue?.length ?? 0)
           }}
-          selection={Platform.OS === 'android' && !isFocused ? { start: 0 } : undefined}
+          onSelectionChange={() => {
+            handleSetStartPosition(undefined)
+          }}
+          selection={
+            Platform.OS === 'android' && typeof startPosition === 'number'
+              ? { start: startPosition }
+              : undefined
+          }
         />
         {showInputLoader && (
           <View style={styles.loadingContainer}>


### PR DESCRIPTION
### Description

Fixes the issue described https://valora-app.slack.com/archives/C04B61SJ6DS/p1668696710173969

The fix is mainly to stop setting the `selection.start` property (i.e. where the cursor is) to 0 on android if the user selection has changed.

After fix:

https://user-images.githubusercontent.com/20150449/202699101-47cbc968-47dd-46e4-afec-f1b5de324366.mp4


### Other changes

n/a

### Tested

manually

### How others should test

n/a

### Related issues

n/a

### Backwards compatibility

Yes