### PR TITLE
fix(cico): navigate to home on cancel/failure if add withdraw menu item is hidden

### DIFF
--- a/src/app/saga.ts
+++ b/src/app/saga.ts
@@ -50,6 +50,7 @@ import { handleDappkitDeepLink } from 'src/dappkit/dappkit'
 import { DappConnectInfo } from 'src/dapps/types'
 import { CeloNewsConfig } from 'src/exchange/types'
 import { FiatAccountSchemaCountryOverrides } from 'src/fiatconnect/types'
+import { navigateToFiatExchangeStart } from 'src/fiatExchanges/navigator'
 import { FiatExchangeFlow } from 'src/fiatExchanges/utils'
 import {
   appVersionDeprecationChannel,
@@ -302,7 +303,7 @@ export function* handleDeepLink(action: OpenDeepLink) {
       navigate(Screens.CashInSuccess, { provider: cicoSuccessParam.split('/')[0] })
       // Some providers append transaction information to the redirect links so can't check for strict equality
     } else if (rawParams.path.startsWith('/cash-in-failure')) {
-      navigate(Screens.FiatExchange)
+      navigateToFiatExchangeStart()
     } else if (isSecureOrigin && rawParams.pathname === '/openScreen' && rawParams.query) {
       // The isSecureOrigin is important. We don't want it to be possible to fire this deep link from outside
       // of our own notifications for security reasons.

--- a/src/fiatExchanges/navigator.test.tsx
+++ b/src/fiatExchanges/navigator.test.tsx
@@ -1,0 +1,25 @@
+import { navigateToFiatExchangeStart } from 'src/fiatExchanges/navigator'
+import { navigate, navigateHome } from 'src/navigator/NavigationService'
+import { Screens } from 'src/navigator/Screens'
+import { getExperimentParams } from 'src/statsig'
+import { mocked } from 'ts-jest/utils'
+
+jest.mock('src/statsig')
+
+describe('navigateToFiatExchangeStart', () => {
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('navigates to FiatExchange if showAddWithdrawOnMenu is true', () => {
+    mocked(getExperimentParams).mockReturnValueOnce({ showAddWithdrawOnMenu: true })
+    navigateToFiatExchangeStart()
+    expect(navigate).toHaveBeenCalledWith(Screens.FiatExchange)
+  })
+
+  it('navigates to Home if showAddWithdrawOnMenu is false', () => {
+    mocked(getExperimentParams).mockReturnValueOnce({ showAddWithdrawOnMenu: false })
+    navigateToFiatExchangeStart()
+    expect(navigateHome).toHaveBeenCalledWith()
+  })
+})

--- a/src/fiatExchanges/navigator.tsx
+++ b/src/fiatExchanges/navigator.tsx
@@ -1,0 +1,16 @@
+import { navigate, navigateHome } from 'src/navigator/NavigationService'
+import { Screens } from 'src/navigator/Screens'
+import { getExperimentParams } from 'src/statsig'
+import { ExperimentConfigs } from 'src/statsig/constants'
+import { StatsigExperiments } from 'src/statsig/types'
+
+export const navigateToFiatExchangeStart = () => {
+  if (
+    getExperimentParams(ExperimentConfigs[StatsigExperiments.HOME_SCREEN_ACTIONS])
+      .showAddWithdrawOnMenu
+  ) {
+    navigate(Screens.FiatExchange)
+  } else {
+    navigateHome()
+  }
+}

--- a/src/fiatconnect/FiatDetailsScreen.test.tsx
+++ b/src/fiatconnect/FiatDetailsScreen.test.tsx
@@ -6,12 +6,13 @@ import * as React from 'react'
 import { Provider } from 'react-redux'
 import { FiatExchangeEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
+import { navigateToFiatExchangeStart } from 'src/fiatExchanges/navigator'
+import FiatConnectQuote from 'src/fiatExchanges/quotes/FiatConnectQuote'
+import { CICOFlow } from 'src/fiatExchanges/utils'
 import { FiatConnectQuoteSuccess } from 'src/fiatconnect'
 import { SendingFiatAccountStatus, submitFiatAccount } from 'src/fiatconnect/slice'
 import { FiatAccountSchemaCountryOverrides } from 'src/fiatconnect/types'
-import FiatConnectQuote from 'src/fiatExchanges/quotes/FiatConnectQuote'
-import { CICOFlow } from 'src/fiatExchanges/utils'
-import { navigate, navigateBack } from 'src/navigator/NavigationService'
+import { navigateBack } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import { createMockStore, getMockStackScreenProps } from 'test/utils'
 import { mockFiatConnectProviderIcon, mockFiatConnectQuotes, mockNavigation } from 'test/values'
@@ -19,6 +20,7 @@ import FiatDetailsScreen from './FiatDetailsScreen'
 
 jest.mock('src/alert/actions')
 jest.mock('src/analytics/ValoraAnalytics')
+jest.mock('src/fiatExchanges/navigator')
 
 jest.mock('src/utils/Logger', () => ({
   __esModule: true,
@@ -174,7 +176,7 @@ describe('FiatDetailsScreen', () => {
     const { getByText } = render(<Provider store={store}>{headerRight}</Provider>)
 
     fireEvent.press(getByText('cancel'))
-    expect(navigate).toHaveBeenCalledWith(Screens.FiatExchange)
+    expect(navigateToFiatExchangeStart).toHaveBeenCalled()
     expect(ValoraAnalytics.track).toHaveBeenCalledWith(
       FiatExchangeEvents.cico_fiat_details_cancel,
       {

--- a/src/fiatconnect/FiatDetailsScreen.tsx
+++ b/src/fiatconnect/FiatDetailsScreen.tsx
@@ -15,6 +15,7 @@ import Dialog from 'src/components/Dialog'
 import KeyboardAwareScrollView from 'src/components/KeyboardAwareScrollView'
 import KeyboardSpacer from 'src/components/KeyboardSpacer'
 import TextInput, { LINE_HEIGHT } from 'src/components/TextInput'
+import { navigateToFiatExchangeStart } from 'src/fiatExchanges/navigator'
 import {
   getSchema,
   isComputedParam,
@@ -30,7 +31,6 @@ import { SendingFiatAccountStatus, submitFiatAccount } from 'src/fiatconnect/sli
 import Checkmark from 'src/icons/Checkmark'
 import InfoIcon from 'src/icons/InfoIcon'
 import { styles as headerStyles } from 'src/navigator/Headers'
-import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import { StackParamList } from 'src/navigator/types'
 import { userLocationDataSelector } from 'src/networkInfo/selectors'
@@ -114,7 +114,7 @@ const FiatDetailsScreen = ({ route, navigation }: Props) => {
               provider: quote.getProviderId(),
               fiatAccountSchema,
             })
-            navigate(Screens.FiatExchange)
+            navigateToFiatExchangeStart()
           }}
           style={styles.cancelBtn}
         />

--- a/src/fiatconnect/RefetchQuoteScreen.test.tsx
+++ b/src/fiatconnect/RefetchQuoteScreen.test.tsx
@@ -4,6 +4,7 @@ import * as React from 'react'
 import { Provider } from 'react-redux'
 import FiatConnectRefetchQuoteScreen from 'src/fiatconnect/RefetchQuoteScreen'
 import { refetchQuote } from 'src/fiatconnect/slice'
+import { navigateToFiatExchangeStart } from 'src/fiatExchanges/navigator'
 import { CICOFlow } from 'src/fiatExchanges/utils'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
@@ -20,7 +21,7 @@ describe('RefetchQuoteScreen', () => {
     jest.clearAllMocks()
   })
 
-  it('navigates to CICO screen when cached quote does not exist', () => {
+  it('navigates to CICO start when cached quote does not exist', () => {
     const props = getMockStackScreenProps(Screens.FiatConnectRefetchQuote, {
       providerId: 'some-provider',
       kycSchema: KycSchema.PersonalDataAndDocuments,
@@ -30,12 +31,12 @@ describe('RefetchQuoteScreen', () => {
         <FiatConnectRefetchQuoteScreen {...props} />
       </Provider>
     )
-    expect(navigate).toHaveBeenCalledTimes(1)
-    expect(navigate).toHaveBeenCalledWith(Screens.FiatExchange)
+    expect(navigateToFiatExchangeStart).toHaveBeenCalledTimes(1)
+    expect(navigateToFiatExchangeStart).toHaveBeenCalledWith()
     expect(store.dispatch).not.toHaveBeenCalled()
   })
 
-  it('navigates to CICO screen on error during quote re-fetch', () => {
+  it('navigates to CICO start on error during quote re-fetch', () => {
     const store = createMockStore({
       fiatConnect: {
         quotesError: 'some error',
@@ -62,8 +63,8 @@ describe('RefetchQuoteScreen', () => {
         <FiatConnectRefetchQuoteScreen {...props} />
       </Provider>
     )
-    expect(navigate).toHaveBeenCalledTimes(1)
-    expect(navigate).toHaveBeenCalledWith(Screens.FiatExchange)
+    expect(navigateToFiatExchangeStart).toHaveBeenCalledTimes(1)
+    expect(navigateToFiatExchangeStart).toHaveBeenCalledWith()
     expect(store.dispatch).toHaveBeenCalledWith(
       refetchQuote({
         flow: CICOFlow.CashOut,

--- a/src/fiatconnect/RefetchQuoteScreen.test.tsx
+++ b/src/fiatconnect/RefetchQuoteScreen.test.tsx
@@ -11,6 +11,8 @@ import { Screens } from 'src/navigator/Screens'
 import { CiCoCurrency } from 'src/utils/currencies'
 import { createMockStore, getMockStackScreenProps } from 'test/utils'
 
+jest.mock('src/fiatExchanges/navigator')
+
 const store = createMockStore()
 
 describe('RefetchQuoteScreen', () => {

--- a/src/fiatconnect/RefetchQuoteScreen.tsx
+++ b/src/fiatconnect/RefetchQuoteScreen.tsx
@@ -2,12 +2,12 @@ import { NativeStackScreenProps } from '@react-navigation/native-stack'
 import React, { useEffect } from 'react'
 import { ActivityIndicator, StyleSheet, View } from 'react-native'
 import { useDispatch, useSelector } from 'react-redux'
+import { navigateToFiatExchangeStart } from 'src/fiatExchanges/navigator'
 import {
   cachedQuoteParamsSelector,
   fiatConnectQuotesErrorSelector,
 } from 'src/fiatconnect/selectors'
 import { refetchQuote } from 'src/fiatconnect/slice'
-import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import { StackParamList } from 'src/navigator/types'
 import colors from 'src/styles/colors'
@@ -25,7 +25,7 @@ export default function FiatConnectRefetchQuoteScreen({ route }: Props) {
     const cachedQuoteParams = cachedQuoteParamsList?.[providerId]?.[kycSchema]
     if (!cachedQuoteParams) {
       // For some reason, we don't have a cached quote; go to beginning of CICO flow
-      navigate(Screens.FiatExchange)
+      navigateToFiatExchangeStart()
     } else {
       dispatch(
         refetchQuote({
@@ -41,7 +41,7 @@ export default function FiatConnectRefetchQuoteScreen({ route }: Props) {
 
   if (fiatConnectQuotesError) {
     // We have a cached quote, but there was some error while re-fetching; go to beginning of CICO flow
-    navigate(Screens.FiatExchange)
+    navigateToFiatExchangeStart()
   }
 
   return (

--- a/src/fiatconnect/ReviewScreen.tsx
+++ b/src/fiatconnect/ReviewScreen.tsx
@@ -24,6 +24,7 @@ import {
   fiatConnectQuotesLoadingSelector,
 } from 'src/fiatconnect/selectors'
 import { createFiatConnectTransfer, refetchQuote } from 'src/fiatconnect/slice'
+import { navigateToFiatExchangeStart } from 'src/fiatExchanges/navigator'
 import FiatConnectQuote from 'src/fiatExchanges/quotes/FiatConnectQuote'
 import { CICOFlow } from 'src/fiatExchanges/utils'
 import i18n from 'src/i18n'
@@ -126,7 +127,7 @@ export default function FiatConnectReviewScreen({ route, navigation }: Props) {
         },
       })
     } else if (previousScreen?.name === Screens.FiatConnectRefetchQuote) {
-      navigate(Screens.FiatExchange)
+      navigateToFiatExchangeStart()
     } else {
       navigateBack()
     }
@@ -693,7 +694,7 @@ FiatConnectReviewScreen.navigationOptions = ({
           flow: route.params.flow,
           provider: route.params.normalizedQuote.getProviderId(),
         })
-        navigate(Screens.FiatExchange)
+        navigateToFiatExchangeStart()
       }}
       style={styles.cancelBtn}
     />


### PR DESCRIPTION
### Description

The Add/Withdraw (FiatExchange) screen doesn't exist if the "Add & Withdraw" drawer menu item is not shown. This PR modifies all places to navigate to home screen instead.

### Test plan

Manual, unit tests

With Add & Withdraw hidden:

https://user-images.githubusercontent.com/5062591/235029218-b49e3456-06b7-42c8-9bd5-7b1486d33ac5.mp4


With Add & Withdraw shown:

https://user-images.githubusercontent.com/5062591/235029225-11f85303-41ea-417d-abbc-55e7b2ec596e.mp4



### Related issues

- Fixes ACT-751

### Backwards compatibility

Yes
