### PR TITLE
feat(home): Hide nav bar in home screen actions experiment

### DIFF
--- a/src/home/WalletHome.test.tsx
+++ b/src/home/WalletHome.test.tsx
@@ -9,6 +9,8 @@ import { Actions as IdentityActions } from 'src/identity/actions'
 import { RootState } from 'src/redux/reducers'
 import { createMockStore, flushMicrotasksQueue, RecursivePartial } from 'test/utils'
 import { mockCeurAddress, mockCusdAddress } from 'test/values'
+import { getExperimentParams } from 'src/statsig'
+import { mocked } from 'ts-jest/utils'
 
 const mockBalances = {
   tokens: {
@@ -88,7 +90,10 @@ const recentDappIds = [dapp.id, deepLinkedDapp.id]
 jest.mock('src/exchange/CeloGoldOverview', () => 'CeloGoldOverview')
 jest.mock('src/transactions/TransactionsList', () => 'TransactionsList')
 jest.mock('src/statsig', () => ({
-  getExperimentParams: jest.fn(() => ({ cashInBottomSheetEnabled: true })),
+  getExperimentParams: jest.fn(() => ({
+    showHomeNavBar: true,
+    cashInBottomSheetEnabled: true,
+  })),
 }))
 describe('WalletHome', () => {
   const mockFetch = fetch as FetchMock
@@ -173,6 +178,20 @@ describe('WalletHome', () => {
         },
       ]
     `)
+  })
+
+  it('hides sections', async () => {
+    mocked(getExperimentParams)
+      .mockReturnValueOnce({
+        showHomeNavBar: false,
+      })
+      .mockReturnValueOnce({
+        cashInBottomSheetEnabled: false,
+      })
+
+    const { queryByTestId } = renderScreen({ ...zeroBalances })
+    expect(queryByTestId('SendOrRequestBar')).toBeFalsy()
+    expect(queryByTestId('cashInBtn')).toBeFalsy()
   })
 
   it("doesn't import contacts if number isn't verified", async () => {

--- a/src/home/WalletHome.tsx
+++ b/src/home/WalletHome.tsx
@@ -58,7 +58,7 @@ function WalletHome() {
   const { onSelectDapp, ConfirmOpenDappBottomSheet } = useOpenDapp()
 
   const { showHomeNavBar } = getExperimentParams(
-    ExperimentConfigs[StatsigExperiments.HOME_SCREEN_QUICK_ACTIONS]
+    ExperimentConfigs[StatsigExperiments.HOME_SCREEN_ACTIONS]
   )
 
   const showTestnetBanner = () => {

--- a/src/home/WalletHome.tsx
+++ b/src/home/WalletHome.tsx
@@ -58,7 +58,7 @@ function WalletHome() {
   const { onSelectDapp, ConfirmOpenDappBottomSheet } = useOpenDapp()
 
   const { showHomeNavBar } = getExperimentParams(
-    ExperimentConfigs[StatsigExperiments.HOME_SCREEN_ACTIONS]
+    ExperimentConfigs[StatsigExperiments.HOME_SCREEN_QUICK_ACTIONS]
   )
 
   const showTestnetBanner = () => {

--- a/src/home/WalletHome.tsx
+++ b/src/home/WalletHome.tsx
@@ -57,6 +57,10 @@ function WalletHome() {
 
   const { onSelectDapp, ConfirmOpenDappBottomSheet } = useOpenDapp()
 
+  const { showHomeNavBar } = getExperimentParams(
+    ExperimentConfigs[StatsigExperiments.HOME_SCREEN_ACTIONS]
+  )
+
   const showTestnetBanner = () => {
     dispatch(
       showMessage(
@@ -173,7 +177,7 @@ function WalletHome() {
         keyExtractor={keyExtractor}
         testID="WalletHome/SectionList"
       />
-      <SendOrRequestBar />
+      {showHomeNavBar && <SendOrRequestBar />}
       {shouldShowCashInBottomSheet() && <CashInBottomSheet />}
       {ConfirmOpenDappBottomSheet}
     </SafeAreaView>

--- a/src/statsig/constants.ts
+++ b/src/statsig/constants.ts
@@ -49,8 +49,8 @@ export const ExperimentConfigs = {
       cashInBottomSheetEnabled: true,
     },
   },
-  [StatsigExperiments.HOME_SCREEN_ACTIONS]: {
-    experimentName: StatsigExperiments.HOME_SCREEN_ACTIONS,
+  [StatsigExperiments.HOME_SCREEN_QUICK_ACTIONS]: {
+    experimentName: StatsigExperiments.HOME_SCREEN_QUICK_ACTIONS,
     defaultValues: {
       showHomeNavBar: true,
     },

--- a/src/statsig/constants.ts
+++ b/src/statsig/constants.ts
@@ -49,6 +49,12 @@ export const ExperimentConfigs = {
       cashInBottomSheetEnabled: true,
     },
   },
+  [StatsigExperiments.HOME_SCREEN_ACTIONS]: {
+    experimentName: StatsigExperiments.HOME_SCREEN_ACTIONS,
+    defaultValues: {
+      showHomeNavBar: true,
+    },
+  },
 }
 
 export const DynamicConfigs = {

--- a/src/statsig/constants.ts
+++ b/src/statsig/constants.ts
@@ -49,8 +49,8 @@ export const ExperimentConfigs = {
       cashInBottomSheetEnabled: true,
     },
   },
-  [StatsigExperiments.HOME_SCREEN_QUICK_ACTIONS]: {
-    experimentName: StatsigExperiments.HOME_SCREEN_QUICK_ACTIONS,
+  [StatsigExperiments.HOME_SCREEN_ACTIONS]: {
+    experimentName: StatsigExperiments.HOME_SCREEN_ACTIONS,
     defaultValues: {
       showHomeNavBar: true,
     },

--- a/src/statsig/types.ts
+++ b/src/statsig/types.ts
@@ -20,6 +20,7 @@ export enum StatsigExperiments {
   ADD_FUNDS_CRYPTO_EXCHANGE_QR_CODE = 'add_funds_crypto_exchange_qr_code',
   RECOVERY_PHRASE_IN_ONBOARDING = 'recovery_phrase_in_onboarding',
   CHOOSE_YOUR_ADVENTURE = 'choose_your_adventure',
+  HOME_SCREEN_ACTIONS = 'home_screen_actions',
 }
 
 export type StatsigParameter =

--- a/src/statsig/types.ts
+++ b/src/statsig/types.ts
@@ -20,7 +20,7 @@ export enum StatsigExperiments {
   ADD_FUNDS_CRYPTO_EXCHANGE_QR_CODE = 'add_funds_crypto_exchange_qr_code',
   RECOVERY_PHRASE_IN_ONBOARDING = 'recovery_phrase_in_onboarding',
   CHOOSE_YOUR_ADVENTURE = 'choose_your_adventure',
-  HOME_SCREEN_QUICK_ACTIONS = 'home_screen_quick_actions',
+  HOME_SCREEN_ACTIONS = 'home_screen_actions',
 }
 
 export type StatsigParameter =

--- a/src/statsig/types.ts
+++ b/src/statsig/types.ts
@@ -20,7 +20,7 @@ export enum StatsigExperiments {
   ADD_FUNDS_CRYPTO_EXCHANGE_QR_CODE = 'add_funds_crypto_exchange_qr_code',
   RECOVERY_PHRASE_IN_ONBOARDING = 'recovery_phrase_in_onboarding',
   CHOOSE_YOUR_ADVENTURE = 'choose_your_adventure',
-  HOME_SCREEN_ACTIONS = 'home_screen_actions',
+  HOME_SCREEN_QUICK_ACTIONS = 'home_screen_quick_actions',
 }
 
 export type StatsigParameter =


### PR DESCRIPTION
### Description

Fixes ACT-702. Adds in some statsig boilerplate/defaults for the home screen actions experiment, and hides the nav bar on the home screen if the `showHomeNavBar` parameter is set to `false`.

### Test plan

Unit and manual tested.

### Related issues

- Fixes ACT-702.

### Backwards compatibility

Yes.
