### PR TITLE
build(deps): upgrade @sentry/react-native to 4.10.1

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -643,7 +643,7 @@ PODS:
     - React-RCTImage
   - RNSecureRandom (1.0.0):
     - React-Core
-  - RNSentry (4.10.0):
+  - RNSentry (4.10.1):
     - React-Core
     - Sentry/HybridSDK (= 7.31.2)
   - RNShare (7.3.2):
@@ -1118,7 +1118,7 @@ SPEC CHECKSUMS:
   RNReanimated: ee33ab40fa252332a36aeed9d936801ed9700b24
   RNScreens: 34cc502acf1b916c582c60003dc3089fa01dc66d
   RNSecureRandom: b0b479d7b934a3e6deea9cb986a9c40cb5f1b360
-  RNSentry: 211e1a62145d5bcb4bee926823061b5af47816c4
+  RNSentry: 3c27f3c57f16bab9835d9555add298571077e0c1
   RNShare: d76b8c9c6e6ffb38fc18f40b4338c9d867592ed3
   RNSVG: 302bfc9905bd8122f08966dc2ce2d07b7b52b9f8
   SDWebImage: a7f831e1a65eb5e285e3fb046a23fcfbf08e696d

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "@segment/analytics-react-native-adjust": "^1.5.3",
     "@segment/analytics-react-native-clevertap": "^1.5.3",
     "@segment/analytics-react-native-firebase": "^1.5.3",
-    "@sentry/react-native": "^4.10.0",
+    "@sentry/react-native": "^4.10.1",
     "@sentry/types": "^7.22.0",
     "@th3rdwave/react-navigation-bottom-sheet": "^0.2.1",
     "@ungap/url-search-params": "^0.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4614,10 +4614,10 @@
     proxy-from-env "^1.1.0"
     which "^2.0.2"
 
-"@sentry/cli@^1.52.4":
-  version "1.74.5"
-  resolved "https://registry.yarnpkg.com/@sentry/cli/-/cli-1.74.5.tgz#4a5c622913087c9ab6f82994da9a7526423779b8"
-  integrity sha512-Ze1ec306ZWHtrxKypOJ8nhtFqkrx2f/6bRH+DcJzEQ3bBePQ0ZnqJTTe4BBHADYBtxFIaUWzCZ6DquLz2Zv/sw==
+"@sentry/cli@^1.72.0":
+  version "1.74.6"
+  resolved "https://registry.yarnpkg.com/@sentry/cli/-/cli-1.74.6.tgz#c4f276e52c6f5e8c8d692845a965988068ebc6f5"
+  integrity sha512-pJ7JJgozyjKZSTjOGi86chIngZMLUlYt2HOog+OJn+WGvqEkVymu8m462j1DiXAnex9NspB4zLLNuZ/R6rTQHg==
   dependencies:
     https-proxy-agent "^5.0.0"
     mkdirp "^0.5.5"
@@ -4656,10 +4656,10 @@
     localforage "^1.8.1"
     tslib "^1.9.3"
 
-"@sentry/react-native@^4.10.0":
-  version "4.10.0"
-  resolved "https://registry.yarnpkg.com/@sentry/react-native/-/react-native-4.10.0.tgz#5824aeecf7dab27afd6f635411f2738faffd546c"
-  integrity sha512-90hPQ+kdHpCPwA6iAuDIvsDi9aM07JMGXP3fHivSIAVWGtpBtYjl+QT1amDorXwW04RdVLCEteL+21t0DxU8Eg==
+"@sentry/react-native@^4.10.1":
+  version "4.10.1"
+  resolved "https://registry.yarnpkg.com/@sentry/react-native/-/react-native-4.10.1.tgz#9e2c1f5dd4b27103882a71503805f86059a7cde9"
+  integrity sha512-yF5g2bCjPpfu4DUVQPlDnSMUdz5bh/i1s9zZ5cnOmA9LsXQulk9o1Z6fTeZ5LkgPzogTRjn0eudvaCz5u+nxaA==
   dependencies:
     "@sentry/browser" "7.21.1"
     "@sentry/cli" "1.74.4"
@@ -4670,7 +4670,7 @@
     "@sentry/tracing" "7.21.1"
     "@sentry/types" "7.21.1"
     "@sentry/utils" "7.21.1"
-    "@sentry/wizard" "1.2.17"
+    "@sentry/wizard" "1.4.0"
 
 "@sentry/react@7.21.1":
   version "7.21.1"
@@ -4711,12 +4711,12 @@
     "@sentry/types" "7.21.1"
     tslib "^1.9.3"
 
-"@sentry/wizard@1.2.17":
-  version "1.2.17"
-  resolved "https://registry.yarnpkg.com/@sentry/wizard/-/wizard-1.2.17.tgz#c3247b47129d002cfa45d7a2048d13dc6513457b"
-  integrity sha512-wXzjOZVDzh+1MhA9tpZXCKNTDusL2Dc298KGQkEkNefbW+OlYbsWwF7GAihLKUjYOSnKKZFzLIwbD+gxwxWxlw==
+"@sentry/wizard@1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@sentry/wizard/-/wizard-1.4.0.tgz#9356ae2cb9e81ee6fa64418d15638607f1a957bd"
+  integrity sha512-Q/f9wJAAAr/YB6oWUzMQP/y5LIgx9la1SanMHNr3hMtVPKkMhvIZO5UWVn2G763yi85zARqSCLDx31/tZd4new==
   dependencies:
-    "@sentry/cli" "^1.52.4"
+    "@sentry/cli" "^1.72.0"
     chalk "^2.4.1"
     glob "^7.1.3"
     inquirer "^6.2.0"


### PR DESCRIPTION
### Description

#3181 - had issues with Android builds as seen in [release-automation](https://github.com/valora-inc/release-automation/actions/runs/3589160617). [Sentry 4.10.1](https://github.com/getsentry/sentry-react-native/releases/tag/4.10.1) includes some fixes for Android builds.

### Other changes

N/A

### Tested

Local production Android build created

### How others should test

N/A

### Related issues

N/A

### Backwards compatibility

Yes