### PR TITLE
fix(statsig): use wallet address instead of account address

### DIFF
--- a/src/analytics/ValoraAnalytics.test.ts
+++ b/src/analytics/ValoraAnalytics.test.ts
@@ -154,11 +154,13 @@ describe('ValoraAnalytics', () => {
   })
 
   it('creates statsig client on initialization with wallet address as user id', async () => {
-    mockStore.getState.mockImplementation(() => getMockStoreData({ web3: { account: '0x1234' } }))
+    mockStore.getState.mockImplementation(() =>
+      getMockStoreData({ web3: { account: '0x1234ABC', mtwAddress: '0x0000' } })
+    )
     await ValoraAnalytics.init()
     expect(Statsig.initialize).toHaveBeenCalledWith(
       'statsig-key',
-      { userID: '0x1234' },
+      { userID: '0x1234abc' },
       { environment: { tier: 'development' }, overrideStableID: 'anonId' }
     )
   })

--- a/src/analytics/ValoraAnalytics.ts
+++ b/src/analytics/ValoraAnalytics.ts
@@ -130,17 +130,17 @@ class ValoraAnalytics {
     }
 
     try {
-      const { accountAddress } = getCurrentUserTraits(store.getState())
-      const stasigUser =
-        typeof accountAddress === 'string'
+      const { walletAddress } = getCurrentUserTraits(store.getState())
+      const statsigUser =
+        typeof walletAddress === 'string'
           ? {
-              userID: accountAddress,
+              userID: walletAddress,
             }
           : null
 
       // getAnonymousId causes the e2e tests to fail
       const overrideStableID = isE2EEnv ? E2E_TEST_STATSIG_ID : await Analytics.getAnonymousId()
-      await Statsig.initialize(STATSIG_API_KEY, stasigUser, {
+      await Statsig.initialize(STATSIG_API_KEY, statsigUser, {
         // StableID should match Segment anonymousId
         overrideStableID,
         environment: STATSIG_ENV,


### PR DESCRIPTION
### Description

Use wallet address instead of account address for statsig user

### Test plan

Unit tests

### Related issues

N/A

### Backwards compatibility

Yes
