### PR TITLE
fix(forced-backup): disable forced backup if experiment param says to

### DIFF
--- a/src/backup/selectors.test.ts
+++ b/src/backup/selectors.test.ts
@@ -1,4 +1,4 @@
-import { shouldForceBackupSelector } from 'src/backup/selectors'
+import { pastForcedBackupDeadlineSelector } from 'src/backup/selectors'
 import { ONE_DAY_IN_MILLIS } from 'src/utils/time'
 import { getMockStoreData } from 'test/utils'
 
@@ -24,25 +24,29 @@ describe('backup/selectors', () => {
     dateNowSpy.mockRestore()
   })
 
-  describe('shouldForceBackupSelector', () => {
+  describe('pastForcedBackupDeadlineSelector', () => {
     it("should not force Recovery Phrase prompt if enough time hasn't passed since creation", () => {
       // Account created 12 hours ago, no delay and no backup.
       expect(
-        shouldForceBackupSelector(mockState(mockCurrentTime - ONE_DAY_IN_MILLIS * 0.5, null, false))
+        pastForcedBackupDeadlineSelector(
+          mockState(mockCurrentTime - ONE_DAY_IN_MILLIS * 0.5, null, false)
+        )
       ).toBe(false)
     })
 
     it('should force Recovery Phrase prompt if enough time passed since account creation', () => {
       // Account created 36 hours ago, no delay and no backup.
       expect(
-        shouldForceBackupSelector(mockState(mockCurrentTime - ONE_DAY_IN_MILLIS * 1.5, null, false))
+        pastForcedBackupDeadlineSelector(
+          mockState(mockCurrentTime - ONE_DAY_IN_MILLIS * 1.5, null, false)
+        )
       ).toBe(true)
     })
 
     it('should not force Recovery Phrase prompt if delay button was just pressed', () => {
       // Account created 36 hours ago, delay pressed less than an hour ago and no backup.
       expect(
-        shouldForceBackupSelector(
+        pastForcedBackupDeadlineSelector(
           mockState(mockCurrentTime - ONE_DAY_IN_MILLIS * 1.5, mockCurrentTime + 10, false)
         )
       ).toBe(false)
@@ -51,7 +55,7 @@ describe('backup/selectors', () => {
     it('should force Recovery Phrase prompt if delay button was pressed a while ago', () => {
       // Account created 36 hours ago, delay pressed over an hour ago and no backup.
       expect(
-        shouldForceBackupSelector(
+        pastForcedBackupDeadlineSelector(
           mockState(mockCurrentTime - ONE_DAY_IN_MILLIS * 1.5, mockCurrentTime - 10, false)
         )
       ).toBe(true)
@@ -60,7 +64,9 @@ describe('backup/selectors', () => {
     it('should not force Recovery Phrase prompt if backup was already completed', () => {
       // Account already backed up.
       expect(
-        shouldForceBackupSelector(mockState(mockCurrentTime - ONE_DAY_IN_MILLIS * 1.5, null, true))
+        pastForcedBackupDeadlineSelector(
+          mockState(mockCurrentTime - ONE_DAY_IN_MILLIS * 1.5, null, true)
+        )
       ).toBe(false)
     })
   })

--- a/src/backup/selectors.ts
+++ b/src/backup/selectors.ts
@@ -3,7 +3,7 @@ import { Screens } from 'src/navigator/Screens'
 import { RootState } from 'src/redux/reducers'
 import { ONE_DAY_IN_MILLIS } from 'src/utils/time'
 
-export const shouldForceBackupSelector = (state: RootState) => {
+export const pastForcedBackupDeadlineSelector = (state: RootState) => {
   if (state.account.backupCompleted) {
     return false
   }

--- a/src/navigator/NavigatorWrapper.test.tsx
+++ b/src/navigator/NavigatorWrapper.test.tsx
@@ -28,12 +28,11 @@ describe('NavigatorWrapper', () => {
 
   function renderNavigatorWrapper() {
     const store = createMockStore()
-    const tree = render(
+    render(
       <Provider store={store}>
         <NavigatorWrapper />
       </Provider>
     )
-    return { tree, store }
   }
 
   it('forces backup when deadline in past and enableForcedBackup is true', () => {

--- a/src/navigator/NavigatorWrapper.test.tsx
+++ b/src/navigator/NavigatorWrapper.test.tsx
@@ -36,11 +36,27 @@ describe('NavigatorWrapper', () => {
     return { tree, store }
   }
 
-  it('forces backup when it should', () => {
+  it('forces backup when deadline in past and enableForcedBackup is true', () => {
     mocked(getExperimentParams).mockReturnValue({ enableForcedBackup: true })
     mocked(pastForcedBackupDeadlineSelector).mockReturnValue(true)
 
     renderNavigatorWrapper()
     expect(navigate).toHaveBeenCalledWith(Screens.BackupForceScreen)
+  })
+
+  it('does not force backup when enableForcedBackup is false', () => {
+    mocked(getExperimentParams).mockReturnValue({ enableForcedBackup: false })
+    mocked(pastForcedBackupDeadlineSelector).mockReturnValue(true)
+
+    renderNavigatorWrapper()
+    expect(navigate).not.toHaveBeenCalledWith(Screens.BackupForceScreen)
+  })
+
+  it('does not force backup when deadline in future', () => {
+    mocked(getExperimentParams).mockReturnValue({ enableForcedBackup: true })
+    mocked(pastForcedBackupDeadlineSelector).mockReturnValue(false)
+
+    renderNavigatorWrapper()
+    expect(navigate).not.toHaveBeenCalledWith(Screens.BackupForceScreen)
   })
 })

--- a/src/navigator/NavigatorWrapper.test.tsx
+++ b/src/navigator/NavigatorWrapper.test.tsx
@@ -1,0 +1,46 @@
+import { getExperimentParams } from 'src/statsig'
+import { mocked } from 'ts-jest/utils'
+import { pastForcedBackupDeadlineSelector } from 'src/backup/selectors'
+import { navigate } from 'src/navigator/NavigationService'
+import { Screens } from 'src/navigator/Screens'
+import { render } from '@testing-library/react-native'
+import * as React from 'react'
+import NavigatorWrapper from 'src/navigator/NavigatorWrapper'
+import { createMockStore } from 'test/utils'
+import { Provider } from 'react-redux'
+
+jest.mock('src/statsig')
+jest.mock('src/backup/selectors')
+jest.mock('src/navigator/NavigationService', () => ({
+  ...(jest.requireActual('src/navigator/NavigationService') as any),
+  navigatorIsReadyRef: { current: false },
+  navigate: jest.fn(),
+}))
+jest.mock('src/sentry/Sentry', () => ({
+  ...(jest.requireActual('src/sentry/Sentry') as any),
+  sentryRoutingInstrumentation: { registerNavigationContainer: jest.fn() },
+}))
+
+describe('NavigatorWrapper', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  function renderNavigatorWrapper() {
+    const store = createMockStore()
+    const tree = render(
+      <Provider store={store}>
+        <NavigatorWrapper />
+      </Provider>
+    )
+    return { tree, store }
+  }
+
+  it('forces backup when it should', () => {
+    mocked(getExperimentParams).mockReturnValue({ enableForcedBackup: true })
+    mocked(pastForcedBackupDeadlineSelector).mockReturnValue(true)
+
+    renderNavigatorWrapper()
+    expect(navigate).toHaveBeenCalledWith(Screens.BackupForceScreen)
+  })
+})

--- a/src/navigator/NavigatorWrapper.tsx
+++ b/src/navigator/NavigatorWrapper.tsx
@@ -13,7 +13,7 @@ import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import { activeScreenChanged } from 'src/app/actions'
 import { getAppLocked } from 'src/app/selectors'
 import UpgradeScreen from 'src/app/UpgradeScreen'
-import { doingBackupFlowSelector, shouldForceBackupSelector } from 'src/backup/selectors'
+import { doingBackupFlowSelector, pastForcedBackupDeadlineSelector } from 'src/backup/selectors'
 import { DEV_RESTORE_NAV_STATE_ON_RELOAD } from 'src/config'
 import {
   navigate,
@@ -30,6 +30,9 @@ import appTheme from 'src/styles/appTheme'
 import { userInSanctionedCountrySelector } from 'src/utils/countryFeatures'
 import Logger from 'src/utils/Logger'
 import { isVersionBelowMinimum } from 'src/utils/versionCheck'
+import { getExperimentParams } from 'src/statsig'
+import { ExperimentConfigs } from 'src/statsig/constants'
+import { StatsigExperiments } from 'src/statsig/types'
 
 // This uses RN Navigation's experimental nav state persistence
 // to improve the hot reloading experience when in DEV mode
@@ -74,7 +77,10 @@ export const NavigatorWrapper = () => {
     return isVersionBelowMinimum(version, minRequiredVersion)
   }, [minRequiredVersion])
 
-  const shouldForceBackup = useSelector(shouldForceBackupSelector)
+  const shouldForceBackup =
+    useSelector(pastForcedBackupDeadlineSelector) &&
+    getExperimentParams(ExperimentConfigs[StatsigExperiments.RECOVERY_PHRASE_IN_ONBOARDING])
+      .enableForcedBackup
   const doingBackupFlow = useSelector(doingBackupFlowSelector)
 
   React.useEffect(() => {


### PR DESCRIPTION
### Description

for the backup in onboarding experiment, we want to turn off forced backup if the experiment param says to do so

### Test plan

automated tests

### Related issues

should have been done in https://linear.app/valora/issue/ACT-643/set-up-statsig-experiment-determine-bucketing-in-wallet-disable-forced

### Backwards compatibility

na