### PR TITLE
chore: ensure statsig init before sagas init

### DIFF
--- a/__mocks__/src/statsig/index.ts
+++ b/__mocks__/src/statsig/index.ts
@@ -1,0 +1,7 @@
+module.exports = {
+  patchUpdateStatsigUser: jest.fn(),
+  getDefaultStatsigUser: jest.fn(),
+  getDynamicConfigParams: jest.fn(),
+  getExperimentParams: jest.fn(),
+  initializeStatsig: jest.fn(),
+}

--- a/src/analytics/ValoraAnalytics.ts
+++ b/src/analytics/ValoraAnalytics.ts
@@ -15,14 +15,10 @@ import {
   isE2EEnv,
   SEGMENT_API_KEY,
   STATSIG_ENV,
-  E2E_TEST_STATSIG_ID,
-  STATSIG_API_KEY,
 } from 'src/config'
 import { store } from 'src/redux/store'
 import Logger from 'src/utils/Logger'
 import { isPresent } from 'src/utils/typescript'
-import { getDefaultStatsigUser } from 'src/statsig'
-import { Statsig } from 'statsig-react-native'
 
 const TAG = 'ValoraAnalytics'
 
@@ -128,21 +124,6 @@ class ValoraAnalytics {
       Logger.info(TAG, 'Segment Analytics Integration initialized!')
     } catch (error) {
       Logger.error(TAG, `Segment setup error: ${error.message}\n`, error)
-    }
-
-    try {
-      const statsigUser = getDefaultStatsigUser()
-      // getAnonymousId causes the e2e tests to fail
-      const overrideStableID = isE2EEnv ? E2E_TEST_STATSIG_ID : await Analytics.getAnonymousId()
-      Logger.debug(TAG, 'Statsig stable ID', overrideStableID)
-      await Statsig.initialize(STATSIG_API_KEY, statsigUser, {
-        // StableID should match Segment anonymousId
-        overrideStableID,
-        environment: STATSIG_ENV,
-        localMode: isE2EEnv,
-      })
-    } catch (error) {
-      Logger.warn(TAG, `Statsig setup error`, error)
     }
   }
 

--- a/src/app/saga.ts
+++ b/src/app/saga.ts
@@ -6,6 +6,7 @@ import DeviceInfo from 'react-native-device-info'
 import * as Keychain from 'react-native-keychain'
 import { eventChannel } from 'redux-saga'
 import {
+  all,
   call,
   cancelled,
   delay,
@@ -94,8 +95,7 @@ const DO_NOT_LOCK_PERIOD = 30000 // 30 sec
 // Work that's done before other sagas are initalized
 // Be mindful to not put long blocking tasks here
 export function* appInit() {
-  yield call(initializeSentry)
-  yield call(initializeStatsig)
+  yield all([call(initializeSentry), call(initializeStatsig)])
   // This step is important if the user if offline and unable to fetch remote
   // config values, we can use the persisted value instead of an empty one
   const sentryNetworkErrors = yield select(sentryNetworkErrorsSelector)

--- a/src/app/saga.ts
+++ b/src/app/saga.ts
@@ -65,6 +65,7 @@ import { retrieveSignedMessage } from 'src/pincode/authentication'
 import { paymentDeepLinkHandlerMerchant } from 'src/qrcode/utils'
 import { handlePaymentDeeplink } from 'src/send/utils'
 import { initializeSentry } from 'src/sentry/Sentry'
+import { initializeStatsig } from 'src/statsig'
 import { isDeepLink, navigateToURI } from 'src/utils/linking'
 import Logger from 'src/utils/Logger'
 import { safely } from 'src/utils/safely'
@@ -94,6 +95,7 @@ const DO_NOT_LOCK_PERIOD = 30000 // 30 sec
 // Be mindful to not put long blocking tasks here
 export function* appInit() {
   yield call(initializeSentry)
+  yield call(initializeStatsig)
   // This step is important if the user if offline and unable to fetch remote
   // config values, we can use the persisted value instead of an empty one
   const sentryNetworkErrors = yield select(sentryNetworkErrorsSelector)


### PR DESCRIPTION
### Description

Satish alerted me to this `'Statsig', 'getExperimentParams: Error getting params for experiment: dapps_filters_and_search', [Error: Call and wait for initialize() to finish first.]` error that occurs on app start every time. This error occurs because the root saga kicks off the dapps saga which kicks off the saga to fetch the dapps list. We query statsig for the experiment variables in this fetch dapps list saga. All of this happens when the redux store is initialised, which is actually before the AppInitGate.

I'm not sure of the context of why the statsig initialisation was done inside the analytics class. Does it need to be? If not, it would be nice to decouple the 2 (since the dependency between the 2 is not obvious). I put the statsig init inside the app init saga, which is run before all other sagas are spawned. This makes it safe to call statsig anywhere else in the app. Yes, this does delay the app since all sagas now wait for statsig, but from the AppInitGate i think this is the result we were looking to achieve anyway.

### Test plan

Actually this error only happens on app load, there are subsequent requests to fetch the dapps list which succeed. So no visible impact, experiment should work as usual. The error is no longer logged, and the app does not feel slower to start.

### Related issues

n/a

### Backwards compatibility

Y
