### PR TITLE
fix(deps): patch for rn to fix on-drag keyboard dismiss on android

### DIFF
--- a/patches/react-native+0.66.4.patch
+++ b/patches/react-native+0.66.4.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/react-native/Libraries/Components/ScrollView/ScrollView.js b/node_modules/react-native/Libraries/Components/ScrollView/ScrollView.js
-index e497288..696781f 100644
+index e497288..083485f 100644
 --- a/node_modules/react-native/Libraries/Components/ScrollView/ScrollView.js
 +++ b/node_modules/react-native/Libraries/Components/ScrollView/ScrollView.js
 @@ -1178,11 +1178,6 @@ class ScrollView extends React.Component<Props, State> {
@@ -14,11 +14,12 @@ index e497288..696781f 100644
      this._observedScrollSinceBecomingResponder = true;
      this.props.onScroll && this.props.onScroll(e);
    };
-@@ -1299,6 +1294,14 @@ class ScrollView extends React.Component<Props, State> {
+@@ -1299,6 +1294,15 @@ class ScrollView extends React.Component<Props, State> {
     */
    _handleScrollBeginDrag: (e: ScrollEvent) => void = (e: ScrollEvent) => {
      FrameRateLogger.beginScroll(); // TODO: track all scrolls after implementing onScrollEndAnimation
-+
++    // Patch from rn fix on main
++    // https://github.com/facebook/react-native/commit/7edf9274cf6d3398075c19cd1cb020a5d6a346a2
 +    if (
 +      Platform.OS === 'android' &&
 +      this.props.keyboardDismissMode === 'on-drag'


### PR DESCRIPTION
### Description

Broken out from #3576. This includes the react native patch for the `on-drag` option of `keyboardDismissMode`. Without this patch the keyboard remains displayed even if `keyboardDismissMode='on-drag'` is set on Android devices.

Patch was merged into react-native main in [7edf9274cf6d3398075c19cd1cb020a5d6a346a2](https://github.com/facebook/react-native/commit/7edf9274cf6d3398075c19cd1cb020a5d6a346a2).

### Test plan

- Tested locally on Android in #3576 after typing in a search input and scrolling.
- Can also be tested by adding `keyboardDismissMode='on-drag'` in [VerificationStartScreen.tsx](https://github.com/valora-inc/wallet/blob/main/src/verify/VerificationStartScreen.tsx#L234).

### Related issues

N/A

### Backwards compatibility

Yes