### PR TITLE
fix: secure send header height

### DIFF
--- a/src/send/ValidateRecipientAccount.tsx
+++ b/src/send/ValidateRecipientAccount.tsx
@@ -2,7 +2,6 @@ import { NativeStackScreenProps } from '@react-navigation/native-stack'
 import * as React from 'react'
 import { WithTranslation } from 'react-i18next'
 import { StyleSheet, Text, View } from 'react-native'
-import { SafeAreaView } from 'react-native-safe-area-context'
 import { connect } from 'react-redux'
 import { SendEvents } from 'src/analytics/Events'
 import { SendOrigin } from 'src/analytics/types'
@@ -273,7 +272,7 @@ export class ValidateRecipientAccount extends React.Component<Props, State> {
         : singleDigitInputValueArr.filter((entry) => /[a-f0-9]/gi.test(entry)).length === 4
 
     return (
-      <SafeAreaView style={styles.container}>
+      <>
         <KeyboardAwareScrollView
           contentContainerStyle={styles.scrollContainer}
           keyboardShouldPersistTaps={'always'}
@@ -319,16 +318,12 @@ export class ValidateRecipientAccount extends React.Component<Props, State> {
             <TextButton onPress={this.toggleModal}>{t('dismiss')}</TextButton>
           </View>
         </Modal>
-      </SafeAreaView>
+      </>
     )
   }
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    justifyContent: 'space-between',
-  },
   scrollContainer: {
     flexGrow: 1,
     paddingHorizontal: 16,

--- a/src/send/__snapshots__/ValidateRecipientAccount.test.tsx.snap
+++ b/src/send/__snapshots__/ValidateRecipientAccount.test.tsx.snap
@@ -1,14 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ValidateRecipientAccount renders correctly when full validation required 1`] = `
-<RNCSafeAreaView
-  style={
-    Object {
-      "flex": 1,
-      "justifyContent": "space-between",
-    }
-  }
->
+Array [
   <RCTScrollView
     contentContainerStyle={
       Object {
@@ -256,7 +249,7 @@ exports[`ValidateRecipientAccount renders correctly when full validation require
         </Text>
       </View>
     </View>
-  </RCTScrollView>
+  </RCTScrollView>,
   <View
     collapsable={false}
     style={
@@ -272,7 +265,7 @@ exports[`ValidateRecipientAccount renders correctly when full validation require
         undefined,
       ]
     }
-  />
+  />,
   <Modal
     animationType="none"
     deviceHeight={null}
@@ -640,19 +633,12 @@ exports[`ValidateRecipientAccount renders correctly when full validation require
         </View>
       </RNCSafeAreaView>
     </View>
-  </Modal>
-</RNCSafeAreaView>
+  </Modal>,
+]
 `;
 
 exports[`ValidateRecipientAccount renders correctly when partial validation required 1`] = `
-<RNCSafeAreaView
-  style={
-    Object {
-      "flex": 1,
-      "justifyContent": "space-between",
-    }
-  }
->
+Array [
   <RCTScrollView
     contentContainerStyle={
       Object {
@@ -1085,7 +1071,7 @@ exports[`ValidateRecipientAccount renders correctly when partial validation requ
         </Text>
       </View>
     </View>
-  </RCTScrollView>
+  </RCTScrollView>,
   <View
     collapsable={false}
     style={
@@ -1101,7 +1087,7 @@ exports[`ValidateRecipientAccount renders correctly when partial validation requ
         undefined,
       ]
     }
-  />
+  />,
   <Modal
     animationType="none"
     deviceHeight={null}
@@ -1469,6 +1455,6 @@ exports[`ValidateRecipientAccount renders correctly when partial validation requ
         </View>
       </RNCSafeAreaView>
     </View>
-  </Modal>
-</RNCSafeAreaView>
+  </Modal>,
+]
 `;


### PR DESCRIPTION
### Description

Adjust the header hight for `ValidateRecipientAccount.tsx`.

#### Screenshots After Android / iOS
<p align="center">
<img src="https://user-images.githubusercontent.com/26950305/202826449-64bf3b32-d6d0-44ae-83a9-94df4f5b423b.png" width="48%" height="auto" />
<img src="https://user-images.githubusercontent.com/26950305/202826476-a6b0e43b-72e0-41b0-a8b5-0c4ec9479bf9.png" width="48%" height="auto" />
</p>

### Other changes

N/A

### Tested

Tested locally on iOS and Android

### How others should test

Check screenshots

### Related issues

N/A

### Backwards compatibility

Yes