### PR TITLE
feat: better packager logs

### DIFF
--- a/src/utils/Logger.ts
+++ b/src/utils/Logger.ts
@@ -324,7 +324,7 @@ class Logger {
             ''.padStart(leftPadding),
             `[${new Date().toISOString().substring(11)}]`,
             // Add the model to help differentiate logs when running multiple devices
-            stylize(` ${RNDeviceInfo.getModel()}`, 'grey'),
+            ` ${stylize(RNDeviceInfo.getModel(), 'grey')}`,
           ].join(''),
           ...data,
         ])

--- a/src/utils/Logger.ts
+++ b/src/utils/Logger.ts
@@ -9,6 +9,7 @@ import { Email } from 'src/account/emailSender'
 import { DEFAULT_SENTRY_NETWORK_ERRORS, LOGGER_LEVEL } from 'src/config'
 import { LoggerLevel } from 'src/utils/LoggerLevels'
 import { readFileChunked } from 'src/utils/readFile'
+import { stylize } from 'src/utils/stylize'
 import { ONE_DAY_IN_MILLIS } from 'src/utils/time'
 
 class Logger {
@@ -310,38 +311,7 @@ class Logger {
     }
 
     if (__DEV__) {
-      const colors = {
-        bold: [1, 22],
-        italic: [3, 23],
-        underline: [4, 24],
-        inverse: [7, 27],
-        white: [37, 39],
-        grey: [90, 39],
-        black: [30, 39],
-        blue: [34, 39],
-        cyan: [36, 39],
-        green: [32, 39],
-        magenta: [35, 39],
-        red: [31, 39],
-        yellow: [33, 39],
-      }
-
-      function stylize(str: string, color: keyof typeof colors) {
-        if (!str) {
-          return ''
-        }
-
-        if (!color) {
-          color = 'white'
-        }
-
-        const codes = colors[color]
-        if (codes) {
-          return '\x1B[' + codes[0] + 'm' + str + '\x1B[' + codes[1] + 'm'
-        }
-        return str
-      }
-
+      // Add more info to the packager logs
       const HMRClient = require('react-native/Libraries/Utilities/HMRClient')
       const RNDeviceInfo = require('react-native-device-info')
       const originalHmrLog = HMRClient.log

--- a/src/utils/stylize.ts
+++ b/src/utils/stylize.ts
@@ -1,0 +1,30 @@
+const colors = {
+  bold: [1, 22],
+  italic: [3, 23],
+  underline: [4, 24],
+  inverse: [7, 27],
+  white: [37, 39],
+  grey: [90, 39],
+  black: [30, 39],
+  blue: [34, 39],
+  cyan: [36, 39],
+  green: [32, 39],
+  magenta: [35, 39],
+  red: [31, 39],
+  yellow: [33, 39],
+}
+
+/**
+ * Add colors to the specified string, for colorized output in terminals
+ */
+export function stylize(str: string, color: keyof typeof colors) {
+  if (!str) {
+    return ''
+  }
+
+  const codes = colors[color]
+  if (codes) {
+    return '\x1B[' + codes[0] + 'm' + str + '\x1B[' + codes[1] + 'm'
+  }
+  return str
+}


### PR DESCRIPTION
### Description

Some improvements:
- Use time instead of timestamp: simpler for us, humans :)
- Aligned times: easier to parse visually
- Add device model with darker color: avoids confusion when multiple devices are connected to the packager. The darker color helps with visual parsing too.

### Test plan

**Packager logs (before)**

<img width="1201" alt="Screenshot 2023-03-07 at 19 26 15" src="https://user-images.githubusercontent.com/57791/223515668-a93b4e33-730b-40fe-b7d8-bf58f8880f9a.png">

**Packager logs (after)**

<img width="1157" alt="Screenshot 2023-03-08 at 11 43 07" src="https://user-images.githubusercontent.com/57791/223702589-6a40d949-f53b-49a4-80c9-d47b7db647f1.png">

### Related issues

- Fixes RET-648

### Backwards compatibility

Yes
