### PR TITLE
fix(statsig): initialize before home screen requests experiments

### DIFF
--- a/__mocks__/src/analytics/ValoraAnalytics.ts
+++ b/__mocks__/src/analytics/ValoraAnalytics.ts
@@ -26,6 +26,7 @@ class ValoraAnalytics {
   page = jest.fn((page: string, eventProperties: {}) => {
     console.log('Page', page, eventProperties)
   })
+  init = jest.fn(() => Promise.resolve())
 }
 
 export default new ValoraAnalytics()

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -14,11 +14,11 @@ import { AppEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import { apolloClient } from 'src/apollo/index'
 import { appMounted, appUnmounted, openDeepLink } from 'src/app/actions'
+import AppInitGate from 'src/app/AppInitGate'
 import AppLoading from 'src/app/AppLoading'
 import ErrorBoundary from 'src/app/ErrorBoundary'
 import { DYNAMIC_LINK_DOMAIN_URI_PREFIX, FIREBASE_ENABLED, isE2EEnv } from 'src/config'
 import i18n from 'src/i18n'
-import I18nGate from 'src/i18n/I18nGate'
 import NavigatorWrapper from 'src/navigator/NavigatorWrapper'
 import { waitUntilSagasFinishLoading } from 'src/redux/sagas'
 import { persistor, store } from 'src/redux/store'
@@ -74,7 +74,6 @@ export class App extends React.Component<Props> {
     if (isE2EEnv) {
       LogBox.ignoreAllLogs(true)
     }
-    await ValoraAnalytics.init()
 
     // Handles opening Clevertap deeplinks when app is closed / in background
     // @ts-expect-error the clevertap ts definition has url as an object, but it
@@ -171,12 +170,12 @@ export class App extends React.Component<Props> {
         <ApolloProvider client={apolloClient}>
           <Provider store={store}>
             <PersistGate loading={<AppLoading />} persistor={persistor}>
-              <I18nGate loading={<AppLoading />}>
+              <AppInitGate loading={<AppLoading />}>
                 <StatusBar backgroundColor="transparent" barStyle="dark-content" />
                 <ErrorBoundary>
                   <NavigatorWrapper />
                 </ErrorBoundary>
-              </I18nGate>
+              </AppInitGate>
             </PersistGate>
           </Provider>
         </ApolloProvider>

--- a/src/app/AppInitGate.test.tsx
+++ b/src/app/AppInitGate.test.tsx
@@ -5,8 +5,8 @@ import 'react-native'
 import { Text } from 'react-native'
 import * as RNLocalize from 'react-native-localize'
 import { Provider } from 'react-redux'
+import AppInitGate from 'src/app/AppInitGate'
 import * as I18n from 'src/i18n'
-import I18nGate from 'src/i18n/I18nGate'
 import * as I18nActions from 'src/i18n/slice'
 import { navigateToError } from 'src/navigator/NavigationService'
 import { createMockStore, flushMicrotasksQueue } from 'test/utils'
@@ -27,9 +27,9 @@ const setLanguageSpy = jest.spyOn(I18nActions, 'setLanguage')
 const renderI18nGate = (language: string | null) =>
   render(
     <Provider store={createMockStore({ i18n: { language } })}>
-      <I18nGate loading={<Text>Loading component</Text>}>
+      <AppInitGate loading={<Text>Loading component</Text>}>
         <Text>App</Text>
-      </I18nGate>
+      </AppInitGate>
     </Provider>
   )
 

--- a/src/app/AppInitGate.tsx
+++ b/src/app/AppInitGate.tsx
@@ -14,6 +14,8 @@ import useChangeLanguage from 'src/i18n/useChangeLanguage'
 import { navigateToError } from 'src/navigator/NavigationService'
 import Logger from 'src/utils/Logger'
 
+const TAG = 'AppInitGate'
+
 interface Props {
   loading: React.ReactNode
   children: React.ReactNode
@@ -39,14 +41,14 @@ const AppInitGate = ({ loading, children }: Props) => {
 
   const initResult = useAsync(
     async () => {
-      Logger.debug('AppInitGate', 'Starting init')
+      Logger.debug(TAG, 'Starting init')
       await Promise.all([i18nInitializer(), ValoraAnalytics.init()])
-      Logger.debug('AppInitGate', 'init completed')
+      Logger.debug(TAG, 'init completed')
     },
     [],
     {
       onError: (error) => {
-        Logger.error('AppInitGate', 'Failed init', error)
+        Logger.error(TAG, 'Failed init', error)
         navigateToError('appInitFailed', error)
       },
     }

--- a/src/app/AppInitGate.tsx
+++ b/src/app/AppInitGate.tsx
@@ -2,6 +2,7 @@ import locales from 'locales'
 import { useAsync } from 'react-async-hook'
 import { findBestAvailableLanguage } from 'react-native-localize'
 import { useSelector } from 'react-redux'
+import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import { DEFAULT_APP_LANGUAGE } from 'src/config'
 import { initI18n } from 'src/i18n'
 import {
@@ -18,35 +19,49 @@ interface Props {
   children: React.ReactNode
 }
 
-const I18nGate = ({ loading, children }: Props) => {
+const AppInitGate = ({ loading, children }: Props) => {
   const changelanguage = useChangeLanguage()
   const allowOtaTranslations = useSelector(allowOtaTranslationsSelector)
   const otaTranslationsAppVersion = useSelector(otaTranslationsAppVersionSelector)
   const language = useSelector(currentLanguageSelector)
   const bestLanguage = findBestAvailableLanguage(Object.keys(locales))?.languageTag
 
-  const i18nInitResult = useAsync(
+  const i18nInitializer = async () => {
+    Logger.debug('i18n', 'Starting i18n init')
+    await initI18n(
+      language || bestLanguage || DEFAULT_APP_LANGUAGE,
+      allowOtaTranslations,
+      otaTranslationsAppVersion
+    )
+    if (!language && bestLanguage) {
+      await changelanguage(bestLanguage)
+    }
+    Logger.debug('i18n', 'i18n init completed')
+  }
+
+  const analyticsInitializer = async () => {
+    Logger.debug('analytics', 'Starting analytics init')
+    await ValoraAnalytics.init()
+    Logger.debug('analytics', 'analytics init completed')
+  }
+
+  const initResult = useAsync(
     async () => {
-      await initI18n(
-        language || bestLanguage || DEFAULT_APP_LANGUAGE,
-        allowOtaTranslations,
-        otaTranslationsAppVersion
-      )
-      if (!language && bestLanguage) {
-        await changelanguage(bestLanguage)
-      }
+      Logger.debug('AppInitGate', 'Starting init')
+      await Promise.all([i18nInitializer(), analyticsInitializer()])
+      Logger.debug('AppInitGate', 'init completed')
     },
     [],
     {
       onError: (error) => {
-        Logger.error('i18n', 'Failed init i18n', error)
+        Logger.error('AppInitGate', 'Failed i18n', error)
         navigateToError('appInitFailed', error)
       },
     }
   )
 
   // type assertion here because https://github.com/DefinitelyTyped/DefinitelyTyped/issues/44572
-  return i18nInitResult.loading ? (loading as JSX.Element) : (children as JSX.Element)
+  return initResult.loading ? (loading as JSX.Element) : (children as JSX.Element)
 }
 
-export default I18nGate
+export default AppInitGate

--- a/src/app/AppInitGate.tsx
+++ b/src/app/AppInitGate.tsx
@@ -27,7 +27,6 @@ const AppInitGate = ({ loading, children }: Props) => {
   const bestLanguage = findBestAvailableLanguage(Object.keys(locales))?.languageTag
 
   const i18nInitializer = async () => {
-    Logger.debug('i18n', 'Starting i18n init')
     await initI18n(
       language || bestLanguage || DEFAULT_APP_LANGUAGE,
       allowOtaTranslations,
@@ -36,25 +35,18 @@ const AppInitGate = ({ loading, children }: Props) => {
     if (!language && bestLanguage) {
       await changelanguage(bestLanguage)
     }
-    Logger.debug('i18n', 'i18n init completed')
-  }
-
-  const analyticsInitializer = async () => {
-    Logger.debug('analytics', 'Starting analytics init')
-    await ValoraAnalytics.init()
-    Logger.debug('analytics', 'analytics init completed')
   }
 
   const initResult = useAsync(
     async () => {
       Logger.debug('AppInitGate', 'Starting init')
-      await Promise.all([i18nInitializer(), analyticsInitializer()])
+      await Promise.all([i18nInitializer(), ValoraAnalytics.init()])
       Logger.debug('AppInitGate', 'init completed')
     },
     [],
     {
       onError: (error) => {
-        Logger.error('AppInitGate', 'Failed i18n', error)
+        Logger.error('AppInitGate', 'Failed init', error)
         navigateToError('appInitFailed', error)
       },
     }

--- a/src/statsig/index.ts
+++ b/src/statsig/index.ts
@@ -32,7 +32,11 @@ export function getExperimentParams<T extends Record<string, StatsigParameter>>(
     const experiment = Statsig.getExperiment(experimentName)
     return getParams({ config: experiment, defaultValues })
   } catch (error) {
-    Logger.warn('getExperimentParams', `Error getting experiment params`, error)
+    Logger.warn(
+      'getExperimentParams',
+      `Error getting params for experiment: ${experimentName}`,
+      error
+    )
     return defaultValues
   }
 }
@@ -48,7 +52,7 @@ export function getDynamicConfigParams<T extends Record<string, StatsigParameter
     const config = Statsig.getConfig(configName)
     return getParams({ config, defaultValues })
   } catch (error) {
-    Logger.warn('getDynamicConfig', `Error getting experiment params`, error)
+    Logger.warn('getDynamicConfig', `Error getting params for dynamic config: ${configName}`, error)
     return defaultValues
   }
 }


### PR DESCRIPTION
### Description

Currently statsig initializes asynchronously (part of ValoraAnalytics.init) and the home screen requests experiments before initialization completes, resulting in loading the default experience and then switching to the appropriate variant. This makes analytics init a blocking call before rendering the first screen (home / onboarding)


### Test plan

Unit test and manual. Also ensured the below `getExperimentParams` warn log doesn't show up:

```
getExperimentParams Error getting experiment params [Error: Call and wait for initialize() to finish first.] 
```

Before:

https://user-images.githubusercontent.com/5062591/229637645-73c24b62-61d9-475a-9459-a74d2e928c0d.mp4


After:

https://user-images.githubusercontent.com/5062591/229638156-244bcac9-9199-4593-bc05-ae194a40ab2d.mp4



### Related issues

N/A

### Backwards compatibility

Yes
