### PR TITLE
chore(logs): remove unnecessary stringification

### DIFF
--- a/src/analytics/ValoraAnalytics.ts
+++ b/src/analytics/ValoraAnalytics.ts
@@ -195,7 +195,7 @@ class ValoraAnalytics {
       ...eventProperties,
     }
 
-    Logger.info(TAG, `Tracking event ${eventName} with properties: ${JSON.stringify(props)}`)
+    Logger.info(TAG, `Tracking event ${eventName} with properties:`, props)
 
     Analytics.track(eventName, props).catch((err) => {
       Logger.error(TAG, `Failed to track event ${eventName}`, err)

--- a/src/consumerIncentives/saga.ts
+++ b/src/consumerIncentives/saga.ts
@@ -110,7 +110,7 @@ function* claimReward(reward: SuperchargePendingReward, index: number, baseNonce
   const tokens: TokenBalances = yield select(tokensByAddressSelector)
   const walletAddress: string = yield call(getConnectedUnlockedAccount)
 
-  Logger.debug(TAG, `Start claiming reward at index ${index}: ${JSON.stringify(reward)}`)
+  Logger.debug(TAG, `Start claiming reward at index ${index}:`, reward)
   const merkleContract: Contract = yield call(
     getContract,
     merkleDistributor.abi,
@@ -132,7 +132,7 @@ function* claimReward(reward: SuperchargePendingReward, index: number, baseNonce
     undefined,
     baseNonce + index
   )
-  Logger.info(TAG, `Claimed reward at index ${index}: ${JSON.stringify(receipt)}`)
+  Logger.info(TAG, `Claimed reward at index ${index}:`, receipt)
   const amount = new BigNumber(reward.amount, 16).div(WEI_PER_TOKEN).toString()
   const tokenAddress = reward.tokenAddress.toLowerCase()
   ValoraAnalytics.track(RewardsEvents.claimed_reward, {
@@ -166,7 +166,7 @@ function* claimRewardV2(reward: SuperchargePendingRewardV2, index: number, baseN
   const tokens: TokenBalances = yield select(tokensByAddressSelector)
   const walletAddress: string = yield call(getConnectedUnlockedAccount)
 
-  Logger.debug(TAG, `Start claiming reward at index ${index}: ${JSON.stringify(reward)}`)
+  Logger.debug(TAG, `Start claiming reward at index ${index}:`, reward)
 
   const normalizer = new TxParamsNormalizer(kit.connection)
   const tx: CeloTx = yield call([normalizer, 'populate'], transaction)
@@ -182,7 +182,7 @@ function* claimRewardV2(reward: SuperchargePendingRewardV2, index: number, baseN
     undefined,
     baseNonce + index
   )
-  Logger.info(TAG, `Claimed reward at index ${index}: ${JSON.stringify(receipt)}`)
+  Logger.info(TAG, `Claimed reward at index ${index}:`, receipt)
   const amount = new BigNumber(details.amount).div(WEI_PER_TOKEN).toString()
   const tokenAddress = details.tokenAddress.toLowerCase()
   ValoraAnalytics.track(RewardsEvents.claimed_reward, {

--- a/src/dappkit/dappkit.ts
+++ b/src/dappkit/dappkit.ts
@@ -155,7 +155,7 @@ function* produceTxSignature(action: RequestTxSignatureAction) {
         if (tx.to) {
           params.to = tx.to
         }
-        Logger.debug(TAG, 'Signing tx with params', JSON.stringify(params))
+        Logger.debug(TAG, 'Signing tx with params', params)
         const signedTx = await web3.eth.signTransaction(params)
         return signedTx.raw
       })

--- a/src/fiatconnect/saga.ts
+++ b/src/fiatconnect/saga.ts
@@ -926,7 +926,7 @@ export function* _initiateTransferWithProvider({
   }
   const transferResult = result.unwrap()
 
-  Logger.info(TAG, `${transferFnName} succeeded`, JSON.stringify(transferResult))
+  Logger.info(TAG, `${transferFnName} succeeded`, transferResult)
   return transferResult
 }
 

--- a/src/firebase/firebase.ts
+++ b/src/firebase/firebase.ts
@@ -77,7 +77,7 @@ export function* checkInitialNotification() {
     ReturnType<FirebaseMessagingTypes.Module['getInitialNotification']>
   > = yield call([firebase.messaging(), 'getInitialNotification'])
   if (initialNotification) {
-    Logger.info(TAG, 'App opened fresh via a notification', JSON.stringify(initialNotification))
+    Logger.info(TAG, 'App opened fresh via a notification', initialNotification)
     yield call(handleNotification, initialNotification, NotificationReceiveState.AppColdStart)
   }
 }
@@ -245,7 +245,7 @@ export async function fetchRemoteConfigValues(): Promise<RemoteConfigValues | nu
   await remoteConfig().fetchAndActivate()
 
   const flags: FirebaseRemoteConfigTypes.ConfigValues = remoteConfig().getAll()
-  Logger.debug(TAG, `Updated remote config values: ${JSON.stringify(flags)}`)
+  Logger.debug(TAG, `Updated remote config values:`, flags)
 
   // When adding a new remote config value there are 2 places that need updating:
   // the RemoteConfigValues interface as well as the REMOTE_CONFIG_VALUES_DEFAULTS map
@@ -382,7 +382,7 @@ export function simpleReadChannel(key: string) {
   return eventChannel((emit: any) => {
     const emitter = (snapshot: FirebaseDatabaseTypes.DataSnapshot) => {
       const value = snapshot.val()
-      Logger.debug(`Got value from Firebase for key ${key}: ${JSON.stringify(value)}`)
+      Logger.debug(`Got value from Firebase for key ${key}:`, value)
       emit(value || {})
     }
 

--- a/src/redux/sagas.ts
+++ b/src/redux/sagas.ts
@@ -81,7 +81,7 @@ function* loggerSaga() {
       return
     }
     try {
-      Logger.debug('redux/saga@logger', JSON.stringify(action))
+      Logger.debug('redux/saga@logger', action)
     } catch (err) {
       Logger.warn('redux/saga@logger', 'could not log action of type', action.type)
     }

--- a/src/send/saga.ts
+++ b/src/send/saga.ts
@@ -150,7 +150,7 @@ export function* watchQrCodeShare() {
     try {
       const result = yield call(shareSVGImage, action.qrCodeSvg)
       // Note: when user cancels the share sheet, result contains {"dismissedAction":true}
-      Logger.info(TAG, 'Share done', JSON.stringify(result))
+      Logger.info(TAG, 'Share done', result)
     } catch (error) {
       Logger.error(TAG, 'Error sharing qr code', error)
     }
@@ -277,7 +277,7 @@ export function* buildAndSendPayment(
     context.id,
     tokenAddress,
     amount,
-    JSON.stringify(feeInfo)
+    feeInfo
   )
 
   yield put(

--- a/src/tokens/saga.ts
+++ b/src/tokens/saga.ts
@@ -167,7 +167,7 @@ export function tokenTransferFactory({ actionName, tag }: TokenTransferFactory) 
         context.id,
         currency,
         amount,
-        feeInfo ? JSON.stringify(feeInfo) : 'undefined'
+        feeInfo
       )
 
       yield put(

--- a/src/transactions/feed/queryHelper.ts
+++ b/src/transactions/feed/queryHelper.ts
@@ -213,13 +213,11 @@ async function queryTransactionsFeed(
   localCurrencyCode: string,
   afterCursor?: string
 ) {
-  Logger.info(
-    `Request to fetch transactions with params: ${JSON.stringify({
-      address,
-      localCurrencyCode,
-      afterCursor,
-    })}`
-  )
+  Logger.info(`Request to fetch transactions with params:`, {
+    address,
+    localCurrencyCode,
+    afterCursor,
+  })
   const response = await fetch(`${config.blockchainApiUrl}/graphql`, {
     method: 'POST',
     headers: {

--- a/src/transactions/send.ts
+++ b/src/transactions/send.ts
@@ -82,10 +82,7 @@ const getLogger = (context: TransactionContext) => {
         ValoraAnalytics.track(TransactionEvents.transaction_confirmed, { txId })
         break
       case SendTransactionLogEventType.ReceiptReceived:
-        Logger.debug(
-          tag,
-          `Transaction id ${txId} received receipt: ${JSON.stringify(event.receipt)}`
-        )
+        Logger.debug(tag, `Transaction id ${txId} received receipt:`, event.receipt)
         ValoraAnalytics.track(TransactionEvents.transaction_receipt_received, { txId })
         break
       case SendTransactionLogEventType.Failed:
@@ -96,7 +93,7 @@ const getLogger = (context: TransactionContext) => {
         })
         break
       case SendTransactionLogEventType.Exception:
-        Logger.error(tag, `Transaction Exception caught ${txId}: `, event.error)
+        Logger.error(tag, `Transaction Exception caught ${txId}:`, event.error)
         ValoraAnalytics.track(TransactionEvents.transaction_exception, {
           txId,
           error: event.error.message,

--- a/src/walletConnect/v1/saga.ts
+++ b/src/walletConnect/v1/saga.ts
@@ -313,11 +313,7 @@ function applyIconFixIfNeeded(session: WalletConnectSessionRequest | WalletConne
 
 // eslint-disable-next-line require-yield
 function* createWalletConnectChannelWithArgs(connectorOpts: IWalletConnectOptions) {
-  Logger.info(
-    TAG + '@createWalletConnectChannelWithArgs',
-    'Creating Wallet',
-    JSON.stringify(connectorOpts)
-  )
+  Logger.info(TAG + '@createWalletConnectChannelWithArgs', 'Creating Wallet', connectorOpts)
   return eventChannel((emit: any) => {
     const connector = new WalletConnectClient({
       ...connectorOpts,

--- a/src/web3/KeychainSigner.ts
+++ b/src/web3/KeychainSigner.ts
@@ -70,7 +70,8 @@ async function getStoredPrivateKey(
 ): Promise<string | null> {
   Logger.debug(
     `${TAG}@getStoredPrivateKey`,
-    `Checking keychain for private key for account ${JSON.stringify(account)}`
+    `Checking keychain for private key for account`,
+    account
   )
   const encryptedPrivateKey = await retrieveStoredItem(accountStorageKey(account))
   if (!encryptedPrivateKey) {
@@ -197,10 +198,7 @@ export class KeychainSigner implements Signer {
     addToV: number,
     encodedTx: RLPEncodedTx
   ): Promise<{ v: number; r: Buffer; s: Buffer }> {
-    Logger.info(
-      `${TAG}@signTransaction`,
-      `Signing transaction: ${JSON.stringify(encodedTx.transaction)}`
-    )
+    Logger.info(`${TAG}@signTransaction`, `Signing transaction:`, encodedTx.transaction)
     const { gasPrice } = encodedTx.transaction
     const gasPriceBN = new BigNumber((gasPrice || 0).toString())
     if (gasPriceBN.isNaN() || gasPriceBN.isLessThanOrEqualTo(0)) {
@@ -218,10 +216,7 @@ export class KeychainSigner implements Signer {
   }
 
   async signTypedData(typedData: EIP712TypedData): Promise<{ v: number; r: Buffer; s: Buffer }> {
-    Logger.info(
-      `${TAG}@signTypedData`,
-      `Signing typed DATA: ${JSON.stringify({ address: this.account, typedData })}`
-    )
+    Logger.info(`${TAG}@signTypedData`, `Signing typed DATA:`, { address: this.account, typedData })
     return this.localSigner.signTypedData(typedData)
   }
 

--- a/src/web3/contracts.ts
+++ b/src/web3/contracts.ts
@@ -56,11 +56,7 @@ export function* initContractKit() {
       address: walletAddress,
       createdAt: new Date(accountCreationTime),
     }
-    Logger.info(
-      `${TAG}@initContractKit`,
-      'Initializing wallet',
-      JSON.stringify(importMnemonicAccount)
-    )
+    Logger.info(`${TAG}@initContractKit`, 'Initializing wallet', importMnemonicAccount)
 
     wallet = yield call(initWallet, importMnemonicAccount)
 


### PR DESCRIPTION
### Description

Following #3545, we no longer need to stringify objects passed to our logger.

### Test plan

- Manually checked logs have all the info needed

### Related issues

- Fixes RET-648

### Backwards compatibility

Not entirely as the data in log file will change a bit, this shouldn't affect anything though.