### PR TITLE
feat(cico): use add funds crypto exchange experiment params

### DIFF
--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -1281,6 +1281,8 @@
     "cryptoExchange": "Cryptocurrency Exchange",
     "feesVary": "Fees Vary",
     "viewExchanges": "View Exchanges",
+    "depositFrom": "Deposit From",
+    "cryptoExchangeOrWallet": "Crypto Exchange or Wallet",
     "card": "Credit / Debit Card",
     "bank": "Bank Account",
     "mobileMoney": "Mobile Money",

--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -1281,7 +1281,7 @@
     "cryptoExchange": "Cryptocurrency Exchange",
     "feesVary": "Fees Vary",
     "viewExchanges": "View Exchanges",
-    "depositFrom": "Deposit From",
+    "depositFrom": "Deposit from",
     "cryptoExchangeOrWallet": "Crypto Exchange or Wallet",
     "card": "Credit / Debit Card",
     "bank": "Bank Account",

--- a/src/analytics/constants.ts
+++ b/src/analytics/constants.ts
@@ -36,7 +36,7 @@ export const ExperimentParams = {
     },
     addFundsExchangesLink: {
       paramName: 'addFundsExchangesLink',
-      defaultValue: SelectProviderExchangesLink.ExchangesScreen,
+      defaultValue: SelectProviderExchangesLink.ExternalExchangesScreen,
     },
   },
 }

--- a/src/fiatExchanges/types.ts
+++ b/src/fiatExchanges/types.ts
@@ -4,6 +4,6 @@ export enum SelectProviderExchangesText {
 }
 
 export enum SelectProviderExchangesLink {
-  ExchangesScreen = 'ExchangesScreen',
-  ExchangesQrScreen = 'ExchangesQrScreen',
+  ExternalExchangesScreen = 'ExternalExchangesScreen',
+  ExchangeQRScreen = 'ExchangeQRScreen',
 }


### PR DESCRIPTION
### Description

Actually uses the experiment params and implements the experiment variant to use the appropriate text and navigate to the right screen.

https://user-images.githubusercontent.com/5062591/207996690-6e1d6836-7a74-47ca-a740-d0d80bfbeb2a.mp4

### Other changes

Renamed enums to exactly match screen names

### Tested

Unit, manual by setting up overrides in statsig


### How others should test

1. Add your wallet address to the appropriate variant of the [experiment in statsig](https://console.statsig.com/4plizaPmWwPL21ASV4QAO0/experiments/add_funds_crypto_exchange_qr_code/setup)
2. Navigate to Add funds, select any currency and enter any amount
3. Ensure external exchanges section is visible on the "Select Payment Method" screen with the appropriate text ("Deposit From" for variant, "Cryptocurrency Exchange" for control)
4. Click on exchanges section and ensure navigation to correct screen ( new Deposit Crypto QR code screen for variant, existing external changes screen for control)

### Related issues

- Fixes ACT-544

### Backwards compatibility

Yes