### PR TITLE
feat(home): add actions carousel based on experiment parameter

### DIFF
--- a/src/home/WalletHome.test.tsx
+++ b/src/home/WalletHome.test.tsx
@@ -7,9 +7,9 @@ import { DappSection } from 'src/dapps/types'
 import WalletHome from 'src/home/WalletHome'
 import { Actions as IdentityActions } from 'src/identity/actions'
 import { RootState } from 'src/redux/reducers'
+import { getExperimentParams } from 'src/statsig'
 import { createMockStore, flushMicrotasksQueue, RecursivePartial } from 'test/utils'
 import { mockCeurAddress, mockCusdAddress } from 'test/values'
-import { getExperimentParams } from 'src/statsig'
 import { mocked } from 'ts-jest/utils'
 
 const mockBalances = {
@@ -92,6 +92,7 @@ jest.mock('src/transactions/TransactionsList', () => 'TransactionsList')
 jest.mock('src/statsig', () => ({
   getExperimentParams: jest.fn(() => ({
     showHomeNavBar: true,
+    showHomeActions: false,
     cashInBottomSheetEnabled: true,
   })),
 }))
@@ -184,6 +185,7 @@ describe('WalletHome', () => {
     mocked(getExperimentParams)
       .mockReturnValueOnce({
         showHomeNavBar: false,
+        showHomeActions: false,
       })
       .mockReturnValueOnce({
         cashInBottomSheetEnabled: false,
@@ -239,6 +241,23 @@ describe('WalletHome', () => {
     })
 
     expect(queryByTestId('cashInBtn')).toBeFalsy()
+  })
+
+  it('Does not render actions when experiment flag is off', () => {
+    const { queryByTestId } = renderScreen()
+
+    expect(queryByTestId('HomeActionsCarousel')).toBeFalsy()
+  })
+
+  it('Renders actions when experiment flag is on', () => {
+    mocked(getExperimentParams).mockReturnValueOnce({
+      showHomeNavBar: true,
+      showHomeActions: true,
+    })
+
+    const { queryByTestId } = renderScreen()
+
+    expect(queryByTestId('HomeActionsCarousel')).toBeTruthy()
   })
 
   describe('recently used dapps', () => {

--- a/src/home/WalletHome.tsx
+++ b/src/home/WalletHome.tsx
@@ -18,6 +18,7 @@ import {
 } from 'src/config'
 import useOpenDapp from 'src/dappsExplorer/useOpenDapp'
 import { refreshAllBalances } from 'src/home/actions'
+import ActionsCarousel from 'src/home/ActionsCarousel'
 import CashInBottomSheet from 'src/home/CashInBottomSheet'
 import DappsCarousel from 'src/home/DappsCarousel'
 import NotificationBox from 'src/home/NotificationBox'
@@ -57,7 +58,7 @@ function WalletHome() {
 
   const { onSelectDapp, ConfirmOpenDappBottomSheet } = useOpenDapp()
 
-  const { showHomeNavBar } = getExperimentParams(
+  const { showHomeActions, showHomeNavBar } = getExperimentParams(
     ExperimentConfigs[StatsigExperiments.HOME_SCREEN_ACTIONS]
   )
 
@@ -143,15 +144,24 @@ function WalletHome() {
 
   const sections = []
 
-  sections.push({
+  const notificationBoxSection = {
     data: [{}],
     renderItem: () => <NotificationBox key={'NotificationBox'} />,
-  })
-
-  sections.push({
+  }
+  const tokenBalanceSection = {
     data: [{}],
     renderItem: () => <HomeTokenBalance key={'HomeTokenBalance'} />,
-  })
+  }
+  const actionsCarouselSection = {
+    data: [{}],
+    renderItem: () => <ActionsCarousel key={'ActionsCarousel'} />,
+  }
+
+  if (showHomeActions) {
+    sections.push(tokenBalanceSection, actionsCarouselSection, notificationBoxSection)
+  } else {
+    sections.push(notificationBoxSection, tokenBalanceSection)
+  }
 
   sections.push({
     data: [{}],

--- a/src/statsig/constants.ts
+++ b/src/statsig/constants.ts
@@ -52,6 +52,7 @@ export const ExperimentConfigs = {
   [StatsigExperiments.HOME_SCREEN_ACTIONS]: {
     experimentName: StatsigExperiments.HOME_SCREEN_ACTIONS,
     defaultValues: {
+      showHomeActions: false,
       showHomeNavBar: true,
     },
   },


### PR DESCRIPTION
### Description

Use experiment flag to show Actions on home screen.

https://user-images.githubusercontent.com/5062591/229044491-b5aefa55-3b8b-4013-ab22-f6801064a55a.mp4



### Test plan

Manual, unit tests

### Related issues

- Fixes ACT-701

### Backwards compatibility

Yes
