### PR TITLE
chore: use the project's TypeScript version instead of the one bundled with VS Code

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,6 +13,8 @@
   },
   "typescript.preferences.importModuleSpecifier": "non-relative",
   "typescript.updateImportsOnFileMove.enabled": "always",
+  // Use the project's TypeScript version instead of the one bundled with VS Code
+  "typescript.tsdk": "node_modules/typescript/lib",
   "editor.codeActionsOnSave": {
     "source.organizeImports": false
   },


### PR DESCRIPTION
This avoids seeing incorrect TS issues in VS Code.

Taken from https://github.com/valora-inc/typescript-app-starter/pull/33