### PR TITLE
fix: dismiss keyboard on bottom sheet open

### DIFF
--- a/src/components/BottomSheet.tsx
+++ b/src/components/BottomSheet.tsx
@@ -1,6 +1,7 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import {
   Dimensions,
+  Keyboard,
   LayoutChangeEvent,
   StyleSheet,
   TouchableWithoutFeedback,
@@ -37,6 +38,10 @@ function BottomSheet({
   const [showingOptions, setOptionsVisible] = useState(isVisible)
   const [pickerHeight, setPickerHeight] = useState(0)
   const safeAreaInsets = useSafeAreaInsets()
+
+  useEffect(() => {
+    if (isVisible) Keyboard.dismiss()
+  }, [isVisible])
 
   const progress = useSharedValue(0)
   const animatedPickerPosition = useAnimatedStyle(

--- a/src/dappsExplorer/useDappInfoBottomSheet.tsx
+++ b/src/dappsExplorer/useDappInfoBottomSheet.tsx
@@ -4,7 +4,7 @@ import BottomSheet, {
 } from '@gorhom/bottom-sheet'
 import React, { useCallback, useMemo, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
-import { StyleSheet, Text, View } from 'react-native'
+import { Keyboard, StyleSheet, Text, View } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { DappExplorerEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
@@ -33,6 +33,8 @@ const useDappInfoBottomSheet = () => {
   }
 
   const openSheet = () => {
+    // dismiss keyboard if it's open prior to showing bottom sheet
+    Keyboard.dismiss()
     ValoraAnalytics.track(DappExplorerEvents.dapp_open_info)
     bottomSheetRef.current?.snapToIndex(0)
   }


### PR DESCRIPTION
### Description

Noticed when working on #3599. Currently if the keyboard is visible the when `openSheet` is called the bottom sheet will display behind the keyboard. If there is no keyboard visible on the screen, then the `Keyboard.dismiss()` method will not have any effect.

#### Added to
- `openSheet` from `src/dappsExplorer/useDappInfoBottomSheet.tsx`
- `src/components/BottomSheet.tsx`

#### Before
https://user-images.githubusercontent.com/26950305/230246866-57bd2246-cb55-4d79-9672-6712e071fb9b.mov

#### After
https://user-images.githubusercontent.com/26950305/230247068-85bc3ada-f6dc-4302-9537-e0e30c3c2642.mov

### Test plan

Tested locally on iOS and Android

### Related issues

N/A

### Backwards compatibility

Yes