### PR TITLE
chore(mtwAddress): remove accountAddress selector to prevent bugs

### DIFF
--- a/src/analytics/ValoraAnalytics.test.ts
+++ b/src/analytics/ValoraAnalytics.test.ts
@@ -38,6 +38,8 @@ jest.mock('statsig-react-native')
 
 const mockDeviceId = 'abc-def-123' // mocked in __mocks__/react-native-device-info.ts (but importing from that file causes weird errors)
 const expectedSessionId = '205ac8350460ad427e35658006b409bbb0ee86c22c57648fe69f359c2da648'
+const mockMTWAddress = '0x123abc' // we've been setting MTW address as lower case for years, so this lowercase fixture data should be ok
+const mockWalletAddress = '0x456def' // we've been setting EOA address as lower case for years, so this lowercase fixture data should be ok
 
 Date.now = jest.fn(() => 1482363367071)
 
@@ -93,6 +95,10 @@ const state = getMockStoreData({
       },
     },
   },
+  web3: {
+    account: mockWalletAddress,
+    mtwAddress: mockMTWAddress,
+  },
   account: {
     pincodeType: PincodeType.CustomPin,
   },
@@ -103,7 +109,7 @@ const state = getMockStoreData({
 global.__DEV__ = false
 
 const defaultSuperProperties = {
-  sAccountAddress: '0x0000000000000000000000000000000000007E57',
+  sAccountAddress: mockMTWAddress,
   sAppBuildNumber: '1',
   sAppBundleId: 'org.celo.mobile.debug',
   sAppVersion: '0.0.1',
@@ -125,7 +131,7 @@ const defaultSuperProperties = {
   sPrevScreenId: undefined,
   sTokenCount: 4,
   sTotalBalanceUsd: 36,
-  sWalletAddress: '0x0000000000000000000000000000000000007e57',
+  sWalletAddress: mockWalletAddress,
   sSuperchargingAmountInUsd: 24,
   sSuperchargingToken: 'cEUR',
 }
@@ -135,7 +141,7 @@ const defaultProperties = {
   celoNetwork: 'alfajores',
   sessionId: expectedSessionId,
   timestamp: 1482363367071,
-  userAddress: '0x0000000000000000000000000000000000007e57',
+  userAddress: mockWalletAddress,
   statsigEnvironment: {
     tier: 'development',
   },

--- a/src/analytics/ValoraAnalytics.test.ts
+++ b/src/analytics/ValoraAnalytics.test.ts
@@ -38,8 +38,7 @@ jest.mock('statsig-react-native')
 
 const mockDeviceId = 'abc-def-123' // mocked in __mocks__/react-native-device-info.ts (but importing from that file causes weird errors)
 const expectedSessionId = '205ac8350460ad427e35658006b409bbb0ee86c22c57648fe69f359c2da648'
-const mockMTWAddress = '0x123abc' // we've been setting MTW address as lower case for years, so this lowercase fixture data should be ok
-const mockWalletAddress = '0x456def' // we've been setting EOA address as lower case for years, so this lowercase fixture data should be ok
+const mockWalletAddress = '0x12AE66CDc592e10B60f9097a7b0D3C59fce29876' // deliberately using checksummed version here
 
 Date.now = jest.fn(() => 1482363367071)
 
@@ -97,7 +96,7 @@ const state = getMockStoreData({
   },
   web3: {
     account: mockWalletAddress,
-    mtwAddress: mockMTWAddress,
+    mtwAddress: null,
   },
   account: {
     pincodeType: PincodeType.CustomPin,
@@ -109,7 +108,7 @@ const state = getMockStoreData({
 global.__DEV__ = false
 
 const defaultSuperProperties = {
-  sAccountAddress: mockMTWAddress,
+  sAccountAddress: mockWalletAddress, // test for backwards compatibility (this field is NOT lower-cased)
   sAppBuildNumber: '1',
   sAppBundleId: 'org.celo.mobile.debug',
   sAppVersion: '0.0.1',
@@ -131,7 +130,7 @@ const defaultSuperProperties = {
   sPrevScreenId: undefined,
   sTokenCount: 4,
   sTotalBalanceUsd: 36,
-  sWalletAddress: mockWalletAddress,
+  sWalletAddress: mockWalletAddress.toLowerCase(), // test for backwards compatibility (this field is lower-cased)
   sSuperchargingAmountInUsd: 24,
   sSuperchargingToken: 'cEUR',
 }
@@ -141,7 +140,7 @@ const defaultProperties = {
   celoNetwork: 'alfajores',
   sessionId: expectedSessionId,
   timestamp: 1482363367071,
-  userAddress: mockWalletAddress,
+  userAddress: mockWalletAddress.toLowerCase(), // test for backwards compatibility (this field is lower-cased)
   statsigEnvironment: {
     tier: 'development',
   },

--- a/src/analytics/selectors.test.ts
+++ b/src/analytics/selectors.test.ts
@@ -6,6 +6,7 @@ import { getMockStoreData } from 'test/utils'
 describe('getCurrentUserTraits', () => {
   it('returns the current user traits', () => {
     const state = getMockStoreData({
+      web3: { mtwAddress: '0x123' },
       account: { defaultCountryCode: '+33', pincodeType: PincodeType.CustomPin },
       goldToken: { balance: '1.01' },
       stableToken: { balances: { [Currency.Dollar]: '2.02', [Currency.Euro]: '3.03' } },
@@ -170,7 +171,7 @@ describe('getCurrentUserTraits', () => {
       },
     })
     expect(getCurrentUserTraits(state)).toStrictEqual({
-      accountAddress: '0x0000000000000000000000000000000000007E57',
+      accountAddress: '0x123',
       appBuildNumber: '1',
       appBundleId: 'org.celo.mobile.debug',
       appVersion: '0.0.1',
@@ -194,5 +195,13 @@ describe('getCurrentUserTraits', () => {
       superchargingToken: 'cEUR',
       superchargingAmountInUsd: 25.9245,
     })
+  })
+  it('uses wallet address as fallback for accountAddress if MTW is null', () => {
+    const state = getMockStoreData({
+      web3: { mtwAddress: null },
+    })
+    expect(getCurrentUserTraits(state).accountAddress).toEqual(
+      '0x0000000000000000000000000000000000007e57'
+    )
   })
 })

--- a/src/analytics/selectors.test.ts
+++ b/src/analytics/selectors.test.ts
@@ -201,7 +201,7 @@ describe('getCurrentUserTraits', () => {
       web3: { mtwAddress: null },
     })
     expect(getCurrentUserTraits(state).accountAddress).toEqual(
-      '0x0000000000000000000000000000000000007e57'
+      '0x0000000000000000000000000000000000007E57' // intentionally using non-lower-cased version here (important for backwards compatibility)
     )
   })
 })

--- a/src/analytics/selectors.ts
+++ b/src/analytics/selectors.ts
@@ -12,11 +12,11 @@ import { getLocalCurrencyCode } from 'src/localCurrency/selectors'
 import { userLocationDataSelector } from 'src/networkInfo/selectors'
 import { coreTokensSelector, tokensWithTokenBalanceSelector } from 'src/tokens/selectors'
 import { sortByUsdBalance } from 'src/tokens/utils'
-import { mtwAddressSelector, walletAddressSelector } from 'src/web3/selectors'
+import { mtwAddressSelector, rawWalletAddressSelector } from 'src/web3/selectors'
 
 export const getCurrentUserTraits = createSelector(
   [
-    walletAddressSelector,
+    rawWalletAddressSelector,
     mtwAddressSelector,
     defaultCountryCodeSelector,
     userLocationDataSelector,
@@ -30,7 +30,7 @@ export const getCurrentUserTraits = createSelector(
     superchargeInfoSelector,
   ],
   (
-    walletAddress,
+    rawWalletAddress,
     mtwAddress,
     phoneCountryCallingCode,
     { countryCodeAlpha2 },
@@ -59,8 +59,8 @@ export const getCurrentUserTraits = createSelector(
     // Don't rename these unless you have a really good reason!
     // They are used in users analytics profiles + super properties
     return {
-      accountAddress: mtwAddress ?? walletAddress,
-      walletAddress,
+      accountAddress: mtwAddress ?? rawWalletAddress,
+      walletAddress: rawWalletAddress?.toLowerCase(),
       phoneCountryCallingCode, // Example: +33
       phoneCountryCodeAlpha2: phoneCountryCallingCode
         ? getRegionCodeFromCountryCode(phoneCountryCallingCode)

--- a/src/analytics/selectors.ts
+++ b/src/analytics/selectors.ts
@@ -12,12 +12,12 @@ import { getLocalCurrencyCode } from 'src/localCurrency/selectors'
 import { userLocationDataSelector } from 'src/networkInfo/selectors'
 import { coreTokensSelector, tokensWithTokenBalanceSelector } from 'src/tokens/selectors'
 import { sortByUsdBalance } from 'src/tokens/utils'
-import { accountAddressSelector, walletAddressSelector } from 'src/web3/selectors'
+import { mtwAddressSelector, walletAddressSelector } from 'src/web3/selectors'
 
 export const getCurrentUserTraits = createSelector(
   [
     walletAddressSelector,
-    accountAddressSelector,
+    mtwAddressSelector,
     defaultCountryCodeSelector,
     userLocationDataSelector,
     currentLanguageSelector,
@@ -31,7 +31,7 @@ export const getCurrentUserTraits = createSelector(
   ],
   (
     walletAddress,
-    accountAddress,
+    mtwAddress,
     phoneCountryCallingCode,
     { countryCodeAlpha2 },
     language,
@@ -59,7 +59,7 @@ export const getCurrentUserTraits = createSelector(
     // Don't rename these unless you have a really good reason!
     // They are used in users analytics profiles + super properties
     return {
-      accountAddress,
+      accountAddress: mtwAddress ?? walletAddress,
       walletAddress,
       phoneCountryCallingCode, // Example: +33
       phoneCountryCodeAlpha2: phoneCountryCallingCode

--- a/src/app/selectors.test.ts
+++ b/src/app/selectors.test.ts
@@ -3,6 +3,7 @@ import {
   createAccountSteps,
   registrationStepsSelector,
   restoreAccountSteps,
+  rewardsEnabledSelector,
   storeWipeRecoverySteps,
   verificationPossibleSelector,
 } from 'src/app/selectors'
@@ -194,4 +195,51 @@ describe('registrationStepsSelector', () => {
       })
     })
   })
+})
+
+describe(rewardsEnabledSelector, () => {
+  const superchargeTokenConfigByToken = { '0xabc': { minBalance: 0, maxBalance: 100 } }
+  it('returns true if MTW non-null and supercharge config non-empty', () => {
+    expect(
+      rewardsEnabledSelector(
+        getMockStoreData({
+          web3: { mtwAddress: '0x123' },
+          app: { superchargeTokenConfigByToken },
+        })
+      )
+    ).toEqual(true)
+  })
+  it('returns true if wallet address non-null and supercharge config non-empty', () => {
+    expect(
+      rewardsEnabledSelector(
+        getMockStoreData({
+          web3: { mtwAddress: null, account: '0x123' },
+          app: { superchargeTokenConfigByToken },
+        })
+      )
+    ).toEqual(true)
+  })
+  it('returns false if supercharge config empty', () => {
+    expect(
+      rewardsEnabledSelector(
+        getMockStoreData({
+          web3: { mtwAddress: null, account: '0x123' },
+          app: { superchargeTokenConfigByToken: {} },
+        })
+      )
+    ).toEqual(false)
+  })
+  it('returns false if wallet address and MTW are null', () => {
+    expect(
+      rewardsEnabledSelector(
+        getMockStoreData({
+          web3: { mtwAddress: null, account: null },
+          app: { superchargeTokenConfigByToken },
+        })
+      )
+    ).toEqual(false)
+  })
+  // NOTE: the case where MTW is non-null and wallet address is null should not be possible, and it's not clear
+  //  whether rewards should be enabled if it did occur (where would we even send the rewards?). so it is intentionally
+  //  not covered.
 })

--- a/src/app/selectors.ts
+++ b/src/app/selectors.ts
@@ -14,7 +14,7 @@ import {
   shouldUseKomenciSelector,
   verificationStatusSelector,
 } from 'src/verify/reducer'
-import { accountAddressSelector } from 'src/web3/selectors'
+import { walletAddressSelector } from 'src/web3/selectors'
 
 export const getRequirePinOnAppOpen = (state: RootState) => {
   return state.app.requirePinOnAppOpen
@@ -78,7 +78,7 @@ export const superchargeTokenConfigByTokenSelector = (state: RootState) =>
   state.app.superchargeTokenConfigByToken
 
 export const rewardsEnabledSelector = createSelector(
-  [accountAddressSelector, superchargeTokenConfigByTokenSelector],
+  [walletAddressSelector, superchargeTokenConfigByTokenSelector],
   (address, superchargeTokenConfigByToken) =>
     !!address && Object.keys(superchargeTokenConfigByToken).length > 0
 )

--- a/src/web3/selectors.ts
+++ b/src/web3/selectors.ts
@@ -8,5 +8,3 @@ export const currentAccountInWeb3KeystoreSelector = (state: RootState) =>
   state.web3.accountInWeb3Keystore
 export const dataEncryptionKeySelector = (state: RootState) => state.web3.dataEncryptionKey
 export const isDekRegisteredSelector = (state: RootState) => state.web3.isDekRegistered
-export const accountAddressSelector = (state: RootState) =>
-  state.web3.mtwAddress ?? state.web3.account

--- a/src/web3/selectors.ts
+++ b/src/web3/selectors.ts
@@ -1,5 +1,17 @@
 import { RootState } from 'src/redux/reducers'
 
+/**
+ * Get the "raw" (non-lower-cased) version of the wallet address in redux state.
+ *
+ * Intended for the niche data analytics use case of preserving backwards-compatibility with
+ *  when we took the wallet address from redux state a different way (not using walletAddressSelector)
+ *  for the "accountAddress" user property, which falls back to EOA if no MTW exists.
+ *
+ * NOTE: modern users (2020 onwards) will *already* have a lower-cased address saved in redux state, so this will
+ *  give the same output as walletAddressSelector most of the time.
+ */
+export const rawWalletAddressSelector = (state: RootState) => state.web3.account ?? null
+
 export const walletAddressSelector = (state: RootState) => state.web3.account?.toLowerCase() ?? null
 // @deprecated please use walletAddressSelector instead.
 export const currentAccountSelector = walletAddressSelector


### PR DESCRIPTION
### Description

Remove accountAddressSelector to prevent bugs like the one Jean fixed [here](https://github.com/valora-inc/wallet/pull/3294/files#diff-8d33cbb0da323fba8e3986c827ba5c2d362c018756e78445f3b6c0606f413780R137). 

The name of the accountAddressSelector introduces high risk of mistaking it for a wallet address selector, but in reality, it selects MTW address and uses wallet address as a fallback. We have largely discontinued use of the MTW address, so this selector should not be needed anymore. 

### Test plan

added unit tests

### Related issues

na

### Backwards compatibility

should be backwards compatible. assumed in 1 place that wallet address is always non-null if MTW address is non-null-- see code comment in `app/selectors.test.ts` for details