### PR TITLE
chore: add requireCPV remote config

### DIFF
--- a/src/app/reducers.ts
+++ b/src/app/reducers.ts
@@ -12,6 +12,7 @@ export interface State {
   loggedIn: boolean
   numberVerified: boolean // decentrally verified
   phoneNumberVerified: boolean // centrally verified
+  requireCPV: boolean
   analyticsEnabled: boolean
   requirePinOnAppOpen: boolean
   appState: AppState
@@ -59,6 +60,7 @@ const initialState = {
   loggedIn: false,
   numberVerified: false,
   phoneNumberVerified: false,
+  requireCPV: REMOTE_CONFIG_VALUES_DEFAULTS.requireCPV,
   analyticsEnabled: true,
   requirePinOnAppOpen: false,
   appState: AppState.Active,
@@ -214,6 +216,7 @@ export const appReducer = (
         maxSwapSlippagePercentage: action.configValues.maxSwapSlippagePercentage,
         networkTimeoutSeconds: action.configValues.networkTimeoutSeconds,
         celoNews: action.configValues.celoNews,
+        requireCPV: action.configValues.requireCPV,
       }
     case Actions.ACTIVE_SCREEN_CHANGED:
       return {

--- a/src/app/saga.ts
+++ b/src/app/saga.ts
@@ -210,6 +210,7 @@ export interface RemoteConfigValues {
   superchargeRewardContractAddress: string
   dappsFilterEnabled: boolean
   dappsSearchEnabled: boolean
+  requireCPV: boolean
 }
 
 export function* appRemoteFeatureFlagSaga() {

--- a/src/app/selectors.ts
+++ b/src/app/selectors.ts
@@ -186,10 +186,12 @@ export const registrationStepsSelector = createSelector(
 
 export const numberVerifiedCentrallySelector = (state: RootState) => state.app.phoneNumberVerified
 
+const requireCPVSelector = (state: RootState) => state.app.requireCPV
+
 export const phoneNumberVerifiedSelector = createSelector(
-  [numberVerifiedCentrallySelector, numberVerifiedSelector],
-  (numberVerifiedCentrally, numberVerifiedDecentrally) =>
-    numberVerifiedCentrally || numberVerifiedDecentrally
+  [numberVerifiedCentrallySelector, numberVerifiedSelector, requireCPVSelector],
+  (numberVerifiedCentrally, numberVerifiedDecentrally, requireCPV) =>
+    requireCPV ? numberVerifiedCentrally : numberVerifiedCentrally || numberVerifiedDecentrally
 )
 
 export const shouldRunVerificationMigrationSelector = createSelector(

--- a/src/fiatExchanges/SimplexScreen.tsx
+++ b/src/fiatExchanges/SimplexScreen.tsx
@@ -7,7 +7,7 @@ import { useDispatch, useSelector } from 'react-redux'
 import { e164NumberSelector } from 'src/account/selectors'
 import { showError } from 'src/alert/actions'
 import { ErrorMessages } from 'src/app/ErrorMessages'
-import { numberVerifiedSelector } from 'src/app/selectors'
+import { phoneNumberVerifiedSelector } from 'src/app/selectors'
 import BackButton from 'src/components/BackButton'
 import Button, { BtnSizes } from 'src/components/Button'
 import WebView from 'src/components/WebView'
@@ -37,7 +37,7 @@ function SimplexScreen({ route, navigation }: Props) {
 
   const account = useSelector(currentAccountSelector)
   const e164PhoneNumber = useSelector(e164NumberSelector)
-  const phoneNumberConfirmed = useSelector(numberVerifiedSelector)
+  const phoneNumberConfirmed = useSelector(phoneNumberVerifiedSelector)
   const localCurrency = useSelector(getLocalCurrencyCode)
   const { ipAddress: userIpAddress } = useSelector(userLocationDataSelector)
 

--- a/src/firebase/firebase.ts
+++ b/src/firebase/firebase.ts
@@ -306,6 +306,7 @@ export async function fetchRemoteConfigValues(): Promise<RemoteConfigValues | nu
     superchargeRewardContractAddress: flags.superchargeRewardContractAddress.asString(),
     dappsFilterEnabled: flags.dappsFilterEnabled.asBoolean(),
     dappsSearchEnabled: flags.dappsSearchEnabled.asBoolean(),
+    requireCPV: flags.requireCPV.asBoolean(),
   }
 }
 

--- a/src/firebase/remoteConfigValuesDefaults.e2e.ts
+++ b/src/firebase/remoteConfigValuesDefaults.e2e.ts
@@ -69,4 +69,5 @@ export const REMOTE_CONFIG_VALUES_DEFAULTS: Omit<
   superchargeRewardContractAddress: '',
   dappsFilterEnabled: false,
   dappsSearchEnabled: false,
+  requireCPV: false,
 }

--- a/src/firebase/remoteConfigValuesDefaults.ts
+++ b/src/firebase/remoteConfigValuesDefaults.ts
@@ -71,4 +71,5 @@ export const REMOTE_CONFIG_VALUES_DEFAULTS: Omit<
   superchargeRewardContractAddress: '',
   dappsFilterEnabled: false,
   dappsSearchEnabled: false,
+  requireCPV: false,
 }

--- a/src/redux/migrations.ts
+++ b/src/redux/migrations.ts
@@ -1063,4 +1063,18 @@ export const migrations = {
       'createAccountCopyTestType'
     ),
   }),
+  114: (state: any) => ({
+    ...state,
+    account: {
+      ...state.account,
+      dismissedGetVerified:
+        state.app.numberVerified && !state.app.phoneNumberVerified
+          ? false
+          : state.account.dismissedGetVerified,
+    },
+    app: {
+      ...state.app,
+      requireCPV: false,
+    },
+  }),
 }

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -23,7 +23,7 @@ const persistConfig: PersistConfig<RootState> = {
   key: 'root',
   // default is -1, increment as we make migrations
   // See https://github.com/valora-inc/wallet/tree/main/WALLET.md#redux-state-migration
-  version: 113,
+  version: 114,
   keyPrefix: `reduxStore-`, // the redux-persist default is `persist:` which doesn't work with some file systems.
   storage: FSStorage(),
   blacklist: ['networkInfo', 'alert', 'imports', 'supercharge', 'swap'],

--- a/src/send/Send.tsx
+++ b/src/send/Send.tsx
@@ -221,9 +221,7 @@ function Send({ route }: Props) {
       <SendHeader isOutgoingPaymentRequest={isOutgoingPaymentRequest} />
       <DisconnectBanner />
       <SendSearchInput input={searchQuery} onChangeText={throttledSearch} />
-      {inviteRewardsEnabled && numberVerified && hasGivenContactPermission && (
-        <InviteRewardsBanner />
-      )}
+      {inviteRewardsEnabled && hasGivenContactPermission && <InviteRewardsBanner />}
       <RecipientPicker
         testID={'RecipientPicker'}
         sections={buildSections()}

--- a/test/RootStateSchema.json
+++ b/test/RootStateSchema.json
@@ -2473,6 +2473,9 @@
                 "rampCashInButtonExpEnabled": {
                     "type": "boolean"
                 },
+                "requireCPV": {
+                    "type": "boolean"
+                },
                 "requirePinOnAppOpen": {
                     "type": "boolean"
                 },
@@ -2563,6 +2566,7 @@
                 "phoneNumberVerified",
                 "pincodeUseExpandedBlocklist",
                 "rampCashInButtonExpEnabled",
+                "requireCPV",
                 "requirePinOnAppOpen",
                 "sentryNetworkErrors",
                 "sentryTracesSampleRate",

--- a/test/schemas.ts
+++ b/test/schemas.ts
@@ -2080,6 +2080,18 @@ export const v113Schema = {
   ),
 }
 
+export const v114Schema = {
+  ...v113Schema,
+  _persist: {
+    ...v113Schema._persist,
+    version: 114,
+  },
+  app: {
+    ...v113Schema.app,
+    requireCPV: false,
+  },
+}
+
 export function getLatestSchema(): Partial<RootState> {
-  return v113Schema as Partial<RootState>
+  return v114Schema as Partial<RootState>
 }


### PR DESCRIPTION
### Description

This PR adds a remote config that we can switch to true when we want to enable manual verification for users who have not migrated to CPV.

### Test plan

n/a

### Related issues

- Fixes RET-638

### Backwards compatibility

Y
