### PR TITLE
chore: remove duplicate openssl pod

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -44,7 +44,10 @@ target "celo" do
   # Note that if you have use_frameworks! enabled, Flipper will not work and
   # you should disable these next few lines.
   use_flipper!()
-  pod 'OpenSSL-Universal', :configurations => ['Debug','Release']
+
+  # import OpenSSL after use_flipper! to avoid OpenSSL only being enabled for debug configurations
+  # Flipper-Folly (2.6.7) requires this specific version of OpenSSL, so declaring it here to avoid duplicate versions in the podfile.lock.
+  pod 'OpenSSL-Universal', '1.1.180', :configurations => ['Debug','Release']
 end
 
 target 'NotificationService' do

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -691,7 +691,6 @@ DEPENDENCIES:
   - FlipperKit/SKIOSNetworkPlugin (= 0.99.0)
   - glog (from `../node_modules/react-native/third-party-podspecs/glog.podspec`)
   - lottie-react-native (from `../node_modules/lottie-react-native`)
-  - OpenSSL-Universal
   - OpenSSL-Universal (= 1.1.180)
   - Permission-AppTrackingTransparency (from `../node_modules/react-native-permissions/ios/AppTrackingTransparency`)
   - Permission-Camera (from `../node_modules/react-native-permissions/ios/Camera`)
@@ -1109,6 +1108,6 @@ SPEC CHECKSUMS:
   Yoga: 099a946cbf84c9b32ffdc4278d72db26710ecf92
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
-PODFILE CHECKSUM: 64ddbb620cec6330b1a8c06a7580d61b328fdc6f
+PODFILE CHECKSUM: b8f61aa65ff2dc78ef536a9e3f2aa2a0ed3d5dab
 
 COCOAPODS: 1.11.3


### PR DESCRIPTION
### Description

I forgot that the upgrade RN 67 branch had automerge enabled, and it was merged before I could tidy this up.

There was some change in RN 67 where OpenSSL was no longer part of the release build. This causes a crash on app start. This [article](https://medium.com/@devsalaar/dyld-library-not-loaded-error-on-ios-react-native-fix-guide-bb0b6a91e85a) was helpful for debugging why this happens - it seems that the use_flipper script adds the OpenSSL pod only for debug configurations. Maybe there is a better solution here but it seems like we just need to manually add OpenSSL. 

### Test plan

n/a

### Related issues

- Fixes RET-683

### Backwards compatibility

y
