### PR TITLE
feat(fiatconnect): add transaction processing screen

### DIFF
--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -1394,6 +1394,10 @@
     "requestNotCompleted": {
       "title": "Your request could not be completed.",
       "description": "Your funds were not able to be transferred. Please try again or contact our support team for help."
+    },
+    "txProcessing": {
+      "title": "Your transaction is still processing.",
+      "description": "This might be due to poor internet connection. Check CeloExplorer for updates."
     }
   },
   "fiatExchangeFlow": {

--- a/src/analytics/Events.tsx
+++ b/src/analytics/Events.tsx
@@ -492,6 +492,8 @@ export enum FiatExchangeEvents {
   cico_fc_transfer_error_contact_support = 'cico_fc_transfer_error_contact_support',
   cico_fc_transfer_success_complete = 'cico_fc_transfer_success_complete',
   cico_fc_transfer_success_view_tx = 'cico_fc_transfer_success_view_tx',
+  cico_fc_transfer_processing_continue = 'cico_fc_transfer_processing_continue',
+  cico_fc_transfer_processing_view_tx = 'cico_fc_transfer_processing_view_tx',
 
   // Fiat Connect KYC status screens
   cico_fc_kyc_status_contact_support = 'cico_fc_kyc_status_contact_support',

--- a/src/analytics/Properties.tsx
+++ b/src/analytics/Properties.tsx
@@ -1149,6 +1149,16 @@ interface FiatExchangeEventsProperties {
     flow: CICOFlow
     txHash: string | null
   }
+  [FiatExchangeEvents.cico_fc_transfer_processing_continue]: {
+    provider: string
+    flow: CICOFlow
+    txHash: string | null
+  }
+  [FiatExchangeEvents.cico_fc_transfer_processing_view_tx]: {
+    provider: string
+    flow: CICOFlow
+    txHash: string | null
+  }
   [FiatExchangeEvents.cico_fc_kyc_status_contact_support]: FiatConnectKycProperties
   [FiatExchangeEvents.cico_fc_kyc_status_back]: FiatConnectKycProperties
   [FiatExchangeEvents.cico_fc_kyc_status_close]: FiatConnectKycProperties

--- a/src/fiatconnect/TransferStatusScreen.tsx
+++ b/src/fiatconnect/TransferStatusScreen.tsx
@@ -10,10 +10,12 @@ import Button, { BtnSizes, BtnTypes } from 'src/components/Button'
 import TextButton from 'src/components/TextButton'
 import Touchable from 'src/components/Touchable'
 import { fiatConnectTransferSelector } from 'src/fiatconnect/selectors'
-import { FiatAccount, FiatConnectTransfer, SendingTransferStatus } from 'src/fiatconnect/slice'
+import { FiatAccount, SendingTransferStatus } from 'src/fiatconnect/slice'
 import FiatConnectQuote from 'src/fiatExchanges/quotes/FiatConnectQuote'
 import { CICOFlow } from 'src/fiatExchanges/utils'
 import CheckmarkCircle from 'src/icons/CheckmarkCircle'
+import CircledIcon from 'src/icons/CircledIcon'
+import ClockIcon from 'src/icons/ClockIcon'
 import OpenLinkIcon from 'src/icons/OpenLinkIcon'
 import { emptyHeader } from 'src/navigator/Headers'
 import { navigate, navigateHome } from 'src/navigator/NavigationService'
@@ -24,6 +26,7 @@ import fontStyles from 'src/styles/fonts'
 import { Spacing } from 'src/styles/styles'
 import variables from 'src/styles/variables'
 import networkConfig from 'src/web3/networkConfig'
+import { walletAddressSelector } from 'src/web3/selectors'
 type Props = NativeStackScreenProps<StackParamList, Screens.FiatConnectTransferStatus>
 
 function onBack(flow: CICOFlow, normalizedQuote: FiatConnectQuote, fiatAccount: FiatAccount) {
@@ -89,13 +92,53 @@ function FailureSection({
   )
 }
 
-function SuccessSection({
+function TxDetails({
+  txHash,
   flow,
-  fiatConnectTransfer,
+  provider,
+  analyticsEvent,
+}: {
+  txHash: string | null
+  flow: CICOFlow
+  provider: string
+  analyticsEvent:
+    | FiatExchangeEvents.cico_fc_transfer_success_view_tx
+    | FiatExchangeEvents.cico_fc_transfer_processing_view_tx
+}) {
+  const { t } = useTranslation()
+  const address = useSelector(walletAddressSelector)
+  const uri = txHash
+    ? `${networkConfig.celoExplorerBaseTxUrl}${txHash}`
+    : `${networkConfig.celoExplorerBaseAddressUrl}${address}`
+
+  const onPressTxDetails = () => {
+    ValoraAnalytics.track(analyticsEvent, {
+      flow,
+      provider,
+      txHash,
+    })
+    navigate(Screens.WebViewScreen, { uri })
+  }
+
+  return (
+    <Touchable testID={'txDetails'} borderless={true} onPress={onPressTxDetails}>
+      <View style={styles.txDetailsContainer}>
+        <Text style={styles.txDetails}>{t('fiatConnectStatusScreen.success.txDetails')}</Text>
+        <OpenLinkIcon color={colors.gray4} />
+      </View>
+    </Touchable>
+  )
+}
+
+function SuccessOrProcessingSection({
+  status,
+  flow,
+  txHash,
   normalizedQuote,
 }: {
+  status: SendingTransferStatus.Completed | SendingTransferStatus.TxProcessing
   flow: CICOFlow
-  fiatConnectTransfer: FiatConnectTransfer
+  txHash: string | null
   normalizedQuote: FiatConnectQuote
 }) {
   const { t } = useTranslation()
@@ -103,42 +146,55 @@ function SuccessSection({
   const timeEstimation = normalizedQuote.getTimeEstimation()!
   const provider = normalizedQuote.getProviderId()
 
-  const onPressTxDetails = () => {
-    ValoraAnalytics.track(FiatExchangeEvents.cico_fc_transfer_success_view_tx, {
-      flow,
-      provider,
-      txHash: fiatConnectTransfer.txHash,
-    })
-    navigate(Screens.WebViewScreen, {
-      uri: `${networkConfig.celoExplorerBaseTxUrl}${fiatConnectTransfer?.txHash}`,
-    })
+  let icon: JSX.Element
+  let title: string
+  let description: string
+  let continueEvent:
+    | FiatExchangeEvents.cico_fc_transfer_success_complete
+    | FiatExchangeEvents.cico_fc_transfer_processing_continue
+  let txDetailsEvent:
+    | FiatExchangeEvents.cico_fc_transfer_success_view_tx
+    | FiatExchangeEvents.cico_fc_transfer_processing_view_tx
+
+  if (status === SendingTransferStatus.Completed) {
+    icon = <CheckmarkCircle />
+    title = t('fiatConnectStatusScreen.success.title')
+    description = t('fiatConnectStatusScreen.success.description', { duration: timeEstimation })
+    continueEvent = FiatExchangeEvents.cico_fc_transfer_success_complete
+    txDetailsEvent = FiatExchangeEvents.cico_fc_transfer_success_view_tx
+  } else {
+    icon = (
+      <CircledIcon>
+        <ClockIcon color={colors.white} height={22} width={22} />
+      </CircledIcon>
+    )
+    title = t('fiatConnectStatusScreen.txProcessing.title')
+    description = t('fiatConnectStatusScreen.txProcessing.description')
+    continueEvent = FiatExchangeEvents.cico_fc_transfer_success_complete
+    txDetailsEvent = FiatExchangeEvents.cico_fc_transfer_processing_view_tx
   }
 
   const onPressContinue = () => {
-    ValoraAnalytics.track(FiatExchangeEvents.cico_fc_transfer_success_complete, {
+    ValoraAnalytics.track(continueEvent, {
       flow,
       provider,
-      txHash: fiatConnectTransfer.txHash,
+      txHash,
     })
     navigateHome()
   }
 
   return (
     <View style={styles.container}>
-      <View style={styles.checkmarkContainer}>
-        <CheckmarkCircle />
-      </View>
-      <Text style={styles.title}>{t('fiatConnectStatusScreen.success.title')}</Text>
-      <Text style={styles.description}>
-        {t('fiatConnectStatusScreen.success.description', { duration: timeEstimation })}
-      </Text>
+      <View style={styles.iconContainer}>{icon}</View>
+      <Text style={styles.title}>{title}</Text>
+      <Text style={styles.description}>{description}</Text>
       {flow === CICOFlow.CashOut && (
-        <Touchable testID={'txDetails'} borderless={true} onPress={onPressTxDetails}>
-          <View style={styles.txDetailsContainer}>
-            <Text style={styles.txDetails}>{t('fiatConnectStatusScreen.success.txDetails')}</Text>
-            <OpenLinkIcon color={colors.gray4} />
-          </View>
-        </Touchable>
+        <TxDetails
+          txHash={txHash}
+          flow={flow}
+          provider={provider}
+          analyticsEvent={txDetailsEvent}
+        />
       )}
       <Button
         style={styles.button}
@@ -177,21 +233,6 @@ export default function FiatConnectTransferStatusScreen({ route, navigation }: P
           />
         </View>
       )
-    case SendingTransferStatus.Completed:
-      navigation.setOptions({
-        ...emptyHeader,
-        headerLeft: () => <View />,
-        headerTitle: t('fiatConnectStatusScreen.success.header'),
-      })
-      return (
-        <SafeAreaView style={styles.content}>
-          <SuccessSection
-            flow={flow}
-            fiatConnectTransfer={fiatConnectTransfer}
-            normalizedQuote={normalizedQuote}
-          />
-        </SafeAreaView>
-      )
     case SendingTransferStatus.Failed:
       navigation.setOptions({
         ...emptyHeader,
@@ -211,9 +252,23 @@ export default function FiatConnectTransferStatusScreen({ route, navigation }: P
           <FailureSection flow={flow} normalizedQuote={normalizedQuote} fiatAccount={fiatAccount} />
         </SafeAreaView>
       )
+    case SendingTransferStatus.Completed:
+      navigation.setOptions({
+        ...emptyHeader,
+        headerLeft: () => <View />,
+        headerTitle: t('fiatConnectStatusScreen.success.header'),
+      })
     case SendingTransferStatus.TxProcessing:
-      // TODO
-      return null
+      return (
+        <SafeAreaView style={styles.content}>
+          <SuccessOrProcessingSection
+            status={fiatConnectTransfer.status}
+            flow={flow}
+            txHash={fiatConnectTransfer.txHash}
+            normalizedQuote={normalizedQuote}
+          />
+        </SafeAreaView>
+      )
     default:
       throw new Error('Invalid transfer status')
   }
@@ -232,7 +287,7 @@ const styles = StyleSheet.create({
   txDetails: {
     color: colors.gray4,
   },
-  checkmarkContainer: {
+  iconContainer: {
     marginBottom: 24,
   },
   container: {

--- a/src/fiatconnect/TransferStatusScreen.tsx
+++ b/src/fiatconnect/TransferStatusScreen.tsx
@@ -140,15 +140,6 @@ function SuccessOrProcessingSection({
     txDetailsEvent = FiatExchangeEvents.cico_fc_transfer_processing_view_tx
   }
 
-  const onPressContinue = () => {
-    ValoraAnalytics.track(continueEvent, {
-      flow,
-      provider,
-      txHash,
-    })
-    navigateHome()
-  }
-
   const onPressTxDetails = () => {
     ValoraAnalytics.track(txDetailsEvent, {
       flow,
@@ -156,6 +147,15 @@ function SuccessOrProcessingSection({
       txHash,
     })
     navigate(Screens.WebViewScreen, { uri })
+  }
+
+  const onPressContinue = () => {
+    ValoraAnalytics.track(continueEvent, {
+      flow,
+      provider,
+      txHash,
+    })
+    navigateHome()
   }
 
   return (

--- a/src/fiatconnect/TransferStatusScreen.tsx
+++ b/src/fiatconnect/TransferStatusScreen.tsx
@@ -92,44 +92,6 @@ function FailureSection({
   )
 }
 
-function TxDetails({
-  txHash,
-  flow,
-  provider,
-  analyticsEvent,
-}: {
-  txHash: string | null
-  flow: CICOFlow
-  provider: string
-  analyticsEvent:
-    | FiatExchangeEvents.cico_fc_transfer_success_view_tx
-    | FiatExchangeEvents.cico_fc_transfer_processing_view_tx
-}) {
-  const { t } = useTranslation()
-  const address = useSelector(walletAddressSelector)
-  const uri = txHash
-    ? `${networkConfig.celoExplorerBaseTxUrl}${txHash}`
-    : `${networkConfig.celoExplorerBaseAddressUrl}${address}`
-
-  const onPressTxDetails = () => {
-    ValoraAnalytics.track(analyticsEvent, {
-      flow,
-      provider,
-      txHash,
-    })
-    navigate(Screens.WebViewScreen, { uri })
-  }
-
-  return (
-    <Touchable testID={'txDetails'} borderless={true} onPress={onPressTxDetails}>
-      <View style={styles.txDetailsContainer}>
-        <Text style={styles.txDetails}>{t('fiatConnectStatusScreen.success.txDetails')}</Text>
-        <OpenLinkIcon color={colors.gray4} />
-      </View>
-    </Touchable>
-  )
-}
-
 function SuccessOrProcessingSection({
   status,
   flow,
@@ -145,6 +107,10 @@ function SuccessOrProcessingSection({
   // TODO: Make sure there's fallback text if we can't get the estimate
   const timeEstimation = normalizedQuote.getTimeEstimation()!
   const provider = normalizedQuote.getProviderId()
+  const address = useSelector(walletAddressSelector)
+  const uri = txHash
+    ? `${networkConfig.celoExplorerBaseTxUrl}${txHash}`
+    : `${networkConfig.celoExplorerBaseAddressUrl}${address}`
 
   let icon: JSX.Element
   let title: string
@@ -183,18 +149,27 @@ function SuccessOrProcessingSection({
     navigateHome()
   }
 
+  const onPressTxDetails = () => {
+    ValoraAnalytics.track(txDetailsEvent, {
+      flow,
+      provider,
+      txHash,
+    })
+    navigate(Screens.WebViewScreen, { uri })
+  }
+
   return (
     <View style={styles.container}>
       <View style={styles.iconContainer}>{icon}</View>
       <Text style={styles.title}>{title}</Text>
       <Text style={styles.description}>{description}</Text>
       {flow === CICOFlow.CashOut && (
-        <TxDetails
-          txHash={txHash}
-          flow={flow}
-          provider={provider}
-          analyticsEvent={txDetailsEvent}
-        />
+        <Touchable testID={'txDetails'} borderless={true} onPress={onPressTxDetails}>
+          <View style={styles.txDetailsContainer}>
+            <Text style={styles.txDetails}>{t('fiatConnectStatusScreen.success.txDetails')}</Text>
+            <OpenLinkIcon color={colors.gray4} />
+          </View>
+        </Touchable>
       )}
       <Button
         style={styles.button}

--- a/src/fiatconnect/TransferStatusScreen.tsx
+++ b/src/fiatconnect/TransferStatusScreen.tsx
@@ -170,7 +170,7 @@ function SuccessOrProcessingSection({
     )
     title = t('fiatConnectStatusScreen.txProcessing.title')
     description = t('fiatConnectStatusScreen.txProcessing.description')
-    continueEvent = FiatExchangeEvents.cico_fc_transfer_success_complete
+    continueEvent = FiatExchangeEvents.cico_fc_transfer_processing_continue
     txDetailsEvent = FiatExchangeEvents.cico_fc_transfer_processing_view_tx
   }
 

--- a/src/web3/networkConfig.ts
+++ b/src/web3/networkConfig.ts
@@ -33,6 +33,7 @@ interface NetworkConfig {
   fetchExchangesUrl: string
   nftsValoraAppUrl: string
   celoExplorerBaseTxUrl: string
+  celoExplorerBaseAddressUrl: string
   approveSwapUrl: string
   executeSwapUrl: string
   verifyPhoneNumberUrl: string
@@ -107,8 +108,14 @@ const REVOKE_PHONE_NUMBER_MAINNET = `${CLOUD_FUNCTIONS_MAINNET}/revokePhoneNumbe
 const MIGRATE_PHONE_VERIFICATION_ALFAJORES = `${CLOUD_FUNCTIONS_STAGING}/migrateASv1Verification`
 const MIGRATE_PHONE_VERIFICATION_MAINNET = `${CLOUD_FUNCTIONS_MAINNET}/migrateASv1Verification`
 
-const CELO_EXPLORER_BASE_TX_URL_ALFAJORES = 'https://explorer.celo.org/alfajores/tx/'
-const CELO_EXPLORER_BASE_TX_URL_MAINNET = 'https://explorer.celo.org/mainnet/tx/'
+const CELO_EXPLORER_BASE_URL_ALFAJORES = 'https://explorer.celo.org/alfajores'
+const CELO_EXPLORER_BASE_URL_MAINNET = 'https://explorer.celo.org/mainnet'
+
+const CELO_EXPLORER_BASE_TX_URL_ALFAJORES = `${CELO_EXPLORER_BASE_URL_ALFAJORES}/tx/`
+const CELO_EXPLORER_BASE_TX_URL_MAINNET = `${CELO_EXPLORER_BASE_URL_MAINNET}/tx/`
+
+const CELO_EXPLORER_BASE_ADDRESS_URL_ALFAJORES = `${CELO_EXPLORER_BASE_URL_ALFAJORES}/address/`
+const CELO_EXPLORER_BASE_ADDRESS_URL_MAINNET = `${CELO_EXPLORER_BASE_URL_MAINNET}/address/`
 
 const NFTS_VALORA_APP_URL = 'https://nfts.valoraapp.com/'
 
@@ -141,6 +148,7 @@ const networkConfigs: { [testnet: string]: NetworkConfig } = {
     fetchExchangesUrl: FETCH_EXCHANGES_URL_ALFAJORES,
     nftsValoraAppUrl: NFTS_VALORA_APP_URL,
     celoExplorerBaseTxUrl: CELO_EXPLORER_BASE_TX_URL_ALFAJORES,
+    celoExplorerBaseAddressUrl: CELO_EXPLORER_BASE_ADDRESS_URL_ALFAJORES,
     approveSwapUrl: APPROVE_SWAP_URL,
     executeSwapUrl: EXECUTE_SWAP_URL,
     verifyPhoneNumberUrl: VERIFY_PHONE_NUMBER_ALFAJORES,
@@ -175,6 +183,7 @@ const networkConfigs: { [testnet: string]: NetworkConfig } = {
     fetchExchangesUrl: FETCH_EXCHANGES_URL_MAINNET,
     nftsValoraAppUrl: NFTS_VALORA_APP_URL,
     celoExplorerBaseTxUrl: CELO_EXPLORER_BASE_TX_URL_MAINNET,
+    celoExplorerBaseAddressUrl: CELO_EXPLORER_BASE_ADDRESS_URL_MAINNET,
     approveSwapUrl: APPROVE_SWAP_URL,
     executeSwapUrl: EXECUTE_SWAP_URL,
     verifyPhoneNumberUrl: VERIFY_PHONE_NUMBER_MAINNET,


### PR DESCRIPTION
### Description

Repurposed SuccessSection in the TransferStatusScreen to also include a transaction processing state, since they both are similar.

https://user-images.githubusercontent.com/5062591/202879707-f03272ec-a397-459a-99f7-329a9a2bb6d0.mp4


### Other changes

N/A

### Tested

Unit tests, manual


### How others should test

N/A

### Related issues

- Resolves ACT-533

### Backwards compatibility

Yes