### PR TITLE
feat!: new User-Agent header on iOS

### DIFF
--- a/ios/celo/AppDelegate.m
+++ b/ios/celo/AppDelegate.m
@@ -13,6 +13,7 @@
 #import <React/RCTBundleURLProvider.h>
 #import <React/RCTRootView.h>
 #import <React/RCTLinkingManager.h>
+#import <React/RCTHTTPRequestHandler.h>
 
 @import Firebase;
 
@@ -46,6 +47,21 @@ static void InitializeFlipper(UIApplication *application) {
 // Use same key as react-native-secure-key-store
 // so we don't reset already working installs
 static NSString * const kHasRunBeforeKey = @"RnSksIsAppInstalled";
+
+static void SetCustomNSURLSessionConfiguration() {
+  RCTSetCustomNSURLSessionConfigurationProvider(^NSURLSessionConfiguration *{
+    NSURLSessionConfiguration *configuration = [NSURLSessionConfiguration defaultSessionConfiguration];
+    
+    NSDictionary *infoDictionary = NSBundle.mainBundle.infoDictionary;
+    NSString *appVersion = [infoDictionary objectForKey:@"CFBundleShortVersionString"];
+    UIDevice *device = UIDevice.currentDevice;
+    // Format we want: Valora/1.0.0 (iOS 14.5; iPhone)
+    NSString *userAgent = [NSString stringWithFormat:@"Valora/%@ (%@ %@; %@)", appVersion, device.systemName, device.systemVersion, device.model];
+    configuration.HTTPAdditionalHeaders = @{ @"User-Agent": userAgent };
+    
+    return configuration;
+  });
+}
 
 @interface AppDelegate ()
 
@@ -86,6 +102,9 @@ static NSString * const kHasRunBeforeKey = @"RnSksIsAppInstalled";
     [FIROptions defaultOptions].deepLinkURLScheme = @"celo";
     [FIRApp configure];
   }
+  
+  SetCustomNSURLSessionConfiguration();
+  
   RCTBridge *bridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:launchOptions];
 
   NSDate *now = [NSDate date];


### PR DESCRIPTION
### Description

PR for iOS to unify the `User-Agent` header for all network requests.

### Test plan

Tested the new `User-Agent` is used for all requests (fetch, Images, etc) using [Proxyman](https://proxyman.io/).

Examples:
<img width="562" alt="Screenshot 2023-01-06 at 11 09 32" src="https://user-images.githubusercontent.com/57791/210982495-9967a6f1-15e6-4eea-9336-b517693ef1d2.png">
<img width="1149" alt="Screenshot 2023-01-06 at 11 13 57" src="https://user-images.githubusercontent.com/57791/210982520-6def18f6-9ad1-4205-b9c2-a0e8e6a5d9fc.png">

### Related issues

- Fixes RET-558

### Backwards compatibility

No, services depending on the existing `User-Agent` need to be updated.