### PR TITLE
fix(firebase): fix firebase messaging initialization

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,5 +1,0 @@
-{
-  "react-native": {
-    "messaging_ios_auto_register_for_remote_messages": false
-  }
-}

--- a/src/account/saga.test.ts
+++ b/src/account/saga.test.ts
@@ -38,7 +38,6 @@ jest.mock('@react-native-firebase/app', () => ({
   app: jest.fn(() => ({
     messaging: () => ({
       getToken: jest.fn().mockResolvedValue('someToken'),
-      registerDeviceForRemoteMessages: jest.fn(),
     }),
   })),
 }))

--- a/src/account/saga.ts
+++ b/src/account/saga.ts
@@ -207,9 +207,6 @@ export function* handleUpdateAccountRegistration() {
     const isEmulator = yield call([DeviceInfo, 'isEmulator'])
     // Emulators can't handle fcm tokens and calling getToken on them will throw an error
     if (!isEmulator) {
-      // `registerDeviceForRemoteMessages` must be called before calling `getToken`
-      // Note: `registerDeviceForRemoteMessages` is really only required for iOS and is a no-op on Android
-      yield call([firebase.app().messaging(), 'registerDeviceForRemoteMessages'])
       fcmToken = yield call([firebase.app().messaging(), 'getToken'])
     }
   } catch (error) {

--- a/src/firebase/firebase.test.ts
+++ b/src/firebase/firebase.test.ts
@@ -23,7 +23,6 @@ const onMessageMock = jest.fn(() => null)
 const onNotificationOpenedAppMock = jest.fn(() => null)
 const getInitialNotificationMock = jest.fn(() => null)
 const setBackgroundMessageHandler = jest.fn(() => null)
-const registerDeviceForRemoteMessagesMock = jest.fn(() => null)
 
 const mockFcmToken = 'token'
 
@@ -37,7 +36,6 @@ const app: any = {
     onMessage: onMessageMock,
     onNotificationOpenedApp: onNotificationOpenedAppMock,
     getInitialNotification: getInitialNotificationMock,
-    registerDeviceForRemoteMessages: registerDeviceForRemoteMessagesMock,
   }),
 }
 
@@ -96,7 +94,6 @@ describe(initializeCloudMessaging, () => {
           call([app.messaging(), 'hasPermission']),
           firebase.messaging.AuthorizationStatus.AUTHORIZED,
         ],
-        [call([app.messaging(), 'registerDeviceForRemoteMessages']), mockFcmToken],
         [call([app.messaging(), 'getToken']), mockFcmToken],
         [call(handleUpdateAccountRegistration), null],
         [
@@ -121,7 +118,6 @@ describe(initializeCloudMessaging, () => {
           call([app.messaging(), 'hasPermission']),
           firebase.messaging.AuthorizationStatus.NOT_DETERMINED,
         ],
-        [call([app.messaging(), 'registerDeviceForRemoteMessages']), mockFcmToken],
         [call([app.messaging(), 'getToken']), mockFcmToken],
       ])
       .put(pushNotificationsPermissionChanged(true))

--- a/src/firebase/firebase.ts
+++ b/src/firebase/firebase.ts
@@ -189,9 +189,6 @@ export function* initializeCloudMessaging(app: ReactNativeFirebase.Module, addre
   const isEmulator = yield call([DeviceInfo, 'isEmulator'])
   // Emulators can't handle fcm tokens and calling getToken on them will throw an error
   if (!isEmulator) {
-    // `registerDeviceForRemoteMessages` must be called before calling `getToken`
-    // Note: `registerDeviceForRemoteMessages` is really only required for iOS and is a no-op on Android
-    yield call([app.messaging(), 'registerDeviceForRemoteMessages'])
     fcmToken = yield call([app.messaging(), 'getToken'])
   }
   if (fcmToken) {


### PR DESCRIPTION
### Description

fixes this issue on the nightly build https://valora-app.slack.com/archives/C04B61SJ6DS/p1683015075041129

### Test plan

Verified manually in the logs that firebase was successfully initialized on first app load and app reloads.

### Related issues

- Fixes #[issue number here]

### Backwards compatibility

Yes