### PR TITLE
fix: skip fetching dapplist during onboarding flow

### DIFF
--- a/src/dapps/saga.test.ts
+++ b/src/dapps/saga.test.ts
@@ -179,6 +179,17 @@ describe('Dapps saga', () => {
       mockFetch.resetMocks()
     })
 
+    it('does not fetch the dapps list if the wallet is not yet initialized', async () => {
+      await expectSaga(handleFetchDappsList)
+        .provide([
+          [select(dappsListApiUrlSelector), 'http://some.url'],
+          [select(walletAddressSelector), null],
+        ])
+        .run()
+
+      expect(mockFetch).not.toHaveBeenCalled()
+    })
+
     it('saves the dapps and categories', async () => {
       const dapp1 = {
         categories: ['finance-tools'],

--- a/src/dapps/saga.ts
+++ b/src/dapps/saga.ts
@@ -72,6 +72,13 @@ export function* handleFetchDappsList() {
   }
 
   const address = yield select(walletAddressSelector)
+  if (!address) {
+    // the dapplist is fetched on app start, but for a new user who has not yet
+    // created or restored a wallet the request will fail.
+    Logger.debug(TAG, 'Wallet address not found')
+    return
+  }
+
   const language = yield select(currentLanguageSelector)
   const shortLanguage = language.split('-')[0]
   const { dappsFilterEnabled, dappsSearchEnabled } = getExperimentParams(


### PR DESCRIPTION
### Description

As the title. Context: https://valora-app.slack.com/archives/C02N3AR2P2S/p1683084313143099

### Test plan

Updated unit tests

### Related issues

n/a

### Backwards compatibility

y
