### PR TITLE
chore: reduce unnecessary fetching of supercharge rewards

### DIFF
--- a/src/consumerIncentives/ConsumerIncentivesHomeScreen.tsx
+++ b/src/consumerIncentives/ConsumerIncentivesHomeScreen.tsx
@@ -280,7 +280,7 @@ export default function ConsumerIncentivesHomeScreen() {
       >
         <Header />
         <Image style={styles.image} source={boostRewards} />
-        {showLoadingIndicator && (
+        {loadingAvailableRewards && (
           <ActivityIndicator size="small" color={colors.greenUI} testID="SuperchargeLoading" />
         )}
 

--- a/src/consumerIncentives/ConsumerIncentivesHomeScreen.tsx
+++ b/src/consumerIncentives/ConsumerIncentivesHomeScreen.tsx
@@ -280,7 +280,7 @@ export default function ConsumerIncentivesHomeScreen() {
       >
         <Header />
         <Image style={styles.image} source={boostRewards} />
-        {loadingAvailableRewards && (
+        {showLoadingIndicator && (
           <ActivityIndicator size="small" color={colors.greenUI} testID="SuperchargeLoading" />
         )}
 

--- a/src/consumerIncentives/ConsumerIncentivesHomeScreen.tsx
+++ b/src/consumerIncentives/ConsumerIncentivesHomeScreen.tsx
@@ -280,9 +280,11 @@ export default function ConsumerIncentivesHomeScreen() {
       >
         <Header />
         <Image style={styles.image} source={boostRewards} />
-        {showLoadingIndicator ? (
+        {loadingAvailableRewards && (
           <ActivityIndicator size="small" color={colors.greenUI} testID="SuperchargeLoading" />
-        ) : canClaimRewards ? (
+        )}
+
+        {canClaimRewards ? (
           <ClaimSuperchargeRewards rewards={superchargeRewards} />
         ) : isSupercharging ? (
           <SuperchargingInfo />

--- a/src/consumerIncentives/ConsumerIncentivesHomeScreen.tsx
+++ b/src/consumerIncentives/ConsumerIncentivesHomeScreen.tsx
@@ -280,11 +280,9 @@ export default function ConsumerIncentivesHomeScreen() {
       >
         <Header />
         <Image style={styles.image} source={boostRewards} />
-        {loadingAvailableRewards && (
+        {showLoadingIndicator ? (
           <ActivityIndicator size="small" color={colors.greenUI} testID="SuperchargeLoading" />
-        )}
-
-        {canClaimRewards ? (
+        ) : canClaimRewards ? (
           <ClaimSuperchargeRewards rewards={superchargeRewards} />
         ) : isSupercharging ? (
           <SuperchargingInfo />

--- a/src/consumerIncentives/selectors.ts
+++ b/src/consumerIncentives/selectors.ts
@@ -83,3 +83,6 @@ export const userIsVerifiedForSuperchargeSelector = createSelector(
 
 export const superchargeV1AddressesSelector = (state: RootState) =>
   state.supercharge.superchargeV1Addresses
+
+export const rewardsRefreshTimestampSelector = (state: RootState) =>
+  state.supercharge.rewardsRefreshTimestamp

--- a/src/consumerIncentives/slice.ts
+++ b/src/consumerIncentives/slice.ts
@@ -19,6 +19,7 @@ export interface State {
   // transaction "to" address against this list to ensure the user is signing a
   // safe transaction
   superchargeV1Addresses: string[]
+  rewardsRefreshTimestamp: number
 }
 
 export const initialState: State = {
@@ -30,6 +31,7 @@ export const initialState: State = {
   superchargeV2Enabled: false,
   superchargeRewardContractAddress: '',
   superchargeV1Addresses: [],
+  rewardsRefreshTimestamp: 0,
 }
 
 const slice = createSlice({
@@ -63,6 +65,7 @@ const slice = createSlice({
       ...state,
       fetchAvailableRewardsLoading: false,
       fetchAvailableRewardsError: false,
+      rewardsRefreshTimestamp: Date.now(),
     }),
     fetchAvailableRewardsFailure: (state) => ({
       ...state,

--- a/src/home/NotificationBox.test.tsx
+++ b/src/home/NotificationBox.test.tsx
@@ -88,6 +88,7 @@ const superchargeSetUp = {
   },
   supercharge: {
     availableRewards: [testReward],
+    rewardsRefreshTimestamp: new Date('2023-03-29T00:00:00.000Z').valueOf(),
   },
 }
 
@@ -95,6 +96,7 @@ const superchargeWithoutRewardsSetUp = {
   ...superchargeSetUp,
   supercharge: {
     availableRewards: [],
+    rewardsRefreshTimestamp: new Date('2023-03-29T00:00:00.000Z').valueOf(),
   },
 }
 
@@ -121,6 +123,10 @@ const mockcUsdWithoutEnoughBalance = {
 }
 
 describe('NotificationBox', () => {
+  beforeAll(() => {
+    jest.spyOn(Date, 'now').mockImplementation(() => new Date('2023-03-31T00:00:00.000Z').valueOf())
+  })
+
   it('renders correctly for with all notifications', () => {
     const store = createMockStore({
       ...storeDataNotificationsEnabled,
@@ -551,5 +557,19 @@ describe('NotificationBox', () => {
     expect(queryByTestId('NotificationView/claimSuperchargeRewards')).toBeFalsy()
     expect(queryByTestId('NotificationView/keepSupercharging')).toBeFalsy()
     expect(queryByTestId('NotificationView/startSupercharging')).toBeFalsy()
+  })
+
+  it('does not try to fetch supercharge rewards if fetched within the last 24 hours', () => {
+    jest.spyOn(Date, 'now').mockImplementation(() => new Date('2023-03-30T00:00:00.000Z').valueOf())
+
+    const store = createMockStore(superchargeSetUp)
+
+    render(
+      <Provider store={store}>
+        <NotificationBox />
+      </Provider>
+    )
+
+    expect(store.getActions()).toEqual([])
   })
 })

--- a/src/home/NotificationBox.tsx
+++ b/src/home/NotificationBox.tsx
@@ -25,6 +25,8 @@ import SimpleMessagingCard, {
 } from 'src/components/SimpleMessagingCard'
 import { RewardsScreenOrigin } from 'src/consumerIncentives/analyticsEventsTracker'
 import {
+  availableRewardsSelector,
+  rewardsRefreshTimestampSelector,
   superchargeInfoSelector,
   userIsVerifiedForSuperchargeSelector,
 } from 'src/consumerIncentives/selectors'
@@ -96,6 +98,8 @@ interface Notification {
   id: string
 }
 
+const REFRESH_REWARDS_INTERVAL = 1000 * 60 * 60 * 24 // 24 hours
+
 function useSimpleActions() {
   const {
     backupCompleted,
@@ -117,6 +121,7 @@ function useSimpleActions() {
   const isSupercharging = numberVerifiedForSupercharge && hasBalanceForSupercharge
 
   const rewardsEnabled = useSelector(rewardsEnabledSelector)
+  const rewardsRefreshTimestamp = useSelector(rewardsRefreshTimestampSelector)
 
   const { superchargeApy } = useSelector((state) => state.app)
 
@@ -125,10 +130,12 @@ function useSimpleActions() {
   const dispatch = useDispatch()
 
   useEffect(() => {
-    dispatch(fetchAvailableRewards())
+    if (Date.now() - rewardsRefreshTimestamp > REFRESH_REWARDS_INTERVAL) {
+      dispatch(fetchAvailableRewards())
+    }
   }, [])
 
-  const superchargeRewards = useSelector((state) => state.supercharge.availableRewards)
+  const superchargeRewards = useSelector(availableRewardsSelector)
 
   const actions: SimpleMessagingCardProps[] = []
   if (!backupCompleted) {

--- a/src/redux/migrations.ts
+++ b/src/redux/migrations.ts
@@ -1099,4 +1099,5 @@ export const migrations = {
   119: (state: any) => state,
   120: (state: any) => state,
   121: (state: any) => state,
+  122: (state: any) => state,
 }

--- a/src/redux/store.test.ts
+++ b/src/redux/store.test.ts
@@ -99,7 +99,7 @@ describe('store state', () => {
       Object {
         "_persist": Object {
           "rehydrated": true,
-          "version": 121,
+          "version": 122,
         },
         "account": Object {
           "acceptedTerms": false,
@@ -319,6 +319,7 @@ describe('store state', () => {
           "fetchAvailableRewardsError": false,
           "fetchAvailableRewardsLoading": false,
           "loading": false,
+          "rewardsRefreshTimestamp": 0,
           "superchargeRewardContractAddress": "",
           "superchargeV1Addresses": Array [],
           "superchargeV2Enabled": false,

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -23,7 +23,7 @@ const persistConfig: PersistConfig<RootState> = {
   key: 'root',
   // default is -1, increment as we make migrations
   // See https://github.com/valora-inc/wallet/tree/main/WALLET.md#redux-state-migration
-  version: 121,
+  version: 122,
   keyPrefix: `reduxStore-`, // the redux-persist default is `persist:` which doesn't work with some file systems.
   storage: FSStorage(),
   blacklist: ['networkInfo', 'alert', 'imports', 'swap'],

--- a/test/RootStateSchema.json
+++ b/test/RootStateSchema.json
@@ -3136,6 +3136,9 @@
                 "loading": {
                     "type": "boolean"
                 },
+                "rewardsRefreshTimestamp": {
+                    "type": "number"
+                },
                 "superchargeRewardContractAddress": {
                     "type": "string"
                 },
@@ -3155,6 +3158,7 @@
                 "fetchAvailableRewardsError",
                 "fetchAvailableRewardsLoading",
                 "loading",
+                "rewardsRefreshTimestamp",
                 "superchargeRewardContractAddress",
                 "superchargeV1Addresses",
                 "superchargeV2Enabled"

--- a/test/schemas.ts
+++ b/test/schemas.ts
@@ -2172,6 +2172,18 @@ export const v121Schema = {
   },
 }
 
+export const v122Schema = {
+  ...v121Schema,
+  _persist: {
+    ...v121Schema._persist,
+    version: 122,
+  },
+  supercharge: {
+    ...v121Schema.supercharge,
+    rewardsRefreshTimestamp: 0,
+  },
+}
+
 export function getLatestSchema(): Partial<RootState> {
-  return v121Schema as Partial<RootState>
+  return v122Schema as Partial<RootState>
 }


### PR DESCRIPTION
### Description

Since the supercharge v2 backend computation is relatively intensive, it'd be nice to reduce the redundant calculations. This will save us some rpc calls quota. This PR aims to implement some kind of cache.

There are 2 places that fetch supercharge rewards:
1. home screen - specifically, the homecards. the rewards data is used to display the supercharge homecards.
2. supercharge screen

I think it is unnecessary to keep fetching supercharge rewards on the home screen. The worst case scenario that comes from this change, is that the "claim your rewards" homecard is displayed later.

This PR:
- add a new redux variable / migration to track last reward fetch time
- in the notifications, only fetch rewards if the previous fetch was more than 24 hours ago

### Test plan

n/a

### Related issues

n/a

### Backwards compatibility

Y
