### PR TITLE
fix: crash when dappListApiUrl is empty

### DIFF
--- a/src/navigator/DrawerNavigator.test.tsx
+++ b/src/navigator/DrawerNavigator.test.tsx
@@ -9,8 +9,32 @@ import { createMockStore } from 'test/utils'
 // TODO avoid rendering WalletHome as we're mostly interested in testing the menu here
 
 describe('DrawerNavigator', () => {
-  // TODO: need to add tests here now that the DrawerNavigator no longer displays balances
-  it.todo('renders correctly')
+  it('shows the expected menu items', () => {
+    const store = createMockStore({
+      app: {
+        showSwapMenuInDrawerMenu: true,
+      },
+      dapps: {
+        dappListApiUrl: 'http://example.com',
+      },
+    })
+    const { queryByTestId } = render(
+      <Provider store={store}>
+        <MockedNavigator component={DrawerNavigator}></MockedNavigator>
+      </Provider>
+    )
+    expect(queryByTestId('Drawer/Header')).toBeTruthy()
+    expect(queryByTestId('Drawer/Username')).toBeTruthy()
+
+    expect(queryByTestId('DrawerItem/home')).toBeTruthy()
+    expect(queryByTestId('DrawerItem/swapScreen.title')).toBeTruthy()
+    expect(queryByTestId('DrawerItem/dappsScreen.title')).toBeTruthy()
+    expect(queryByTestId('DrawerItem/celoGold')).toBeTruthy()
+    expect(queryByTestId('DrawerItem/addAndWithdraw')).toBeTruthy()
+    expect(queryByTestId('DrawerItem/invite')).toBeTruthy()
+    expect(queryByTestId('DrawerItem/settings')).toBeTruthy()
+    expect(queryByTestId('DrawerItem/help')).toBeTruthy()
+  })
 
   it('does not include username when username is empty', () => {
     const store = createMockStore({
@@ -25,5 +49,19 @@ describe('DrawerNavigator', () => {
     )
     expect(queryByTestId('Drawer/Header')).toBeTruthy()
     expect(queryByTestId('Drawer/Username')).toBeNull()
+  })
+
+  it('hides the dapps menu item when dappListApiUrl is empty', () => {
+    const store = createMockStore({
+      dapps: {
+        dappListApiUrl: '',
+      },
+    })
+    const { queryByTestId } = render(
+      <Provider store={store}>
+        <MockedNavigator component={DrawerNavigator}></MockedNavigator>
+      </Provider>
+    )
+    expect(queryByTestId('DrawerItem/dappsScreen.title')).toBeNull()
   })
 })

--- a/src/navigator/DrawerNavigator.tsx
+++ b/src/navigator/DrawerNavigator.tsx
@@ -261,7 +261,7 @@ export default function DrawerNavigator() {
         celoMenuItem
       )}
 
-      {dappsListUrl && (
+      {!!dappsListUrl && (
         <Drawer.Screen
           name={Screens.DAppsExplorerScreen}
           component={DAppsExplorerScreen}


### PR DESCRIPTION
### Description

Title says it all.

### Test plan

- Added new tests
- Manually by setting an empty `dappListApiUrl` and seeing the crash before the fix

### Related issues

- Fixes RET-585

### Backwards compatibility

Yes
