### PR TITLE
fix: use CPV with e2e tests after komenci sunset

### DIFF
--- a/e2e/src/Rewards.spec.js
+++ b/e2e/src/Rewards.spec.js
@@ -24,8 +24,8 @@ describe('Given Rewards', () => {
       await waitForElementId('ConsumerIncentives/CTA')
       await element(by.id('ConsumerIncentives/CTA')).tap()
       await enterPinUiIfNecessary()
-      await waitForElementId('VerificationEducationHeader')
-      await expect(element(by.id('VerificationEducationHeader'))).toBeVisible()
+      await waitForElementId('PhoneVerificationHeader')
+      await expect(element(by.id('PhoneVerificationHeader'))).toBeVisible()
     })
 
     it(':ios: Then should navigate back to consumer incentives', async () => {

--- a/e2e/src/usecases/NewAccountOnboarding.js
+++ b/e2e/src/usecases/NewAccountOnboarding.js
@@ -35,8 +35,8 @@ export default NewAccountOnboarding = () => {
     await enterPinUi()
 
     // Skip Phone Number verification
-    await element(by.id('VerificationEducationSkipHeader')).tap()
-    await element(by.id('VerificationSkipDialog/PrimaryAction')).tap()
+    await element(by.id('PhoneVerificationSkipHeader')).tap()
+    await element(by.id('PhoneVerificationSkipDialog/PrimaryAction')).tap()
 
     // Arrived to Home screen
     await dismissCashInBottomSheet()

--- a/e2e/src/usecases/NewAccountPhoneVerification.js
+++ b/e2e/src/usecases/NewAccountPhoneVerification.js
@@ -181,7 +181,7 @@ export default NewAccountPhoneVerification = () => {
     await element(by.id('PhoneVerificationLearnMore')).tap()
 
     // Assert modal action is visible
-    await waitForElementId('VerificationLearnMoreDialog/PrimaryAction')
+    await waitForElementId('PhoneVerificationLearnMoreDialog/PrimaryAction')
 
     // Assert able to dismiss modal and skip
     await element(by.text('Dismiss')).tap()

--- a/e2e/src/usecases/NewAccountPhoneVerification.js
+++ b/e2e/src/usecases/NewAccountPhoneVerification.js
@@ -187,9 +187,9 @@ export default NewAccountPhoneVerification = () => {
     await element(by.text('Dismiss')).tap()
     await element(by.text('Skip')).tap()
 
-    // Assert VerificationSkipDialog modal actions are visible
-    await waitForElementId('VerificationSkipDialog/PrimaryAction')
-    await waitForElementId('VerificationSkipDialog/SecondaryAction')
+    // Assert PhoneVerificationSkipDialog modal actions are visible
+    await waitForElementId('PhoneVerificationSkipDialog/PrimaryAction')
+    await waitForElementId('PhoneVerificationSkipDialog/SecondaryAction')
 
     // Assert Back button is enabled
     let goBackButtonAttributes = await element(by.text('Go Back')).getAttributes()

--- a/e2e/src/usecases/NewAccountPhoneVerification.js
+++ b/e2e/src/usecases/NewAccountPhoneVerification.js
@@ -175,10 +175,10 @@ export default NewAccountPhoneVerification = () => {
     await expect(element(by.text('Connect your phone number'))).toBeVisible()
     let skipAttributes = await element(by.text('Skip')).getAttributes()
     jestExpect(skipAttributes.enabled).toBe(true)
-    await waitForElementId('doINeedToConfirm')
+    await waitForElementId('PhoneVerificationLearnMore')
 
     // Tap 'Do I need to connect?' button
-    await element(by.id('doINeedToConfirm')).tap()
+    await element(by.id('PhoneVerificationLearnMore')).tap()
 
     // Assert modal action is visible
     await waitForElementId('VerificationLearnMoreDialog/PrimaryAction')

--- a/e2e/src/usecases/RestoreAccountOnboarding.js
+++ b/e2e/src/usecases/RestoreAccountOnboarding.js
@@ -74,12 +74,12 @@ export default RestoreAccountOnboarding = () => {
   })
 
   it('Verify Education', async () => {
-    await waitForElementId('VerificationEducationSkipHeader')
+    await waitForElementId('PhoneVerificationSkipHeader')
 
     // skip
-    await element(by.id('VerificationEducationSkipHeader')).tap()
+    await element(by.id('PhoneVerificationSkipHeader')).tap()
     // confirmation popup skip
-    await element(by.id('VerificationSkipDialog/PrimaryAction')).tap()
+    await element(by.id('PhoneVerificationSkipDialog/PrimaryAction')).tap()
   })
 
   it('Wallet Home', async () => {

--- a/e2e/src/utils/utils.js
+++ b/e2e/src/utils/utils.js
@@ -186,12 +186,12 @@ export async function quickOnboarding(mnemonic = SAMPLE_BACKUP_KEY) {
     } catch {}
 
     // Verify Education
-    await waitForElementId('VerificationEducationSkipHeader')
+    await waitForElementId('PhoneVerificationSkipHeader')
     // Skip
-    await element(by.id('VerificationEducationSkipHeader')).tap()
+    await element(by.id('PhoneVerificationSkipHeader')).tap()
     // Confirmation popup skip
-    await waitForElementId('VerificationSkipDialog/PrimaryAction')
-    await element(by.id('VerificationSkipDialog/PrimaryAction')).tap()
+    await waitForElementId('PhoneVerificationSkipDialog/PrimaryAction')
+    await element(by.id('PhoneVerificationSkipDialog/PrimaryAction')).tap()
 
     // Assert on Wallet Home Screen
     await dismissCashInBottomSheet()

--- a/src/firebase/remoteConfigValuesDefaults.e2e.ts
+++ b/src/firebase/remoteConfigValuesDefaults.e2e.ts
@@ -69,6 +69,6 @@ export const REMOTE_CONFIG_VALUES_DEFAULTS: Omit<
   maxSwapSlippagePercentage: 2,
   inviteMethod: InviteMethodType.Escrow,
   showGuidedOnboardingCopy: false,
-  centralPhoneVerificationEnabled: false,
+  centralPhoneVerificationEnabled: true,
   networkTimeoutSeconds: 30,
 }

--- a/src/firebase/remoteConfigValuesDefaults.ts
+++ b/src/firebase/remoteConfigValuesDefaults.ts
@@ -68,6 +68,6 @@ export const REMOTE_CONFIG_VALUES_DEFAULTS: Omit<
   maxSwapSlippagePercentage: 2,
   inviteMethod: InviteMethodType.Escrow,
   showGuidedOnboardingCopy: false,
-  centralPhoneVerificationEnabled: false,
+  centralPhoneVerificationEnabled: true,
   networkTimeoutSeconds: 30,
 }

--- a/src/pincode/PincodeSet.tsx
+++ b/src/pincode/PincodeSet.tsx
@@ -13,6 +13,7 @@ import { PincodeType } from 'src/account/reducer'
 import { OnboardingEvents, SettingsEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import {
+  centralPhoneVerificationEnabledSelector,
   registrationStepsSelector,
   showGuidedOnboardingSelector,
   skipVerificationSelector,
@@ -52,6 +53,7 @@ interface StateProps {
   supportedBiometryType: BIOMETRY_TYPE | null
   skipVerification: boolean
   showGuidedOnboarding: boolean
+  centralPhoneVerificationEnabled: boolean
 }
 
 interface DispatchProps {
@@ -83,6 +85,7 @@ function mapStateToProps(state: RootState): StateProps {
     supportedBiometryType: supportedBiometryTypeSelector(state),
     skipVerification: skipVerificationSelector(state),
     showGuidedOnboarding: showGuidedOnboardingSelector(state),
+    centralPhoneVerificationEnabled: centralPhoneVerificationEnabledSelector(state),
   }
 }
 
@@ -170,7 +173,7 @@ export class PincodeSet extends React.Component<Props, State> {
       navigate(Screens.ImportWallet)
     } else if (
       this.props.hideVerification ||
-      !this.props.route.params?.komenciAvailable ||
+      (!this.props.route.params?.komenciAvailable && !this.props.centralPhoneVerificationEnabled) ||
       this.props.skipVerification
     ) {
       this.props.initializeAccount()

--- a/src/redux/store.test.ts
+++ b/src/redux/store.test.ts
@@ -130,7 +130,7 @@ describe('store state', () => {
           "cashInButtonExpEnabled": false,
           "celoEducationUri": null,
           "celoEuroEnabled": true,
-          "centralPhoneVerificationEnabled": false,
+          "centralPhoneVerificationEnabled": true,
           "coinbasePayEnabled": false,
           "createAccountCopyTestType": "ACCOUNT",
           "fiatConnectCashInEnabled": false,

--- a/src/verify/VerificationStartScreen.tsx
+++ b/src/verify/VerificationStartScreen.tsx
@@ -119,7 +119,7 @@ function VerificationStartScreen({
         !route.params?.hideOnboardingStep && (
           <TopBarTextButton
             title={t('skip')}
-            testID="VerificationEducationSkipHeader"
+            testID="PhoneVerificationSkipHeader"
             onPress={onPressSkip}
             titleStyle={{ color: colors.goldDark }}
           />
@@ -248,7 +248,7 @@ function VerificationStartScreen({
         actionPress={onPressSkipConfirm}
         secondaryActionPress={onPressSkipCancel}
         secondaryActionText={t('phoneVerificationScreen.skip.cancel')}
-        testID="VerificationSkipDialog"
+        testID="PhoneVerificationSkipDialog"
       >
         {t('phoneVerificationScreen.skip.body')}
       </Dialog>

--- a/src/verify/VerificationStartScreen.tsx
+++ b/src/verify/VerificationStartScreen.tsx
@@ -119,7 +119,7 @@ function VerificationStartScreen({
         !route.params?.hideOnboardingStep && (
           <TopBarTextButton
             title={t('skip')}
-            testID="PhoneVerificationSkipHeader"
+            testID="VerificationEducationSkipHeader"
             onPress={onPressSkip}
             titleStyle={{ color: colors.goldDark }}
           />
@@ -248,7 +248,7 @@ function VerificationStartScreen({
         actionPress={onPressSkipConfirm}
         secondaryActionPress={onPressSkipCancel}
         secondaryActionText={t('phoneVerificationScreen.skip.cancel')}
-        testID="PhoneVerificationSkipDialog"
+        testID="VerificationSkipDialog"
       >
         {t('phoneVerificationScreen.skip.body')}
       </Dialog>


### PR DESCRIPTION
### Description

Komenci has been shut down and the onboarding pincode screen checks for it's uptime before navigating to the phone verification screen. This is not necessary with CPV, this PR adds this logic.

### Other changes

Update test id's - rather than update the tests i updated the test id of the component :/ didn't think it mattered to much

### Tested

Run CI, test manually


### How others should test

Create a new account, you should see phone verification in the onboarding flow

### Related issues

n/a

### Backwards compatibility

Y