### PR TITLE
fix(dapps): tweak dapps title and description to match the designs

### DIFF
--- a/src/dappsExplorer/DappCard.tsx
+++ b/src/dappsExplorer/DappCard.tsx
@@ -109,11 +109,12 @@ const styles = StyleSheet.create({
     padding: 0,
   },
   title: {
-    ...fontStyles.small,
+    ...fontStyles.small500,
+    lineHeight: 24,
     color: Colors.dark,
   },
   subtitle: {
-    ...fontStyles.small,
+    ...fontStyles.xsmall,
     color: Colors.gray5,
   },
 })

--- a/src/styles/fonts.tsx
+++ b/src/styles/fonts.tsx
@@ -33,6 +33,12 @@ const standards = {
     fontFamily: Inter.Regular,
     color: colors.dark,
   },
+  xsmall: {
+    fontSize: 12,
+    lineHeight: 16,
+    fontFamily: Inter.Regular,
+    color: colors.dark,
+  },
 }
 // Figma Font Styles
 const fontStyles = StyleSheet.create({
@@ -81,12 +87,15 @@ const fontStyles = StyleSheet.create({
   large: standards.large,
   regular: standards.regular,
   small: standards.small,
+  xsmall: standards.xsmall,
   large600: { ...standards.large, fontFamily: Inter.SemiBold },
   regular600: { ...standards.regular, fontFamily: Inter.SemiBold },
   small600: { ...standards.small, fontFamily: Inter.SemiBold },
+  xsmall600: { ...standards.xsmall, fontFamily: Inter.SemiBold },
   large500: { ...standards.large, fontFamily: Inter.Medium },
   regular500: { ...standards.regular, fontFamily: Inter.Medium },
   small500: { ...standards.small, fontFamily: Inter.Medium },
+  xsmall500: { ...standards.xsmall, fontFamily: Inter.Medium },
   center: {
     textAlign: 'center',
   },


### PR DESCRIPTION
### Description

Following https://github.com/valora-inc/wallet/pull/3499, the dapps screen didn't look good anymore.

Plus, added an `xsmall` font style for places where we need 12px text.

Following the 

### Test plan

**before/after**

<img src="https://user-images.githubusercontent.com/57791/224063403-f448a64f-38a9-4c0b-9330-3ef2c4c639ed.png" width="50%" /><img src="https://user-images.githubusercontent.com/57791/224063534-3c5bdce4-652f-4036-b03c-fbe1d6cf2270.png" width="50%" />

### Related issues

- Discussed with Reed on Slack

### Backwards compatibility

Yes
