### PR TITLE
feat: display dapps disclaimer on dapps bottom sheet

### DIFF
--- a/e2e/src/usecases/WalletConnectV2.js
+++ b/e2e/src/usecases/WalletConnectV2.js
@@ -141,7 +141,7 @@ export default WalletConnect = () => {
 
   beforeEach(async () => {
     // wait for any banners to disappear
-    await sleep(3000)
+    await sleep(5000)
   })
 
   afterAll(async () => {

--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -1248,6 +1248,8 @@
     "buttonLabel": "Tell me more"
   },
   "dappsDisclaimerAllDapps": "{{appName}} is not affiliated with these dapps and makes no representations or claims in using them. Please acknowledge the risk before using a dapp by reviewing the user agreement or privacy policy.",
+  "dappsDisclaimerSingleDapp": "{{appName}} is not affiliated with this dapp and makes no representations in using it. Always review a dapps user agreement or privacy policy.",
+  "dappsDisclaimerUnlistedDapp": "This dapp is not listed in {{appName}}. {{appName}} is not affiliated with this dapp and makes no representations in using it. Always review a dapps user agreement or privacy policy.",
   "recentlyUsedDapps": "Recently Used Dapps",
   "favoritedDapps": "Favorited Dapps",
   "allDapps": "All Dapps",

--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -1248,8 +1248,8 @@
     "buttonLabel": "Tell me more"
   },
   "dappsDisclaimerAllDapps": "{{appName}} is not affiliated with these dapps and makes no representations or claims in using them. Please acknowledge the risk before using a dapp by reviewing the user agreement or privacy policy.",
-  "dappsDisclaimerSingleDapp": "{{appName}} is not affiliated with this dapp and makes no representations in using it. Always review a dapps user agreement or privacy policy.",
-  "dappsDisclaimerUnlistedDapp": "This dapp is not listed in {{appName}}. {{appName}} is not affiliated with this dapp and makes no representations in using it. Always review a dapps user agreement or privacy policy.",
+  "dappsDisclaimerSingleDapp": "{{appName}} is not affiliated with this dapp and makes no representations in using it. Always review a dapp's user agreement or privacy policy.",
+  "dappsDisclaimerUnlistedDapp": "This dapp is not listed in {{appName}}. {{appName}} is not affiliated with this dapp and makes no representations in using it. Always review a dapp's user agreement or privacy policy.",
   "recentlyUsedDapps": "Recently Used Dapps",
   "favoritedDapps": "Favorited Dapps",
   "allDapps": "All Dapps",

--- a/src/dappkit/DappKitSignTxScreen.tsx
+++ b/src/dappkit/DappKitSignTxScreen.tsx
@@ -21,7 +21,9 @@ import fontStyles from 'src/styles/fonts'
 import { Spacing } from 'src/styles/styles'
 import variables from 'src/styles/variables'
 import Logger from 'src/utils/Logger'
+import DappsDisclaimer from 'src/walletConnect/screens/DappsDisclaimer'
 import RequestContent from 'src/walletConnect/screens/RequestContent'
+import { useIsDappListed } from 'src/walletConnect/screens/useIsDappListed'
 
 const TAG = 'dappkit/DappKitSignTxScreen'
 
@@ -35,6 +37,7 @@ const DappKitSignTxScreen = ({ route }: Props) => {
   const dappConnectInfo = useSelector(dappConnectInfoSelector)
   const dispatch = useDispatch()
   const { t } = useTranslation()
+  const isDappListed = useIsDappListed(callback)
 
   if (!dappKitRequest) {
     Logger.error(TAG, 'No request found in navigation props')
@@ -93,6 +96,8 @@ const DappKitSignTxScreen = ({ route }: Props) => {
             <CopyIcon />
           </Touchable>
         </View>
+
+        <DappsDisclaimer isDappListed={isDappListed} />
       </RequestContent>
     </SafeAreaView>
   )

--- a/src/walletConnect/screens/ActionRequest.test.tsx
+++ b/src/walletConnect/screens/ActionRequest.test.tsx
@@ -244,7 +244,7 @@ describe('ActionRequest with WalletConnect V2', () => {
           'Message to sign'
         )
       ).toBeTruthy()
-      expect(getByText('dappsDisclaimerSingleDapp')).toBeTruthy()
+      expect(getByText('dappsDisclaimerUnlistedDapp')).toBeTruthy()
     })
 
     it('copies the request payload', () => {

--- a/src/walletConnect/screens/ActionRequest.test.tsx
+++ b/src/walletConnect/screens/ActionRequest.test.tsx
@@ -54,6 +54,9 @@ describe('ActionRequest with WalletConnect V1', () => {
         ],
       },
     },
+    dapps: {
+      dappsMinimalDisclaimerEnabled: true,
+    },
   })
 
   beforeEach(() => {
@@ -87,6 +90,7 @@ describe('ActionRequest with WalletConnect V1', () => {
           'Message to sign'
         )
       ).toBeTruthy()
+      expect(getByText('dappsDisclaimerUnlistedDapp')).toBeTruthy()
     })
 
     it('shows request details with raw string if message cannot be decoded', () => {

--- a/src/walletConnect/screens/ActionRequest.test.tsx
+++ b/src/walletConnect/screens/ActionRequest.test.tsx
@@ -218,6 +218,9 @@ describe('ActionRequest with WalletConnect V2', () => {
           sessions: [v2Session],
         },
       },
+      dapps: {
+        dappsMinimalDisclaimerEnabled: true,
+      },
     })
 
     beforeEach(() => {
@@ -241,6 +244,7 @@ describe('ActionRequest with WalletConnect V2', () => {
           'Message to sign'
         )
       ).toBeTruthy()
+      expect(getByText('dappsDisclaimerSingleDapp')).toBeTruthy()
     })
 
     it('copies the request payload', () => {

--- a/src/walletConnect/screens/ActionRequest.tsx
+++ b/src/walletConnect/screens/ActionRequest.tsx
@@ -6,7 +6,9 @@ import { useDispatch, useSelector } from 'react-redux'
 import Logger from 'src/utils/Logger'
 import { getDescriptionFromAction, SupportedActions } from 'src/walletConnect/constants'
 import ActionRequestPayload from 'src/walletConnect/screens/ActionRequestPayload'
+import DappsDisclaimer from 'src/walletConnect/screens/DappsDisclaimer'
 import RequestContent, { useDappMetadata } from 'src/walletConnect/screens/RequestContent'
+import { useIsDappListed } from 'src/walletConnect/screens/useIsDappListed'
 import {
   acceptRequest as acceptRequestV1,
   denyRequest as denyRequestV1,
@@ -47,6 +49,7 @@ function ActionRequestV1({ pendingAction }: PropsV1) {
   const { action, peerId } = pendingAction
   const activeSession = useSelector(selectSessionFromPeerId(peerId))
   const { url, dappName, dappImageUrl } = useDappMetadata(activeSession?.peerMeta)
+  const isDappListed = useIsDappListed(url)
 
   if (!activeSession) {
     // should never happen
@@ -75,6 +78,7 @@ function ActionRequestV1({ pendingAction }: PropsV1) {
       dappUrl={url}
     >
       <ActionRequestPayload walletConnectVersion={1} session={activeSession} request={action} />
+      <DappsDisclaimer isDappListed={isDappListed} />
     </RequestContent>
   )
 }

--- a/src/walletConnect/screens/ActionRequest.tsx
+++ b/src/walletConnect/screens/ActionRequest.tsx
@@ -89,6 +89,7 @@ function ActionRequestV2({ pendingAction }: PropsV2) {
 
   const activeSession = useSelector(selectSessionFromTopic(pendingAction.topic))
   const { url, dappName, dappImageUrl } = useDappMetadata(activeSession?.peer.metadata)
+  const isDappListed = useIsDappListed(url)
 
   if (!activeSession) {
     // should never happen
@@ -125,6 +126,7 @@ function ActionRequestV2({ pendingAction }: PropsV2) {
         session={activeSession}
         request={pendingAction}
       />
+      <DappsDisclaimer isDappListed={isDappListed} />
     </RequestContent>
   )
 }

--- a/src/walletConnect/screens/DappsDisclaimer.tsx
+++ b/src/walletConnect/screens/DappsDisclaimer.tsx
@@ -1,0 +1,45 @@
+import React from 'react'
+import { useTranslation } from 'react-i18next'
+import { StyleSheet, Text } from 'react-native'
+import { useSelector } from 'react-redux'
+import { dappConnectInfoSelector, dappsMinimalDisclaimerEnabledSelector } from 'src/dapps/selectors'
+import { DappConnectInfo } from 'src/dapps/types'
+import Colors from 'src/styles/colors'
+import fontStyles from 'src/styles/fonts'
+import { Spacing } from 'src/styles/styles'
+
+interface Props {
+  isDappListed: boolean
+}
+
+const DappsDisclaimer = ({ isDappListed }: Props) => {
+  const { t } = useTranslation()
+  const dappsMinimalDisclaimerEnabled = useSelector(dappsMinimalDisclaimerEnabledSelector)
+  const dappConnectInfo = useSelector(dappConnectInfoSelector)
+
+  if (dappsMinimalDisclaimerEnabled) {
+    return (
+      <Text style={styles.dappNotListedDisclaimer}>
+        {isDappListed ? t('dappsDisclaimerSingleDapp') : t('dappsDisclaimerUnlistedDapp')}
+      </Text>
+    )
+  }
+
+  if (!isDappListed && dappConnectInfo === DappConnectInfo.Basic) {
+    return <Text style={styles.dappNotListedDisclaimer}>{t('dappNotListed')}</Text>
+  }
+
+  return null
+}
+
+const styles = StyleSheet.create({
+  dappNotListedDisclaimer: {
+    ...fontStyles.small,
+    color: Colors.gray5,
+    marginBottom: Spacing.Thick24,
+    textAlign: 'center',
+    marginTop: 'auto',
+  },
+})
+
+export default DappsDisclaimer

--- a/src/walletConnect/screens/RequestContent.tsx
+++ b/src/walletConnect/screens/RequestContent.tsx
@@ -5,17 +5,12 @@ import { useTranslation } from 'react-i18next'
 import { Image, StyleSheet, Text, View } from 'react-native'
 import { useSelector } from 'react-redux'
 import Button, { BtnSizes, BtnTypes } from 'src/components/Button'
-import {
-  activeDappSelector,
-  dappConnectInfoSelector,
-  dappsMinimalDisclaimerEnabledSelector,
-} from 'src/dapps/selectors'
+import { activeDappSelector, dappConnectInfoSelector } from 'src/dapps/selectors'
 import { DappConnectInfo } from 'src/dapps/types'
 import Logo from 'src/icons/Logo'
 import { Colors } from 'src/styles/colors'
 import fontStyles from 'src/styles/fonts'
 import { getShadowStyle, Shadow, Spacing } from 'src/styles/styles'
-import { useIsDappListed } from 'src/walletConnect/screens/useIsDappListed'
 
 interface RequestDetail {
   label: string
@@ -91,9 +86,7 @@ function RequestContent({
   const { t } = useTranslation()
 
   const [isAccepting, setIsAccepting] = useState(false)
-  const dappsMinimalDisclaimerEnabled = useSelector(dappsMinimalDisclaimerEnabledSelector)
   const dappConnectInfo = useSelector(dappConnectInfoSelector)
-  const isDappListed = useIsDappListed(dappUrl)
 
   const isAcceptingRef = useRef(false)
 
@@ -115,8 +108,6 @@ function RequestContent({
       }
     }
   }, [])
-
-  const showDappNotListedDisclaimer = dappConnectInfo === DappConnectInfo.Basic && !isDappListed
 
   return (
     <>
@@ -169,16 +160,6 @@ function RequestContent({
         {children}
       </View>
 
-      {dappsMinimalDisclaimerEnabled ? (
-        <Text style={styles.dappNotListedDisclaimer}>
-          {showDappNotListedDisclaimer
-            ? t('dappsDisclaimerUnlistedDapp')
-            : t('dappsDisclaimerSingleDapp')}
-        </Text>
-      ) : showDappNotListedDisclaimer ? (
-        <Text style={styles.dappNotListedDisclaimer}>{t('dappNotListed')}</Text>
-      ) : null}
-
       <Button
         type={BtnTypes.PRIMARY}
         size={BtnSizes.FULL}
@@ -229,12 +210,6 @@ const styles = StyleSheet.create({
     ...fontStyles.small,
     lineHeight: 20,
     marginBottom: Spacing.Thick24,
-  },
-  dappNotListedDisclaimer: {
-    ...fontStyles.small,
-    color: Colors.gray5,
-    marginBottom: Spacing.Thick24,
-    textAlign: 'center',
   },
   placeholderLogoBackground: {
     backgroundColor: Colors.light,

--- a/src/walletConnect/screens/RequestContent.tsx
+++ b/src/walletConnect/screens/RequestContent.tsx
@@ -5,7 +5,11 @@ import { useTranslation } from 'react-i18next'
 import { Image, StyleSheet, Text, View } from 'react-native'
 import { useSelector } from 'react-redux'
 import Button, { BtnSizes, BtnTypes } from 'src/components/Button'
-import { activeDappSelector, dappConnectInfoSelector } from 'src/dapps/selectors'
+import {
+  activeDappSelector,
+  dappConnectInfoSelector,
+  dappsMinimalDisclaimerEnabledSelector,
+} from 'src/dapps/selectors'
 import { DappConnectInfo } from 'src/dapps/types'
 import Logo from 'src/icons/Logo'
 import { Colors } from 'src/styles/colors'
@@ -87,6 +91,7 @@ function RequestContent({
   const { t } = useTranslation()
 
   const [isAccepting, setIsAccepting] = useState(false)
+  const dappsMinimalDisclaimerEnabled = useSelector(dappsMinimalDisclaimerEnabledSelector)
   const dappConnectInfo = useSelector(dappConnectInfoSelector)
   const isDappListed = useIsDappListed(dappUrl)
 
@@ -110,6 +115,8 @@ function RequestContent({
       }
     }
   }, [])
+
+  const showDappNotListedDisclaimer = dappConnectInfo === DappConnectInfo.Basic && !isDappListed
 
   return (
     <>
@@ -162,9 +169,15 @@ function RequestContent({
         {children}
       </View>
 
-      {dappConnectInfo === DappConnectInfo.Basic && !isDappListed && (
+      {dappsMinimalDisclaimerEnabled ? (
+        <Text style={styles.dappNotListedDisclaimer}>
+          {showDappNotListedDisclaimer
+            ? t('dappsDisclaimerUnlistedDapp')
+            : t('dappsDisclaimerSingleDapp')}
+        </Text>
+      ) : showDappNotListedDisclaimer ? (
         <Text style={styles.dappNotListedDisclaimer}>{t('dappNotListed')}</Text>
-      )}
+      ) : null}
 
       <Button
         type={BtnTypes.PRIMARY}
@@ -221,6 +234,7 @@ const styles = StyleSheet.create({
     ...fontStyles.small,
     color: Colors.gray5,
     marginBottom: Spacing.Thick24,
+    textAlign: 'center',
   },
   placeholderLogoBackground: {
     backgroundColor: Colors.light,


### PR DESCRIPTION
### Description

This PR adds the dapps disclaimer to the dapps bottom sheet for the variant group of the dapps disclaimer experiment.

### Test plan

Added a unit test for the happy flow, that seemed like the most important one. Screenshot:

![Simulator Screen Shot - iPhone 14 Pro Max - 2023-02-01 at 13 57 29](https://user-images.githubusercontent.com/20150449/216050156-d4511062-0fe5-45b1-9bec-e302253f8269.png)


### Related issues

- Fixes RET-551

### Backwards compatibility

Y
