### PR TITLE
chore: remove supercharge from redux persist blacklist

### DIFF
--- a/src/consumerIncentives/slice.ts
+++ b/src/consumerIncentives/slice.ts
@@ -78,24 +78,25 @@ const slice = createSlice({
     }),
   },
   extraReducers: (builder) => {
-    builder.addCase(REHYDRATE, (state, action: RehydrateAction) => ({
-      ...state,
-      ...getRehydratePayload(action, 'supercharge'),
-      loading: false,
-      error: false,
-      fetchAvailableRewardsLoading: false,
-      fetchAvailableRewardsError: false,
-      availableRewards: [],
-    }))
-    builder.addCase(
-      AppActions.UPDATE_REMOTE_CONFIG_VALUES,
-      (state, action: UpdateConfigValuesAction) => {
-        state.superchargeV2Enabled = action.configValues.superchargeV2Enabled
-        state.superchargeRewardContractAddress =
-          action.configValues.superchargeRewardContractAddress
-        state.superchargeV1Addresses = action.configValues.superchargeV1Addresses
-      }
-    )
+    builder
+      .addCase(REHYDRATE, (state, action: RehydrateAction) => ({
+        ...state,
+        ...getRehydratePayload(action, 'supercharge'),
+        loading: false,
+        error: false,
+        fetchAvailableRewardsLoading: false,
+        fetchAvailableRewardsError: false,
+        availableRewards: [],
+      }))
+      .addCase(
+        AppActions.UPDATE_REMOTE_CONFIG_VALUES,
+        (state, action: UpdateConfigValuesAction) => {
+          state.superchargeV2Enabled = action.configValues.superchargeV2Enabled
+          state.superchargeRewardContractAddress =
+            action.configValues.superchargeRewardContractAddress
+          state.superchargeV1Addresses = action.configValues.superchargeV1Addresses
+        }
+      )
   },
 })
 

--- a/src/consumerIncentives/slice.ts
+++ b/src/consumerIncentives/slice.ts
@@ -1,6 +1,8 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import { REHYDRATE, RehydrateAction } from 'redux-persist'
 import { Actions as AppActions, UpdateConfigValuesAction } from 'src/app/actions'
 import { SuperchargePendingReward, SuperchargePendingRewardV2 } from 'src/consumerIncentives/types'
+import { getRehydratePayload } from 'src/redux/persist-helper'
 
 export interface State {
   loading: boolean
@@ -76,6 +78,15 @@ const slice = createSlice({
     }),
   },
   extraReducers: (builder) => {
+    builder.addCase(REHYDRATE, (state, action: RehydrateAction) => ({
+      ...state,
+      ...getRehydratePayload(action, 'supercharge'),
+      loading: false,
+      error: false,
+      fetchAvailableRewardsLoading: false,
+      fetchAvailableRewardsError: false,
+      availableRewards: [],
+    }))
     builder.addCase(
       AppActions.UPDATE_REMOTE_CONFIG_VALUES,
       (state, action: UpdateConfigValuesAction) => {

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -26,7 +26,7 @@ const persistConfig: PersistConfig<RootState> = {
   version: 119,
   keyPrefix: `reduxStore-`, // the redux-persist default is `persist:` which doesn't work with some file systems.
   storage: FSStorage(),
-  blacklist: ['networkInfo', 'alert', 'imports', 'supercharge', 'swap'],
+  blacklist: ['networkInfo', 'alert', 'imports', 'swap'],
   stateReconciler: autoMergeLevel2,
   migrate: async (...args) => {
     const migrate = createMigrate(migrations)


### PR DESCRIPTION
### Description

To ensure that remote config values in the store are persisted (and we don't always hit the v1 supercharge endpoint for no reason once v2 is enabled.)

### Test plan

Manually tested

### Related issues

n/a

### Backwards compatibility

Y
