### PR TITLE
refactor: avoid "exposing" the cloud functions base URL

### DIFF
--- a/src/consumerIncentives/saga.test.ts
+++ b/src/consumerIncentives/saga.test.ts
@@ -89,7 +89,7 @@ describe('fetchAvailableRewardsSaga', () => {
   }
   const error = new Error('Unexpected error')
 
-  const availableRewardsUri = `${config.cloudFunctionsUrl}/fetchAvailableSuperchargeRewards?address=${userAddress}`
+  const availableRewardsUri = `${config.fetchAvailableSuperchargeRewards}?address=${userAddress}`
 
   it('stores rewards after fetching them', async () => {
     await expectSaga(fetchAvailableRewardsSaga)

--- a/src/consumerIncentives/saga.ts
+++ b/src/consumerIncentives/saga.ts
@@ -135,7 +135,7 @@ export function* fetchAvailableRewardsSaga() {
   try {
     const response: Response = yield call(
       fetchWithTimeout,
-      `${config.cloudFunctionsUrl}/fetchAvailableSuperchargeRewards?address=${address}`
+      `${config.fetchAvailableSuperchargeRewards}?address=${address}`
     )
     const data: { availableRewards: SuperchargePendingReward[] } = yield call([response, 'json'])
     yield put(setAvailableRewards(data.availableRewards))

--- a/src/sentry/Sentry.ts
+++ b/src/sentry/Sentry.ts
@@ -2,7 +2,7 @@ import * as Sentry from '@sentry/react-native'
 import DeviceInfo from 'react-native-device-info'
 import { select } from 'redux-saga/effects'
 import { sentryTracesSampleRateSelector } from 'src/app/selectors'
-import { APP_BUNDLE_ID, DEFAULT_FORNO_URL, SENTRY_CLIENT_URL, SENTRY_ENABLED } from 'src/config'
+import { APP_BUNDLE_ID, SENTRY_CLIENT_URL, SENTRY_ENABLED } from 'src/config'
 import networkConfig from 'src/web3/networkConfig'
 import Logger from 'src/utils/Logger'
 import { currentAccountSelector } from 'src/web3/selectors'
@@ -38,12 +38,7 @@ export function* initializeSentry() {
   //   https://docs.sentry.io/platforms/javascript/performance/instrumentation/automatic-instrumentation/#tracingorigins
   // If you want to match against a specific domain (which we do) make sure to
   // use the domain name (not the URL).
-  const tracingOrigins = [
-    DEFAULT_FORNO_URL,
-    networkConfig.blockchainApiUrl,
-    networkConfig.cloudFunctionsUrl,
-    networkConfig.inHouseLiquidityURL,
-  ].map((url) => {
+  const tracingOrigins = networkConfig.sentryTracingUrls.map((url) => {
     // hostname does not include the port (while host does include the port).
     // Use hostname because it will match agaist a request to the host on any
     // port.

--- a/src/web3/networkConfig.ts
+++ b/src/web3/networkConfig.ts
@@ -1,7 +1,7 @@
 import { Address } from '@celo/base'
 import { OdisUtils } from '@celo/identity'
 import { Environment as PersonaEnvironment } from 'react-native-persona'
-import { BIDALI_URL, DEFAULT_TESTNET, RECAPTCHA_SITE_KEY } from 'src/config'
+import { DEFAULT_FORNO_URL, BIDALI_URL, DEFAULT_TESTNET, RECAPTCHA_SITE_KEY } from 'src/config'
 import Logger from 'src/utils/Logger'
 
 export enum Testnets {
@@ -15,7 +15,7 @@ interface NetworkConfig {
   odisUrl: string // Phone Number Privacy service url
   odisPubKey: string
   komenciUrl: string
-  cloudFunctionsUrl: string
+  sentryTracingUrls: string[]
   allowedMtwImplementations: string[]
   currentMtwImplementationAddress: string
   recaptchaSiteKey: string
@@ -43,6 +43,7 @@ interface NetworkConfig {
   lookupAddressUrl: string
   revokePhoneNumberUrl: string
   migratePhoneVerificationUrl: string
+  fetchAvailableSuperchargeRewards: string
 }
 
 const KOMENCI_URL_MAINNET = 'https://mainnet-komenci.azurefd.net'
@@ -108,6 +109,9 @@ const REVOKE_PHONE_NUMBER_MAINNET = `${CLOUD_FUNCTIONS_MAINNET}/revokePhoneNumbe
 const MIGRATE_PHONE_VERIFICATION_ALFAJORES = `${CLOUD_FUNCTIONS_STAGING}/migrateASv1Verification`
 const MIGRATE_PHONE_VERIFICATION_MAINNET = `${CLOUD_FUNCTIONS_MAINNET}/migrateASv1Verification`
 
+const FETCH_AVAILABLE_SUPERCHARGE_REWARDS_ALFAJORES = `${CLOUD_FUNCTIONS_STAGING}/fetchAvailableSuperchargeRewards`
+const FETCH_AVAILABLE_SUPERCHARGE_REWARDS_MAINNET = `${CLOUD_FUNCTIONS_MAINNET}/fetchAvailableSuperchargeRewards`
+
 const CELO_EXPLORER_BASE_URL_ALFAJORES = 'https://explorer.celo.org/alfajores'
 const CELO_EXPLORER_BASE_URL_MAINNET = 'https://explorer.celo.org/mainnet'
 
@@ -130,7 +134,12 @@ const networkConfigs: { [testnet: string]: NetworkConfig } = {
     odisUrl: OdisUtils.Query.ODIS_ALFAJORES_CONTEXT.odisUrl,
     odisPubKey: OdisUtils.Query.ODIS_ALFAJORES_CONTEXT.odisPubKey,
     komenciUrl: KOMENCI_URL_STAGING,
-    cloudFunctionsUrl: CLOUD_FUNCTIONS_STAGING,
+    sentryTracingUrls: [
+      DEFAULT_FORNO_URL,
+      'https://blockchain-api-dot-celo-mobile-alfajores.appspot.com',
+      CLOUD_FUNCTIONS_STAGING,
+      'https://liquidity-dot-celo-mobile-alfajores.appspot.com',
+    ],
     allowedMtwImplementations: ALLOWED_MTW_IMPLEMENTATIONS_STAGING,
     currentMtwImplementationAddress: CURRENT_MTW_IMPLEMENTATION_ADDRESS_STAGING,
     recaptchaSiteKey: RECAPTCHA_SITE_KEY,
@@ -158,6 +167,7 @@ const networkConfigs: { [testnet: string]: NetworkConfig } = {
     lookupAddressUrl: LOOKUP_ADDRESS_ALFAJORES,
     revokePhoneNumberUrl: REVOKE_PHONE_NUMBER_ALFAJORES,
     migratePhoneVerificationUrl: MIGRATE_PHONE_VERIFICATION_ALFAJORES,
+    fetchAvailableSuperchargeRewards: FETCH_AVAILABLE_SUPERCHARGE_REWARDS_ALFAJORES,
   },
   [Testnets.mainnet]: {
     networkId: '42220',
@@ -165,7 +175,12 @@ const networkConfigs: { [testnet: string]: NetworkConfig } = {
     odisUrl: OdisUtils.Query.ODIS_MAINNET_CONTEXT.odisUrl,
     odisPubKey: OdisUtils.Query.ODIS_MAINNET_CONTEXT.odisPubKey,
     komenciUrl: KOMENCI_URL_MAINNET,
-    cloudFunctionsUrl: CLOUD_FUNCTIONS_MAINNET,
+    sentryTracingUrls: [
+      DEFAULT_FORNO_URL,
+      'https://blockchain-api-dot-celo-mobile-mainnet.appspot.com',
+      CLOUD_FUNCTIONS_MAINNET,
+      'https://liquidity-dot-celo-mobile-mainnet.appspot.com',
+    ],
     allowedMtwImplementations: ALLOWED_MTW_IMPLEMENTATIONS_MAINNET,
     currentMtwImplementationAddress: CURRENT_MTW_IMPLEMENTATION_ADDRESS_MAINNET,
     recaptchaSiteKey: RECAPTCHA_SITE_KEY,
@@ -193,6 +208,7 @@ const networkConfigs: { [testnet: string]: NetworkConfig } = {
     lookupAddressUrl: LOOKUP_ADDRESS_MAINNET,
     revokePhoneNumberUrl: REVOKE_PHONE_NUMBER_MAINNET,
     migratePhoneVerificationUrl: MIGRATE_PHONE_VERIFICATION_MAINNET,
+    fetchAvailableSuperchargeRewards: FETCH_AVAILABLE_SUPERCHARGE_REWARDS_MAINNET,
   },
 }
 


### PR DESCRIPTION
We expose it specifically for Sentry, but another piece of code was using it to construct a REST API endpoint (instead of following the convention of defining API endpoints explicitly in networkConfig.ts). This change is pretty mundane, but the intent it to make it harder to avoid the convention.