### PR TITLE
fix: yoga build issue with XCode 14

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -32,6 +32,7 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: |
+            patches
             node_modules
             */*/node_modules
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
@@ -51,6 +52,7 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: |
+            patches
             node_modules
             */*/node_modules
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
@@ -71,6 +73,7 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: |
+            patches
             node_modules
             */*/node_modules
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
@@ -89,6 +92,7 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: |
+            patches
             node_modules
             */*/node_modules
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
@@ -107,6 +111,7 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: |
+            patches
             node_modules
             */*/node_modules
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,7 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: |
+            patches
             node_modules
             */*/node_modules
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}

--- a/patches/react-native+0.66.4.patch
+++ b/patches/react-native+0.66.4.patch
@@ -45,3 +45,18 @@ index 175c561..f393ab0 100644
  
    if (_delegate && [_delegate respondsToSelector:@selector(updateJSExceptionWithMessage:stack:exceptionId:)]) {
      [_delegate updateJSExceptionWithMessage:message stack:stack exceptionId:[NSNumber numberWithDouble:exceptionId]];
+diff --git a/node_modules/react-native/ReactCommon/yoga/yoga/Yoga.cpp b/node_modules/react-native/ReactCommon/yoga/yoga/Yoga.cpp
+index 2c68674..a94eca1 100644
+--- a/node_modules/react-native/ReactCommon/yoga/yoga/Yoga.cpp
++++ b/node_modules/react-native/ReactCommon/yoga/yoga/Yoga.cpp
+@@ -2229,7 +2229,9 @@ static float YGDistributeFreeSpaceSecondPass(
+         depth,
+         generationCount);
+     node->setLayoutHadOverflow(
+-        node->getLayout().hadOverflow() |
++        // adding this patch to resolve build error on XCode 14
++        // https://github.com/facebook/react-native/issues/36758
++        node->getLayout().hadOverflow() ||
+         currentRelativeChild->getLayout().hadOverflow());
+   }
+   return deltaFreeSpace;


### PR DESCRIPTION
### Description

Backports a fix for a yoga build error in [react-native](https://github.com/facebook/react-native) for XCode 14 - [Related GitHub Issue](https://github.com/facebook/yoga/issues/1224) - [React Native Fix](https://github.com/facebook/yoga/commit/f174de70afdde2492e8677bd0e716eb41bf64469)
Adds the patches folder to the cache path to avoid a cache hit when only a patch file has changed.

### Test plan

Tested locally on iOS.

### Related issues

N/A

### Backwards compatibility

Yes