### PR TITLE
chore(deps): add react-native-fast-crypto to .depcheckrc

### DIFF
--- a/.depcheckrc
+++ b/.depcheckrc
@@ -5,6 +5,7 @@ ignores: [
   "metro-react-native-babel-preset",
   "prettier-plugin-java",
   "pretty-quick",
+  "react-native-fast-crypto", # react-native-bip39 requires
   "react-native-version",
   "react-native-kill-packager",
   "ts-node",


### PR DESCRIPTION
### Description

So this isn't flagged by depcheck

### Other changes

N/A

### Tested

Using yarn depcheck 


### How others should test

N/A

### Related issues

N/A

### Backwards compatibility

N/A