### PR TITLE
fix: check verification status before displaying phone number on drawer

### DIFF
--- a/src/navigator/DrawerNavigator.test.tsx
+++ b/src/navigator/DrawerNavigator.test.tsx
@@ -64,4 +64,86 @@ describe('DrawerNavigator', () => {
     )
     expect(queryByTestId('DrawerItem/dappsScreen.title')).toBeNull()
   })
+
+  describe('phone number in drawer', () => {
+    it('shows the phone number when the user is verified', () => {
+      const store = createMockStore({
+        app: {
+          requireCPV: true,
+          numberVerified: false,
+          phoneNumberVerified: true,
+        },
+        account: {
+          e164PhoneNumber: '+13023061234',
+        },
+      })
+      const { getByText } = render(
+        <Provider store={store}>
+          <MockedNavigator component={DrawerNavigator}></MockedNavigator>
+        </Provider>
+      )
+
+      expect(getByText('+1 302-306-1234')).toBeTruthy()
+    })
+
+    it("shows the phone number when the user is verified decentrally and we don't require CPV", () => {
+      const store = createMockStore({
+        app: {
+          requireCPV: false,
+          numberVerified: true,
+          phoneNumberVerified: false,
+        },
+        account: {
+          e164PhoneNumber: '+13023061234',
+        },
+      })
+      const { getByText } = render(
+        <Provider store={store}>
+          <MockedNavigator component={DrawerNavigator}></MockedNavigator>
+        </Provider>
+      )
+
+      expect(getByText('+1 302-306-1234')).toBeTruthy()
+    })
+
+    it('hides the phone number when the user is verified decentrally and we require CPV', () => {
+      const store = createMockStore({
+        app: {
+          requireCPV: true,
+          numberVerified: true,
+          phoneNumberVerified: false,
+        },
+        account: {
+          e164PhoneNumber: '+13023061234',
+        },
+      })
+      const { queryByText } = render(
+        <Provider store={store}>
+          <MockedNavigator component={DrawerNavigator}></MockedNavigator>
+        </Provider>
+      )
+
+      expect(queryByText('+1 302-306-1234')).toBeFalsy()
+    })
+
+    it('shows no phone number when the user is not verified', () => {
+      const store = createMockStore({
+        app: {
+          requireCPV: true,
+          numberVerified: false,
+          phoneNumberVerified: false,
+        },
+        account: {
+          e164PhoneNumber: '+13023061234',
+        },
+      })
+      const { queryByText } = render(
+        <Provider store={store}>
+          <MockedNavigator component={DrawerNavigator}></MockedNavigator>
+        </Provider>
+      )
+
+      expect(queryByText('+1 302-306-1234')).toBeFalsy()
+    })
+  })
 })

--- a/src/navigator/DrawerNavigator.tsx
+++ b/src/navigator/DrawerNavigator.tsx
@@ -35,7 +35,7 @@ import SettingsScreen from 'src/account/Settings'
 import Support from 'src/account/Support'
 import { HomeEvents, RewardsEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
-import { celoNewsConfigSelector } from 'src/app/selectors'
+import { celoNewsConfigSelector, phoneNumberVerifiedSelector } from 'src/app/selectors'
 import BackupIntroduction from 'src/backup/BackupIntroduction'
 import AccountNumber from 'src/components/AccountNumber'
 import ContactCircleSelf from 'src/components/ContactCircleSelf'
@@ -168,6 +168,7 @@ function CustomDrawerContent(props: DrawerContentComponentProps<DrawerContentOpt
   const defaultCountryCode = useSelector(defaultCountryCodeSelector)
   const account = useSelector(currentAccountSelector)
   const appVersion = deviceInfoModule.getVersion()
+  const phoneNumberVerified = useSelector(phoneNumberVerifiedSelector)
 
   const dispatch = useDispatch()
   useEffect(() => {
@@ -187,7 +188,7 @@ function CustomDrawerContent(props: DrawerContentComponentProps<DrawerContentOpt
             {displayName}
           </Text>
         )}
-        {e164PhoneNumber && (
+        {phoneNumberVerified && e164PhoneNumber && (
           <PhoneNumberWithFlag
             e164PhoneNumber={e164PhoneNumber}
             defaultCountryCode={defaultCountryCode ? defaultCountryCode : undefined}


### PR DESCRIPTION


### Description

As the title

### Test plan

n/a

### Related issues

n/a

### Backwards compatibility

Y
