### PR TITLE
chore: upgrade react-native-shake to v5

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -456,7 +456,7 @@ PODS:
     - React-Core
   - react-native-safe-area-context (3.4.1):
     - React-Core
-  - react-native-shake (3.5.0):
+  - react-native-shake (5.1.1):
     - React-Core
   - react-native-simple-toast (1.1.4):
     - React-Core
@@ -1064,7 +1064,7 @@ SPEC CHECKSUMS:
   react-native-netinfo: 2517ad504b3d303e90d7a431b0fcaef76d207983
   react-native-randombytes: b6677f7d495c27e9ee0dbd77ebc97b3c59173729
   react-native-safe-area-context: 9e40fb181dac02619414ba1294d6c2a807056ab9
-  react-native-shake: 41a1ea8ec541fccf3f01566edef8d3cb722b00e3
+  react-native-shake: 51c01abaf54a05d1ee23ddb8faad424c9fcc0569
   react-native-simple-toast: 8ee5d23f0b92b935ab7434cdb65159ce12dfb4b7
   react-native-splash-screen: 4312f786b13a81b5169ef346d76d33bc0c6dc457
   react-native-webview: 2e8fe70dc32b50d3231c23043f8e8b5a5525d346

--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
     "react-native-safe-area-context": "^3.4.1",
     "react-native-screens": "^3.18.2",
     "react-native-securerandom": "^1.0.1",
-    "react-native-shake": "~3.5.0",
+    "react-native-shake": "^5.1.1",
     "react-native-share": "^7.3.2",
     "react-native-simple-toast": "^1.1.4",
     "react-native-skeleton-placeholder": "^5.2.4",

--- a/patches/react-native-shake+5.1.1.patch
+++ b/patches/react-native-shake+5.1.1.patch
@@ -1,0 +1,11 @@
+diff --git a/node_modules/react-native-shake/react-native-shake.podspec b/node_modules/react-native-shake/react-native-shake.podspec
+index cc5975b..437bce7 100644
+--- a/node_modules/react-native-shake/react-native-shake.podspec
++++ b/node_modules/react-native-shake/react-native-shake.podspec
+@@ -15,5 +15,5 @@ Pod::Spec.new do |s|
+   s.source        = { :git => "https://github.com/Doko-Demo-Doa/react-native-shake", :tag => "v#{s.version}" }
+   s.source_files  = "ios/**/*.{h,m,swift}"
+ 
+-  s.dependency 'React'
++  s.dependency 'React-Core'
+ end

--- a/src/account/ShakeForSupport.tsx
+++ b/src/account/ShakeForSupport.tsx
@@ -27,13 +27,15 @@ export default function ShakeForSupport() {
       // Don't listen to the shake event if the app is not in the foreground
       return
     }
-    RNShake.addEventListener('ShakeEvent', () => {
+
+    const subscription = RNShake.addListener(() => {
       Logger.info('NavigatorWrapper', 'Shake Event')
       // TODO: Cancel all modals before this
       setIsVisible(true)
     })
+
     return () => {
-      RNShake.removeEventListener('ShakeEvent')
+      subscription?.remove()
     }
   }, [appState])
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11093,7 +11093,7 @@ interpret@^1.0.0:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.4.0.tgz#665ab8bc4da27a774a40584e812e3e0fa45b1a1e"
   integrity sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==
 
-invariant@2.2.4, invariant@^2.2.2, invariant@^2.2.4, invariant@^2.2.x:
+invariant@2.2.4, invariant@^2.2.2, invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
@@ -15822,12 +15822,10 @@ react-native-securerandom@^1.0.1:
   dependencies:
     base64-js "*"
 
-react-native-shake@~3.5.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/react-native-shake/-/react-native-shake-3.5.0.tgz#6eb1c6bfa59065b2b6b7aa7250532aa6558b41bc"
-  integrity sha512-Sf3xFybq6Ps0eq4K5auGgSHQihKn+ixLhikIerhYbB3HhVeB38Un6vei7k3ugMWxcUCUG7kbVEIn3a2g9afkpA==
-  dependencies:
-    invariant "^2.2.x"
+react-native-shake@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/react-native-shake/-/react-native-shake-5.1.1.tgz#733657764b0395b26f26576bba51e2dcbcecfe89"
+  integrity sha512-h6O8LnFd3LkvoYx7O0afM6rO9fDKomZ1EyomGgKRDyFhinxYIU7Z4uPYtwA4Z1Cd3frEEKTLNKHI1Eu0MOI3Yw==
 
 react-native-share@^7.3.2:
   version "7.3.2"


### PR DESCRIPTION
### Description

The breaking change is only in the syntax of the shake subscription https://github.com/Doko-Demo-Doa/react-native-shake#usage. Unfortunately the newest version overrides [the fix for xcode 12 compatibility](https://github.com/Doko-Demo-Doa/react-native-shake/commit/b275ce3c77fe56cb05d2426b45b8b36fceca7c05) so i added a patch.

### Test plan

This flow is covered by e2e tests

### Related issues

- Fixes RET-566

### Backwards compatibility

Y
