### PR TITLE
feat(celo-news): skip Celo education carousel when celo news is enabled

### DIFF
--- a/src/navigator/DrawerNavigator.tsx
+++ b/src/navigator/DrawerNavigator.tsx
@@ -33,7 +33,7 @@ import SettingsScreen from 'src/account/Settings'
 import Support from 'src/account/Support'
 import { HomeEvents, RewardsEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
-import { inviteMethodSelector } from 'src/app/selectors'
+import { celoNewsConfigSelector, inviteMethodSelector } from 'src/app/selectors'
 import { InviteMethodType } from 'src/app/types'
 import BackupIntroduction from 'src/backup/BackupIntroduction'
 import AccountNumber from 'src/components/AccountNumber'
@@ -201,12 +201,34 @@ export default function DrawerNavigator() {
 
   const shouldShowRecoveryPhraseInSettings = useSelector(shouldShowRecoveryPhraseInSettingsSelector)
   const backupCompleted = useSelector(backupCompletedSelector)
+  const isCeloNewsEnabled = useSelector(celoNewsConfigSelector).enabled
 
   const drawerContent = (props: DrawerContentComponentProps<DrawerContentOptions>) => (
     <CustomDrawerContent {...props} />
   )
 
   const shouldShowSwapMenuInDrawerMenu = useSelector(isAppSwapsEnabledSelector)
+
+  // Show ExchangeHomeScreen if the user has completed the Celo education
+  // or if the Celo News feature is enabled
+  // Otherwise, show the Celo education screen
+  const celoMenuItem =
+    isCeloEducationComplete || isCeloNewsEnabled ? (
+      <Drawer.Screen
+        name={Screens.ExchangeHomeScreen}
+        component={ExchangeHomeScreen}
+        options={{ title: t('celoGold'), drawerIcon: Gold }}
+      />
+    ) : (
+      <Drawer.Screen
+        name={Screens.GoldEducation}
+        component={GoldEducation}
+        options={{
+          title: t('celoGold'),
+          drawerIcon: Gold,
+        }}
+      />
+    )
 
   return (
     <Drawer.Navigator
@@ -237,24 +259,7 @@ export default function DrawerNavigator() {
           options={{ title: t('swapScreen.title'), drawerIcon: Swap }}
         />
       ) : (
-        <>
-          {(isCeloEducationComplete && (
-            <Drawer.Screen
-              name={Screens.ExchangeHomeScreen}
-              component={ExchangeHomeScreen}
-              options={{ title: t('celoGold'), drawerIcon: Gold }}
-            />
-          )) || (
-            <Drawer.Screen
-              name={Screens.GoldEducation}
-              component={GoldEducation}
-              options={{
-                title: t('celoGold'),
-                drawerIcon: Gold,
-              }}
-            />
-          )}
-        </>
+        celoMenuItem
       )}
 
       {dappsListUrl && (
@@ -293,26 +298,11 @@ export default function DrawerNavigator() {
           options={{ title: t('invite'), drawerIcon: InviteIcon }}
         />
       )}
-      {shouldShowSwapMenuInDrawerMenu && (
-        <>
-          {(isCeloEducationComplete && (
-            <Drawer.Screen
-              name={Screens.ExchangeHomeScreen}
-              component={ExchangeHomeScreen}
-              options={{ title: t('celoGold'), drawerIcon: Gold }}
-            />
-          )) || (
-            <Drawer.Screen
-              name={Screens.GoldEducation}
-              component={GoldEducation}
-              options={{
-                title: t('celoGold'),
-                drawerIcon: Gold,
-              }}
-            />
-          )}
-        </>
-      )}
+
+      {
+        // When swap is enabled, the celo menu item is here
+        shouldShowSwapMenuInDrawerMenu && celoMenuItem
+      }
 
       <Drawer.Screen
         name={Screens.Settings}


### PR DESCRIPTION
### Description

From the [experiment design](https://www.notion.so/valora-inc/Celo-news-feed-43e09037425949b38f2fdc79812a62e3) we learned users tapping the CELO menu item drop at the Celo education carousel.
So when Celo News is enabled, we now skip it too.

Note: I slightly refactored the menu item thing so we don't have to repeat ourselves.

### Test plan

- When Celo News is enabled, tapping the CELO menu item should directly show the news feed, without the Celo education carousel.

### Related issues

Discussed on [Slack](https://valora-app.slack.com/archives/C0494B52JTH/p1671805415760139).

### Backwards compatibility

Yes