### PR TITLE
chore: add cache control for fetching supercharge rewards

### DIFF
--- a/android/app/src/main/java/org/celo/mobile/MainApplication.java
+++ b/android/app/src/main/java/org/celo/mobile/MainApplication.java
@@ -65,7 +65,7 @@ public class MainApplication
     super.onCreate();
     SoLoader.init(this, /* native exopackage */false);
     initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
-    OkHttpClientProvider.setOkHttpClientFactory(new UserAgentClientFactory());
+    OkHttpClientProvider.setOkHttpClientFactory(new UserAgentClientFactory(this));
   }
 
   @Override

--- a/android/app/src/main/java/org/celo/mobile/UserAgentClientFactory.java
+++ b/android/app/src/main/java/org/celo/mobile/UserAgentClientFactory.java
@@ -1,14 +1,21 @@
 package org.celo.mobile;
 
+import android.content.Context;
 import com.facebook.react.modules.network.OkHttpClientFactory;
 import com.facebook.react.modules.network.OkHttpClientProvider;
 import okhttp3.OkHttpClient;
 
 public class UserAgentClientFactory implements OkHttpClientFactory {
 
+  private Context context;
+
+  public UserAgentClientFactory(Context context) {
+    this.context = context;
+  }
+
   public OkHttpClient createNewNetworkModuleClient() {
     return OkHttpClientProvider
-      .createClientBuilder()
+      .createClientBuilder(this.context)
       .addInterceptor(new UserAgentInterceptor())
       .build();
   }

--- a/src/consumerIncentives/saga.ts
+++ b/src/consumerIncentives/saga.ts
@@ -96,7 +96,7 @@ export function* claimRewardsSaga({ payload: rewards }: ReturnType<typeof claimR
       )
     }
     yield put(setAvailableRewards([]))
-    yield put(fetchAvailableRewards())
+    yield put(fetchAvailableRewards({ forceRefresh: true }))
     yield put(claimRewardsSuccess())
     yield put(showMessage(i18n.t('superchargeClaimSuccess')))
     navigateHome()
@@ -200,7 +200,7 @@ function* claimRewardV2(reward: SuperchargePendingRewardV2, index: number, baseN
   }
 }
 
-export function* fetchAvailableRewardsSaga() {
+export function* fetchAvailableRewardsSaga({ payload }: ReturnType<typeof fetchAvailableRewards>) {
   const address: string | null = yield select(walletAddressSelector)
   if (!address) {
     Logger.debug(TAG, 'Skipping fetching available rewards since no address was found')
@@ -223,7 +223,13 @@ export function* fetchAvailableRewardsSaga() {
     const response: Response = yield call(
       fetchWithTimeout,
       `${superchargeRewardsUrl}?address=${address}`,
-      null,
+      payload?.forceRefresh
+        ? {
+            headers: {
+              'Cache-Control': 'max-age=0',
+            },
+          }
+        : null,
       SUPERCHARGE_FETCH_TIMEOUT
     )
     const data: { availableRewards: SuperchargePendingReward[] | SuperchargePendingRewardV2[] } =

--- a/src/consumerIncentives/slice.ts
+++ b/src/consumerIncentives/slice.ts
@@ -54,7 +54,10 @@ const slice = createSlice({
       loading: false,
       error: true,
     }),
-    fetchAvailableRewards: (state) => ({
+    fetchAvailableRewards: (
+      state,
+      action: PayloadAction<{ forceRefresh: boolean } | undefined>
+    ) => ({
       ...state,
       fetchAvailableRewardsLoading: true,
       fetchAvailableRewardsError: false,


### PR DESCRIPTION
### Description

This PR expects that a `cache-control: max-age=X` will be returned in the response header for the fetch supercharge service.

After claiming rewards, refresh the cache. 

### Test plan

Checking that cache-control works:
1. Load the app - verify that the server has been hit, the response is stored
2. Reload the app - verify that the server is not hit again

Checking that the refresh works (after modifying the response on the server):
3. After dispatching an action that triggers the force refresh: verify that the server has been hit, the new response is stored
4. Reload the app - verify that the server is not hit again, and the response in step 3 (instead of 1) is stored

### Related issues

- Fixes RET-707

### Backwards compatibility

Y
