### PR TITLE
chore: switch to upstream version of @react-native-clipboard/clipboard

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -554,7 +554,7 @@ PODS:
     - Segment-Firebase (~> 2.7.7)
   - RNCAsyncStorage (1.17.10):
     - React-Core
-  - RNCClipboard (1.2.3):
+  - RNCClipboard (1.11.1):
     - React-Core
   - RNCMaskedView (0.2.6):
     - React-Core
@@ -760,7 +760,7 @@ DEPENDENCIES:
   - "RNAnalyticsIntegration-CleverTap (from `../node_modules/@segment/analytics-react-native-clevertap`)"
   - "RNAnalyticsIntegration-Firebase (from `../node_modules/@segment/analytics-react-native-firebase`)"
   - "RNCAsyncStorage (from `../node_modules/@react-native-async-storage/async-storage`)"
-  - "RNCClipboard (from `../node_modules/@react-native-community/clipboard`)"
+  - "RNCClipboard (from `../node_modules/@react-native-clipboard/clipboard`)"
   - "RNCMaskedView (from `../node_modules/@react-native-masked-view/masked-view`)"
   - "RNCPicker (from `../node_modules/@react-native-picker/picker`)"
   - RNDeviceInfo (from `../node_modules/react-native-device-info`)
@@ -951,7 +951,7 @@ EXTERNAL SOURCES:
   RNCAsyncStorage:
     :path: "../node_modules/@react-native-async-storage/async-storage"
   RNCClipboard:
-    :path: "../node_modules/@react-native-community/clipboard"
+    :path: "../node_modules/@react-native-clipboard/clipboard"
   RNCMaskedView:
     :path: "../node_modules/@react-native-masked-view/masked-view"
   RNCPicker:
@@ -1097,7 +1097,7 @@ SPEC CHECKSUMS:
   RNAnalyticsIntegration-CleverTap: 924d284c088c6008e7599c06dda472742de22c89
   RNAnalyticsIntegration-Firebase: 27eb53875cc0208cc64ec35f06fb0f9e3c012add
   RNCAsyncStorage: 0c357f3156fcb16c8589ede67cc036330b6698ca
-  RNCClipboard: 546484405eaa1c8a3eccce77b8c8871242e73b20
+  RNCClipboard: 2834e1c4af68697089cdd455ee4a4cdd198fa7dd
   RNCMaskedView: c298b644a10c0c142055b3ae24d83879ecb13ccd
   RNCPicker: 0250e95ad170569a96f5b0555cdd5e65b9084dca
   RNDeviceInfo: 8b83e99e290deaf1bab71673cc636776ef647b6f

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "@komenci/contracts": "1.1.0",
     "@komenci/kit": "1.0.0-beta1",
     "@react-native-async-storage/async-storage": "^1.17.10",
-    "@react-native-community/clipboard": "git+https://github.com/celo-org/clipboard#5afb848",
+    "@react-native-clipboard/clipboard": "^1.11.1",
     "@react-native-community/netinfo": "^5.8.0",
     "@react-native-cookies/cookies": "^6.2.1",
     "@react-native-firebase/app": "11.5.0",

--- a/src/app/Debug.tsx
+++ b/src/app/Debug.tsx
@@ -1,4 +1,4 @@
-import Clipboard from '@react-native-community/clipboard'
+import Clipboard from '@react-native-clipboard/clipboard'
 import * as React from 'react'
 import { StyleSheet, Text } from 'react-native'
 import DeviceInfo from 'react-native-device-info'

--- a/src/backup/BackupPhraseContainer.tsx
+++ b/src/backup/BackupPhraseContainer.tsx
@@ -1,4 +1,4 @@
-import Clipboard from '@react-native-community/clipboard'
+import Clipboard from '@react-native-clipboard/clipboard'
 import * as React from 'react'
 import { WithTranslation } from 'react-i18next'
 import { Platform, StyleSheet, Text, TextInput, View, ViewStyle } from 'react-native'

--- a/src/components/AccountNumber.test.tsx
+++ b/src/components/AccountNumber.test.tsx
@@ -1,11 +1,11 @@
-import Clipboard from '@react-native-community/clipboard'
+import Clipboard from '@react-native-clipboard/clipboard'
 import { fireEvent, render } from '@testing-library/react-native'
 import * as React from 'react'
 import 'react-native'
 import AccountNumber from 'src/components/AccountNumber'
 import { mockAccount } from 'test/values'
 
-jest.mock('@react-native-community/clipboard', () => ({
+jest.mock('@react-native-clipboard/clipboard', () => ({
   setString: jest.fn(),
 }))
 

--- a/src/components/AccountNumber.tsx
+++ b/src/components/AccountNumber.tsx
@@ -1,5 +1,5 @@
 import { getAddressChunks } from '@celo/utils/lib/address'
-import Clipboard from '@react-native-community/clipboard'
+import Clipboard from '@react-native-clipboard/clipboard'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 import { StyleSheet, Text, TouchableOpacity } from 'react-native'

--- a/src/components/SessionId.tsx
+++ b/src/components/SessionId.tsx
@@ -1,4 +1,4 @@
-import Clipboard from '@react-native-community/clipboard'
+import Clipboard from '@react-native-clipboard/clipboard'
 import React from 'react'
 import { StyleSheet, Text, TouchableOpacity } from 'react-native'
 import colors from 'src/styles/colors'

--- a/src/components/WithPasteAware.tsx
+++ b/src/components/WithPasteAware.tsx
@@ -1,6 +1,6 @@
 // HOC to add a paste button to a text input
 
-import Clipboard from '@react-native-community/clipboard'
+import Clipboard from '@react-native-clipboard/clipboard'
 import * as React from 'react'
 import { AppState, NativeEventSubscription, ViewProps } from 'react-native'
 import { deviceIsIos14OrNewer } from 'src/utils/IosVersionUtils'

--- a/src/utils/useClipboard.ts
+++ b/src/utils/useClipboard.ts
@@ -1,4 +1,4 @@
-import Clipboard from '@react-native-community/clipboard'
+import Clipboard from '@react-native-clipboard/clipboard'
 import { useEffect, useState } from 'react'
 import { AppState } from 'react-native'
 import { deviceIsIos14OrNewer } from 'src/utils/IosVersionUtils'

--- a/src/walletConnect/screens/RequestContentRow.tsx
+++ b/src/walletConnect/screens/RequestContentRow.tsx
@@ -1,4 +1,4 @@
-import Clipboard from '@react-native-community/clipboard'
+import Clipboard from '@react-native-clipboard/clipboard'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 import { StyleSheet, Text, View } from 'react-native'

--- a/yarn.lock
+++ b/yarn.lock
@@ -4187,6 +4187,11 @@
   dependencies:
     merge-options "^3.0.4"
 
+"@react-native-clipboard/clipboard@^1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@react-native-clipboard/clipboard/-/clipboard-1.11.1.tgz#d3a9e685ce2383b1e92b89a334896c5575cc103d"
+  integrity sha512-nvSIIHzybVWqYxcJE5hpT17ekxAAg383Ggzw5WrYHtkKX61N1AwaKSNmXs5xHV7pmKSOe/yWjtSwxIzfW51I5Q==
+
 "@react-native-community/cli-debugger-ui@^6.0.0-rc.0":
   version "6.0.0-rc.0"
   resolved "https://registry.yarnpkg.com/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-6.0.0-rc.0.tgz#774378626e4b70f5e1e2e54910472dcbaffa1536"
@@ -4323,10 +4328,6 @@
     strip-ansi "^5.2.0"
     sudo-prompt "^9.0.0"
     wcwidth "^1.0.1"
-
-"@react-native-community/clipboard@git+https://github.com/celo-org/clipboard#5afb848":
-  version "1.2.3"
-  resolved "git+https://github.com/celo-org/clipboard#5afb8484215495bce475efb8da24e65339e21164"
 
 "@react-native-community/eslint-config@^1.1.0":
   version "1.1.0"


### PR DESCRIPTION
The upstream version includes our changes:

  * Our changes: https://github.com/react-native-clipboard/clipboard/compare/master...valora-inc:clipboard:master
  * Commit pulling in our changes: https://github.com/react-native-clipboard/clipboard/commit/a83fce847e2e1e2895bc1e45658b886d01bef8bc
