### PR TITLE
fix: Add invite reward banner for cUSD invite rewards

### DIFF
--- a/locales/en-US/translation.json
+++ b/locales/en-US/translation.json
@@ -596,6 +596,10 @@
     "title": "Invite friends and collect NFTs",
     "body": "Once they set up their {{appName}} wallet and connect their number, you’ll each get an exclusive NFT."
   },
+  "inviteRewardsBannerCUSD": {
+    "title": "Invite friends and earn rewards",
+    "body": "Once they set up their {{appName}} wallet and connect their number, you will both get rewarded with 1 cUSD."
+  },
   "inviteWithUrl": {
     "title": "Invite a friend",
     "body": "Connect and share value with your friends and family on {{appName}}.",

--- a/src/send/InviteRewardsBanner.tsx
+++ b/src/send/InviteRewardsBanner.tsx
@@ -1,17 +1,30 @@
 import React, { useEffect } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import { Image, StyleSheet, Text, View } from 'react-native'
+import { useSelector } from 'react-redux'
 import { InviteEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import { INVITE_REWARDS_LEARN_MORE } from 'src/config'
 import { notificationInvite } from 'src/images/Images'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
+import { inviteRewardsTypeSelector } from 'src/send/selectors'
+import { InviteRewardsType } from 'src/send/types'
 import colors from 'src/styles/colors'
 import fontStyles from 'src/styles/fonts'
 
 export function InviteRewardsBanner() {
   const { t } = useTranslation()
+  const inviteRewardsType = useSelector(inviteRewardsTypeSelector)
+
+  // Default to NFT invite rewards banner
+  let title = t('inviteRewardsBanner.title')
+  let bodyKey = 'inviteRewardsBanner.body'
+
+  if (inviteRewardsType === InviteRewardsType.CUSD) {
+    title = t('inviteRewardsBannerCUSD.title')
+    bodyKey = 'inviteRewardsBannerCUSD.body'
+  }
 
   useEffect(() => {
     ValoraAnalytics.track(InviteEvents.invite_banner_impression)
@@ -25,9 +38,9 @@ export function InviteRewardsBanner() {
     <View style={styles.container} testID="InviteRewardsBanner">
       <Image source={notificationInvite} resizeMode="contain" />
       <View style={styles.textContainer}>
-        <Text style={fontStyles.small600}>{t('inviteRewardsBanner.title')}</Text>
+        <Text style={fontStyles.small600}>{title}</Text>
         <Text style={styles.bodyText}>
-          <Trans i18nKey="inviteRewardsBanner.body">
+          <Trans i18nKey={bodyKey}>
             <Text onPress={handleOpenInviteTerms} style={styles.learnMore} />
           </Trans>
         </Text>

--- a/src/send/Send.test.tsx
+++ b/src/send/Send.test.tsx
@@ -73,7 +73,7 @@ describe('Send', () => {
     expect(tree.queryByTestId('InviteRewardsBanner')).toBeFalsy()
   })
 
-  it('renders correctly with invite rewards enabled', async () => {
+  it('renders correctly with NFT invite rewards enabled', async () => {
     const store = createMockStore({
       ...defaultStore,
       send: {
@@ -89,7 +89,30 @@ describe('Send', () => {
       </Provider>
     )
 
-    expect(tree.queryByTestId('InviteRewardsBanner')).toBeTruthy()
+    expect(tree.getByText('inviteRewardsBanner.title')).toBeTruthy()
+    expect(tree.getByTestId('InviteRewardsBanner')).toHaveTextContent('inviteRewardsBanner.body')
+  })
+
+  it('renders correctly with cUSD invite rewards enabled', async () => {
+    const store = createMockStore({
+      ...defaultStore,
+      send: {
+        ...defaultStore.send,
+        inviteRewardsVersion: 'v5',
+        inviteRewardCusd: 1,
+      },
+    })
+
+    const tree = render(
+      <Provider store={store}>
+        <Send {...mockScreenProps({})} />
+      </Provider>
+    )
+
+    expect(tree.getByText('inviteRewardsBannerCUSD.title')).toBeTruthy()
+    expect(tree.getByTestId('InviteRewardsBanner')).toHaveTextContent(
+      'inviteRewardsBannerCUSD.body'
+    )
   })
 
   it('looks up a contact, prompts token entry, navigates to the send amount screen', async () => {


### PR DESCRIPTION
### Description

Fixes a missing change that should have been in #3555. The invite rewards banner in the send flow should properly indicate the expected reward type.

### Test plan

Added unit test and manual tested in emulator.

### Related issues

- Fixes RET-635

### Backwards compatibility

Backwards compatible. No previous translation keys changed, only added new.
