### PR TITLE
chore: align dapps screen horizontal margins

### DIFF
--- a/src/dappsExplorer/DAppsExplorerScreen.tsx
+++ b/src/dappsExplorer/DAppsExplorerScreen.tsx
@@ -162,7 +162,7 @@ export function DAppsExplorerScreen() {
             }
             style={styles.sectionList}
             contentContainerStyle={{
-              padding: Spacing.Regular16,
+              padding: Spacing.Thick24,
               paddingBottom: Math.max(insets.bottom, Spacing.Regular16),
             }}
             // Workaround iOS setting an incorrect automatic inset at the top
@@ -241,7 +241,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     flexDirection: 'row',
     flex: 1,
-    marginHorizontal: Spacing.Smallest8,
   },
   // Padding values honor figma designs
   categoryTextContainer: {


### PR DESCRIPTION
### Description

Requested by Reed, this PR makes the dapps screen horizontal margins consistent. Reed and Nitya have decided on 24px margins going forward. Notice in the "before" screenshot how the left edge of "Explore ways to use your crypto" is indented compared to the dapps cards.

Before:
![Simulator Screen Shot - iPhone 11 - 2023-01-18 at 12 22 17](https://user-images.githubusercontent.com/20150449/213159139-723a134b-b429-4bfd-afd1-77dc64e2fb6b.png)

After:
![Simulator Screen Shot - iPhone 11 - 2023-01-18 at 12 22 07](https://user-images.githubusercontent.com/20150449/213159157-e4e00b44-58c5-41e4-a506-c9393bd3c79d.png)

### Test plan

n/a

### Related issues

n/a

### Backwards compatibility

Y
