### PR TITLE
feat: add alert that can be dismissed for the session

### DIFF
--- a/src/alert/AlertBanner.tsx
+++ b/src/alert/AlertBanner.tsx
@@ -1,22 +1,32 @@
 import React, { memo, useMemo } from 'react'
 import { useDispatch } from 'react-redux'
-import { hideAlert } from 'src/alert/actions'
-import { ErrorDisplayType } from 'src/alert/reducer'
+import { hideAlert, hideAlertForSession } from 'src/alert/actions'
+import { activeAlertSelector, ErrorDisplayType } from 'src/alert/reducer'
 import SmartTopAlert from 'src/components/SmartTopAlert'
 import useSelector from 'src/redux/useSelector'
 
 function AlertBanner() {
-  const alert = useSelector((state) => state.alert)
+  const activeAlert = useSelector(activeAlertSelector)
   const dispatch = useDispatch()
 
   const displayAlert = useMemo(() => {
-    if (alert?.displayMethod === ErrorDisplayType.BANNER && (alert.title || alert.message)) {
+    if (
+      activeAlert?.displayMethod === ErrorDisplayType.BANNER &&
+      (activeAlert.title || activeAlert.message)
+    ) {
       const onPress = () => {
-        const action = alert?.action ?? hideAlert()
-        dispatch(action)
+        if (activeAlert.action) {
+          dispatch(activeAlert.action)
+        }
+
+        if (activeAlert.preventReappear) {
+          dispatch(hideAlertForSession(activeAlert.message))
+        } else {
+          dispatch(hideAlert())
+        }
       }
 
-      const { type, title, message, buttonMessage, dismissAfter } = alert
+      const { type, title, message, buttonMessage, dismissAfter } = activeAlert
 
       return {
         type,
@@ -29,7 +39,7 @@ function AlertBanner() {
     } else {
       return null
     }
-  }, [alert])
+  }, [activeAlert])
 
   return <SmartTopAlert alert={displayAlert} />
 }

--- a/src/alert/actions.ts
+++ b/src/alert/actions.ts
@@ -11,6 +11,7 @@ import i18n from 'src/i18n'
 export enum Actions {
   SHOW = 'ALERT/SHOW',
   HIDE = 'ALERT/HIDE',
+  HIDE_FOR_SESSION = 'ALERT/HIDE_FOR_SESSION',
 }
 
 export enum AlertTypes {
@@ -28,6 +29,7 @@ export interface ShowAlertAction {
   alertType: AlertTypes
   displayMethod: ErrorDisplayType
   message: string
+  preventReappear?: boolean
   dismissAfter?: number | null
   buttonMessage?: string | null
   action?: AlertAction | null
@@ -40,9 +42,19 @@ export const showMessage = (
   dismissAfter?: number | null,
   buttonMessage?: string | null,
   action?: AlertAction | null,
-  title?: string | null
+  title?: string | null,
+  preventReappear = false
 ): ShowAlertAction => {
-  return showAlert(AlertTypes.MESSAGE, message, dismissAfter, buttonMessage, action, title)
+  return showAlert(
+    AlertTypes.MESSAGE,
+    message,
+    dismissAfter,
+    buttonMessage,
+    action,
+    title,
+    undefined,
+    preventReappear
+  )
 }
 
 export const showError = (
@@ -91,7 +103,8 @@ const showAlert = (
   buttonMessage?: string | null,
   action?: AlertAction | null,
   title?: string | null,
-  underlyingError?: ErrorMessages | null
+  underlyingError?: ErrorMessages | null,
+  preventReappear = false
 ): ShowAlertAction => {
   return {
     type: Actions.SHOW,
@@ -103,6 +116,7 @@ const showAlert = (
     action,
     title,
     underlyingError,
+    preventReappear,
   }
 }
 
@@ -110,8 +124,18 @@ interface HideAlertAction {
   type: Actions.HIDE
 }
 
+interface HideAlertForSessionAction {
+  type: Actions.HIDE_FOR_SESSION
+  alertMessage: string
+}
+
 export const hideAlert = (): HideAlertAction => ({
   type: Actions.HIDE,
 })
 
-export type ActionTypes = ShowAlertAction | HideAlertAction
+export const hideAlertForSession = (alertMessage: string): HideAlertForSessionAction => ({
+  type: Actions.HIDE_FOR_SESSION,
+  alertMessage,
+})
+
+export type ActionTypes = ShowAlertAction | HideAlertAction | HideAlertForSessionAction

--- a/src/components/TokenBalance.tsx
+++ b/src/components/TokenBalance.tsx
@@ -1,9 +1,10 @@
 import BigNumber from 'bignumber.js'
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Image, StyleProp, StyleSheet, Text, TextStyle, TouchableOpacity, View } from 'react-native'
 import { useDispatch, useSelector } from 'react-redux'
-import { hideAlert, showMessage } from 'src/alert/actions'
+import { showMessage } from 'src/alert/actions'
+import { dismissedAlertsSelector } from 'src/alert/reducer'
 import { FiatExchangeEvents, HomeEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import Dialog from 'src/components/Dialog'
@@ -79,6 +80,10 @@ function useErrorMessageWithRefresh() {
   const tokensInfoUnavailable = useSelector(tokensInfoUnavailableSelector)
   const tokenFetchError = useSelector(tokenFetchErrorSelector)
   const localCurrencyError = useSelector(localCurrencyExchangeRateErrorSelector)
+  const dismissedAlerts = useSelector(dismissedAlertsSelector)
+
+  const alertMessage = t('outOfSyncBanner.message')
+  const hasDismissedError = useMemo(() => dismissedAlerts.includes(alertMessage), [dismissedAlerts])
 
   const dispatch = useDispatch()
 
@@ -86,18 +91,17 @@ function useErrorMessageWithRefresh() {
     !isE2EEnv && tokensInfoUnavailable && (tokenFetchError || localCurrencyError)
 
   useEffect(() => {
-    if (shouldShowError) {
+    if (shouldShowError && !hasDismissedError) {
       dispatch(
         showMessage(
-          t('outOfSyncBanner.message'),
+          alertMessage,
           null,
           t('outOfSyncBanner.button'),
           refreshAllBalances(),
-          t('outOfSyncBanner.title')
+          t('outOfSyncBanner.title'),
+          true
         )
       )
-    } else {
-      dispatch(hideAlert())
     }
   }, [shouldShowError])
 }

--- a/src/tokens/saga.ts
+++ b/src/tokens/saga.ts
@@ -2,8 +2,7 @@ import { CeloTransactionObject, toTransactionObject } from '@celo/connect'
 import { CeloContract, StableToken } from '@celo/contractkit'
 import { GoldTokenWrapper } from '@celo/contractkit/lib/wrappers/GoldTokenWrapper'
 import { StableTokenWrapper } from '@celo/contractkit/lib/wrappers/StableTokenWrapper'
-import { retryAsync } from '@celo/utils/lib/async'
-import { gql } from 'apollo-boost'
+import { retryAsync, sleep } from '@celo/utils/lib/async'
 import BigNumber from 'bignumber.js'
 import { call, put, select, spawn, take, takeEvery } from 'redux-saga/effects'
 import * as erc20 from 'src/abis/IERC20.json'
@@ -11,7 +10,6 @@ import * as stableToken from 'src/abis/StableToken.json'
 import { showErrorOrFallback } from 'src/alert/actions'
 import { AppEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
-import { apolloClient } from 'src/apollo'
 import { TokenTransactionType } from 'src/apollo/types'
 import { ErrorMessages } from 'src/app/ErrorMessages'
 import { DOLLAR_MIN_AMOUNT_ACCOUNT_FUNDED, isE2EEnv } from 'src/config'
@@ -253,25 +251,27 @@ interface UserBalancesResponse {
 export async function fetchTokenBalancesForAddress(
   address: string
 ): Promise<FetchedTokenBalance[]> {
-  const response = await apolloClient.query<UserBalancesResponse, { address: string }>({
-    query: gql`
-      query FetchUserBalances($address: Address!) {
-        userBalances(address: $address) {
-          balances {
-            tokenAddress
-            balance
-          }
-        }
-      }
-    `,
-    variables: {
-      address,
-    },
-    fetchPolicy: 'network-only',
-    errorPolicy: 'all',
-  })
+  await sleep(1000)
+  throw new Error('test')
+  // const response = await apolloClient.query<UserBalancesResponse, { address: string }>({
+  //   query: gql`
+  //     query FetchUserBalances($address: Address!) {
+  //       userBalances(address: $address) {
+  //         balances {
+  //           tokenAddress
+  //           balance
+  //         }
+  //       }
+  //     }
+  //   `,
+  //   variables: {
+  //     address,
+  //   },
+  //   fetchPolicy: 'network-only',
+  //   errorPolicy: 'all',
+  // })
 
-  return response.data.userBalances.balances
+  // return response.data.userBalances.balances
 }
 
 export function* fetchTokenBalancesSaga() {


### PR DESCRIPTION
### Description

This PR allows the offline banner to be achknowledged and hidden for the rest of the session.

Approach:
- alerts redux now has a list of dismissed alerts, which will not be displayed again
- create a new type of hide action that dismisses the alerts for the whole session

This is a quick-ish fix, it doesn't address the issue of how we can let users know that their balances are up to date again but the current implementation also doesn't cater for this.

### Test plan

<!-- Demonstrate the change is solid, or why it doesn't need testing.
Example: add any manual testing steps or scenarios (if not obvious), screenshots / videos if the pull request changes the user interface.
-->

### Related issues

- Fixes RET-597

### Backwards compatibility

<!-- Brief explanation of why these changes are/are not backwards compatible. -->
