### PR TITLE
fix: flakey offramps test for link at bottom of screen

### DIFF
--- a/e2e/src/usecases/OffRamps.js
+++ b/e2e/src/usecases/OffRamps.js
@@ -14,7 +14,8 @@ export default offRamps = () => {
 
   describe('When on Add & Withdraw', () => {
     it('Then should have support link', async () => {
-      await waitForElementId('otherFundingOptions')
+      await element(by.id('FiatExchange/scrollView')).scrollTo('bottom')
+      await expect(element(by.id('otherFundingOptions'))).toBeVisible()
     })
 
     it('Then should display total balance and navigate back', async () => {

--- a/src/account/FiatExchange.tsx
+++ b/src/account/FiatExchange.tsx
@@ -73,7 +73,7 @@ function FiatExchange() {
   return (
     <SafeAreaView style={styles.container}>
       <DrawerTopBar />
-      <ScrollView contentContainerStyle={styles.contentContainer}>
+      <ScrollView testID="FiatExchange/scrollView" contentContainerStyle={styles.contentContainer}>
         <View style={styles.headerContainer}>
           <FiatExchangeTokenBalance key={'FiatExchangeTokenBalance'} />
           <Image source={fiatExchange} style={styles.image} resizeMode={'contain'} />


### PR DESCRIPTION
### Description

This offramps iOS e2e test has been failing a lot recently, it is checking for the support link at the bottom of the screen
and we reduced the screensize that we run the CI against in iOS recently.

This PR adds a scroll before checking for the support link.


### Test plan

Examples of failing CI: https://github.com/valora-inc/wallet/actions/runs/4510490052/jobs/7942102524?pr=3583, https://github.com/valora-inc/wallet/actions/runs/4528001939/jobs/7979587903?pr=3577

screenshot of the error. note that the element that the test cannot find is the "How to fund your account" text at the very bottom.
<img src="https://user-images.githubusercontent.com/20150449/227910471-4605c1cf-dc56-429b-8c1c-f5b42d9cbb99.png" width=200 />

### Related issues

n/a

### Backwards compatibility

Y
