### PR TITLE
fix(logger): `[object Object]` logged instead of the serialized data

### DIFF
--- a/src/utils/Logger.test.ts
+++ b/src/utils/Logger.test.ts
@@ -45,23 +45,29 @@ jest.mock('react-native-fs', () => {
 describe('utils/Logger', () => {
   it('Logger overrides console.debug', () => {
     console.debug = jest.fn()
-    Logger.debug('Test/Debug', 'Test message #1', 'Test message #2')
+    Logger.debug('Test/Debug', 'Test message #1', 'Test message #2', { someVal: 'test' })
     expect(console.debug).toBeCalledTimes(1)
-    expect(console.debug).toHaveBeenCalledWith('Test/Debug/Test message #1, Test message #2')
+    expect(console.debug).toHaveBeenCalledWith('Test/Debug', 'Test message #1', 'Test message #2', {
+      someVal: 'test',
+    })
   })
 
   it('Logger overrides console.info', () => {
     console.info = jest.fn()
-    Logger.info('Test/Info', 'Test message #1', 'Test message #2')
+    Logger.info('Test/Info', 'Test message #1', 'Test message #2', { someVal: 'test' })
     expect(console.info).toBeCalledTimes(1)
-    expect(console.info).toHaveBeenCalledWith('Test/Info/Test message #1, Test message #2')
+    expect(console.info).toHaveBeenCalledWith('Test/Info', 'Test message #1', 'Test message #2', {
+      someVal: 'test',
+    })
   })
 
   it('Logger.warn pipes to console.warn', () => {
     console.warn = jest.fn()
-    Logger.warn('Test/Warn', 'Test message #1', 'Test message #2')
+    Logger.warn('Test/Warn', 'Test message #1', 'Test message #2', { someVal: 'test' })
     expect(console.warn).toBeCalledTimes(1)
-    expect(console.warn).toHaveBeenCalledWith('Test/Warn/Test message #1, Test message #2')
+    expect(console.warn).toHaveBeenCalledWith('Test/Warn', 'Test message #1', 'Test message #2', {
+      someVal: 'test',
+    })
   })
 
   it('Logger.error pipes to console.error', () => {
@@ -99,7 +105,9 @@ describe('utils/Logger', () => {
     await Logger.cleanupOldLogs()
     expect(console.debug).toHaveBeenCalledTimes(1)
     expect(console.debug).toHaveBeenCalledWith(
-      'Logger/cleanupOldLogs/Deleting React Native log file older than 60 days, __CACHES_DIRECTORY_PATH__/rn_logs/toDelete.txt'
+      'Logger/cleanupOldLogs',
+      'Deleting React Native log file older than 60 days',
+      '__CACHES_DIRECTORY_PATH__/rn_logs/toDelete.txt'
     )
   })
 })

--- a/src/utils/Logger.ts
+++ b/src/utils/Logger.ts
@@ -33,21 +33,21 @@ class Logger {
     if (this.level < LoggerLevel.Debug) {
       return
     }
-    console.debug(`${tag}/${messages.join(', ')}`)
+    console.debug(tag, ...messages)
   }
 
   info = (tag: string, ...messages: any[]) => {
     if (this.level < LoggerLevel.Info) {
       return
     }
-    console.info(`${tag}/${messages.join(', ')}`)
+    console.info(tag, ...messages)
   }
 
   warn = (tag: string, ...messages: any[]) => {
     if (this.level < LoggerLevel.Warn) {
       return
     }
-    console.warn(`${tag}/${messages.join(', ')}`)
+    console.warn(tag, ...messages)
   }
 
   error = (
@@ -57,7 +57,6 @@ class Logger {
     shouldSanitizeError = false,
     valueToPurge?: string
   ) => {
-    // console.error would display red box, therefore, we will log to console.info instead.
     const sanitizedError =
       error && shouldSanitizeError ? this.sanitizeError(error, valueToPurge) : error
     const errorMsg = this.getErrorMessage(sanitizedError)


### PR DESCRIPTION
### Description

Long time issue finally fixed 😅 
Letting `console` do its job is better.

See also: #3546

### Test plan

**before**

```
 DEBUG  [08:35:39.590Z] iPhone 13 TEST/This is Logger.debug, [object Object]
 INFO   [08:35:39.591Z] iPhone 13 TEST/This is Logger.info, [object Object]
 WARN   [08:35:39.591Z] iPhone 13 TEST/This is Logger.warn, [object Object]
 ERROR  [08:35:39.595Z] iPhone 13 TEST :: This is Logger.error :: Test error in rootSaga$@http://localhost:8081/index.bundle?platform=ios&dev=true&minify=false&modulesOnly=false&ru :: network connected true
```

**after**

```
 DEBUG  [08:37:33.787Z] iPhone 13 TEST This is Logger.debug {"someVal": "test"}
 INFO   [08:37:33.792Z] iPhone 13 TEST This is Logger.info {"someVal": "test"}
 WARN   [08:37:33.793Z] iPhone 13 TEST This is Logger.warn {"someVal": "test"}
 ERROR  [08:37:33.797Z] iPhone 13 TEST :: This is Logger.error :: Test error in rootSaga$@http://localhost:8081/index.bundle?platform=ios&dev=true&minify=false&modulesOnly=false&ru :: network connected true
```

### Related issues

- Fixes RET-648

### Backwards compatibility

Not entirely as the data in the log file will change a bit, this shouldn't affect anything though.
