### PR TITLE
fix: broken dapps support url

### DIFF
--- a/e2e/src/usecases/DappListDisplay.js
+++ b/e2e/src/usecases/DappListDisplay.js
@@ -25,11 +25,16 @@ export default DappListDisplay = () => {
     await waitFor(element(by.id(`RNWebView`)))
       .toBeVisible()
       .withTimeout(10 * 1000)
-    const url = new URL(DAPPS_LEARN_MORE)
     // Should show correct hostname in webview
-    await waitFor(element(by.text(url.hostname)))
+    await waitFor(element(by.text('support.valoraapp.com')))
       .toBeVisible()
       .withTimeout(10 * 1000)
+    await element(by.id('WebViewScreen/CloseButton')).tap()
+
+    await waitFor(element(by.id('DAppsExplorerScreen/InfoBottomSheet')))
+      .toBeVisible()
+      .withTimeout(10 * 1000)
+    await element(by.id('DAppsExplorerScreen/InfoBottomSheet')).swipe('down', 'fast')
   })
 
   it('should show dapp bottom sheet when dapp is selected', async () => {
@@ -45,8 +50,9 @@ export default DappListDisplay = () => {
     await waitFor(element(by.id(`WebViewScreen/${dappList.applications[0].name}`)))
       .toBeVisible()
       .withTimeout(10 * 1000)
+    const url = new URL(dappList.applications[0].url)
     // Should show correct hostname in webview
-    await waitFor(element(by.text('support.valoraapp.com')))
+    await waitFor(element(by.text(url.hostname)))
       .toBeVisible()
       .withTimeout(10 * 1000)
   })

--- a/e2e/src/usecases/DappListDisplay.js
+++ b/e2e/src/usecases/DappListDisplay.js
@@ -1,4 +1,3 @@
-import { DAPPS_LEARN_MORE } from '../../../src/config'
 import { fetchDappList, navigateToDappList } from '../utils/dappList'
 import { reloadReactNative } from '../utils/retries'
 import { getElementText, getElementTextList, sleep, waitForElementId } from '../utils/utils'
@@ -46,9 +45,8 @@ export default DappListDisplay = () => {
     await waitFor(element(by.id(`WebViewScreen/${dappList.applications[0].name}`)))
       .toBeVisible()
       .withTimeout(10 * 1000)
-    const url = new URL(dappList.applications[0].url)
     // Should show correct hostname in webview
-    await waitFor(element(by.text(url.hostname)))
+    await waitFor(element(by.text('support.valoraapp.com')))
       .toBeVisible()
       .withTimeout(10 * 1000)
   })

--- a/scripts/sync_branding.sh
+++ b/scripts/sync_branding.sh
@@ -21,7 +21,7 @@ echo $mobile_root
 cd "$mobile_root"
 
 # Please update the sha when valora branding updates are needed
-valora_branding_sha=ddb5819cc83a99ef2149b2a5fbf4616d36635394
+valora_branding_sha=74d31b4513a868793c453a0d9c92e34314730a24
 
 if [[ "$branding" == "valora" ]]; then
   # prevents git from asking credentials

--- a/src/dappsExplorer/useDappInfoBottomSheet.tsx
+++ b/src/dappsExplorer/useDappInfoBottomSheet.tsx
@@ -54,7 +54,11 @@ const useDappInfoBottomSheet = () => {
         backdropComponent={renderBackdrop}
         handleIndicatorStyle={styles.handle}
       >
-        <View style={[styles.container, { paddingBottom }]} onLayout={handleContentLayout}>
+        <View
+          style={[styles.container, { paddingBottom }]}
+          onLayout={handleContentLayout}
+          testID="DAppsExplorerScreen/InfoBottomSheet"
+        >
           <Text style={styles.title}>{t('dappsScreenInfoSheet.title')}</Text>
           <Text style={styles.description}>{t('dappsScreenInfoSheet.description')}</Text>
           <Button

--- a/src/webview/WebViewScreen.tsx
+++ b/src/webview/WebViewScreen.tsx
@@ -89,6 +89,7 @@ function WebViewScreen({ route, navigation }: Props) {
           title={t('close')}
           onPress={navigateBack}
           titleStyle={{ color: colors.gray4, paddingHorizontal: 0 }}
+          testID="WebViewScreen/CloseButton"
         />
       ),
     })


### PR DESCRIPTION
### Description

I forgot to update the branding hash after I added the new dapps support link, the CI was passing with [silent errors](https://github.com/valora-inc/wallet/actions/runs/4053160940/jobs/6973448494) in my branch, which i didn't notice. the CI correctly fails on [main](https://github.com/valora-inc/wallet/actions/runs/4053379964/jobs/6973931410).

### Test plan

n/a

### Related issues

- Fixes RET-550

### Backwards compatibility

Y