### PR TITLE
chore(statsig): setup feature gate for bitmama widget

### DIFF
--- a/src/fiatExchanges/SelectProvider.test.tsx
+++ b/src/fiatExchanges/SelectProvider.test.tsx
@@ -17,6 +17,7 @@ import {
   fetchExchanges,
   fetchLegacyMobileMoneyProviders,
   fetchProviders,
+  filterByFeatureFlags,
   LegacyMobileMoneyProvider,
 } from './utils'
 
@@ -30,6 +31,7 @@ jest.mock('./utils', () => ({
   fetchProviders: jest.fn(),
   fetchLegacyMobileMoneyProviders: jest.fn(),
   fetchExchanges: jest.fn(),
+  filterByFeatureFlags: jest.fn().mockImplementation((providers) => providers),
 }))
 
 jest.mock('@coinbase/cbpay-js', () => {
@@ -118,6 +120,7 @@ describe(SelectProviderScreen, () => {
   })
 
   it('calls fetchProviders correctly', async () => {
+    ;(fetchProviders as jest.Mock).mockImplementation(() => mockProviders)
     render(
       <Provider store={mockStore}>
         <SelectProviderScreen {...mockScreenProps()} />
@@ -138,6 +141,7 @@ describe(SelectProviderScreen, () => {
         walletAddress: mockAccount.toLowerCase(),
       })
     )
+    expect(filterByFeatureFlags).toHaveBeenCalledWith(mockProviders)
   })
   it('calls fetchExchanges correctly', async () => {
     render(

--- a/src/fiatExchanges/SelectProvider.tsx
+++ b/src/fiatExchanges/SelectProvider.tsx
@@ -6,7 +6,6 @@ import { useTranslation } from 'react-i18next'
 import { ActivityIndicator, ScrollView, StyleSheet, Text, View } from 'react-native'
 import { useDispatch, useSelector } from 'react-redux'
 import { showError } from 'src/alert/actions'
-import { ExperimentConfigs } from 'src/statsig/constants'
 import { FiatExchangeEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import { ErrorMessages } from 'src/app/ErrorMessages'
@@ -36,6 +35,9 @@ import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import { StackParamList } from 'src/navigator/types'
 import { userLocationDataSelector } from 'src/networkInfo/selectors'
+import { getExperimentParams } from 'src/statsig'
+import { ExperimentConfigs } from 'src/statsig/constants'
+import { StatsigExperiments } from 'src/statsig/types'
 import colors from 'src/styles/colors'
 import fontStyles from 'src/styles/fonts'
 import variables from 'src/styles/variables'
@@ -49,14 +51,13 @@ import {
   fetchLegacyMobileMoneyProviders,
   fetchProviders,
   FiatExchangeFlow,
+  filterByFeatureFlags,
   filterLegacyMobileMoneyProviders,
   filterProvidersByPaymentMethod,
   LegacyMobileMoneyProvider,
   PaymentMethod,
   resolveCloudFunctionDigitalAsset,
 } from './utils'
-import { StatsigExperiments } from 'src/statsig/types'
-import { getExperimentParams } from 'src/statsig'
 
 const TAG = 'SelectProviderScreen'
 
@@ -149,7 +150,10 @@ export default function SelectProviderScreen({ route, navigation }: Props) {
         userLocation.countryCodeAlpha2,
         digitalAsset
       )
-      return { externalProviders, legacyMobileMoneyProviders }
+      return {
+        externalProviders: filterByFeatureFlags(externalProviders),
+        legacyMobileMoneyProviders,
+      }
     } catch (error) {
       dispatch(showError(ErrorMessages.PROVIDER_FETCH_FAILED))
     }

--- a/src/fiatExchanges/utils.test.ts
+++ b/src/fiatExchanges/utils.test.ts
@@ -1,0 +1,24 @@
+import { filterByFeatureFlags } from 'src/fiatExchanges/utils'
+import { getFeatureGate } from 'src/statsig'
+import { mockProviders } from 'test/values'
+
+jest.mock('src/statsig')
+
+describe('filterByFeatureFlags', () => {
+  it('returns undefined if no providers are passed in', () => {
+    const filterdProviders = filterByFeatureFlags(undefined)
+    expect(filterdProviders).toBeUndefined()
+  })
+  it('filters out bitmama widget if feature flag is false', () => {
+    ;(getFeatureGate as jest.Mock).mockImplementation(() => false)
+    const filterdProviders = filterByFeatureFlags(mockProviders)
+    expect(filterdProviders).toEqual(
+      mockProviders.filter((provider) => provider.name !== 'Bitmama')
+    )
+  })
+  it('does not filter out bitmama widget if feature flag is true', () => {
+    ;(getFeatureGate as jest.Mock).mockImplementation(() => true)
+    const filterdProviders = filterByFeatureFlags(mockProviders)
+    expect(filterdProviders).toEqual(mockProviders)
+  })
+})

--- a/src/fiatExchanges/utils.tsx
+++ b/src/fiatExchanges/utils.tsx
@@ -4,6 +4,8 @@ import { FIREBASE_ENABLED } from 'src/config'
 import { ExternalExchangeProvider } from 'src/fiatExchanges/ExternalExchanges'
 import { LocalCurrencyCode } from 'src/localCurrency/consts'
 import { UserLocationData } from 'src/networkInfo/saga'
+import { getFeatureGate } from 'src/statsig'
+import { StatsigFeatureGates } from 'src/statsig/types'
 import { CiCoCurrency, Currency } from 'src/utils/currencies'
 import { fetchWithTimeout } from 'src/utils/fetchWithTimeout'
 import Logger from 'src/utils/Logger'
@@ -311,4 +313,19 @@ export function resolveCloudFunctionDigitalAsset(
     [CiCoCurrency.cREAL]: CloudFunctionDigitalAsset.CREAL,
   }
   return mapping[currency]
+}
+
+// Filters out providers that are disabled by feature flags
+export const filterByFeatureFlags = (externalProviders?: FetchProvidersOutput[]) => {
+  const providerFlagMap: { [key: string]: boolean } = {
+    Bitmama: getFeatureGate(StatsigFeatureGates.SHOULD_SHOW_BITMAMA_WIDGET),
+  }
+
+  return externalProviders?.filter((provider) => {
+    const providerName = provider.name
+    if (providerName in providerFlagMap) {
+      return providerFlagMap[providerName]
+    }
+    return true
+  })
 }

--- a/src/statsig/index.test.ts
+++ b/src/statsig/index.test.ts
@@ -99,14 +99,14 @@ describe('Statsig helpers', () => {
       ;(Statsig.checkGate as jest.Mock).mockImplementation(() => {
         throw new Error('mock error')
       })
-      const featureName = StatsigFeatureGates.SHOULD_SHOW_BITMAMMA_WIDGET
+      const featureName = StatsigFeatureGates.SHOULD_SHOW_BITMAMA_WIDGET
       const output = getFeatureGate(featureName)
       expect(Logger.warn).toHaveBeenCalled()
       expect(output).toEqual(false)
     })
     it('returns Statsig value if no error is thrown', () => {
       ;(Statsig.checkGate as jest.Mock).mockImplementation(() => true)
-      const featureName = StatsigFeatureGates.SHOULD_SHOW_BITMAMMA_WIDGET
+      const featureName = StatsigFeatureGates.SHOULD_SHOW_BITMAMA_WIDGET
       const output = getFeatureGate(featureName)
       expect(Logger.warn).not.toHaveBeenCalled()
       expect(Statsig.checkGate).toHaveBeenCalledWith(featureName)

--- a/src/statsig/index.test.ts
+++ b/src/statsig/index.test.ts
@@ -1,6 +1,6 @@
 import { DynamicConfigs, ExperimentConfigs } from 'src/statsig/constants'
-import { getDynamicConfigParams, getExperimentParams } from 'src/statsig/index'
-import { StatsigDynamicConfigs, StatsigExperiments } from 'src/statsig/types'
+import { getDynamicConfigParams, getExperimentParams, getFeatureGate } from 'src/statsig/index'
+import { StatsigDynamicConfigs, StatsigExperiments, StatsigFeatureGates } from 'src/statsig/types'
 import Logger from 'src/utils/Logger'
 import { Statsig } from 'statsig-react-native'
 
@@ -92,6 +92,25 @@ describe('Statsig helpers', () => {
       expect(getMock).toHaveBeenCalledWith('param1', 'defaultValue1')
       expect(getMock).toHaveBeenCalledWith('param2', 'defaultValue2')
       expect(output).toEqual({ param1: 'statsigValue1', param2: 'statsigValue2' })
+    })
+  })
+  describe('getFeatureGate', () => {
+    it('returns false if getting statsig feature gate throws error', () => {
+      ;(Statsig.checkGate as jest.Mock).mockImplementation(() => {
+        throw new Error('mock error')
+      })
+      const featureName = StatsigFeatureGates.SHOULD_SHOW_BITMAMMA_WIDGET
+      const output = getFeatureGate(featureName)
+      expect(Logger.warn).toHaveBeenCalled()
+      expect(output).toEqual(false)
+    })
+    it('returns Statsig value if no error is thrown', () => {
+      ;(Statsig.checkGate as jest.Mock).mockImplementation(() => true)
+      const featureName = StatsigFeatureGates.SHOULD_SHOW_BITMAMMA_WIDGET
+      const output = getFeatureGate(featureName)
+      expect(Logger.warn).not.toHaveBeenCalled()
+      expect(Statsig.checkGate).toHaveBeenCalledWith(featureName)
+      expect(output).toEqual(true)
     })
   })
 })

--- a/src/statsig/index.ts
+++ b/src/statsig/index.ts
@@ -1,4 +1,9 @@
-import { StatsigDynamicConfigs, StatsigExperiments, StatsigParameter } from 'src/statsig/types'
+import {
+  StatsigDynamicConfigs,
+  StatsigExperiments,
+  StatsigFeatureGates,
+  StatsigParameter,
+} from 'src/statsig/types'
 import Logger from 'src/utils/Logger'
 import { DynamicConfig, Statsig } from 'statsig-react-native'
 
@@ -50,5 +55,14 @@ export function getDynamicConfigParams<T extends Record<string, StatsigParameter
   } catch (error) {
     Logger.warn('getDynamicConfig', `Error getting experiment params`, error)
     return defaultValues
+  }
+}
+
+export function getFeatureGate(featureGateName: StatsigFeatureGates) {
+  try {
+    return Statsig.checkGate(featureGateName)
+  } catch (error) {
+    Logger.warn('getFeatureGate', `Error getting feature gate`, error)
+    return false
   }
 }

--- a/src/statsig/types.ts
+++ b/src/statsig/types.ts
@@ -16,6 +16,10 @@ export enum StatsigDynamicConfigs {
   USERNAME_BLOCK_LIST = 'username_block_list',
 }
 
+export enum StatsigFeatureGates {
+  SHOULD_SHOW_BITMAMMA_WIDGET = 'should_show_bitmamma_widget',
+}
+
 export enum StatsigExperiments {
   ADD_FUNDS_CRYPTO_EXCHANGE_QR_CODE = 'add_funds_crypto_exchange_qr_code',
   RECOVERY_PHRASE_IN_ONBOARDING = 'recovery_phrase_in_onboarding',

--- a/src/statsig/types.ts
+++ b/src/statsig/types.ts
@@ -17,7 +17,7 @@ export enum StatsigDynamicConfigs {
 }
 
 export enum StatsigFeatureGates {
-  SHOULD_SHOW_BITMAMMA_WIDGET = 'should_show_bitmamma_widget',
+  SHOULD_SHOW_BITMAMA_WIDGET = 'should_show_bitmama_widget',
 }
 
 export enum StatsigExperiments {

--- a/test/values.ts
+++ b/test/values.ts
@@ -690,6 +690,19 @@ export const mockProviders: FetchProvidersOutput[] = [
     cashIn: false,
     cashOut: true,
   },
+  {
+    name: 'Bitmama',
+    restricted: false,
+    unavailable: false,
+    paymentMethods: [PaymentMethod.Card, PaymentMethod.Bank],
+    url: 'www.fakewebsite.com',
+    logo: 'https://firebasestorage.googleapis.com/v0/b/celo-mobile-mainnet.appspot.com/o/images%2Framp.png?alt=media',
+    logoWide:
+      'https://firebasestorage.googleapis.com/v0/b/celo-mobile-mainnet.appspot.com/o/images%2Fsimplex.jpg?alt=media',
+    quote: [],
+    cashIn: false,
+    cashOut: true,
+  },
 ]
 
 export const mockFiatConnectProviderImage =


### PR DESCRIPTION
### Description

Setup a light helper for feature gates and [this feature gate](https://console.statsig.com/4plizaPmWwPL21ASV4QAO0/gates/should_show_bitmama_widget)

Integrate into select providers to filter bitmama widget

### Test plan

unit tests added

### Related issues

https://linear.app/valora/issue/ACT-667/statsig-dynamic-config-for-whitelisting-tester-addresses-for-widget

### Backwards compatibility

Yes