### PR TITLE
fix: low allowance swap issues

### DIFF
--- a/src/swap/saga.test.ts
+++ b/src/swap/saga.test.ts
@@ -1,5 +1,4 @@
 import { expectSaga } from 'redux-saga-test-plan'
-import { throwError } from 'redux-saga-test-plan/providers'
 import { call, select } from 'redux-saga/effects'
 import { SwapEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
@@ -84,12 +83,15 @@ describe(swapSubmitSaga, () => {
   })
 
   it('should set swap state correctly on error', async () => {
+    ;(sendTransaction as jest.Mock).mockImplementationOnce(() => {
+      throw new Error('fake error')
+    })
     await expectSaga(swapSubmitSaga, mockSwap)
       .withState(store.getState())
       .provide([
         [select(walletAddressSelector), mockAccount],
         [call(getContractKit), contractKit],
-        [call(getConnectedUnlockedAccount), throwError(new Error('fake error'))],
+        [call(getConnectedUnlockedAccount), mockAccount],
       ])
       .put(swapApprove())
       .put(swapError())

--- a/src/web3/networkConfig.ts
+++ b/src/web3/networkConfig.ts
@@ -117,7 +117,6 @@ const CELO_EXPLORER_BASE_ADDRESS_URL_MAINNET = `${CELO_EXPLORER_BASE_URL_MAINNET
 const NFTS_VALORA_APP_URL = 'https://nfts.valoraapp.com/'
 
 const APPROVE_SWAP_URL = `${CLOUD_FUNCTIONS_MAINNET}/approveSwap`
-const EXECUTE_SWAP_URL = `${CLOUD_FUNCTIONS_MAINNET}/executeSwap`
 
 const networkConfigs: { [testnet: string]: NetworkConfig } = {
   [Testnets.alfajores]: {

--- a/src/web3/networkConfig.ts
+++ b/src/web3/networkConfig.ts
@@ -34,7 +34,6 @@ interface NetworkConfig {
   celoExplorerBaseTxUrl: string
   celoExplorerBaseAddressUrl: string
   approveSwapUrl: string
-  executeSwapUrl: string
   verifyPhoneNumberUrl: string
   verifySmsCodeUrl: string
   getPublicDEKUrl: string
@@ -152,7 +151,6 @@ const networkConfigs: { [testnet: string]: NetworkConfig } = {
     celoExplorerBaseTxUrl: CELO_EXPLORER_BASE_TX_URL_ALFAJORES,
     celoExplorerBaseAddressUrl: CELO_EXPLORER_BASE_ADDRESS_URL_ALFAJORES,
     approveSwapUrl: APPROVE_SWAP_URL,
-    executeSwapUrl: EXECUTE_SWAP_URL,
     verifyPhoneNumberUrl: VERIFY_PHONE_NUMBER_ALFAJORES,
     verifySmsCodeUrl: VERIFY_SMS_CODE_ALFAJORES,
     getPublicDEKUrl: GET_PUBLIC_DEK_ALFAJORES,
@@ -192,7 +190,6 @@ const networkConfigs: { [testnet: string]: NetworkConfig } = {
     celoExplorerBaseTxUrl: CELO_EXPLORER_BASE_TX_URL_MAINNET,
     celoExplorerBaseAddressUrl: CELO_EXPLORER_BASE_ADDRESS_URL_MAINNET,
     approveSwapUrl: APPROVE_SWAP_URL,
-    executeSwapUrl: EXECUTE_SWAP_URL,
     verifyPhoneNumberUrl: VERIFY_PHONE_NUMBER_MAINNET,
     verifySmsCodeUrl: VERIFY_SMS_CODE_MAINNET,
     getPublicDEKUrl: GET_PUBLIC_DEK_MAINNET,


### PR DESCRIPTION
### Description

We are calling 0x api twice, one to get the details of the swaps (the amounts and prices) and another to confirm everything is ready to execute the swap. This increases how long the swaps take to complete, two fetches instead of one and produces errors with the guaranteed price when the buy amount is set. To simplify we are now using the transaction object returned from the `/approveSwap` endpoint instead of subsequently calling the `/executeSwap` endpoint and using the swap transaction present in that response. This is more inline with the [0x API docs](https://docs.0x.org/0x-api-swap/guides/swap-tokens-with-0x-api) and will make future swap router implementations easier.

### Test plan

Tested locally on Android and saga tests updated.

### Related issues

- Fixes RET-572

### Backwards compatibility

<!-- Brief explanation of why these changes are/are not backwards compatible. -->
Yes