### PR TITLE
fix: ensure max number of dapps in dapps carousel

### DIFF
--- a/src/home/DappsCarousel.test.tsx
+++ b/src/home/DappsCarousel.test.tsx
@@ -165,6 +165,27 @@ describe('DappsCarousel', () => {
       expect(selectDappSpy).toHaveBeenCalledTimes(1)
       expect(selectDappSpy).toHaveBeenCalledWith({ ...dappsList[2], openedFrom: 'recently used' })
     })
+
+    it('only renders the maximum allowed number of dapps', () => {
+      const { getAllByTestId } = render(
+        <Provider
+          store={createMockStore({
+            dapps: {
+              recentDappIds, // this has length 2
+              maxNumRecentDapps: 1,
+              dappsList,
+            },
+          })}
+        >
+          <DappsCarousel onSelectDapp={jest.fn()} />
+        </Provider>
+      )
+
+      const dapps = getAllByTestId('RecentlyUsedDapps/Dapp')
+
+      expect(dapps).toHaveLength(1)
+      expect(within(dapps[0]).getByText(dappsList[0].name)).toBeTruthy()
+    })
   })
 
   describe('favorite dapps', () => {
@@ -216,6 +237,29 @@ describe('DappsCarousel', () => {
         ...dappsList[3],
         openedFrom: 'favorites home screen',
       })
+    })
+
+    it('only renders the maximum allowed number of dapps', () => {
+      const { getAllByTestId } = render(
+        <Provider
+          store={createMockStore({
+            dapps: {
+              recentDappIds, // this has length 2
+              dappsList,
+              maxNumRecentDapps: 1,
+              dappFavoritesEnabled: true,
+              favoriteDappIds, // this has length 2
+            },
+          })}
+        >
+          <DappsCarousel onSelectDapp={jest.fn()} />
+        </Provider>
+      )
+
+      const dapps = getAllByTestId('FavoritedDapps/Dapp')
+
+      expect(dapps).toHaveLength(1)
+      expect(within(dapps[0]).getByText(dappsList[1].name)).toBeTruthy()
     })
   })
 
@@ -285,6 +329,25 @@ describe('DappsCarousel', () => {
         section: 'recently used',
         horizontalPosition: 3,
       })
+    })
+
+    it('should not render content or track impressions if maxNumRecentDapps is 0', () => {
+      const { toJSON } = render(
+        <Provider
+          store={createMockStore({
+            dapps: {
+              recentDappIds: dappsList.map((dapp) => dapp.id),
+              maxNumRecentDapps: 0,
+              dappsList,
+            },
+          })}
+        >
+          <DappsCarousel onSelectDapp={jest.fn()} />
+        </Provider>
+      )
+
+      expect(toJSON()).toBeNull()
+      expect(ValoraAnalytics.track).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/home/DappsCarousel.tsx
+++ b/src/home/DappsCarousel.tsx
@@ -41,7 +41,6 @@ const windowWidth = Dimensions.get('window').width
 
 const useDappsCarouselDapps = () => {
   const { t } = useTranslation()
-  const maxNumRecentDapps = useSelector(maxNumRecentDappsSelector)
   const dappFavoritesEnabled = useSelector(dappFavoritesEnabledSelector)
   const recentlyUsedDapps = useSelector(recentDappsSelector)
   const favoritedDapps = useSelector(favoriteDappsSelector)
@@ -55,7 +54,7 @@ const useDappsCarouselDapps = () => {
     }
   }
 
-  if (maxNumRecentDapps > 0 && recentlyUsedDapps.length > 0) {
+  if (recentlyUsedDapps.length > 0) {
     return {
       dapps: recentlyUsedDapps,
       section: DappSection.RecentlyUsed,
@@ -75,13 +74,15 @@ const useDappsCarouselDapps = () => {
 
 function DappsCarousel({ onSelectDapp }: Props) {
   const { t } = useTranslation()
-
+  const maxNumRecentDapps = useSelector(maxNumRecentDappsSelector)
   const { dapps, section, title, testID } = useDappsCarouselDapps()
 
   const lastViewedDapp = useRef(-1)
 
+  const shouldShowCarousel = maxNumRecentDapps > 0 && dapps.length > 0
+
   useEffect(() => {
-    if (dapps.length > 0) {
+    if (shouldShowCarousel) {
       trackDappsImpressionForScrollPosition(0)
     }
   }, [])
@@ -119,7 +120,7 @@ function DappsCarousel({ onSelectDapp }: Props) {
     trackDappsImpressionForScrollPosition(event.nativeEvent.contentOffset.x)
   }
 
-  if (!dapps.length) {
+  if (!shouldShowCarousel) {
     return null
   }
 
@@ -135,7 +136,7 @@ function DappsCarousel({ onSelectDapp }: Props) {
         onScroll={handleScroll}
         scrollEventThrottle={50}
       >
-        {dapps.map((dapp) => (
+        {dapps.slice(0, maxNumRecentDapps).map((dapp) => (
           <Card style={styles.card} rounded={true} shadow={Shadow.SoftLight} key={dapp.id}>
             <Touchable
               onPress={() => onSelectDapp({ ...dapp, openedFrom: section })}

--- a/src/home/DappsCarousel.tsx
+++ b/src/home/DappsCarousel.tsx
@@ -74,12 +74,12 @@ const useDappsCarouselDapps = () => {
 
 function DappsCarousel({ onSelectDapp }: Props) {
   const { t } = useTranslation()
-  const maxNumRecentDapps = useSelector(maxNumRecentDappsSelector)
+  const maxNumDisplayedDapps = useSelector(maxNumRecentDappsSelector)
   const { dapps, section, title, testID } = useDappsCarouselDapps()
 
   const lastViewedDapp = useRef(-1)
 
-  const shouldShowCarousel = maxNumRecentDapps > 0 && dapps.length > 0
+  const shouldShowCarousel = maxNumDisplayedDapps > 0 && dapps.length > 0
 
   useEffect(() => {
     if (shouldShowCarousel) {
@@ -136,7 +136,7 @@ function DappsCarousel({ onSelectDapp }: Props) {
         onScroll={handleScroll}
         scrollEventThrottle={50}
       >
-        {dapps.slice(0, maxNumRecentDapps).map((dapp) => (
+        {dapps.slice(0, maxNumDisplayedDapps).map((dapp) => (
           <Card style={styles.card} rounded={true} shadow={Shadow.SoftLight} key={dapp.id}>
             <Touchable
               onPress={() => onSelectDapp({ ...dapp, openedFrom: section })}


### PR DESCRIPTION
### Description

During the refactor to create the dapps carousel, the maximum number of dapps got lost :( This PR fixes that, and adds tests. The remote config variable is a bit confusingly named now since it is not specific to recently used dapps, i can change this including the actual remote config variable in a follow up PR. 

### Test plan

Added unit tests, tested manually

### Related issues

N/A

### Backwards compatibility

Y