### PR TITLE
fix(onboarding): land on the correct screen if bailed on recovery phrase

### DIFF
--- a/src/account/actions.ts
+++ b/src/account/actions.ts
@@ -31,8 +31,8 @@ export enum Actions {
   DISMISS_START_SUPERCHARGING = 'ACCOUNT/DISMISS_START_SUPERCHARGING',
   SAVE_SIGNED_MESSAGE = 'ACCOUNT/SAVE_SIGNED_MESSAGE',
   SET_CELO_EDUCATION_COMPLETED = 'ACCOUNT/SET_CELO_EDUCATION_COMPLETED',
-  RECOVERY_PHRASE_IN_ONBOARDING_SEEN = 'ACCOUNT/RECOVERY_PHRASE_IN_ONBOARDING_SEEN',
-  RECOVERY_PHRASE_IN_ONBOARDING_SAVED = 'ACCOUNT/RECOVERY_PHRASE_IN_ONBOARDING_SAVED',
+  RECOVERY_PHRASE_IN_ONBOARDING_STARTED = 'ACCOUNT/RECOVERY_PHRASE_IN_ONBOARDING_STARTED',
+  RECOVERY_PHRASE_IN_ONBOARDING_COMPLETED = 'ACCOUNT/RECOVERY_PHRASE_IN_ONBOARDING_COMPLETED',
 }
 
 export interface ChooseCreateAccountAction {
@@ -162,12 +162,12 @@ export interface SetCeloEducationCompletedAction {
   celoEducationCompleted: boolean
 }
 
-export interface RecoveryPhraseInOnboardingSeen {
-  type: Actions.RECOVERY_PHRASE_IN_ONBOARDING_SEEN
+export interface RecoveryPhraseInOnboardingStarted {
+  type: Actions.RECOVERY_PHRASE_IN_ONBOARDING_STARTED
 }
 
-export interface RecoveryPhraseInOnboardingSaved {
-  type: Actions.RECOVERY_PHRASE_IN_ONBOARDING_SAVED
+export interface RecoveryPhraseInOnboardingCompleted {
+  type: Actions.RECOVERY_PHRASE_IN_ONBOARDING_COMPLETED
 }
 
 export type ActionTypes =
@@ -199,8 +199,8 @@ export type ActionTypes =
   | DismissStartSuperchargingAction
   | SaveSignedMessage
   | SetCeloEducationCompletedAction
-  | RecoveryPhraseInOnboardingSeen
-  | RecoveryPhraseInOnboardingSaved
+  | RecoveryPhraseInOnboardingStarted
+  | RecoveryPhraseInOnboardingCompleted
 
 export function chooseCreateAccount(now: number): ChooseCreateAccountAction {
   return {
@@ -357,10 +357,10 @@ export const setGoldEducationCompleted = (): SetCeloEducationCompletedAction => 
   celoEducationCompleted: true,
 })
 
-export const recoveryPhraseInOnboardingSeen = (): RecoveryPhraseInOnboardingSeen => ({
-  type: Actions.RECOVERY_PHRASE_IN_ONBOARDING_SEEN,
+export const recoveryPhraseInOnboardingStarted = (): RecoveryPhraseInOnboardingStarted => ({
+  type: Actions.RECOVERY_PHRASE_IN_ONBOARDING_STARTED,
 })
 
-export const recoveryPhraseInOnboardingSaved = (): RecoveryPhraseInOnboardingSaved => ({
-  type: Actions.RECOVERY_PHRASE_IN_ONBOARDING_SAVED,
+export const recoveryPhraseInOnboardingCompleted = (): RecoveryPhraseInOnboardingCompleted => ({
+  type: Actions.RECOVERY_PHRASE_IN_ONBOARDING_COMPLETED,
 })

--- a/src/account/actions.ts
+++ b/src/account/actions.ts
@@ -31,6 +31,7 @@ export enum Actions {
   DISMISS_START_SUPERCHARGING = 'ACCOUNT/DISMISS_START_SUPERCHARGING',
   SAVE_SIGNED_MESSAGE = 'ACCOUNT/SAVE_SIGNED_MESSAGE',
   SET_CELO_EDUCATION_COMPLETED = 'ACCOUNT/SET_CELO_EDUCATION_COMPLETED',
+  RECOVERY_PHRASE_IN_ONBOARDING_SEEN = 'ACCOUNT/RECOVERY_PHRASE_IN_ONBOARDING_SEEN',
 }
 
 export interface ChooseCreateAccountAction {
@@ -160,6 +161,10 @@ export interface SetCeloEducationCompletedAction {
   celoEducationCompleted: boolean
 }
 
+export interface RecoveryPhraseInOnboardingSeen {
+  type: Actions.RECOVERY_PHRASE_IN_ONBOARDING_SEEN
+}
+
 export type ActionTypes =
   | ChooseCreateAccountAction
   | ChooseRestoreAccountAction
@@ -189,6 +194,7 @@ export type ActionTypes =
   | DismissStartSuperchargingAction
   | SaveSignedMessage
   | SetCeloEducationCompletedAction
+  | RecoveryPhraseInOnboardingSeen
 
 export function chooseCreateAccount(now: number): ChooseCreateAccountAction {
   return {
@@ -343,4 +349,8 @@ export const saveSignedMessage = (): SaveSignedMessage => ({
 export const setGoldEducationCompleted = (): SetCeloEducationCompletedAction => ({
   type: Actions.SET_CELO_EDUCATION_COMPLETED,
   celoEducationCompleted: true,
+})
+
+export const recoveryPhraseInOnboardingSeen = (): RecoveryPhraseInOnboardingSeen => ({
+  type: Actions.RECOVERY_PHRASE_IN_ONBOARDING_SEEN,
 })

--- a/src/account/actions.ts
+++ b/src/account/actions.ts
@@ -32,6 +32,7 @@ export enum Actions {
   SAVE_SIGNED_MESSAGE = 'ACCOUNT/SAVE_SIGNED_MESSAGE',
   SET_CELO_EDUCATION_COMPLETED = 'ACCOUNT/SET_CELO_EDUCATION_COMPLETED',
   RECOVERY_PHRASE_IN_ONBOARDING_SEEN = 'ACCOUNT/RECOVERY_PHRASE_IN_ONBOARDING_SEEN',
+  RECOVERY_PHRASE_IN_ONBOARDING_SAVED = 'ACCOUNT/RECOVERY_PHRASE_IN_ONBOARDING_SAVED',
 }
 
 export interface ChooseCreateAccountAction {
@@ -165,6 +166,10 @@ export interface RecoveryPhraseInOnboardingSeen {
   type: Actions.RECOVERY_PHRASE_IN_ONBOARDING_SEEN
 }
 
+export interface RecoveryPhraseInOnboardingSaved {
+  type: Actions.RECOVERY_PHRASE_IN_ONBOARDING_SAVED
+}
+
 export type ActionTypes =
   | ChooseCreateAccountAction
   | ChooseRestoreAccountAction
@@ -195,6 +200,7 @@ export type ActionTypes =
   | SaveSignedMessage
   | SetCeloEducationCompletedAction
   | RecoveryPhraseInOnboardingSeen
+  | RecoveryPhraseInOnboardingSaved
 
 export function chooseCreateAccount(now: number): ChooseCreateAccountAction {
   return {
@@ -353,4 +359,8 @@ export const setGoldEducationCompleted = (): SetCeloEducationCompletedAction => 
 
 export const recoveryPhraseInOnboardingSeen = (): RecoveryPhraseInOnboardingSeen => ({
   type: Actions.RECOVERY_PHRASE_IN_ONBOARDING_SEEN,
+})
+
+export const recoveryPhraseInOnboardingSaved = (): RecoveryPhraseInOnboardingSaved => ({
+  type: Actions.RECOVERY_PHRASE_IN_ONBOARDING_SAVED,
 })

--- a/src/account/reducer.ts
+++ b/src/account/reducer.ts
@@ -33,6 +33,7 @@ export interface State {
   dismissedKeepSupercharging: boolean
   dismissedStartSupercharging: boolean
   celoEducationCompleted: boolean
+  hasSeenRecoveryPhraseInOnboarding: boolean
 }
 
 export enum PincodeType {
@@ -95,6 +96,7 @@ export const initialState: State = {
   dismissedKeepSupercharging: false,
   dismissedStartSupercharging: false,
   celoEducationCompleted: false,
+  hasSeenRecoveryPhraseInOnboarding: false,
 }
 
 export const reducer = (
@@ -265,6 +267,11 @@ export const reducer = (
       return {
         ...state,
         celoEducationCompleted: action.celoEducationCompleted,
+      }
+    case Actions.RECOVERY_PHRASE_IN_ONBOARDING_SEEN:
+      return {
+        ...state,
+        hasSeenRecoveryPhraseInOnboarding: true,
       }
     default:
       return state

--- a/src/account/reducer.ts
+++ b/src/account/reducer.ts
@@ -69,9 +69,9 @@ export enum FinclusiveKycStatus {
 }
 
 export enum RecoveryPhraseInOnboardingStatus {
-  NotSeen = 'NotSeen', // ineligible and control users, and variant users who have not reached the "ProtectWallet" screen
-  Seen = 'Seen', // variant users who have reached the "ProtectWallet" screen, but not clicked "I've saved it"
-  Saved = 'Saved', // variant users who have clicked "I've saved it"
+  NotStarted = 'NotStarted', // ineligible and control users, and variant users who have not reached the "ProtectWallet" screen
+  InProgress = 'InProgress', // variant users who have reached the "ProtectWallet" screen, but not clicked "I've saved it"
+  Completed = 'Completed', // variant users who have clicked "I've saved it"
 }
 
 export const initialState: State = {
@@ -102,7 +102,7 @@ export const initialState: State = {
   dismissedKeepSupercharging: false,
   dismissedStartSupercharging: false,
   celoEducationCompleted: false,
-  recoveryPhraseInOnboardingStatus: RecoveryPhraseInOnboardingStatus.NotSeen,
+  recoveryPhraseInOnboardingStatus: RecoveryPhraseInOnboardingStatus.NotStarted,
 }
 
 export const reducer = (
@@ -274,15 +274,15 @@ export const reducer = (
         ...state,
         celoEducationCompleted: action.celoEducationCompleted,
       }
-    case Actions.RECOVERY_PHRASE_IN_ONBOARDING_SEEN:
+    case Actions.RECOVERY_PHRASE_IN_ONBOARDING_STARTED:
       return {
         ...state,
-        recoveryPhraseInOnboardingStatus: RecoveryPhraseInOnboardingStatus.Seen,
+        recoveryPhraseInOnboardingStatus: RecoveryPhraseInOnboardingStatus.InProgress,
       }
-    case Actions.RECOVERY_PHRASE_IN_ONBOARDING_SAVED:
+    case Actions.RECOVERY_PHRASE_IN_ONBOARDING_COMPLETED:
       return {
         ...state,
-        recoveryPhraseInOnboardingStatus: RecoveryPhraseInOnboardingStatus.Saved,
+        recoveryPhraseInOnboardingStatus: RecoveryPhraseInOnboardingStatus.Completed,
       }
     default:
       return state

--- a/src/account/reducer.ts
+++ b/src/account/reducer.ts
@@ -33,7 +33,7 @@ export interface State {
   dismissedKeepSupercharging: boolean
   dismissedStartSupercharging: boolean
   celoEducationCompleted: boolean
-  hasSeenRecoveryPhraseInOnboarding: boolean
+  recoveryPhraseInOnboardingStatus: RecoveryPhraseInOnboardingStatus
 }
 
 export enum PincodeType {
@@ -68,6 +68,12 @@ export enum FinclusiveKycStatus {
   InReview = 4,
 }
 
+export enum RecoveryPhraseInOnboardingStatus {
+  NotSeen = 'NotSeen', // ineligible and control users, and variant users who have not reached the "ProtectWallet" screen
+  Seen = 'Seen', // variant users who have reached the "ProtectWallet" screen, but not clicked "I've saved it"
+  Saved = 'Saved', // variant users who have clicked "I've saved it"
+}
+
 export const initialState: State = {
   name: null,
   e164PhoneNumber: null,
@@ -96,7 +102,7 @@ export const initialState: State = {
   dismissedKeepSupercharging: false,
   dismissedStartSupercharging: false,
   celoEducationCompleted: false,
-  hasSeenRecoveryPhraseInOnboarding: false,
+  recoveryPhraseInOnboardingStatus: RecoveryPhraseInOnboardingStatus.NotSeen,
 }
 
 export const reducer = (
@@ -271,7 +277,12 @@ export const reducer = (
     case Actions.RECOVERY_PHRASE_IN_ONBOARDING_SEEN:
       return {
         ...state,
-        hasSeenRecoveryPhraseInOnboarding: true,
+        recoveryPhraseInOnboardingStatus: RecoveryPhraseInOnboardingStatus.Seen,
+      }
+    case Actions.RECOVERY_PHRASE_IN_ONBOARDING_SAVED:
+      return {
+        ...state,
+        recoveryPhraseInOnboardingStatus: RecoveryPhraseInOnboardingStatus.Saved,
       }
     default:
       return state

--- a/src/account/selectors.ts
+++ b/src/account/selectors.ts
@@ -59,3 +59,5 @@ export const celoEducationCompletedSelector = (state: RootState) =>
   state.account.celoEducationCompleted
 
 export const startOnboardingTimeSelector = (state: RootState) => state.account.startOnboardingTime
+export const recoveryPhraseInOnboardingStatusSelector = (state: RootState) =>
+  state.account.recoveryPhraseInOnboardingStatus

--- a/src/analytics/ValoraAnalytics.ts
+++ b/src/analytics/ValoraAnalytics.ts
@@ -140,6 +140,7 @@ class ValoraAnalytics {
 
       // getAnonymousId causes the e2e tests to fail
       const overrideStableID = isE2EEnv ? E2E_TEST_STATSIG_ID : await Analytics.getAnonymousId()
+      Logger.debug(TAG, 'Statsig stable ID', overrideStableID)
       await Statsig.initialize(STATSIG_API_KEY, statsigUser, {
         // StableID should match Segment anonymousId
         overrideStableID,

--- a/src/navigator/Navigator.tsx
+++ b/src/navigator/Navigator.tsx
@@ -20,7 +20,6 @@ import AccounSetupFailureScreen from 'src/account/AccountSetupFailureScreen'
 import GoldEducation from 'src/account/GoldEducation'
 import Licenses from 'src/account/Licenses'
 import Profile from 'src/account/Profile'
-import { PincodeType } from 'src/account/reducer'
 import StoreWipeRecoveryScreen from 'src/account/StoreWipeRecoveryScreen'
 import SupportContact from 'src/account/SupportContact'
 import { CeloExchangeEvents } from 'src/analytics/Events'
@@ -87,6 +86,7 @@ import {
   noHeaderGestureDisabled,
   nuxNavigationOptions,
 } from 'src/navigator/Headers'
+import { getInitialRoute } from 'src/navigator/initialRoute'
 import { navigateBack, navigateToExchangeHome } from 'src/navigator/NavigationService'
 import QRNavigator from 'src/navigator/QRNavigator'
 import { Screens } from 'src/navigator/Screens'
@@ -122,9 +122,6 @@ import ValidateRecipientAccount, {
 import ValidateRecipientIntro, {
   validateRecipientIntroScreenNavOptions,
 } from 'src/send/ValidateRecipientIntro'
-import { getExperimentParams } from 'src/statsig'
-import { ExperimentConfigs } from 'src/statsig/constants'
-import { StatsigExperiments } from 'src/statsig/types'
 import SwapExecuteScreen from 'src/swap/SwapExecuteScreen'
 import SwapReviewScreen from 'src/swap/SwapReviewScreen'
 import TokenBalancesScreen from 'src/tokens/TokenBalances'
@@ -609,7 +606,7 @@ const mapStateToProps = (state: RootState) => {
     account: state.web3.account,
     hasSeenVerificationNux: state.identity.hasSeenVerificationNux,
     askedContactsPermission: state.identity.askedContactsPermission,
-    hasSeenRecoveryPhraseInOnboarding: state.account.hasSeenRecoveryPhraseInOnboarding,
+    recoveryPhraseInOnboardingStatus: state.account.recoveryPhraseInOnboardingStatus,
   }
 }
 
@@ -626,30 +623,18 @@ export function MainStackScreen() {
       pincodeType,
       account,
       hasSeenVerificationNux,
-      hasSeenRecoveryPhraseInOnboarding,
+      recoveryPhraseInOnboardingStatus,
     } = mapStateToProps(store.getState())
 
-    let initialRoute: InitialRouteName
-
-    if (!language) {
-      initialRoute = Screens.Language
-    } else if (!acceptedTerms || pincodeType === PincodeType.Unset) {
-      // allow empty username
-      // User didn't go far enough in onboarding, start again from education
-      initialRoute = Screens.Welcome
-    } else if (!account) {
-      initialRoute = choseToRestoreAccount ? Screens.ImportWallet : Screens.Welcome
-    } else if (
-      getExperimentParams(ExperimentConfigs[StatsigExperiments.RECOVERY_PHRASE_IN_ONBOARDING])
-        .showRecoveryPhraseInOnboarding &&
-      !hasSeenRecoveryPhraseInOnboarding
-    ) {
-      initialRoute = Screens.ProtectWallet
-    } else if (!hasSeenVerificationNux) {
-      initialRoute = Screens.VerificationStartScreen
-    } else {
-      initialRoute = Screens.DrawerNavigator
-    }
+    const initialRoute: InitialRouteName = getInitialRoute({
+      choseToRestoreAccount,
+      language,
+      acceptedTerms,
+      pincodeType,
+      account,
+      hasSeenVerificationNux,
+      recoveryPhraseInOnboardingStatus,
+    })
 
     setInitialRoute(initialRoute)
     Logger.info(`${TAG}@MainStackScreen`, `Initial route: ${initialRoute}`)

--- a/src/navigator/Navigator.tsx
+++ b/src/navigator/Navigator.tsx
@@ -63,13 +63,13 @@ import ExternalExchanges, {
   externalExchangesScreenOptions,
 } from 'src/fiatExchanges/ExternalExchanges'
 import FiatExchangeAmount from 'src/fiatExchanges/FiatExchangeAmount'
-import WithdrawSpend from 'src/fiatExchanges/WithdrawSpend'
 import FiatExchangeCurrency, {
   fiatExchangesOptionsScreenOptions,
 } from 'src/fiatExchanges/FiatExchangeCurrency'
 import SelectProviderScreen from 'src/fiatExchanges/SelectProvider'
 import SimplexScreen from 'src/fiatExchanges/SimplexScreen'
 import Spend, { spendScreenOptions } from 'src/fiatExchanges/Spend'
+import WithdrawSpend from 'src/fiatExchanges/WithdrawSpend'
 import i18n from 'src/i18n'
 import { currentLanguageSelector } from 'src/i18n/selectors'
 import PhoneNumberLookupQuotaScreen from 'src/identity/PhoneNumberLookupQuotaScreen'
@@ -122,6 +122,9 @@ import ValidateRecipientAccount, {
 import ValidateRecipientIntro, {
   validateRecipientIntroScreenNavOptions,
 } from 'src/send/ValidateRecipientIntro'
+import { getExperimentParams } from 'src/statsig'
+import { ExperimentConfigs } from 'src/statsig/constants'
+import { StatsigExperiments } from 'src/statsig/types'
 import SwapExecuteScreen from 'src/swap/SwapExecuteScreen'
 import SwapReviewScreen from 'src/swap/SwapReviewScreen'
 import TokenBalancesScreen from 'src/tokens/TokenBalances'
@@ -606,6 +609,7 @@ const mapStateToProps = (state: RootState) => {
     account: state.web3.account,
     hasSeenVerificationNux: state.identity.hasSeenVerificationNux,
     askedContactsPermission: state.identity.askedContactsPermission,
+    hasSeenRecoveryPhraseInOnboarding: state.account.hasSeenRecoveryPhraseInOnboarding,
   }
 }
 
@@ -622,6 +626,7 @@ export function MainStackScreen() {
       pincodeType,
       account,
       hasSeenVerificationNux,
+      hasSeenRecoveryPhraseInOnboarding,
     } = mapStateToProps(store.getState())
 
     let initialRoute: InitialRouteName
@@ -634,6 +639,12 @@ export function MainStackScreen() {
       initialRoute = Screens.Welcome
     } else if (!account) {
       initialRoute = choseToRestoreAccount ? Screens.ImportWallet : Screens.Welcome
+    } else if (
+      getExperimentParams(ExperimentConfigs[StatsigExperiments.RECOVERY_PHRASE_IN_ONBOARDING])
+        .showRecoveryPhraseInOnboarding &&
+      !hasSeenRecoveryPhraseInOnboarding
+    ) {
+      initialRoute = Screens.ProtectWallet
     } else if (!hasSeenVerificationNux) {
       initialRoute = Screens.VerificationStartScreen
     } else {

--- a/src/navigator/initalRoute.test.tsx
+++ b/src/navigator/initalRoute.test.tsx
@@ -1,0 +1,77 @@
+import { PincodeType, RecoveryPhraseInOnboardingStatus } from 'src/account/reducer'
+import { getInitialRoute } from 'src/navigator/initialRoute'
+import { Screens } from 'src/navigator/Screens'
+
+describe('initialRoute', () => {
+  const defaultArgs = {
+    choseToRestoreAccount: false,
+    language: 'en',
+    acceptedTerms: true,
+    pincodeType: PincodeType.CustomPin,
+    account: '0x1234',
+    hasSeenVerificationNux: true,
+    recoveryPhraseInOnboardingStatus: RecoveryPhraseInOnboardingStatus.NotSeen,
+  }
+
+  it('returns language screen if no language is set', () => {
+    expect(getInitialRoute({ ...defaultArgs, language: null })).toEqual(Screens.Language)
+  })
+
+  it('returns welcome screen if not accepted terms', () => {
+    expect(getInitialRoute({ ...defaultArgs, acceptedTerms: false })).toEqual(Screens.Welcome)
+  })
+
+  it('returns welcome screen if not pincode is unset', () => {
+    expect(getInitialRoute({ ...defaultArgs, pincodeType: PincodeType.Unset })).toEqual(
+      Screens.Welcome
+    )
+  })
+
+  it('returns welcome screen if account is null', () => {
+    expect(getInitialRoute({ ...defaultArgs, account: null })).toEqual(Screens.Welcome)
+  })
+
+  it('returns import wallet screen if account is null and choose to restore account', () => {
+    expect(getInitialRoute({ ...defaultArgs, account: null, choseToRestoreAccount: true })).toEqual(
+      Screens.ImportWallet
+    )
+  })
+
+  it('returns protect wallet if recovery phrase in onboarding seen but not saved', () => {
+    expect(
+      getInitialRoute({
+        ...defaultArgs,
+        recoveryPhraseInOnboardingStatus: RecoveryPhraseInOnboardingStatus.Seen,
+      })
+    ).toEqual(Screens.ProtectWallet)
+  })
+
+  it('returns PN verification if not seen verification', () => {
+    expect(getInitialRoute({ ...defaultArgs, hasSeenVerificationNux: false })).toEqual(
+      Screens.VerificationStartScreen
+    )
+  })
+
+  it('returns PN verification if not seen verification and saved recovery phrase', () => {
+    expect(
+      getInitialRoute({
+        ...defaultArgs,
+        hasSeenVerificationNux: false,
+        recoveryPhraseInOnboardingStatus: RecoveryPhraseInOnboardingStatus.Saved,
+      })
+    ).toEqual(Screens.VerificationStartScreen)
+  })
+
+  it('returns drawer navigator if all onboarding complete', () => {
+    expect(getInitialRoute(defaultArgs)).toEqual(Screens.DrawerNavigator)
+  })
+
+  it('returns drawer navigator if all onboarding complete and saved recovery phrase', () => {
+    expect(
+      getInitialRoute({
+        ...defaultArgs,
+        recoveryPhraseInOnboardingStatus: RecoveryPhraseInOnboardingStatus.Saved,
+      })
+    ).toEqual(Screens.DrawerNavigator)
+  })
+})

--- a/src/navigator/initalRoute.test.tsx
+++ b/src/navigator/initalRoute.test.tsx
@@ -10,7 +10,7 @@ describe('initialRoute', () => {
     pincodeType: PincodeType.CustomPin,
     account: '0x1234',
     hasSeenVerificationNux: true,
-    recoveryPhraseInOnboardingStatus: RecoveryPhraseInOnboardingStatus.NotSeen,
+    recoveryPhraseInOnboardingStatus: RecoveryPhraseInOnboardingStatus.NotStarted,
   }
 
   it('returns language screen if no language is set', () => {
@@ -41,7 +41,7 @@ describe('initialRoute', () => {
     expect(
       getInitialRoute({
         ...defaultArgs,
-        recoveryPhraseInOnboardingStatus: RecoveryPhraseInOnboardingStatus.Seen,
+        recoveryPhraseInOnboardingStatus: RecoveryPhraseInOnboardingStatus.InProgress,
       })
     ).toEqual(Screens.ProtectWallet)
   })
@@ -57,7 +57,7 @@ describe('initialRoute', () => {
       getInitialRoute({
         ...defaultArgs,
         hasSeenVerificationNux: false,
-        recoveryPhraseInOnboardingStatus: RecoveryPhraseInOnboardingStatus.Saved,
+        recoveryPhraseInOnboardingStatus: RecoveryPhraseInOnboardingStatus.Completed,
       })
     ).toEqual(Screens.VerificationStartScreen)
   })
@@ -70,7 +70,7 @@ describe('initialRoute', () => {
     expect(
       getInitialRoute({
         ...defaultArgs,
-        recoveryPhraseInOnboardingStatus: RecoveryPhraseInOnboardingStatus.Saved,
+        recoveryPhraseInOnboardingStatus: RecoveryPhraseInOnboardingStatus.Completed,
       })
     ).toEqual(Screens.DrawerNavigator)
   })

--- a/src/navigator/initialRoute.tsx
+++ b/src/navigator/initialRoute.tsx
@@ -26,7 +26,7 @@ export function getInitialRoute({
     return Screens.Welcome
   } else if (!account) {
     return choseToRestoreAccount ? Screens.ImportWallet : Screens.Welcome
-  } else if (recoveryPhraseInOnboardingStatus === RecoveryPhraseInOnboardingStatus.Seen) {
+  } else if (recoveryPhraseInOnboardingStatus === RecoveryPhraseInOnboardingStatus.InProgress) {
     return Screens.ProtectWallet
   } else if (!hasSeenVerificationNux) {
     return Screens.VerificationStartScreen

--- a/src/navigator/initialRoute.tsx
+++ b/src/navigator/initialRoute.tsx
@@ -1,0 +1,36 @@
+import { PincodeType, RecoveryPhraseInOnboardingStatus } from 'src/account/reducer'
+import { Screens } from 'src/navigator/Screens'
+
+export function getInitialRoute({
+  choseToRestoreAccount,
+  language,
+  acceptedTerms,
+  pincodeType,
+  account,
+  hasSeenVerificationNux,
+  recoveryPhraseInOnboardingStatus,
+}: {
+  choseToRestoreAccount: boolean | undefined
+  language: string | null
+  acceptedTerms: boolean
+  pincodeType: PincodeType
+  account: string | null
+  hasSeenVerificationNux: boolean
+  recoveryPhraseInOnboardingStatus: RecoveryPhraseInOnboardingStatus
+}) {
+  if (!language) {
+    return Screens.Language
+  } else if (!acceptedTerms || pincodeType === PincodeType.Unset) {
+    // allow empty username
+    // User didn't go far enough in onboarding, start again from education
+    return Screens.Welcome
+  } else if (!account) {
+    return choseToRestoreAccount ? Screens.ImportWallet : Screens.Welcome
+  } else if (recoveryPhraseInOnboardingStatus === RecoveryPhraseInOnboardingStatus.Seen) {
+    return Screens.ProtectWallet
+  } else if (!hasSeenVerificationNux) {
+    return Screens.VerificationStartScreen
+  } else {
+    return Screens.DrawerNavigator
+  }
+}

--- a/src/onboarding/registration/OnboardingRecoveryPhrase.test.tsx
+++ b/src/onboarding/registration/OnboardingRecoveryPhrase.test.tsx
@@ -1,15 +1,16 @@
+import Clipboard from '@react-native-clipboard/clipboard'
+import { fireEvent, render, waitFor } from '@testing-library/react-native'
 import * as React from 'react'
 import 'react-native'
-import OnboardingRecoveryPhrase from 'src/onboarding/registration/OnboardingRecoveryPhrase'
-import { fireEvent, render, waitFor } from '@testing-library/react-native'
 import { Provider } from 'react-redux'
-import { createMockStore, getMockStackScreenProps } from 'test/utils'
-import { Screens } from 'src/navigator/Screens'
-import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
+import { recoveryPhraseInOnboardingSaved } from 'src/account/actions'
 import { OnboardingEvents } from 'src/analytics/Events'
-import { mockOnboardingProps, mockTwelveWordMnemonic } from 'test/values'
+import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
+import { Screens } from 'src/navigator/Screens'
+import OnboardingRecoveryPhrase from 'src/onboarding/registration/OnboardingRecoveryPhrase'
 import { goToNextOnboardingScreen } from 'src/onboarding/steps'
-import Clipboard from '@react-native-clipboard/clipboard'
+import { createMockStore, getMockStackScreenProps } from 'test/utils'
+import { mockOnboardingProps, mockTwelveWordMnemonic } from 'test/values'
 
 jest.mock('src/analytics/ValoraAnalytics')
 jest.mock('src/backup/utils', () => ({
@@ -33,6 +34,7 @@ describe('OnboardingRecoveryPhraseScreen', () => {
       account: '0xaccount',
     },
   })
+  store.dispatch = jest.fn()
   beforeEach(() => {
     jest.clearAllMocks()
   })
@@ -45,6 +47,7 @@ describe('OnboardingRecoveryPhraseScreen', () => {
     fireEvent.press(getByTestId('protectWalletBottomSheetContinue'))
     expect(ValoraAnalytics.track).toHaveBeenCalledTimes(1)
     expect(ValoraAnalytics.track).toHaveBeenCalledWith(OnboardingEvents.protect_wallet_complete)
+    expect(store.dispatch).toHaveBeenCalledWith(recoveryPhraseInOnboardingSaved())
     expect(goToNextOnboardingScreen).toBeCalledWith({
       firstScreenInCurrentStep: Screens.ProtectWallet,
       onboardingProps: mockOnboardingProps,

--- a/src/onboarding/registration/OnboardingRecoveryPhrase.test.tsx
+++ b/src/onboarding/registration/OnboardingRecoveryPhrase.test.tsx
@@ -3,7 +3,7 @@ import { fireEvent, render, waitFor } from '@testing-library/react-native'
 import * as React from 'react'
 import 'react-native'
 import { Provider } from 'react-redux'
-import { recoveryPhraseInOnboardingSaved } from 'src/account/actions'
+import { recoveryPhraseInOnboardingCompleted } from 'src/account/actions'
 import { OnboardingEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import { Screens } from 'src/navigator/Screens'
@@ -47,7 +47,7 @@ describe('OnboardingRecoveryPhraseScreen', () => {
     fireEvent.press(getByTestId('protectWalletBottomSheetContinue'))
     expect(ValoraAnalytics.track).toHaveBeenCalledTimes(1)
     expect(ValoraAnalytics.track).toHaveBeenCalledWith(OnboardingEvents.protect_wallet_complete)
-    expect(store.dispatch).toHaveBeenCalledWith(recoveryPhraseInOnboardingSaved())
+    expect(store.dispatch).toHaveBeenCalledWith(recoveryPhraseInOnboardingCompleted())
     expect(goToNextOnboardingScreen).toBeCalledWith({
       firstScreenInCurrentStep: Screens.ProtectWallet,
       onboardingProps: mockOnboardingProps,

--- a/src/onboarding/registration/OnboardingRecoveryPhrase.tsx
+++ b/src/onboarding/registration/OnboardingRecoveryPhrase.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next'
 import { ScrollView, StyleSheet, Text, View } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { useDispatch, useSelector } from 'react-redux'
-import { recoveryPhraseInOnboardingSaved } from 'src/account/actions'
+import { recoveryPhraseInOnboardingCompleted } from 'src/account/actions'
 import { OnboardingEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import BackupPhraseContainer, {
@@ -81,7 +81,7 @@ function OnboardingRecoveryPhrase({ navigation }: Props) {
   }
   const onPressContinue = () => {
     ValoraAnalytics.track(OnboardingEvents.protect_wallet_complete)
-    dispatch(recoveryPhraseInOnboardingSaved())
+    dispatch(recoveryPhraseInOnboardingCompleted())
     goToNextOnboardingScreen({ firstScreenInCurrentStep: Screens.ProtectWallet, onboardingProps })
   }
 

--- a/src/onboarding/registration/OnboardingRecoveryPhrase.tsx
+++ b/src/onboarding/registration/OnboardingRecoveryPhrase.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next'
 import { ScrollView, StyleSheet, Text, View } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { useDispatch, useSelector } from 'react-redux'
-import { recoveryPhraseInOnboardingSeen } from 'src/account/actions'
+import { recoveryPhraseInOnboardingSaved } from 'src/account/actions'
 import { OnboardingEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import BackupPhraseContainer, {
@@ -81,7 +81,7 @@ function OnboardingRecoveryPhrase({ navigation }: Props) {
   }
   const onPressContinue = () => {
     ValoraAnalytics.track(OnboardingEvents.protect_wallet_complete)
-    dispatch(recoveryPhraseInOnboardingSeen())
+    dispatch(recoveryPhraseInOnboardingSaved())
     goToNextOnboardingScreen({ firstScreenInCurrentStep: Screens.ProtectWallet, onboardingProps })
   }
 

--- a/src/onboarding/registration/OnboardingRecoveryPhrase.tsx
+++ b/src/onboarding/registration/OnboardingRecoveryPhrase.tsx
@@ -1,35 +1,36 @@
+import Clipboard from '@react-native-clipboard/clipboard'
 import { NativeStackScreenProps } from '@react-navigation/native-stack'
 import React, { useLayoutEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { View, ScrollView, StyleSheet, Text } from 'react-native'
+import { ScrollView, StyleSheet, Text, View } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
-import { useSelector } from 'react-redux'
-import Clipboard from '@react-native-clipboard/clipboard'
+import { useDispatch, useSelector } from 'react-redux'
+import { recoveryPhraseInOnboardingSeen } from 'src/account/actions'
 import { OnboardingEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
+import BackupPhraseContainer, {
+  BackupPhraseContainerMode,
+  BackupPhraseType,
+} from 'src/backup/BackupPhraseContainer'
+import { useAccountKey } from 'src/backup/utils'
+import BottomSheet from 'src/components/BottomSheet'
 import Button, { BtnSizes, BtnTypes } from 'src/components/Button'
+import TextButton from 'src/components/TextButton'
+import CopyIcon from 'src/icons/CopyIcon'
 import { HeaderTitleWithSubtitle, nuxNavigationOptionsOnboarding } from 'src/navigator/Headers'
 import { Screens } from 'src/navigator/Screens'
 import { TopBarTextButton } from 'src/navigator/TopBarButton'
 import { StackParamList } from 'src/navigator/types'
-import CopyIcon from 'src/icons/CopyIcon'
-import { useAccountKey } from 'src/backup/utils'
 import {
   getOnboardingStepValues,
   goToNextOnboardingScreen,
   onboardingPropsSelector,
 } from 'src/onboarding/steps'
-import BackupPhraseContainer, {
-  BackupPhraseContainerMode,
-  BackupPhraseType,
-} from 'src/backup/BackupPhraseContainer'
 import { default as useTypedSelector } from 'src/redux/useSelector'
 import colors from 'src/styles/colors'
 import fontStyles from 'src/styles/fonts'
-import { twelveWordMnemonicEnabledSelector } from 'src/web3/selectors'
-import BottomSheet from 'src/components/BottomSheet'
-import TextButton from 'src/components/TextButton'
 import Logger from 'src/utils/Logger'
+import { twelveWordMnemonicEnabledSelector } from 'src/web3/selectors'
 
 type Props = NativeStackScreenProps<StackParamList, Screens.OnboardingRecoveryPhrase>
 
@@ -40,6 +41,7 @@ function OnboardingRecoveryPhrase({ navigation }: Props) {
   const { step, totalSteps } = getOnboardingStepValues(Screens.ProtectWallet, onboardingProps)
   const accountKey = useAccountKey()
   const [showBottomSheet, setShowBottomSheet] = useState(false)
+  const dispatch = useDispatch()
 
   const { t } = useTranslation()
 
@@ -79,6 +81,7 @@ function OnboardingRecoveryPhrase({ navigation }: Props) {
   }
   const onPressContinue = () => {
     ValoraAnalytics.track(OnboardingEvents.protect_wallet_complete)
+    dispatch(recoveryPhraseInOnboardingSeen())
     goToNextOnboardingScreen({ firstScreenInCurrentStep: Screens.ProtectWallet, onboardingProps })
   }
 

--- a/src/onboarding/registration/ProtectWallet.test.tsx
+++ b/src/onboarding/registration/ProtectWallet.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, waitFor } from '@testing-library/react-native'
 import * as React from 'react'
 import 'react-native'
 import { Provider } from 'react-redux'
+import { recoveryPhraseInOnboardingSeen } from 'src/account/actions'
 import { OnboardingEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import { navigate } from 'src/navigator/NavigationService'
@@ -56,6 +57,7 @@ describe('ProtectWalletScreen', () => {
       account: '0xaccount',
     },
   })
+  store.dispatch = jest.fn()
   beforeEach(() => {
     jest.clearAllMocks()
     mocked(getExperimentParams).mockReturnValue(mockExperimentParams)
@@ -68,6 +70,7 @@ describe('ProtectWalletScreen', () => {
         <ProtectWallet {...mockScreenProps} />
       </Provider>
     )
+    expect(store.dispatch).toHaveBeenCalledWith(recoveryPhraseInOnboardingSeen())
     await waitFor(() => {
       expect(getByTestId('recoveryPhraseCard')).toBeTruthy()
       expect(queryByTestId('cloudBackupCard')).toBeNull()
@@ -79,6 +82,7 @@ describe('ProtectWalletScreen', () => {
         <ProtectWallet {...mockScreenProps} />
       </Provider>
     )
+    expect(store.dispatch).toHaveBeenCalledWith(recoveryPhraseInOnboardingSeen())
     await waitFor(() => {
       expect(getByTestId('recoveryPhraseCard')).toBeTruthy()
       expect(getByTestId('cloudBackupCard')).toBeTruthy()

--- a/src/onboarding/registration/ProtectWallet.test.tsx
+++ b/src/onboarding/registration/ProtectWallet.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, waitFor } from '@testing-library/react-native'
 import * as React from 'react'
 import 'react-native'
 import { Provider } from 'react-redux'
-import { recoveryPhraseInOnboardingSeen } from 'src/account/actions'
+import { recoveryPhraseInOnboardingStarted } from 'src/account/actions'
 import { RecoveryPhraseInOnboardingStatus } from 'src/account/reducer'
 import { OnboardingEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
@@ -71,7 +71,7 @@ describe('ProtectWalletScreen', () => {
         <ProtectWallet {...mockScreenProps} />
       </Provider>
     )
-    expect(store.dispatch).toHaveBeenCalledWith(recoveryPhraseInOnboardingSeen())
+    expect(store.dispatch).toHaveBeenCalledWith(recoveryPhraseInOnboardingStarted())
     await waitFor(() => {
       expect(getByTestId('recoveryPhraseCard')).toBeTruthy()
       expect(queryByTestId('cloudBackupCard')).toBeNull()
@@ -83,20 +83,20 @@ describe('ProtectWalletScreen', () => {
         <ProtectWallet {...mockScreenProps} />
       </Provider>
     )
-    expect(store.dispatch).toHaveBeenCalledWith(recoveryPhraseInOnboardingSeen())
+    expect(store.dispatch).toHaveBeenCalledWith(recoveryPhraseInOnboardingStarted())
     await waitFor(() => {
       expect(getByTestId('recoveryPhraseCard')).toBeTruthy()
       expect(getByTestId('cloudBackupCard')).toBeTruthy()
     })
   })
-  it('does not dispatch event if recoveryPhraseInOnboardingStatus is already set to seen', async () => {
+  it('does not dispatch event if recoveryPhraseInOnboardingStatus is not NotStarted', async () => {
     const mockStore = createMockStore({
       web3: {
         twelveWordMnemonicEnabled: true,
         account: '0xaccount',
       },
       account: {
-        recoveryPhraseInOnboardingStatus: RecoveryPhraseInOnboardingStatus.Seen,
+        recoveryPhraseInOnboardingStatus: RecoveryPhraseInOnboardingStatus.InProgress,
       },
     })
     const { getByTestId } = render(

--- a/src/onboarding/registration/ProtectWallet.test.tsx
+++ b/src/onboarding/registration/ProtectWallet.test.tsx
@@ -3,6 +3,7 @@ import * as React from 'react'
 import 'react-native'
 import { Provider } from 'react-redux'
 import { recoveryPhraseInOnboardingSeen } from 'src/account/actions'
+import { RecoveryPhraseInOnboardingStatus } from 'src/account/reducer'
 import { OnboardingEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import { navigate } from 'src/navigator/NavigationService'
@@ -83,6 +84,27 @@ describe('ProtectWalletScreen', () => {
       </Provider>
     )
     expect(store.dispatch).toHaveBeenCalledWith(recoveryPhraseInOnboardingSeen())
+    await waitFor(() => {
+      expect(getByTestId('recoveryPhraseCard')).toBeTruthy()
+      expect(getByTestId('cloudBackupCard')).toBeTruthy()
+    })
+  })
+  it('does not dispatch event if recoveryPhraseInOnboardingStatus is already set to seen', async () => {
+    const mockStore = createMockStore({
+      web3: {
+        twelveWordMnemonicEnabled: true,
+        account: '0xaccount',
+      },
+      account: {
+        recoveryPhraseInOnboardingStatus: RecoveryPhraseInOnboardingStatus.Seen,
+      },
+    })
+    const { getByTestId } = render(
+      <Provider store={mockStore}>
+        <ProtectWallet {...mockScreenProps} />
+      </Provider>
+    )
+    expect(store.dispatch).not.toHaveBeenCalled()
     await waitFor(() => {
       expect(getByTestId('recoveryPhraseCard')).toBeTruthy()
       expect(getByTestId('cloudBackupCard')).toBeTruthy()

--- a/src/onboarding/registration/ProtectWallet.tsx
+++ b/src/onboarding/registration/ProtectWallet.tsx
@@ -5,7 +5,7 @@ import { ActivityIndicator, ScrollView, StyleSheet, Text, View } from 'react-nat
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { useDispatch, useSelector } from 'react-redux'
 import seedrandom from 'seedrandom'
-import { recoveryPhraseInOnboardingSeen } from 'src/account/actions'
+import { recoveryPhraseInOnboardingStarted } from 'src/account/actions'
 import { RecoveryPhraseInOnboardingStatus } from 'src/account/reducer'
 import { recoveryPhraseInOnboardingStatusSelector } from 'src/account/selectors'
 import { OnboardingEvents } from 'src/analytics/Events'
@@ -84,8 +84,8 @@ function ProtectWallet({ navigation }: Props) {
   }, [navigation, step, totalSteps])
 
   useEffect(() => {
-    if (recoveryPhraseInOnboardingStatus === RecoveryPhraseInOnboardingStatus.NotSeen) {
-      dispatch(recoveryPhraseInOnboardingSeen())
+    if (recoveryPhraseInOnboardingStatus === RecoveryPhraseInOnboardingStatus.NotStarted) {
+      dispatch(recoveryPhraseInOnboardingStarted())
     }
   })
 

--- a/src/onboarding/registration/ProtectWallet.tsx
+++ b/src/onboarding/registration/ProtectWallet.tsx
@@ -1,10 +1,11 @@
 import { NativeStackScreenProps } from '@react-navigation/native-stack'
-import React, { useLayoutEffect, useState } from 'react'
+import React, { useEffect, useLayoutEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ActivityIndicator, ScrollView, StyleSheet, Text, View } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
-import { useSelector } from 'react-redux'
+import { useDispatch, useSelector } from 'react-redux'
 import seedrandom from 'seedrandom'
+import { recoveryPhraseInOnboardingSeen } from 'src/account/actions'
 import { OnboardingEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import BottomSheet from 'src/components/BottomSheet'
@@ -49,6 +50,7 @@ function ProtectWallet({ navigation }: Props) {
   const address = useSelector(walletAddressSelector)
   const [showBottomSheet, setShowBottomSheet] = useState(false)
   const { t } = useTranslation()
+  const dispatch = useDispatch()
 
   const cloudBackupIndex = getCloudBackupIndex(address)
 
@@ -77,6 +79,10 @@ function ProtectWallet({ navigation }: Props) {
       headerLeft: undefined,
     })
   }, [navigation, step, totalSteps])
+
+  useEffect(() => {
+    dispatch(recoveryPhraseInOnboardingSeen())
+  })
 
   const onPressRecoveryPhrase = () => {
     ValoraAnalytics.track(OnboardingEvents.protect_wallet_use_recovery, {

--- a/src/onboarding/registration/ProtectWallet.tsx
+++ b/src/onboarding/registration/ProtectWallet.tsx
@@ -6,6 +6,8 @@ import { SafeAreaView } from 'react-native-safe-area-context'
 import { useDispatch, useSelector } from 'react-redux'
 import seedrandom from 'seedrandom'
 import { recoveryPhraseInOnboardingSeen } from 'src/account/actions'
+import { RecoveryPhraseInOnboardingStatus } from 'src/account/reducer'
+import { recoveryPhraseInOnboardingStatusSelector } from 'src/account/selectors'
 import { OnboardingEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import BottomSheet from 'src/components/BottomSheet'
@@ -51,6 +53,7 @@ function ProtectWallet({ navigation }: Props) {
   const [showBottomSheet, setShowBottomSheet] = useState(false)
   const { t } = useTranslation()
   const dispatch = useDispatch()
+  const recoveryPhraseInOnboardingStatus = useSelector(recoveryPhraseInOnboardingStatusSelector)
 
   const cloudBackupIndex = getCloudBackupIndex(address)
 
@@ -81,7 +84,9 @@ function ProtectWallet({ navigation }: Props) {
   }, [navigation, step, totalSteps])
 
   useEffect(() => {
-    dispatch(recoveryPhraseInOnboardingSeen())
+    if (recoveryPhraseInOnboardingStatus === RecoveryPhraseInOnboardingStatus.NotSeen) {
+      dispatch(recoveryPhraseInOnboardingSeen())
+    }
   })
 
   const onPressRecoveryPhrase = () => {

--- a/src/redux/migrations.ts
+++ b/src/redux/migrations.ts
@@ -1,5 +1,5 @@
 import _ from 'lodash'
-import { FinclusiveKycStatus } from 'src/account/reducer'
+import { FinclusiveKycStatus, RecoveryPhraseInOnboardingStatus } from 'src/account/reducer'
 import { CodeInputStatus } from 'src/components/CodeInput'
 import { DEFAULT_SENTRY_NETWORK_ERRORS, DEFAULT_SENTRY_TRACES_SAMPLE_RATE } from 'src/config'
 import { DappConnectInfo, DappV1, DappV2 } from 'src/dapps/types'
@@ -1103,7 +1103,7 @@ export const migrations = {
     ...state,
     account: {
       ...state.account,
-      hasSeenRecoveryPhraseInOnboarding: true,
+      recoveryPhraseInOnboardingStatus: RecoveryPhraseInOnboardingStatus.NotSeen,
     },
   }),
 }

--- a/src/redux/migrations.ts
+++ b/src/redux/migrations.ts
@@ -1103,7 +1103,7 @@ export const migrations = {
     ...state,
     account: {
       ...state.account,
-      recoveryPhraseInOnboardingStatus: RecoveryPhraseInOnboardingStatus.NotSeen,
+      recoveryPhraseInOnboardingStatus: RecoveryPhraseInOnboardingStatus.NotStarted,
     },
   }),
 }

--- a/src/redux/migrations.ts
+++ b/src/redux/migrations.ts
@@ -1099,4 +1099,11 @@ export const migrations = {
   119: (state: any) => state,
   120: (state: any) => state,
   121: (state: any) => state,
+  122: (state: any) => ({
+    ...state,
+    account: {
+      ...state.account,
+      hasSeenRecoveryPhraseInOnboarding: true,
+    },
+  }),
 }

--- a/src/redux/store.test.ts
+++ b/src/redux/store.test.ts
@@ -99,7 +99,7 @@ describe('store state', () => {
       Object {
         "_persist": Object {
           "rehydrated": true,
-          "version": 121,
+          "version": 122,
         },
         "account": Object {
           "acceptedTerms": false,
@@ -128,6 +128,7 @@ describe('store state', () => {
           "pincodeType": "Unset",
           "profileUploaded": false,
           "recoveringFromStoreWipe": false,
+          "recoveryPhraseInOnboardingStatus": "NotStarted",
           "startOnboardingTime": undefined,
         },
         "alert": null,

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -23,7 +23,7 @@ const persistConfig: PersistConfig<RootState> = {
   key: 'root',
   // default is -1, increment as we make migrations
   // See https://github.com/valora-inc/wallet/tree/main/WALLET.md#redux-state-migration
-  version: 121,
+  version: 122,
   keyPrefix: `reduxStore-`, // the redux-persist default is `persist:` which doesn't work with some file systems.
   storage: FSStorage(),
   blacklist: ['networkInfo', 'alert', 'imports', 'swap'],

--- a/test/RootStateSchema.json
+++ b/test/RootStateSchema.json
@@ -2081,6 +2081,14 @@
             "additionalProperties": false,
             "type": "object"
         },
+        "RecoveryPhraseInOnboardingStatus": {
+            "enum": [
+                "NotSeen",
+                "Saved",
+                "Seen"
+            ],
+            "type": "string"
+        },
         "RelayerTypes.ProtocolOptions": {
             "additionalProperties": false,
             "properties": {
@@ -2690,9 +2698,6 @@
                 "hasMigratedToNewBip39": {
                     "type": "boolean"
                 },
-                "hasSeenRecoveryPhraseInOnboarding": {
-                    "type": "boolean"
-                },
                 "name": {
                     "type": [
                         "null",
@@ -2717,6 +2722,9 @@
                 "recoveringFromStoreWipe": {
                     "type": "boolean"
                 },
+                "recoveryPhraseInOnboardingStatus": {
+                    "$ref": "#/definitions/RecoveryPhraseInOnboardingStatus"
+                },
                 "startOnboardingTime": {
                     "type": "number"
                 }
@@ -2737,11 +2745,11 @@
                 "dismissedStartSupercharging",
                 "e164PhoneNumber",
                 "hasMigratedToNewBip39",
-                "hasSeenRecoveryPhraseInOnboarding",
                 "name",
                 "photosNUXClicked",
                 "pictureUri",
-                "pincodeType"
+                "pincodeType",
+                "recoveryPhraseInOnboardingStatus"
             ],
             "type": "object"
         },

--- a/test/RootStateSchema.json
+++ b/test/RootStateSchema.json
@@ -2083,9 +2083,9 @@
         },
         "RecoveryPhraseInOnboardingStatus": {
             "enum": [
-                "NotSeen",
-                "Saved",
-                "Seen"
+                "Completed",
+                "InProgress",
+                "NotStarted"
             ],
             "type": "string"
         },

--- a/test/RootStateSchema.json
+++ b/test/RootStateSchema.json
@@ -2690,6 +2690,9 @@
                 "hasMigratedToNewBip39": {
                     "type": "boolean"
                 },
+                "hasSeenRecoveryPhraseInOnboarding": {
+                    "type": "boolean"
+                },
                 "name": {
                     "type": [
                         "null",
@@ -2734,6 +2737,7 @@
                 "dismissedStartSupercharging",
                 "e164PhoneNumber",
                 "hasMigratedToNewBip39",
+                "hasSeenRecoveryPhraseInOnboarding",
                 "name",
                 "photosNUXClicked",
                 "pictureUri",

--- a/test/schemas.ts
+++ b/test/schemas.ts
@@ -2172,6 +2172,18 @@ export const v121Schema = {
   },
 }
 
+export const v122Schema = {
+  ...v121Schema,
+  _persist: {
+    ...v121Schema._persist,
+    version: 122,
+  },
+  account: {
+    ...v121Schema.account,
+    hasSeenRecoveryPhraseInOnboarding: false,
+  },
+}
+
 export function getLatestSchema(): Partial<RootState> {
-  return v121Schema as Partial<RootState>
+  return v122Schema as Partial<RootState>
 }

--- a/test/schemas.ts
+++ b/test/schemas.ts
@@ -2184,7 +2184,7 @@ export const v122Schema = {
   },
   account: {
     ...v121Schema.account,
-    recoveryPhraseInOnboardingStatus: RecoveryPhraseInOnboardingStatus.NotSeen,
+    recoveryPhraseInOnboardingStatus: RecoveryPhraseInOnboardingStatus.NotStarted,
   },
 }
 

--- a/test/schemas.ts
+++ b/test/schemas.ts
@@ -1,5 +1,9 @@
 import _ from 'lodash'
-import { FinclusiveKycStatus, PincodeType } from 'src/account/reducer'
+import {
+  FinclusiveKycStatus,
+  PincodeType,
+  RecoveryPhraseInOnboardingStatus,
+} from 'src/account/reducer'
 import { AppState } from 'src/app/actions'
 import { CodeInputStatus } from 'src/components/CodeInput'
 import { DappConnectInfo, DappV1, DappV2 } from 'src/dapps/types'
@@ -2180,7 +2184,7 @@ export const v122Schema = {
   },
   account: {
     ...v121Schema.account,
-    hasSeenRecoveryPhraseInOnboarding: false,
+    recoveryPhraseInOnboardingStatus: RecoveryPhraseInOnboardingStatus.NotSeen,
   },
 }
 


### PR DESCRIPTION
### Description

Currently if the user bails on recovery phrase screen in onboarding, the next time the app is launched, the user lands on the PN verification screen. This updates it so that for the experiment variant, the user lands on the recovery phrase screen.

### Test plan

Manual and unit

Control:

https://user-images.githubusercontent.com/5062591/230488403-ea89bb01-9e4a-4e87-9dfa-0b6fae786730.mp4

V1 - backup on onboarding


https://user-images.githubusercontent.com/5062591/230488682-7d4721f9-81c9-46f1-8a01-2152d1cce103.mp4



V2 - fake door


https://user-images.githubusercontent.com/5062591/230488716-0f2c3317-6b03-4bbe-8292-9e5689df15c8.mp4






### Related issues

- Fixes ACT-700

### Backwards compatibility

Yes
