### PR TITLE
feat(fiatconnect): transfer status loading description

### DIFF
--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -1376,6 +1376,7 @@
   },
   "fiatConnectStatusScreen": {
     "tryAgain": "Try Again",
+    "stillProcessing": "We're still processing your transaction. Please wait.",
     "cashOut": {
       "cancel": "Cancel Withdrawal",
       "contactSupportPrefill": "I'm having trouble withdrawing my funds."

--- a/src/fiatconnect/TransferStatusScreen.test.tsx
+++ b/src/fiatconnect/TransferStatusScreen.test.tsx
@@ -330,7 +330,7 @@ describe('TransferStatusScreen', () => {
     })
     it('Shows explanation if taking a while', async () => {
       const mockProps = mockScreenProps(CICOFlow.CashIn)
-      const store = mockStore({ transfer: mockFiatConnectTransfers[4] })
+      const store = mockStore({ status: SendingTransferStatus.Sending })
       const { getByTestId } = render(
         <Provider store={store}>
           <TransferStatusScreen {...mockProps} />

--- a/src/fiatconnect/TransferStatusScreen.test.tsx
+++ b/src/fiatconnect/TransferStatusScreen.test.tsx
@@ -14,6 +14,7 @@ import { Screens } from 'src/navigator/Screens'
 import networkConfig from 'src/web3/networkConfig'
 import { createMockStore, getMockStackScreenProps } from 'test/utils'
 import { mockFiatConnectQuotes } from 'test/values'
+import { act } from 'react-test-renderer'
 
 jest.mock('src/analytics/ValoraAnalytics')
 
@@ -281,6 +282,23 @@ describe('TransferStatusScreen', () => {
       )
       expect(getByTestId('loadingTransferStatus')).toBeTruthy()
       expect(mockProps.navigation.setOptions).not.toBeCalled()
+    })
+    it('Shows explanation if taking a while', async () => {
+      const mockProps = mockScreenProps(CICOFlow.CashIn)
+      const store = mockStore({ transfer: mockFiatConnectTransfers[4] })
+      const { getByTestId } = render(
+        <Provider store={store}>
+          <TransferStatusScreen {...mockProps} />
+        </Provider>
+      )
+      expect(getByTestId('loadingTransferStatus')).toBeTruthy()
+      expect(getByTestId('loadingDescription')).toHaveTextContent('')
+      await act(async () => {
+        jest.runOnlyPendingTimers()
+      })
+      expect(getByTestId('loadingDescription')).toHaveTextContent(
+        'fiatConnectStatusScreen.stillProcessing'
+      )
     })
   })
 })

--- a/src/fiatconnect/TransferStatusScreen.tsx
+++ b/src/fiatconnect/TransferStatusScreen.tsx
@@ -25,7 +25,7 @@ import { Spacing } from 'src/styles/styles'
 import variables from 'src/styles/variables'
 import networkConfig from 'src/web3/networkConfig'
 
-const LOADING_DESCRIPTION_TIMEOUT_MS = 5000
+const LOADING_DESCRIPTION_TIMEOUT_MS = 8000
 
 type Props = NativeStackScreenProps<StackParamList, Screens.FiatConnectTransferStatus>
 

--- a/src/fiatconnect/TransferStatusScreen.tsx
+++ b/src/fiatconnect/TransferStatusScreen.tsx
@@ -1,5 +1,5 @@
 import { NativeStackScreenProps } from '@react-navigation/native-stack'
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ActivityIndicator, SafeAreaView, StyleSheet, Text, View } from 'react-native'
 import { useSelector } from 'react-redux'
@@ -24,6 +24,9 @@ import fontStyles from 'src/styles/fonts'
 import { Spacing } from 'src/styles/styles'
 import variables from 'src/styles/variables'
 import networkConfig from 'src/web3/networkConfig'
+
+const LOADING_DESCRIPTION_TIMEOUT_MS = 5000
+
 type Props = NativeStackScreenProps<StackParamList, Screens.FiatConnectTransferStatus>
 
 function onBack(flow: CICOFlow, normalizedQuote: FiatConnectQuote, fiatAccount: FiatAccount) {
@@ -188,10 +191,22 @@ export default function FiatConnectTransferStatusScreen({ route, navigation }: P
     })
   }
 
+  // add loading description if sending is taking a while
+  const [loadingDescription, setLoadingDescription] = useState('')
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      setLoadingDescription(t('fiatConnectStatusScreen.stillProcessing'))
+    }, LOADING_DESCRIPTION_TIMEOUT_MS)
+    return () => clearTimeout(timeout)
+  }, [])
+
   if (fiatConnectTransfer.isSending) {
     return (
       <View style={styles.activityIndicatorContainer}>
         <ActivityIndicator testID="loadingTransferStatus" size="large" color={colors.greenBrand} />
+        <Text style={styles.loadingDescription} testID="loadingDescription">
+          {loadingDescription}
+        </Text>
       </View>
     )
   }
@@ -237,6 +252,13 @@ const styles = StyleSheet.create({
   },
   description: {
     ...fontStyles.regular,
+    textAlign: 'center',
+    marginTop: 12,
+    paddingHorizontal: 48,
+    paddingBottom: 24,
+  },
+  loadingDescription: {
+    ...fontStyles.large,
     textAlign: 'center',
     marginTop: 12,
     paddingHorizontal: 48,


### PR DESCRIPTION
### Description

If the transfer is taking a while, shows some text.

### Other changes

na

### Tested

added unit test

used hacks to get the screen to display locally. here's what it looks like:

<img width="319" alt="Screen Shot 2022-11-21 at 5 35 02 PM" src="https://user-images.githubusercontent.com/7979215/203195139-3d69a55f-32f2-4443-9787-5b6746993719.png">

video version to show the timeout behavior:

https://user-images.githubusercontent.com/7979215/203195993-f3f1d083-98d8-4371-a584-eefdb8e146c7.mp4

compare to designs:

https://www.figma.com/file/PJptgCmZjQ6TMIfRYvgRjw/Withdraw-Status?node-id=2%3A1451&t=frjLRFll8bk6xTAj-4


### How others should test

na

### Related issues

fixes https://linear.app/valora/issue/ACT-532/show-text-under-transfer-out-spinner-after-some-timeout-is-reached

### Backwards compatibility

na