### PR TITLE
fix(send): Dismiss keyboard on Send screen bottom sheet

### DIFF
--- a/e2e/src/usecases/SecureSend.js
+++ b/e2e/src/usecases/SecureSend.js
@@ -1,5 +1,11 @@
 import { reloadReactNative } from '../utils/retries'
-import { enterPinUiIfNecessary, inputNumberKeypad, scrollIntoView, sleep } from '../utils/utils'
+import {
+  enterPinUiIfNecessary,
+  inputNumberKeypad,
+  scrollIntoView,
+  sleep,
+  addComment,
+} from '../utils/utils'
 const faker = require('@faker-js/faker')
 
 const PHONE_NUMBER = '+12057368924'
@@ -11,9 +17,7 @@ export default SecureSend = () => {
     await reloadReactNative()
   })
 
-  // TODO: Unskip this test when the ODIS V1 debacle is resolved and fixed in code
-  // https://valora-app.slack.com/archives/C025V1D6F3J/p1676979118551299
-  it.skip('Send cUSD to phone number with multiple mappings', async () => {
+  it('Send cUSD to phone number with multiple mappings', async () => {
     let randomContent = faker.lorem.words()
     await waitFor(element(by.id('SendOrRequestBar/SendButton')))
       .toBeVisible()
@@ -25,6 +29,12 @@ export default SecureSend = () => {
     await element(by.id('SearchInput')).replaceText(PHONE_NUMBER)
     await element(by.id('SearchInput')).tapReturnKey()
     await element(by.id('RecipientItem')).tap()
+
+    // Select the currency
+    await waitFor(element(by.id('cUSDBalance')))
+      .toBeVisible()
+      .withTimeout(30 * 1000)
+    await element(by.id('cUSDBalance')).tap()
 
     // Enter the amount and review
     await inputNumberKeypad(AMOUNT_TO_SEND)
@@ -53,8 +63,7 @@ export default SecureSend = () => {
     await element(by.id('ConfirmAccountButton')).tap()
 
     // Write a comment.
-    await element(by.id('commentInput/send')).replaceText(`${randomContent}\n`)
-    await element(by.id('commentInput/send')).tapReturnKey()
+    await addComment(randomContent)
 
     // Wait for the confirm button to be clickable. If it takes too long this test
     // will be flaky :(

--- a/e2e/src/usecases/SecureSend.js
+++ b/e2e/src/usecases/SecureSend.js
@@ -27,7 +27,6 @@ export default SecureSend = () => {
     // Look for an address and tap on it.
     await element(by.id('SearchInput')).tap()
     await element(by.id('SearchInput')).replaceText(PHONE_NUMBER)
-    await element(by.id('SearchInput')).tapReturnKey()
     await element(by.id('RecipientItem')).tap()
 
     // Select the currency

--- a/e2e/src/usecases/Send.js
+++ b/e2e/src/usecases/Send.js
@@ -36,6 +36,9 @@ export default Send = () => {
 
     it('Then tapping a recipient should show bottom sheet', async () => {
       await element(by.text('0xe5f5...8846')).atIndex(0).tap()
+      await waitFor(element(by.id('CELOBalance')))
+        .toBeVisible()
+        .withTimeout(30 * 1000)
       await expect(element(by.id('CELOBalance'))).toBeVisible()
       await expect(element(by.id('cUSDBalance'))).toBeVisible()
       await expect(element(by.id('cEURBalance'))).toBeVisible()

--- a/src/send/Send.tsx
+++ b/src/send/Send.tsx
@@ -117,12 +117,15 @@ function Send({ route }: Props) {
       return
     }
 
+    // Dismiss the keyboard as soon as we know the verification status, so it does not
+    // interfere with the invite modal or bottom sheet.
+    Keyboard.dismiss()
+
     if (recipientVerificationStatus === RecipientVerificationStatus.UNVERIFIED) {
       setShowInviteModal(true)
       return
     }
 
-    Keyboard.dismiss()
     // Only show currency picker once we know that the recipient is verified,
     // and only if the user is permitted to change tokens.
     if (defaultTokenOverride) {

--- a/src/send/Send.tsx
+++ b/src/send/Send.tsx
@@ -121,6 +121,20 @@ function Send({ route }: Props) {
       setShowInviteModal(true)
       return
     }
+
+    // Only show currency picker once we know that the recipient is verified,
+    // and only if the user is permitted to change tokens.
+    if (defaultTokenOverride) {
+      navigate(Screens.SendAmount, {
+        defaultTokenOverride,
+        forceTokenAddress,
+        recipient,
+        isOutgoingPaymentRequest,
+        origin: isOutgoingPaymentRequest ? SendOrigin.AppRequestFlow : SendOrigin.AppSendFlow,
+      })
+    } else {
+      setShowCurrencyPicker(true)
+    }
   }, [recipient, recipientVerificationStatus])
 
   const onSelectRecipient = useCallback(
@@ -135,20 +149,7 @@ function Send({ route }: Props) {
           usedSearchBar: searchQuery.length > 0,
         }
       )
-
       setSelectedRecipient(recipient)
-
-      if (defaultTokenOverride) {
-        navigate(Screens.SendAmount, {
-          defaultTokenOverride,
-          forceTokenAddress,
-          recipient,
-          isOutgoingPaymentRequest,
-          origin: isOutgoingPaymentRequest ? SendOrigin.AppRequestFlow : SendOrigin.AppSendFlow,
-        })
-      } else {
-        setShowCurrencyPicker(true)
-      }
     },
     [isOutgoingPaymentRequest, searchQuery]
   )

--- a/src/send/Send.tsx
+++ b/src/send/Send.tsx
@@ -3,7 +3,7 @@ import { throttle } from 'lodash'
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { useAsync } from 'react-async-hook'
 import { useTranslation } from 'react-i18next'
-import { Platform, StyleSheet } from 'react-native'
+import { Keyboard, Platform, StyleSheet } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { useDispatch } from 'react-redux'
 import { defaultCountryCodeSelector } from 'src/account/selectors'
@@ -122,6 +122,7 @@ function Send({ route }: Props) {
       return
     }
 
+    Keyboard.dismiss()
     // Only show currency picker once we know that the recipient is verified,
     // and only if the user is permitted to change tokens.
     if (defaultTokenOverride) {


### PR DESCRIPTION
### Description

See [this Slack thread](https://valora-app.slack.com/archives/C04B61SJ6DS/p1678289764167129) for more context.
Currently, on the send flow, it's possible for the keyboard to be present _on top_ of the bottom sheet under certain circumstances. This PR explicitly dismisses the keyboard when the bottom sheet is made visible.

### Test plan

Manual tested and sort-of-e2e tested. Video below:

https://user-images.githubusercontent.com/569401/223771083-e8f97839-1b80-4a6d-93d2-d470d3c8e6ae.mp4

### Backwards compatibility

Yes.