### PR TITLE
feat!: new User-Agent header on Android

### DIFF
--- a/android/app/src/main/java/org/celo/mobile/MainApplication.java
+++ b/android/app/src/main/java/org/celo/mobile/MainApplication.java
@@ -12,6 +12,7 @@ import com.facebook.react.ReactInstanceManager;
 import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
 import com.facebook.react.bridge.JSIModulePackage;
+import com.facebook.react.modules.network.OkHttpClientProvider;
 import com.facebook.react.shell.MainReactPackage;
 import com.facebook.soloader.SoLoader;
 import com.swmansion.reanimated.ReanimatedJSIModulePackage;
@@ -64,6 +65,7 @@ public class MainApplication
     super.onCreate();
     SoLoader.init(this, /* native exopackage */false);
     initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
+    OkHttpClientProvider.setOkHttpClientFactory(new UserAgentClientFactory());
   }
 
   @Override

--- a/android/app/src/main/java/org/celo/mobile/UserAgentClientFactory.java
+++ b/android/app/src/main/java/org/celo/mobile/UserAgentClientFactory.java
@@ -1,0 +1,15 @@
+package org.celo.mobile;
+
+import com.facebook.react.modules.network.OkHttpClientFactory;
+import com.facebook.react.modules.network.OkHttpClientProvider;
+import okhttp3.OkHttpClient;
+
+public class UserAgentClientFactory implements OkHttpClientFactory {
+
+  public OkHttpClient createNewNetworkModuleClient() {
+    return OkHttpClientProvider
+      .createClientBuilder()
+      .addInterceptor(new UserAgentInterceptor())
+      .build();
+  }
+}

--- a/android/app/src/main/java/org/celo/mobile/UserAgentInterceptor.java
+++ b/android/app/src/main/java/org/celo/mobile/UserAgentInterceptor.java
@@ -1,0 +1,33 @@
+package org.celo.mobile;
+
+import android.os.Build;
+import java.io.IOException;
+import okhttp3.Interceptor;
+import okhttp3.Request;
+import okhttp3.Response;
+
+public class UserAgentInterceptor implements Interceptor {
+
+  public UserAgentInterceptor() {}
+
+  @Override
+  public Response intercept(Interceptor.Chain chain) throws IOException {
+    Request originalRequest = chain.request();
+    Request requestWithUserAgent = originalRequest
+      .newBuilder()
+      .removeHeader("User-Agent")
+      .addHeader(
+        "User-Agent",
+        // Format we want: Valora/1.0.0 (Android 12; Pixel 5)
+        String.format(
+          "Valora/%s (Android %s; %s)",
+          BuildConfig.VERSION_NAME,
+          Build.VERSION.RELEASE,
+          Build.MODEL
+        )
+      )
+      .build();
+
+    return chain.proceed(requestWithUserAgent);
+  }
+}


### PR DESCRIPTION
### Description

PR for Android to unify the `User-Agent` header for all network requests.

### Test plan

Tested the new `User-Agent` is used for all requests (fetch, Images, etc) using [Proxyman](https://proxyman.io/).

Examples:
- forno: <img width="1143" alt="Screenshot 2023-01-06 at 12 34 07" src="https://user-images.githubusercontent.com/57791/211006338-a5c88d14-9257-4b7e-b865-6b17bf64974d.png">
- an image: <img width="1141" alt="Screenshot 2023-01-06 at 12 43 31" src="https://user-images.githubusercontent.com/57791/211006365-fc5ce5a4-284d-4c47-a42d-40c906a573bf.png">

Browsing in our WebView keeps the default User-Agent, as expected, here with Bidali:

<img width="975" alt="Screenshot 2023-01-06 at 12 38 13" src="https://user-images.githubusercontent.com/57791/211006411-b96725a6-b9bb-4c33-a47b-fa07d77ebb8b.png">

### Related issues

- Fixes RET-558

### Backwards compatibility

No, services depending on the existing `User-Agent` need to be updated.