### PR TITLE
chore(dev-deps): remove @babel/runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -199,7 +199,6 @@
     "@babel/plugin-proposal-decorators": "^7.12.1",
     "@babel/plugin-proposal-numeric-separator": "^7.14.5",
     "@babel/plugin-transform-named-capturing-groups-regex": "^7.17.12",
-    "@babel/runtime": "^7.12.5",
     "@faker-js/faker": "^5.5.3",
     "@graphql-codegen/add": "^1.10.0",
     "@graphql-codegen/cli": "^1.10.0",


### PR DESCRIPTION
### Description

Flagged by depcheck. Per [docs](https://babeljs.io/docs/en/babel-runtime), looks like this needs to be used as a runtime dependency (not a dev dependency) along with [@babel/plugin-transform-runtime](https://babeljs.io/docs/en/babel-plugin-transform-runtime), but we don't use this plugin.

### Test plan

CI

### Related issues

N/A

### Backwards compatibility

N/A
