### PR TITLE
chore: remove redundant haptic on settings item

### DIFF
--- a/src/components/SettingsItem.tsx
+++ b/src/components/SettingsItem.tsx
@@ -5,7 +5,6 @@ import TextInput from 'src/components/TextInput'
 import ForwardChevron from 'src/icons/ForwardChevron'
 import colors from 'src/styles/colors'
 import fontStyles from 'src/styles/fonts'
-import { vibrateInformative } from 'src/styles/hapticFeedback'
 
 interface WrapperProps {
   testID?: string
@@ -78,15 +77,11 @@ export function SettingsItemSwitch({
   value,
   details,
 }: SettingsItemSwitchProps) {
-  const handleValueChange = (value: boolean) => {
-    vibrateInformative()
-    onValueChange(value)
-  }
   return (
     <Wrapper>
       <View style={styles.container}>
         <Title value={title} />
-        <Switch testID={testID} value={value} onValueChange={handleValueChange} />
+        <Switch testID={testID} value={value} onValueChange={onValueChange} />
       </View>
       {details && (
         <View>


### PR DESCRIPTION


### Description

As the title, this component already has native haptics so we don't need to add another one.

### Test plan

n/a

### Related issues

n/a

### Backwards compatibility

Y
