### PR TITLE
feat(home-actions): add new swap screen used by home actions

### DIFF
--- a/src/home/ActionsCarousel.test.tsx
+++ b/src/home/ActionsCarousel.test.tsx
@@ -22,7 +22,7 @@ describe('ActionsCarousel', () => {
     [HomeActionName.Send, 'send', Screens.Send, undefined],
     [HomeActionName.Receive, 'receive', Screens.QRNavigator, undefined],
     [HomeActionName.Add, 'add', Screens.FiatExchangeCurrency, { flow: FiatExchangeFlow.CashIn }],
-    [HomeActionName.Swap, 'swap', Screens.SwapScreen, undefined],
+    [HomeActionName.Swap, 'swap', Screens.SwapActionScreen, undefined],
     [HomeActionName.Request, 'request', Screens.Send, { isOutgoingPaymentRequest: true }],
     [HomeActionName.Withdraw, 'withdraw', Screens.WithdrawSpend, undefined],
   ])(

--- a/src/home/ActionsCarousel.tsx
+++ b/src/home/ActionsCarousel.tsx
@@ -51,7 +51,7 @@ function ActionsCarousel() {
       title: t('homeActions.swap'),
       icon: <HomeActionsSwap />,
       onPress: () => {
-        navigate(Screens.SwapScreen)
+        navigate(Screens.SwapActionScreen)
       },
     },
     {

--- a/src/navigator/Navigator.tsx
+++ b/src/navigator/Navigator.tsx
@@ -63,13 +63,13 @@ import ExternalExchanges, {
   externalExchangesScreenOptions,
 } from 'src/fiatExchanges/ExternalExchanges'
 import FiatExchangeAmount from 'src/fiatExchanges/FiatExchangeAmount'
-import WithdrawSpend from 'src/fiatExchanges/WithdrawSpend'
 import FiatExchangeCurrency, {
   fiatExchangesOptionsScreenOptions,
 } from 'src/fiatExchanges/FiatExchangeCurrency'
 import SelectProviderScreen from 'src/fiatExchanges/SelectProvider'
 import SimplexScreen from 'src/fiatExchanges/SimplexScreen'
 import Spend, { spendScreenOptions } from 'src/fiatExchanges/Spend'
+import WithdrawSpend from 'src/fiatExchanges/WithdrawSpend'
 import i18n from 'src/i18n'
 import { currentLanguageSelector } from 'src/i18n/selectors'
 import PhoneNumberLookupQuotaScreen from 'src/identity/PhoneNumberLookupQuotaScreen'
@@ -122,6 +122,7 @@ import ValidateRecipientAccount, {
 import ValidateRecipientIntro, {
   validateRecipientIntroScreenNavOptions,
 } from 'src/send/ValidateRecipientIntro'
+import SwapActionScreen from 'src/swap/SwapActionScreen'
 import SwapExecuteScreen from 'src/swap/SwapExecuteScreen'
 import SwapReviewScreen from 'src/swap/SwapReviewScreen'
 import TokenBalancesScreen from 'src/tokens/TokenBalances'
@@ -582,8 +583,18 @@ const generalScreens = (Navigator: typeof Stack) => (
   </>
 )
 
+const swapActionScreenOptions = {
+  ...headerWithBackButton,
+  headerTitle: i18n.t('swapScreen.title'),
+}
+
 const swapScreens = (Navigator: typeof Stack) => (
   <>
+    <Navigator.Screen
+      name={Screens.SwapActionScreen}
+      component={SwapActionScreen}
+      options={swapActionScreenOptions}
+    />
     <Navigator.Screen
       name={Screens.SwapReviewScreen}
       component={SwapReviewScreen}

--- a/src/navigator/Screens.tsx
+++ b/src/navigator/Screens.tsx
@@ -85,6 +85,7 @@ export enum Screens {
   StoreWipeRecoveryScreen = 'StoreWipeRecoveryScreen',
   Support = 'Support',
   SupportContact = 'SupportContact',
+  SwapActionScreen = 'SwapActionScreen',
   SwapScreen = 'SwapScreen',
   SwapExecuteScreen = 'SwapExecuteScreen',
   SwapReviewScreen = 'SwapReviewScreen',

--- a/src/navigator/types.tsx
+++ b/src/navigator/types.tsx
@@ -310,6 +310,7 @@ export type StackParamList = {
       }
     | undefined
   [Screens.Sync]: undefined
+  [Screens.SwapActionScreen]: undefined
   [Screens.SwapScreen]: undefined
   [Screens.SwapExecuteScreen]: undefined
   [Screens.SwapReviewScreen]: undefined

--- a/src/swap/SwapActionScreen.tsx
+++ b/src/swap/SwapActionScreen.tsx
@@ -1,0 +1,8 @@
+import React from 'react'
+import { SwapScreenSection } from 'src/swap/SwapScreen'
+
+function SwapActionScreen() {
+  return <SwapScreenSection showDrawerTopNav={false} />
+}
+
+export default SwapActionScreen

--- a/src/swap/SwapScreen.test.tsx
+++ b/src/swap/SwapScreen.test.tsx
@@ -9,7 +9,7 @@ import { TRANSACTION_FEES_LEARN_MORE } from 'src/brandingConfig'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import { setSwapUserInput } from 'src/swap/slice'
-import SwapScreen from 'src/swap/SwapScreen'
+import SwapScreen, { SwapScreenSection } from 'src/swap/SwapScreen'
 import { Field } from 'src/swap/types'
 import networkConfig from 'src/web3/networkConfig'
 import { createMockStore } from 'test/utils'
@@ -27,7 +27,7 @@ jest.mock('react-native-localize', () => ({
 
 const now = Date.now()
 
-const renderScreen = ({ celoBalance = '10', cUSDBalance = '20.456' }) => {
+const renderScreen = ({ celoBalance = '10', cUSDBalance = '20.456', showDrawerTopNav = true }) => {
   const store = createMockStore({
     tokens: {
       tokenBalances: {
@@ -91,7 +91,11 @@ const renderScreen = ({ celoBalance = '10', cUSDBalance = '20.456' }) => {
 
   const tree = render(
     <Provider store={store}>
-      <SwapScreen />
+      {showDrawerTopNav ? (
+        <SwapScreen />
+      ) : (
+        <SwapScreenSection showDrawerTopNav={showDrawerTopNav} />
+      )}
     </Provider>
   )
   const [swapFromContainer, swapToContainer] = tree.getAllByTestId('SwapAmountInput')
@@ -116,10 +120,11 @@ describe('SwapScreen', () => {
   })
 
   it('should display the correct elements on load', () => {
-    const { getByText, swapFromContainer, swapToContainer } = renderScreen({})
+    const { getByText, swapFromContainer, swapToContainer, queryByTestId } = renderScreen({})
 
     expect(getByText('swapScreen.title')).toBeTruthy()
     expect(getByText('swapScreen.review')).toBeDisabled()
+    expect(queryByTestId('SwapScreen/DrawerBar')).toBeTruthy()
 
     expect(within(swapFromContainer).getByText('swapScreen.swapFrom')).toBeTruthy()
     expect(within(swapFromContainer).getByTestId('SwapAmountInput/MaxButton')).toBeTruthy()
@@ -594,5 +599,23 @@ describe('SwapScreen', () => {
         }),
       ])
     )
+  })
+
+  it('should be able to hide top drawer nav when parameter is set', () => {
+    const { getByText, swapFromContainer, swapToContainer, queryByTestId } = renderScreen({
+      showDrawerTopNav: false,
+    })
+
+    expect(queryByTestId('SwapScreen/DrawerBar')).toBeFalsy()
+    expect(getByText('swapScreen.review')).toBeDisabled()
+
+    expect(within(swapFromContainer).getByText('swapScreen.swapFrom')).toBeTruthy()
+    expect(within(swapFromContainer).getByTestId('SwapAmountInput/MaxButton')).toBeTruthy()
+    expect(within(swapFromContainer).getByTestId('SwapAmountInput/TokenSelect')).toBeTruthy()
+    expect(within(swapFromContainer).getByText('CELO')).toBeTruthy()
+
+    expect(within(swapToContainer).getByText('swapScreen.swapTo')).toBeTruthy()
+    expect(within(swapToContainer).getByTestId('SwapAmountInput/TokenSelect')).toBeTruthy()
+    expect(within(swapToContainer).getByText('swapScreen.swapToTokenSelection')).toBeTruthy()
   })
 })

--- a/src/swap/SwapScreen.tsx
+++ b/src/swap/SwapScreen.tsx
@@ -4,7 +4,7 @@ import React, { useEffect, useMemo, useState } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import { Keyboard, StyleSheet, Text, View } from 'react-native'
 import { getNumberFormatSettings } from 'react-native-localize'
-import { SafeAreaView } from 'react-native-safe-area-context'
+import { Edge, SafeAreaView } from 'react-native-safe-area-context'
 import { useDispatch, useSelector } from 'react-redux'
 import { showError } from 'src/alert/actions'
 import { SwapEvents } from 'src/analytics/Events'
@@ -42,7 +42,11 @@ const DEFAULT_SWAP_AMOUNT: SwapAmount = {
 
 const { decimalSeparator } = getNumberFormatSettings()
 
-export function SwapScreen() {
+function SwapScreen() {
+  return <SwapScreenSection showDrawerTopNav={true} />
+}
+
+export function SwapScreenSection({ showDrawerTopNav }: { showDrawerTopNav?: boolean }) {
   const { t } = useTranslation()
   const dispatch = useDispatch()
 
@@ -251,25 +255,30 @@ export function SwapScreen() {
     navigate(Screens.WebViewScreen, { uri: SWAP_LEARN_MORE })
   }
 
+  const edges: Edge[] | undefined = showDrawerTopNav ? undefined : ['bottom']
+
   return (
-    <SafeAreaView style={styles.safeAreaContainer}>
-      <DrawerTopBar
-        middleElement={
-          <View style={styles.headerContainer}>
-            <Text style={headerStyles.headerTitle}>{t('swapScreen.title')}</Text>
-            {exchangeRate && fromToken && toToken && (
-              <Text
-                style={[headerStyles.headerSubTitle, fetchingSwapQuote ? styles.mutedHeader : {}]}
-              >
-                {`1 ${fromToken.symbol} ≈ ${new BigNumber(exchangeRate).toFormat(
-                  5,
-                  BigNumber.ROUND_DOWN
-                )} ${toToken.symbol}`}
-              </Text>
-            )}
-          </View>
-        }
-      />
+    <SafeAreaView style={styles.safeAreaContainer} edges={edges}>
+      {showDrawerTopNav && (
+        <DrawerTopBar
+          testID={'SwapScreen/DrawerBar'}
+          middleElement={
+            <View style={styles.headerContainer}>
+              <Text style={headerStyles.headerTitle}>{t('swapScreen.title')}</Text>
+              {exchangeRate && fromToken && toToken && (
+                <Text
+                  style={[headerStyles.headerSubTitle, fetchingSwapQuote ? styles.mutedHeader : {}]}
+                >
+                  {`1 ${fromToken.symbol} ≈ ${new BigNumber(exchangeRate).toFormat(
+                    5,
+                    BigNumber.ROUND_DOWN
+                  )} ${toToken.symbol}`}
+                </Text>
+              )}
+            </View>
+          }
+        />
+      )}
       <KeyboardAwareScrollView contentContainerStyle={styles.contentContainer}>
         <View style={styles.swapAmountsContainer}>
           <SwapAmountInput


### PR DESCRIPTION
### Description

Part 1 of ACT-704. This PR adds a new swap screen that the "Swap" home action will redirect to. The new screen removes the hamburger menu and replaces it with a back button that redirects to the home screen.

For the same reasons as described in #3610, it is necessary to add a new Swap screen rather than use existing one which is used in the Drawer navigation.


https://user-images.githubusercontent.com/20508929/230185109-349a8f0c-8d05-41e2-9982-3e3763cabcac.mp4



### Test plan

Added unit tests

### Related issues

- Partially resolves ACT-704

### Backwards compatibility

Yes