### PR TITLE
chore(deps): remove css-what resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -303,7 +303,6 @@
     "underscore": "^1.12.1",
     "react-native-flipper": "^0.127.0",
     "y18n": "5.0.8",
-    "css-what": "5.0.1",
     "normalize-url": "6.0.1",
     "trim-newlines": "^4.0.2",
     "glob-parent": "^5.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8182,10 +8182,10 @@ css-tree@^1.0.0-alpha.39:
     mdn-data "2.0.14"
     source-map "^0.6.1"
 
-css-what@5.0.1, css-what@^6.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/css-what/-/css-what-5.0.1.tgz#3efa820131f4669a8ac2408f9c32e7c7de9f4cad"
-  integrity sha512-FYDTSHb/7KXsWICVsxdmiExPjCfRC4qRFBdVwv7Ax9hMnvMmEjP9RfxTEZ3qPZGmADDn2vAKSo9UcN1jKVYscg==
+css-what@^6.0.1:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/css-what/-/css-what-6.1.0.tgz#fb5effcf76f1ddea2c81bdfaa4de44e79bac70f4"
+  integrity sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==
 
 cssom@^0.4.4:
   version "0.4.4"


### PR DESCRIPTION
### Description

This resolution was added to fix a vulnerability (#455), which occurred because react-native-svg had css-what@^3.2.1 as a downstream dependency. However, react-native-svg now has css-what@^6.0.1 as a downstream dependency, so this resolution is unnecessary.

### Test plan

CI

### Related issues

N/A

### Backwards compatibility

Yes