### PR TITLE
chore: hide swaps from drawer menu for SG, PH and JP

### DIFF
--- a/src/flags.ts
+++ b/src/flags.ts
@@ -81,4 +81,9 @@ export const countryFeatures = {
     XI: true, // Northern Ireland
     XK: true, // Kosovo
   },
+  SWAP_RESTRICTED_COUNTRY: {
+    SG: true, // Singapore
+    PH: true, // Philippines
+    JP: true, // Japan
+  },
 }

--- a/src/navigator/DrawerNavigator.tsx
+++ b/src/navigator/DrawerNavigator.tsx
@@ -65,6 +65,7 @@ import { default as useSelector } from 'src/redux/useSelector'
 import colors from 'src/styles/colors'
 import fontStyles from 'src/styles/fonts'
 import SwapScreen from 'src/swap/SwapScreen'
+import { userInSwapRestrictedCountrySelector } from 'src/utils/countryFeatures'
 import Logger from 'src/utils/Logger'
 import { currentAccountSelector } from 'src/web3/selectors'
 
@@ -206,7 +207,9 @@ export default function DrawerNavigator() {
     <CustomDrawerContent {...props} />
   )
 
-  const shouldShowSwapMenuInDrawerMenu = useSelector(isAppSwapsEnabledSelector)
+  const inAppSwapsEnabled = useSelector(isAppSwapsEnabledSelector)
+  const isSwapRestricted = useSelector(userInSwapRestrictedCountrySelector)
+  const shouldShowSwapMenuInDrawerMenu = inAppSwapsEnabled && !isSwapRestricted
 
   return (
     <Drawer.Navigator

--- a/src/utils/countryFeatures.ts
+++ b/src/utils/countryFeatures.ts
@@ -29,3 +29,9 @@ export const userInSanctionedCountrySelector = createSelector(
   userLocationDataSelector,
   ({ countryCodeAlpha2 }) => getCountryFeatures(countryCodeAlpha2 ?? '').SANCTIONED_COUNTRY ?? false
 )
+
+export const userInSwapRestrictedCountrySelector = createSelector(
+  userLocationDataSelector,
+  ({ countryCodeAlpha2 }) =>
+    getCountryFeatures(countryCodeAlpha2 ?? '').SWAP_RESTRICTED_COUNTRY ?? false
+)


### PR DESCRIPTION
### Description

Hides the swap drawer menu item for Singapore, Philippines and Japan.

### Test plan

Tested by adding US as a `SWAP_RESTRICTED_COUNTRY` and checking that the swap drawer menu item doesn't appear.

### Related issues

N/A

### Backwards compatibility

Yes