### PR TITLE
fix: phone number format not recognised on verification screen

### DIFF
--- a/src/components/ValidatedTextInput.tsx
+++ b/src/components/ValidatedTextInput.tsx
@@ -22,6 +22,10 @@ interface OwnProps {
     | null
 }
 
+export interface PhoneValidatorProps {
+  validator: ValidatorKind.Phone
+  countryCallingCode: string
+}
 export interface IntegerValidatorProps {
   validator: ValidatorKind.Integer
 }
@@ -43,19 +47,17 @@ export type ValidatorProps =
   | DecimalValidatorProps
   | CustomValidatorProps
 
-export interface PhoneValidatorProps {
-  validator: ValidatorKind.Phone
-  countryCallingCode: string
-}
-
-export type ValidatedTextInputProps = OwnProps & PhoneValidatorProps & TextInputProps
+export type ValidatedTextInputProps = OwnProps & ValidatorProps & TextInputProps
 
 export default class ValidatedTextInput extends React.Component<ValidatedTextInputProps> {
   onChangeText = (input: string): void => {
     // some countries support multiple phone number lengths. since we add the
     // country code to a validated phone number in the UI, we need to omit the
     // country code from subsequent validations if the user types a longer number
-    const rawInput = input.split(this.props.countryCallingCode)[1] ?? input
+    const rawInput =
+      this.props.validator === ValidatorKind.Phone
+        ? input.split(this.props.countryCallingCode)[1] ?? input
+        : input
     const validated = validateInput(rawInput, this.props)
 
     // Don't propagate change if new change is invalid
@@ -68,7 +70,10 @@ export default class ValidatedTextInput extends React.Component<ValidatedTextInp
   }
 
   getMaxLength = () => {
-    const { numberOfDecimals, value, decimalSeparator } = this.props
+    const { numberOfDecimals, validator, value, decimalSeparator } = this.props
+    if (validator !== ValidatorKind.Decimal || !numberOfDecimals) {
+      return undefined
+    }
     const decimalPos = value.indexOf(decimalSeparator ?? '.')
     if (decimalPos === -1) {
       return undefined

--- a/src/components/ValidatedTextInput.tsx
+++ b/src/components/ValidatedTextInput.tsx
@@ -22,6 +22,27 @@ interface OwnProps {
     | null
 }
 
+export interface IntegerValidatorProps {
+  validator: ValidatorKind.Integer
+}
+
+export interface DecimalValidatorProps {
+  validator: ValidatorKind.Decimal
+  numberOfDecimals: number
+}
+
+// Required props for a custom input validator
+export interface CustomValidatorProps {
+  validator: ValidatorKind.Custom
+  customValidator: (input: string) => string
+}
+
+export type ValidatorProps =
+  | PhoneValidatorProps
+  | IntegerValidatorProps
+  | DecimalValidatorProps
+  | CustomValidatorProps
+
 export interface PhoneValidatorProps {
   validator: ValidatorKind.Phone
   countryCallingCode: string

--- a/src/components/ValidatedTextInput.tsx
+++ b/src/components/ValidatedTextInput.tsx
@@ -26,6 +26,7 @@ export interface PhoneValidatorProps {
   validator: ValidatorKind.Phone
   countryCallingCode: string
 }
+
 export interface IntegerValidatorProps {
   validator: ValidatorKind.Integer
 }
@@ -53,12 +54,13 @@ export default class ValidatedTextInput extends React.Component<ValidatedTextInp
   onChangeText = (input: string): void => {
     // some countries support multiple phone number lengths. since we add the
     // country code to a validated phone number in the UI, we need to omit the
-    // country code from subsequent validations if the user types a longer number
-    const rawInput =
+    // country code from subsequent validations if the user types a longer number.
+    // note: the countryCallingCode is a string like "+31"
+    const userInput =
       this.props.validator === ValidatorKind.Phone
         ? input.split(this.props.countryCallingCode)[1] ?? input
         : input
-    const validated = validateInput(rawInput, this.props)
+    const validated = validateInput(userInput, this.props)
 
     // Don't propagate change if new change is invalid
     if (this.props.value === validated) {


### PR DESCRIPTION
### Description

Context: https://valora-app.slack.com/archives/C029MMTD529/p1677719177909599, https://valora-app.slack.com/archives/C025V1D6F3J/p1678194369634539?thread_ts=1677719863.631589&cid=C025V1D6F3J

We use the value in the phone number text input to do the phone number validation, but as soon as the validation succeeds, we add the country code to the text input. Subsequent validations are performed with a phone number that includes the country code, which always fails. This PR fixes this issue.

### Test plan

This phone number can now be validated:
https://user-images.githubusercontent.com/20150449/223467814-ae6beaeb-6ccd-4dfb-8ca7-77c9fcb376e9.mp4

We can also backspace on a validated number:
https://user-images.githubusercontent.com/20150449/223469228-5e1232c3-de01-49d8-9cee-4020ad71a903.mp4



### Related issues

- Fixes RET-553, ENG-29, RET-646

### Backwards compatibility

Y
