### PR TITLE
fix(wc): prevent unhandled errors from cancelling all WC action handlers

### DIFF
--- a/src/walletConnect/v1/saga.ts
+++ b/src/walletConnect/v1/saga.ts
@@ -4,7 +4,7 @@ import '@react-native-firebase/messaging'
 import WalletConnectClient from '@walletconnect/client'
 import { IWalletConnectOptions } from '@walletconnect/legacy-types'
 import { EventChannel, eventChannel } from 'redux-saga'
-import { call, fork, put, select, take, takeEvery } from 'redux-saga/effects'
+import { call, fork, put, select, spawn, take, takeEvery } from 'redux-saga/effects'
 import { WalletConnectEvents } from 'src/analytics/Events'
 import { WalletConnect1Properties } from 'src/analytics/Properties'
 import { WalletConnectPairingOrigin } from 'src/analytics/types'
@@ -19,6 +19,7 @@ import { Screens } from 'src/navigator/Screens'
 import { SentryTransactionHub } from 'src/sentry/SentryTransactionHub'
 import { SentryTransaction } from 'src/sentry/SentryTransactions'
 import Logger from 'src/utils/Logger'
+import { safely } from 'src/utils/safely'
 import {
   getDefaultRequestTrackedPropertiesV1,
   getDefaultSessionTrackedPropertiesV1,
@@ -497,18 +498,18 @@ function* checkPersistedState(): any {
 }
 
 export function* walletConnectV1Saga() {
-  yield takeEvery(Actions.INITIALISE_CONNECTION_V1, handleInitialiseWalletConnect)
+  yield takeEvery(Actions.INITIALISE_CONNECTION_V1, safely(handleInitialiseWalletConnect))
 
-  yield takeEvery(Actions.ACCEPT_SESSION_V1, acceptSession)
-  yield takeEvery(Actions.DENY_SESSION_V1, denySession)
-  yield takeEvery(Actions.CLOSE_SESSION_V1, closeSession)
-  yield takeEvery(Actions.ACCEPT_REQUEST_V1, acceptRequest)
-  yield takeEvery(Actions.DENY_REQUEST_V1, denyRequest)
+  yield takeEvery(Actions.ACCEPT_SESSION_V1, safely(acceptSession))
+  yield takeEvery(Actions.DENY_SESSION_V1, safely(denySession))
+  yield takeEvery(Actions.CLOSE_SESSION_V1, safely(closeSession))
+  yield takeEvery(Actions.ACCEPT_REQUEST_V1, safely(acceptRequest))
+  yield takeEvery(Actions.DENY_REQUEST_V1, safely(denyRequest))
 
-  yield takeEvery(Actions.SESSION_V1, handleSessionRequest)
-  yield takeEvery(Actions.PAYLOAD_V1, handlePayloadRequest)
+  yield takeEvery(Actions.SESSION_V1, safely(handleSessionRequest))
+  yield takeEvery(Actions.PAYLOAD_V1, safely(handlePayloadRequest))
 
-  yield call(checkPersistedState)
+  yield spawn(checkPersistedState)
 }
 
 export function* initialiseWalletConnectV1(uri: string, origin: WalletConnectPairingOrigin) {

--- a/src/walletConnect/v2/saga.ts
+++ b/src/walletConnect/v2/saga.ts
@@ -6,7 +6,17 @@ import SignClient from '@walletconnect/sign-client'
 import { SessionTypes, SignClientTypes } from '@walletconnect/types'
 import { getSdkError } from '@walletconnect/utils'
 import { EventChannel, eventChannel } from 'redux-saga'
-import { call, delay, put, race, select, take, takeEvery, takeLeading } from 'redux-saga/effects'
+import {
+  call,
+  delay,
+  put,
+  race,
+  select,
+  spawn,
+  take,
+  takeEvery,
+  takeLeading,
+} from 'redux-saga/effects'
 import { WalletConnectEvents } from 'src/analytics/Events'
 import { WalletConnect2Properties } from 'src/analytics/Properties'
 import { DappRequestOrigin, WalletConnectPairingOrigin } from 'src/analytics/types'
@@ -20,6 +30,7 @@ import i18n from 'src/i18n'
 import { isBottomSheetVisible, navigate, navigateBack } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import Logger from 'src/utils/Logger'
+import { safely } from 'src/utils/safely'
 import {
   getDefaultRequestTrackedPropertiesV2,
   getDefaultSessionTrackedPropertiesV2,
@@ -551,19 +562,19 @@ function* checkPersistedState() {
 }
 
 export function* walletConnectV2Saga() {
-  yield takeLeading(Actions.INITIALISE_CLIENT_V2, handleInitialiseWalletConnect)
-  yield takeEvery(Actions.INITIALISE_PAIRING_V2, handleInitialisePairing)
-  yield takeEvery(Actions.CLOSE_SESSION_V2, closeSession)
+  yield takeLeading(Actions.INITIALISE_CLIENT_V2, safely(handleInitialiseWalletConnect))
+  yield takeEvery(Actions.INITIALISE_PAIRING_V2, safely(handleInitialisePairing))
+  yield takeEvery(Actions.CLOSE_SESSION_V2, safely(closeSession))
 
-  yield takeEvery(Actions.SESSION_PROPOSAL_V2, handleIncomingSessionRequest)
-  yield takeEvery(Actions.ACCEPT_SESSION_V2, acceptSession)
-  yield takeEvery(Actions.DENY_SESSION_V2, denySession)
+  yield takeEvery(Actions.SESSION_PROPOSAL_V2, safely(handleIncomingSessionRequest))
+  yield takeEvery(Actions.ACCEPT_SESSION_V2, safely(acceptSession))
+  yield takeEvery(Actions.DENY_SESSION_V2, safely(denySession))
 
-  yield takeEvery(Actions.SESSION_PAYLOAD_V2, handleIncomingActionRequest)
-  yield takeEvery(Actions.ACCEPT_REQUEST_V2, handleAcceptRequest)
-  yield takeEvery(Actions.DENY_REQUEST_V2, handleDenyRequest)
+  yield takeEvery(Actions.SESSION_PAYLOAD_V2, safely(handleIncomingActionRequest))
+  yield takeEvery(Actions.ACCEPT_REQUEST_V2, safely(handleAcceptRequest))
+  yield takeEvery(Actions.DENY_REQUEST_V2, safely(handleDenyRequest))
 
-  yield call(checkPersistedState)
+  yield spawn(checkPersistedState)
 }
 
 export function* initialiseWalletConnectV2(uri: string, origin: WalletConnectPairingOrigin) {


### PR DESCRIPTION
### Description

This PR fixes the issue observed where any unhandled error in a WC action handler would cancel all other listeners for WC actions. The only way to recover was to restart the app.

It uses the `safely` helper added in #3526.

Note: there are other places in the codebase suffering from the same issue. We can open additional PRs for them.

### Test plan

- Added unit test

### Related issues

- Fixes RET-654

### Backwards compatibility

Yes