### PR TITLE
fix(fiatconnect): avoid allowing user to retry if tx might still be pending

### DIFF
--- a/src/transactions/send.test.ts
+++ b/src/transactions/send.test.ts
@@ -73,6 +73,10 @@ describe('isTxPossiblyPending', () => {
     const result = isTxPossiblyPending(new Error('nonce too low error!!!'))
     expect(result).toBe(true)
   })
+  it('returns true when failed to check for tx receipt', () => {
+    const result = isTxPossiblyPending(new Error('Failed to check for transaction receipt:\n{}')) // error message copied from user's logs
+    expect(result).toBe(true)
+  })
   it('returns false when error is unrelated', () => {
     const result = isTxPossiblyPending(new Error('some unrelated error!!!'))
     expect(result).toBe(false)

--- a/src/transactions/send.ts
+++ b/src/transactions/send.ts
@@ -33,6 +33,7 @@ const NONCE_TOO_LOW_ERROR = 'nonce too low'
 const OUT_OF_GAS_ERROR = 'out of gas'
 const ALWAYS_FAILING_ERROR = 'always failing transaction'
 const KNOWN_TX_ERROR = 'known transaction'
+const CHECK_FOR_TX_RECEIPT_ERROR = 'failed to check for transaction receipt'
 
 // 90s. Maximum total time to wait for confirmation when sending a transaction. (Includes grace period)
 const TX_TIMEOUT = 90000
@@ -352,6 +353,14 @@ export function isTxPossiblyPending(err: any): boolean {
     Logger.error(
       `${TAG}@isTxPossiblyPending`,
       'Nonce too low, possible from retrying. Will not reattempt.'
+    )
+    return true
+  }
+
+  if (message.includes(CHECK_FOR_TX_RECEIPT_ERROR)) {
+    Logger.error(
+      `${TAG}@isTxPossiblyPending`,
+      'Failed to check for tx receipt, but tx still might be confirmed. Will not reattempt'
     )
     return true
   }


### PR DESCRIPTION
### Description

We've seen a case in testing where a user got this error in their logs
```
info [2023-01-23T17:15:17.387Z] FiatConnectSaga :: Transaction failed: c2ba9fc0-4f75-4526-b383-b59e947fc981 :: Failed to check for transaction receipt:
{} in _fireError@/private/var/containers/Bundle/Application/DA4D4DB7-095F-4CFC-A18B-4162D7E9283D/celo.app/ :: network connected true
```
and was presented with the option to retry the FiatConnect transfer, but when they retried, they ended up with 2 transfers. 

If we get that tx error, we should avoid allowing the user to retry their transfer, since it may still be confirmed.

### Test plan

unit tested. not sure we can reproduce this one manually.

### Related issues

na

### Backwards compatibility

yes