### PR TITLE
fix(qrcode): Switch the Exhange QR code screen to encode address

### DIFF
--- a/src/fiatExchanges/ExchangeQR.tsx
+++ b/src/fiatExchanges/ExchangeQR.tsx
@@ -1,33 +1,33 @@
+import Clipboard from '@react-native-clipboard/clipboard'
 import { RouteProp } from '@react-navigation/native'
-import { StackParamList } from 'src/navigator/types'
 import { NativeStackScreenProps } from '@react-navigation/native-stack'
-import React, { useRef, useState, useLayoutEffect } from 'react'
+import React, { useLayoutEffect, useRef, useState } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
-import { StyleSheet, View, Text } from 'react-native'
-import { useDispatch } from 'react-redux'
-import { Screens } from 'src/navigator/Screens'
-import StyledQRCode from 'src/qrcode/StyledQRCode'
-import { useSelector } from 'react-redux'
-import { SVG, shareQRCode } from 'src/send/actions'
-import Logger from 'src/utils/Logger'
-import { FiatExchangeEvents } from 'src/analytics/Events'
-import BackButton from 'src/components/BackButton'
-import { emptyHeader } from 'src/navigator/Headers'
-import { CICOFlow } from './utils'
-import i18n from 'src/i18n'
-import { TopBarIconButton } from 'src/navigator/TopBarButton'
-import Share from 'src/icons/Share'
-import { walletAddressSelector } from 'src/web3/selectors'
+import { StyleSheet, Text, View } from 'react-native'
+import { useDispatch, useSelector } from 'react-redux'
 import { nameSelector } from 'src/account/selectors'
-import variables from 'src/styles/variables'
+import { FiatExchangeEvents } from 'src/analytics/Events'
+import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
+import BackButton from 'src/components/BackButton'
+import Button from 'src/components/Button'
+import ExchangesBottomSheet from 'src/components/ExchangesBottomSheet'
+import { ExternalExchangeProvider } from 'src/fiatExchanges/ExternalExchanges'
+import i18n from 'src/i18n'
+import Paste from 'src/icons/Paste'
+import Share from 'src/icons/Share'
+import { emptyHeader } from 'src/navigator/Headers'
+import { Screens } from 'src/navigator/Screens'
+import { TopBarIconButton } from 'src/navigator/TopBarButton'
+import { StackParamList } from 'src/navigator/types'
+import { QRCodeDataType } from 'src/qrcode/schema'
+import StyledQRCode from 'src/qrcode/StyledQRCode'
+import { shareQRCode, SVG } from 'src/send/actions'
 import colors from 'src/styles/colors'
 import fontStyles from 'src/styles/fonts'
-import Button from 'src/components/Button'
-import Paste from 'src/icons/Paste'
-import Clipboard from '@react-native-clipboard/clipboard'
-import ExchangesBottomSheet from 'src/components/ExchangesBottomSheet'
-import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
-import { ExternalExchangeProvider } from 'src/fiatExchanges/ExternalExchanges'
+import variables from 'src/styles/variables'
+import Logger from 'src/utils/Logger'
+import { walletAddressSelector } from 'src/web3/selectors'
+import { CICOFlow } from './utils'
 
 type Props = NativeStackScreenProps<StackParamList, Screens.ExchangeQR>
 
@@ -88,7 +88,7 @@ export default function ExchangeQR({ route, navigation }: Props) {
   return (
     <View style={styles.container}>
       <View style={styles.qrContainer}>
-        <StyledQRCode qrSvgRef={qrSvgRef} />
+        <StyledQRCode dataType={QRCodeDataType.Address} qrSvgRef={qrSvgRef} />
       </View>
 
       {displayName && (

--- a/src/qrcode/QRCode.tsx
+++ b/src/qrcode/QRCode.tsx
@@ -24,15 +24,26 @@ export const mapStateToProps = (state: RootState) => ({
   e164PhoneNumber: state.account.e164PhoneNumber || undefined,
 })
 
-export default function QRCodeDisplay({ qrSvgRef, dataType }: Props) {
-  const data = useSelector(mapStateToProps, shallowEqual)
-
-  // ValoraDeepLink generates a QR code that deeplinks into the walletconnect send flow of the valora app
-  // Address generates a QR code that has the walletAddress as plaintext that is readable by wallets such as Coinbase and Metamask
-  const qrContent = useMemo(
+// ValoraDeepLink generates a QR code that deeplinks into the walletconnect send flow of the valora app
+// Address generates a QR code that has the walletAddress as plaintext that is readable by wallets such as Coinbase and Metamask
+export function useQRContent(
+  dataType: QRCodeDataType,
+  data: {
+    address: string
+    displayName: string | undefined
+    e164PhoneNumber: string | undefined
+  }
+) {
+  return useMemo(
     () => (dataType === QRCodeDataType.ValoraDeepLink ? urlFromUriData(data) : data.address),
     [data.address, data.displayName, data.e164PhoneNumber, data]
   )
+}
+
+export default function QRCodeDisplay({ qrSvgRef, dataType }: Props) {
+  const data = useSelector(mapStateToProps, shallowEqual)
+  const qrContent = useQRContent(dataType, data)
+
   return (
     <SafeAreaView style={styles.container}>
       <AvatarSelf iconSize={64} displayNameStyle={fontStyles.h2} />

--- a/src/qrcode/QRCode.tsx
+++ b/src/qrcode/QRCode.tsx
@@ -1,11 +1,12 @@
-import React, { useMemo } from 'react'
+import React from 'react'
 import { StyleSheet, View } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { shallowEqual, useSelector } from 'react-redux'
 import { nameSelector } from 'src/account/selectors'
 import { AvatarSelf } from 'src/components/AvatarSelf'
 import QRCode from 'src/qrcode/QRGen'
-import { QRCodeDataType, urlFromUriData } from 'src/qrcode/schema'
+import { QRCodeDataType } from 'src/qrcode/schema'
+import { useQRContent } from 'src/qrcode/utils'
 import { RootState } from 'src/redux/reducers'
 import { SVG } from 'src/send/actions'
 import colors from 'src/styles/colors'
@@ -23,22 +24,6 @@ export const mapStateToProps = (state: RootState) => ({
   displayName: nameSelector(state) || undefined,
   e164PhoneNumber: state.account.e164PhoneNumber || undefined,
 })
-
-// ValoraDeepLink generates a QR code that deeplinks into the walletconnect send flow of the valora app
-// Address generates a QR code that has the walletAddress as plaintext that is readable by wallets such as Coinbase and Metamask
-export function useQRContent(
-  dataType: QRCodeDataType,
-  data: {
-    address: string
-    displayName: string | undefined
-    e164PhoneNumber: string | undefined
-  }
-) {
-  return useMemo(
-    () => (dataType === QRCodeDataType.ValoraDeepLink ? urlFromUriData(data) : data.address),
-    [data.address, data.displayName, data.e164PhoneNumber, data]
-  )
-}
 
 export default function QRCodeDisplay({ qrSvgRef, dataType }: Props) {
   const data = useSelector(mapStateToProps, shallowEqual)

--- a/src/qrcode/StyledQRCode.tsx
+++ b/src/qrcode/StyledQRCode.tsx
@@ -1,22 +1,21 @@
-import React, { useMemo } from 'react'
-import StyledQRCode from 'src/qrcode/StyledQRGen'
-import { shallowEqual, useSelector } from 'react-redux'
-import { mapStateToProps } from 'src/qrcode/QRCode'
-import { urlFromUriData } from 'src/qrcode/schema'
-import { SVG } from 'src/send/actions'
+import React from 'react'
 import { View } from 'react-native'
+import { shallowEqual, useSelector } from 'react-redux'
+import { mapStateToProps, useQRContent } from 'src/qrcode/QRCode'
+import { QRCodeDataType } from 'src/qrcode/schema'
+import StyledQRCode from 'src/qrcode/StyledQRGen'
+import { SVG } from 'src/send/actions'
 import variables from 'src/styles/variables'
 
 interface Props {
   qrSvgRef: React.MutableRefObject<SVG>
+  dataType: QRCodeDataType
 }
 
-export default function StyledQRCodeDisplay({ qrSvgRef }: Props) {
+export default function StyledQRCodeDisplay({ qrSvgRef, dataType }: Props) {
   const data = useSelector(mapStateToProps, shallowEqual)
-  const qrContent = useMemo(
-    () => urlFromUriData(data),
-    [data.address, data.displayName, data.e164PhoneNumber]
-  )
+  const qrContent = useQRContent(dataType, data)
+
   return (
     <View testID="styledQRCode">
       <StyledQRCode value={qrContent} size={variables.width / 2} svgRef={qrSvgRef} />

--- a/src/qrcode/StyledQRCode.tsx
+++ b/src/qrcode/StyledQRCode.tsx
@@ -1,9 +1,10 @@
 import React from 'react'
 import { View } from 'react-native'
 import { shallowEqual, useSelector } from 'react-redux'
-import { mapStateToProps, useQRContent } from 'src/qrcode/QRCode'
+import { mapStateToProps } from 'src/qrcode/QRCode'
 import { QRCodeDataType } from 'src/qrcode/schema'
 import StyledQRCode from 'src/qrcode/StyledQRGen'
+import { useQRContent } from 'src/qrcode/utils'
 import { SVG } from 'src/send/actions'
 import variables from 'src/styles/variables'
 

--- a/src/qrcode/utils.test.tsx
+++ b/src/qrcode/utils.test.tsx
@@ -1,0 +1,37 @@
+import { render } from '@testing-library/react-native'
+import * as React from 'react'
+import 'react-native'
+import { View } from 'react-native'
+import { QRCodeDataType, urlFromUriData } from 'src/qrcode/schema'
+import { useQRContent } from 'src/qrcode/utils'
+import { mockAccount, mockE164Number, mockName } from 'test/values'
+
+describe('useQRContent', () => {
+  const data = {
+    address: mockAccount,
+    displayName: mockName,
+    e164PhoneNumber: mockE164Number,
+  }
+  const MockComponent = (props: {
+    dataType: QRCodeDataType
+    data: {
+      address: string
+      displayName: string | undefined
+      e164PhoneNumber: string | undefined
+    }
+  }) => {
+    const qrCodeString = useQRContent(props.dataType, props.data)
+    return <View testID="qrCodeString">{qrCodeString}</View>
+  }
+  it('returns a url when dataType is ValoraDeepLink', () => {
+    const { getByTestId } = render(
+      <MockComponent dataType={QRCodeDataType.ValoraDeepLink} data={data} />
+    )
+    expect(getByTestId('qrCodeString').children[0]).toEqual(urlFromUriData(data))
+  })
+
+  it('returns an address when dataType is address', () => {
+    const { getByTestId } = render(<MockComponent dataType={QRCodeDataType.Address} data={data} />)
+    expect(getByTestId('qrCodeString').children[0]).toEqual(data.address)
+  })
+})

--- a/src/qrcode/utils.ts
+++ b/src/qrcode/utils.ts
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import * as RNFS from 'react-native-fs'
 import Share from 'react-native-share'
 import { call, fork, put } from 'redux-saga/effects'
@@ -10,7 +11,7 @@ import { validateRecipientAddressSuccess } from 'src/identity/actions'
 import { E164NumberToAddressType } from 'src/identity/reducer'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
-import { UriData, uriDataFromUrl } from 'src/qrcode/schema'
+import { QRCodeDataType, UriData, uriDataFromUrl, urlFromUriData } from 'src/qrcode/schema'
 import {
   getRecipientFromAddress,
   recipientHasNumber,
@@ -31,6 +32,22 @@ export enum BarcodeTypes {
 const TAG = 'QR/utils'
 
 const QRFileName = '/celo-qr.png'
+
+// ValoraDeepLink generates a QR code that deeplinks into the walletconnect send flow of the valora app
+// Address generates a QR code that has the walletAddress as plaintext that is readable by wallets such as Coinbase and Metamask
+export function useQRContent(
+  dataType: QRCodeDataType,
+  data: {
+    address: string
+    displayName: string | undefined
+    e164PhoneNumber: string | undefined
+  }
+) {
+  return useMemo(
+    () => (dataType === QRCodeDataType.ValoraDeepLink ? urlFromUriData(data) : data.address),
+    [data.address, data.displayName, data.e164PhoneNumber, data]
+  )
+}
 
 export async function shareSVGImage(svg: SVG) {
   if (!svg) {


### PR DESCRIPTION
### Description

Old QR screens were already updated to be able to handle address, new screen needs it too. 

Exchange QR screen should always encode address.

### Test plan

Tested by updating the code locally to display the Exchange QR Code screen and successfully scanned the QR code with metamask and coinbase. 

### Related issues

https://linear.app/valora/issue/ACT-543/update-qr-code-within-qr-code-screen

