### PR TITLE
fix(verification): hide learn more link behind keyboard

### DIFF
--- a/src/verify/VerificationStartScreen.tsx
+++ b/src/verify/VerificationStartScreen.tsx
@@ -246,6 +246,7 @@ function VerificationStartScreen({
           testID="PhoneVerificationContinue"
         />
       </KeyboardAwareScrollView>
+      <KeyboardSpacer />
       <View style={styles.bottomButtonContainer}>
         <TextButton
           testID="PhoneVerificationLearnMore"
@@ -255,7 +256,6 @@ function VerificationStartScreen({
           {t('phoneVerificationScreen.learnMore.buttonLabel')}
         </TextButton>
       </View>
-      <KeyboardSpacer />
       <InfoBottomSheet
         isVisible={showLearnMoreDialog}
         title={t('phoneVerificationScreen.learnMore.title')}
@@ -297,6 +297,9 @@ const styles = StyleSheet.create({
   bottomButtonContainer: {
     padding: Spacing.Thick24,
     alignItems: 'center',
+
+    // borderWidth: 1,
+    // borderColor: colors.onboardingBrownLight,
   },
   learnMore: {
     color: colors.onboardingBrownLight,

--- a/src/verify/VerificationStartScreen.tsx
+++ b/src/verify/VerificationStartScreen.tsx
@@ -221,7 +221,7 @@ function VerificationStartScreen({
     <SafeAreaView style={styles.container} edges={['bottom']}>
       <KeyboardAwareScrollView
         style={[styles.scrollContainer, headerHeight ? { marginTop: headerHeight } : undefined]}
-        keyboardShouldPersistTaps="always"
+        keyboardShouldPersistTaps="never"
       >
         <Text style={styles.header} testID="PhoneVerificationHeader">
           {t('phoneVerificationScreen.title')}

--- a/src/verify/VerificationStartScreen.tsx
+++ b/src/verify/VerificationStartScreen.tsx
@@ -297,9 +297,6 @@ const styles = StyleSheet.create({
   bottomButtonContainer: {
     padding: Spacing.Thick24,
     alignItems: 'center',
-
-    // borderWidth: 1,
-    // borderColor: colors.onboardingBrownLight,
   },
   learnMore: {
     color: colors.onboardingBrownLight,


### PR DESCRIPTION
### Description

It was [reported](https://valora-app.slack.com/archives/C04B61SJ6DS/p1678096341076279) that the keyboard would sometimes raise the 'learn more' link and end up clipping part of the Verification flow. This change hides the learn more link behind the keyboard when its open to avoid the issue.

https://user-images.githubusercontent.com/8432644/223781160-b20318c5-e688-43a9-84f1-6afaaa441b86.mov


https://user-images.githubusercontent.com/8432644/223795427-e43ea159-60f7-4d5a-a1ee-2b42319b6389.mp4



### Test plan

<!-- Demonstrate the change is solid, or why it doesn't need testing.
Example: add any manual testing steps or scenarios (if not obvious), screenshots / videos if the pull request changes the user interface.
-->

### Related issues

- Fixes #[issue number here]

### Backwards compatibility

<!-- Brief explanation of why these changes are/are not backwards compatible. -->
