### PR TITLE
chore: resolve warning for bottom sheet navigator

### DIFF
--- a/src/navigator/Navigator.tsx
+++ b/src/navigator/Navigator.tsx
@@ -8,10 +8,7 @@ import {
   createNativeStackNavigator,
   NativeStackNavigationOptions,
 } from '@react-navigation/native-stack'
-import {
-  BottomSheetScreenProps,
-  createBottomSheetNavigator,
-} from '@th3rdwave/react-navigation-bottom-sheet'
+import { createBottomSheetNavigator } from '@th3rdwave/react-navigation-bottom-sheet'
 import * as React from 'react'
 import { LayoutChangeEvent, PixelRatio, Platform } from 'react-native'
 import SplashScreen from 'react-native-splash-screen'
@@ -732,24 +729,15 @@ function nativeBottomSheets(
 ) {
   return (
     <>
-      <BottomSheet.Screen
-        name={Screens.WalletConnectRequest}
-        component={(
-          props: BottomSheetScreenProps<StackParamList, Screens.WalletConnectRequest>
-        ) => <WalletConnectRequest handleContentLayout={handleContentLayout} {...props} />}
-      />
-      <BottomSheet.Screen
-        name={Screens.DappKitAccountScreen}
-        component={(
-          props: BottomSheetScreenProps<StackParamList, Screens.DappKitAccountScreen>
-        ) => <DappKitAccountScreen handleContentLayout={handleContentLayout} {...props} />}
-      />
-      <BottomSheet.Screen
-        name={Screens.DappKitSignTxScreen}
-        component={(props: BottomSheetScreenProps<StackParamList, Screens.DappKitSignTxScreen>) => (
-          <DappKitSignTxScreen handleContentLayout={handleContentLayout} {...props} />
-        )}
-      />
+      <BottomSheet.Screen name={Screens.WalletConnectRequest}>
+        {(props) => <WalletConnectRequest handleContentLayout={handleContentLayout} {...props} />}
+      </BottomSheet.Screen>
+      <BottomSheet.Screen name={Screens.DappKitAccountScreen}>
+        {(props) => <DappKitAccountScreen handleContentLayout={handleContentLayout} {...props} />}
+      </BottomSheet.Screen>
+      <BottomSheet.Screen name={Screens.DappKitSignTxScreen}>
+        {(props) => <DappKitSignTxScreen handleContentLayout={handleContentLayout} {...props} />}
+      </BottomSheet.Screen>
     </>
   )
 }


### PR DESCRIPTION
### Description

Noticed this warning when running in dev mode a lot. Applied the recommended fix from [here](https://github.com/react-navigation/react-navigation/issues/8517#issuecomment-663838298).

```Looks like you're passing an inline function for 'component' prop for the screen 'DappKitSignTxScreen' (e.g. component={() => <SomeComponent />}). Passing an inline function will cause the component state to be lost on re-render and cause perf issues since it's re-created every render. You can pass the function as children to 'Screen' instead to achieve the desired behaviour.```


### Test plan

Tested locally on iOS by swapping cUSD to Ethix on Ubeswap.

### Related issues

N/A

### Backwards compatibility

Yes