### PR TITLE
fix: walletconnect should deny requests on error

### DIFF
--- a/src/walletConnect/v1/saga.ts
+++ b/src/walletConnect/v1/saga.ts
@@ -207,7 +207,7 @@ function* acceptRequest(r: AcceptRequest) {
     SentryTransactionHub.finishTransaction(SentryTransaction.wallet_connect_transaction)
   } catch (e) {
     Logger.debug(TAG + '@acceptRequest', e.message)
-    connector?.rejectRequest({ id, jsonrpc, error: e.message })
+    yield put(denyRequestAction(peerId, request, e.message))
     ValoraAnalytics.track(WalletConnectEvents.wc_request_accept_error, {
       ...defaultTrackedProperties,
       error: e.message,

--- a/src/walletConnect/v2/saga.ts
+++ b/src/walletConnect/v2/saga.ts
@@ -419,6 +419,7 @@ function* handleAcceptRequest({ request }: AcceptRequest) {
       ...defaultTrackedProperties,
       error: e.message,
     })
+    yield put(denyRequest(request, getSdkError('USER_REJECTED')))
   }
 
   yield call(handlePendingStateOrNavigateBack)

--- a/src/walletConnect/walletConnect.ts
+++ b/src/walletConnect/walletConnect.ts
@@ -73,6 +73,7 @@ export function* handleLoadingWithTimeout(origin: WalletConnectPairingOrigin) {
     sessionRequestReceivedV1: take(ActionsV1.SESSION_V1),
     sessionRequestReceivedV2: take(ActionsV2.SESSION_PROPOSAL_V2),
     actionRequestReceived: take(ActionsV1.PAYLOAD_V1),
+    actionRequestReceivedV2: take(ActionsV2.SESSION_PAYLOAD_V2),
   })
 
   if (timedOut) {


### PR DESCRIPTION
### Description

After a user accepts a WC action request, we trigger a saga to execute the approval. If the saga fails, we should trigger the flow to reject the action so that the pending action does not persist in the redux store (to be handled in the next app sessions). the saga fails if the user is prompted for their pin and cancel the pincode screen. 

I _think_ that is the right thing to do, in the v1 saga i see we attempt to reject the request on the `connector` directly but do not handle the redux state. in the v2 saga we just do nothing.

### Test plan

Manually tested

### Related issues

- Fixes RET-551

### Backwards compatibility

Y
