### PR TITLE
refactor(statsig): move constants and types to statsig dir

### DIFF
--- a/src/analytics/types.ts
+++ b/src/analytics/types.ts
@@ -26,16 +26,3 @@ export enum DappRequestOrigin {
   InAppWebView = 'in_app_web_view',
   External = 'external',
 }
-
-// Statsig types. TODO(any): consider moving to a statsig/types file
-export enum StatsigLayers {
-  NAME_AND_PICTURE_SCREEN = 'name_and_picture_screen',
-}
-
-export enum StatsigDynamicConfigs {
-  USERNAME_BLOCK_LIST = 'username_block_list',
-}
-
-export enum StatsigExperiments {
-  ADD_FUNDS_CRYPTO_EXCHANGE_QR_CODE = 'add_funds_crypto_exchange_qr_code',
-}

--- a/src/fiatExchanges/SelectProvider.tsx
+++ b/src/fiatExchanges/SelectProvider.tsx
@@ -6,9 +6,8 @@ import { useTranslation } from 'react-i18next'
 import { ActivityIndicator, ScrollView, StyleSheet, Text, View } from 'react-native'
 import { useDispatch, useSelector } from 'react-redux'
 import { showError } from 'src/alert/actions'
-import { ExperimentParams } from 'src/analytics/constants'
+import { ExperimentParams } from 'src/statsig/constants'
 import { FiatExchangeEvents } from 'src/analytics/Events'
-import { StatsigExperiments } from 'src/analytics/types'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import { ErrorMessages } from 'src/app/ErrorMessages'
 import { coinbasePayEnabledSelector } from 'src/app/selectors'
@@ -57,6 +56,7 @@ import {
   PaymentMethod,
   resolveCloudFunctionDigitalAsset,
 } from './utils'
+import { StatsigExperiments } from 'src/statsig/types'
 
 const TAG = 'SelectProviderScreen'
 

--- a/src/onboarding/registration/NameAndPicture.tsx
+++ b/src/onboarding/registration/NameAndPicture.tsx
@@ -7,9 +7,8 @@ import { useDispatch } from 'react-redux'
 import { setName, setPicture } from 'src/account/actions'
 import { nameSelector, recoveringFromStoreWipeSelector } from 'src/account/selectors'
 import { hideAlert, showError } from 'src/alert/actions'
-import { ConfigParams, LayerParams } from 'src/analytics/constants'
+import { ConfigParams, LayerParams } from 'src/statsig/constants'
 import { OnboardingEvents } from 'src/analytics/Events'
-import { StatsigDynamicConfigs, StatsigLayers } from 'src/analytics/types'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import { ErrorMessages } from 'src/app/ErrorMessages'
 import {
@@ -35,6 +34,7 @@ import fontStyles from 'src/styles/fonts'
 import { saveProfilePicture } from 'src/utils/image'
 import Logger from 'src/utils/Logger'
 import { Statsig } from 'statsig-react-native'
+import { StatsigDynamicConfigs, StatsigLayers } from 'src/statsig/types'
 
 type Props = NativeStackScreenProps<StackParamList, Screens.NameAndPicture>
 

--- a/src/statsig/constants.ts
+++ b/src/statsig/constants.ts
@@ -1,4 +1,4 @@
-// TODO(any): consider moving to a statsig/constants and make it more type safe
+// TODO(any): consider making it more type safe
 import { SelectProviderExchangesLink, SelectProviderExchangesText } from 'src/fiatExchanges/types'
 import { StatsigDynamicConfigs, StatsigExperiments, StatsigLayers } from 'src/statsig/types'
 

--- a/src/statsig/constants.ts
+++ b/src/statsig/constants.ts
@@ -1,6 +1,6 @@
 // TODO(any): consider moving to a statsig/constants and make it more type safe
-import { StatsigDynamicConfigs, StatsigExperiments, StatsigLayers } from 'src/analytics/types'
 import { SelectProviderExchangesLink, SelectProviderExchangesText } from 'src/fiatExchanges/types'
+import { StatsigDynamicConfigs, StatsigExperiments, StatsigLayers } from 'src/statsig/types'
 
 export const LayerParams = {
   [StatsigLayers.NAME_AND_PICTURE_SCREEN]: {

--- a/src/statsig/types.ts
+++ b/src/statsig/types.ts
@@ -1,0 +1,11 @@
+export enum StatsigLayers {
+  NAME_AND_PICTURE_SCREEN = 'name_and_picture_screen',
+}
+
+export enum StatsigDynamicConfigs {
+  USERNAME_BLOCK_LIST = 'username_block_list',
+}
+
+export enum StatsigExperiments {
+  ADD_FUNDS_CRYPTO_EXCHANGE_QR_CODE = 'add_funds_crypto_exchange_qr_code',
+}


### PR DESCRIPTION
### Description

minor cleanup to move statsig types and constants out of analytics files

### Test plan

existing automated tests and build ci should cover this

### Related issues

na

### Backwards compatibility

na