### PR TITLE
feat(swap): input validation and decimal keyboard type

### DIFF
--- a/src/swap/SwapAmountInput.tsx
+++ b/src/swap/SwapAmountInput.tsx
@@ -80,6 +80,7 @@ const SwapAmountInput = ({
           style={[styles.input, { opacity: showInputLoader ? 0 : 1 }]}
           editable={!showInputLoader}
           keyboardType="decimal-pad"
+          autoCapitalize="words"
           autoFocus={autoFocus}
           // unset lineHeight to allow ellipsis on long inputs on iOS
           inputStyle={[

--- a/src/swap/SwapAmountInput.tsx
+++ b/src/swap/SwapAmountInput.tsx
@@ -80,6 +80,8 @@ const SwapAmountInput = ({
           style={[styles.input, { opacity: showInputLoader ? 0 : 1 }]}
           editable={!showInputLoader}
           keyboardType="decimal-pad"
+          // Work around for RN issue with Samsung keyboards
+          // https://github.com/facebook/react-native/issues/22005
           autoCapitalize="words"
           autoFocus={autoFocus}
           // unset lineHeight to allow ellipsis on long inputs on iOS

--- a/src/swap/SwapAmountInput.tsx
+++ b/src/swap/SwapAmountInput.tsx
@@ -77,7 +77,7 @@ const SwapAmountInput = ({
           // hide input when loading to prevent the UI height from jumping
           style={[styles.input, { opacity: showInputLoader ? 0 : 1 }]}
           editable={!showInputLoader}
-          keyboardType="numeric"
+          keyboardType="decimal-pad"
           autoFocus={autoFocus}
           // unset lineHeight to allow ellipsis on long inputs on iOS
           inputStyle={[

--- a/src/swap/SwapScreen.tsx
+++ b/src/swap/SwapScreen.tsx
@@ -247,7 +247,8 @@ export function SwapScreenSection({ showDrawerTopNav }: { showDrawerTopNav: bool
       setUpdatedField(fieldType)
       setSwapAmount((prev) => ({
         ...prev,
-        [fieldType]: value,
+        // Regex to match only numbers and one decimal separator
+        [fieldType]: value.match(/^(?:\d+[.,]?\d*|[.,]\d*|[.,])$/)?.join('') ?? prev[fieldType],
       }))
     }
     setShowMaxSwapAmountWarning(false)


### PR DESCRIPTION
### Description

- Adds input validation that takes into account using either the decimal separator `,` or `.`.
- Changes the keyboard type to `decimal-pad`.


#### Video iOS

https://user-images.githubusercontent.com/26950305/232643065-9ad1d143-5f95-4d0c-b08b-37dd42afbe0f.mov

#### Android Keyboard Types: `numeric` (before) / `decimal-pad` (after)

<p align="center">
<img src="https://user-images.githubusercontent.com/26950305/233462591-a0867e1c-2dd9-4a5a-87d4-29e4caab0e35.png" width="48%" height="auto" />
<img src="https://user-images.githubusercontent.com/26950305/233462539-8414e076-c55c-4d91-b971-fa7c21b88879.png" width="48%" height="auto" />
</p>

### Test plan

Tested locally on Android and iOS.
Keyboard tested with `,` and `.` variants by setting device region on iOS to France.

### Related issues

- #3074

### Backwards compatibility

Yes