### PR TITLE
fix: ensure pincode buttons fit on all screen sizes

### DIFF
--- a/src/pincode/Pincode.tsx
+++ b/src/pincode/Pincode.tsx
@@ -4,11 +4,13 @@
  */
 import React, { useEffect } from 'react'
 import { Keyboard, StyleSheet, Text, View } from 'react-native'
+import { ScrollView } from 'react-native-gesture-handler'
 import NumberKeypad from 'src/components/NumberKeypad'
 import { PIN_LENGTH } from 'src/pincode/authentication'
 import PincodeDisplay from 'src/pincode/PincodeDisplay'
 import colors from 'src/styles/colors'
 import fontStyles from 'src/styles/fonts'
+import { Spacing } from 'src/styles/styles'
 
 interface Props {
   title?: string // shown as H1
@@ -56,14 +58,14 @@ function Pincode({
 
   return (
     <View style={styles.container}>
-      <View style={styles.titleContainer}>
+      <ScrollView contentContainerStyle={styles.scrollContainer}>
         <Text style={styles.title}>{title}</Text>
         <Text style={styles.subtitle}>{subtitle}</Text>
-      </View>
-      <View style={styles.pincodeContainer}>
-        <PincodeDisplay pin={pin} maxLength={maxLength} />
-      </View>
-      <Text style={styles.error}>{errorText || ' '}</Text>
+        <View style={styles.pincodeContainer}>
+          <PincodeDisplay pin={pin} maxLength={maxLength} />
+        </View>
+        <Text style={styles.error}>{errorText || ''}</Text>
+      </ScrollView>
       <View style={styles.spacer} />
       <NumberKeypad onDigitPress={onDigitPress} onBackspacePress={onBackspacePress} />
     </View>
@@ -81,7 +83,7 @@ const styles = StyleSheet.create({
     ...fontStyles.regular500,
     color: colors.warning,
     textAlign: 'center',
-    marginBottom: 24,
+    marginBottom: Spacing.Thick24,
   },
   pincodeContainer: {
     marginVertical: 48,
@@ -95,11 +97,12 @@ const styles = StyleSheet.create({
   title: {
     ...fontStyles.h1,
     textAlign: 'center',
-    marginBottom: 16,
+    marginBottom: Spacing.Regular16,
   },
-  titleContainer: {
-    marginTop: 76,
-    marginHorizontal: 24,
+  scrollContainer: {
+    flexGrow: 1,
+    justifyContent: 'center',
+    marginHorizontal: Spacing.Thick24,
   },
 })
 

--- a/src/pincode/PincodeSet.tsx
+++ b/src/pincode/PincodeSet.tsx
@@ -270,6 +270,7 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: colors.onboardingBackground,
     justifyContent: 'space-between',
+    paddingTop: 72,
   },
   changePinContainer: {
     flex: 1,


### PR DESCRIPTION
### Description

We need to ensure that the pincode screen content fits on the screen, or else users could be blocked from entering their pincode for transactions.

This PR is a quick solution for now - 
- make the pincode keyboard always available

### Test plan

Tested with iPhone SE (I could repo the original problem with this screen size) with slightly larger device font.

https://user-images.githubusercontent.com/20150449/225001593-4f12f240-e128-44cb-ba86-ad55d492c895.mp4


https://user-images.githubusercontent.com/20150449/225001599-d796f0c7-0cee-43c5-ba87-a7b2dae2bb9b.mp4



https://user-images.githubusercontent.com/20150449/225003939-980fa63f-f633-425d-8da6-9704cbd33370.mp4



### Related issues

- Fixes SUP-62

### Backwards compatibility

Y
