### PR TITLE
chore: add new native bottom sheet component

### DIFF
--- a/src/components/BottomSheet.tsx
+++ b/src/components/BottomSheet.tsx
@@ -1,0 +1,95 @@
+import GorhomBottomSheet, {
+  BottomSheetBackdrop,
+  useBottomSheetDynamicSnapPoints,
+} from '@gorhom/bottom-sheet'
+import React, { useCallback, useMemo } from 'react'
+import { StyleSheet, Text, View } from 'react-native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import Button, { BtnSizes, BtnTypes } from 'src/components/Button'
+import Colors from 'src/styles/colors'
+import fontStyles from 'src/styles/fonts'
+import { Spacing } from 'src/styles/styles'
+
+interface Props {
+  forwardedRef: React.RefObject<GorhomBottomSheet>
+  title: string
+  buttonLabel: string
+  buttonOnPress: () => void
+  buttonType?: BtnTypes
+  description?: string
+  children?: React.ReactNode
+  testId: string
+}
+
+const BottomSheet = ({
+  forwardedRef,
+  title,
+  buttonLabel,
+  buttonOnPress,
+  buttonType = BtnTypes.PRIMARY,
+  description,
+  children,
+  testId,
+}: Props) => {
+  const insets = useSafeAreaInsets()
+  const paddingBottom = Math.max(insets.bottom, Spacing.Thick24)
+
+  const initialSnapPoints = useMemo(() => ['CONTENT_HEIGHT'], [])
+  const { animatedHandleHeight, animatedSnapPoints, animatedContentHeight, handleContentLayout } =
+    useBottomSheetDynamicSnapPoints(initialSnapPoints)
+
+  const renderBackdrop = useCallback(
+    (props) => <BottomSheetBackdrop {...props} disappearsOnIndex={-1} appearsOnIndex={0} />,
+    []
+  )
+
+  return (
+    <GorhomBottomSheet
+      ref={forwardedRef}
+      index={-1}
+      snapPoints={animatedSnapPoints}
+      handleHeight={animatedHandleHeight}
+      contentHeight={animatedContentHeight}
+      enablePanDownToClose
+      backdropComponent={renderBackdrop}
+      handleIndicatorStyle={styles.handle}
+    >
+      <View
+        style={[styles.container, { paddingBottom }]}
+        onLayout={handleContentLayout}
+        testID={testId}
+      >
+        <Text style={styles.title}>{title}</Text>
+        {description && <Text style={styles.description}>{description}</Text>}
+        {children}
+        <Button
+          text={buttonLabel}
+          onPress={buttonOnPress}
+          size={BtnSizes.FULL}
+          type={buttonType}
+          testID={`${testId}/PrimaryAction`}
+        />
+      </View>
+    </GorhomBottomSheet>
+  )
+}
+
+const styles = StyleSheet.create({
+  handle: {
+    backgroundColor: Colors.gray3,
+  },
+  container: {
+    paddingHorizontal: Spacing.Thick24,
+    paddingVertical: Spacing.Regular16,
+  },
+  title: {
+    ...fontStyles.h2,
+    marginBottom: Spacing.Regular16,
+  },
+  description: {
+    ...fontStyles.small,
+    marginBottom: Spacing.Large32,
+  },
+})
+
+export default BottomSheet

--- a/src/dappsExplorer/useDappInfoBottomSheet.tsx
+++ b/src/dappsExplorer/useDappInfoBottomSheet.tsx
@@ -1,31 +1,19 @@
-import BottomSheet, {
-  BottomSheetBackdrop,
-  useBottomSheetDynamicSnapPoints,
-} from '@gorhom/bottom-sheet'
-import React, { useCallback, useMemo, useRef } from 'react'
+import GorhomBottomSheet from '@gorhom/bottom-sheet'
+import React, { useMemo, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Keyboard, StyleSheet, Text, View } from 'react-native'
-import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { Keyboard } from 'react-native'
 import { DappExplorerEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
-import Button, { BtnSizes, BtnTypes } from 'src/components/Button'
+import BottomSheet from 'src/components/BottomSheet'
+import { BtnTypes } from 'src/components/Button'
 import { DAPPS_LEARN_MORE } from 'src/config'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
-import Colors from 'src/styles/colors'
-import fontStyles from 'src/styles/fonts'
-import { Spacing } from 'src/styles/styles'
 
 const useDappInfoBottomSheet = () => {
   const { t } = useTranslation()
-  const insets = useSafeAreaInsets()
-  const paddingBottom = Math.max(insets.bottom, Spacing.Thick24)
 
-  const bottomSheetRef = useRef<BottomSheet>(null)
-
-  const initialSnapPoints = useMemo(() => ['CONTENT_HEIGHT'], [])
-  const { animatedHandleHeight, animatedSnapPoints, animatedContentHeight, handleContentLayout } =
-    useBottomSheetDynamicSnapPoints(initialSnapPoints)
+  const bottomSheetRef = useRef<GorhomBottomSheet>(null)
 
   const onPressMore = () => {
     ValoraAnalytics.track(DappExplorerEvents.dapp_open_more_info)
@@ -39,41 +27,19 @@ const useDappInfoBottomSheet = () => {
     bottomSheetRef.current?.snapToIndex(0)
   }
 
-  const renderBackdrop = useCallback(
-    (props) => <BottomSheetBackdrop {...props} disappearsOnIndex={-1} appearsOnIndex={0} />,
-    []
-  )
-
   const DappInfoBottomSheet = useMemo(
     () => (
       <BottomSheet
-        ref={bottomSheetRef}
-        index={-1}
-        snapPoints={animatedSnapPoints}
-        handleHeight={animatedHandleHeight}
-        contentHeight={animatedContentHeight}
-        enablePanDownToClose
-        backdropComponent={renderBackdrop}
-        handleIndicatorStyle={styles.handle}
-      >
-        <View
-          style={[styles.container, { paddingBottom }]}
-          onLayout={handleContentLayout}
-          testID="DAppsExplorerScreen/InfoBottomSheet"
-        >
-          <Text style={styles.title}>{t('dappsScreenInfoSheet.title')}</Text>
-          <Text style={styles.description}>{t('dappsScreenInfoSheet.description')}</Text>
-          <Button
-            text={t('dappsScreenInfoSheet.buttonLabel')}
-            onPress={onPressMore}
-            size={BtnSizes.FULL}
-            type={BtnTypes.SECONDARY}
-            testID="DAppsExplorerScreen/InfoBottomSheet/PrimaryAction"
-          />
-        </View>
-      </BottomSheet>
+        forwardedRef={bottomSheetRef}
+        title={t('dappsScreenInfoSheet.title')}
+        description={t('dappsScreenInfoSheet.description')}
+        buttonLabel={t('dappsScreenInfoSheet.buttonLabel')}
+        buttonOnPress={onPressMore}
+        buttonType={BtnTypes.SECONDARY}
+        testId="DAppsExplorerScreen/InfoBottomSheet"
+      />
     ),
-    [animatedSnapPoints, animatedHandleHeight, animatedContentHeight, handleContentLayout]
+    []
   )
 
   return {
@@ -81,23 +47,5 @@ const useDappInfoBottomSheet = () => {
     DappInfoBottomSheet,
   }
 }
-
-const styles = StyleSheet.create({
-  handle: {
-    backgroundColor: Colors.gray3,
-  },
-  container: {
-    paddingHorizontal: Spacing.Thick24,
-    paddingVertical: Spacing.Regular16,
-  },
-  title: {
-    ...fontStyles.h2,
-    marginBottom: Spacing.Regular16,
-  },
-  description: {
-    ...fontStyles.small,
-    marginBottom: Spacing.Large32,
-  },
-})
 
 export default useDappInfoBottomSheet


### PR DESCRIPTION
### Description

This PR creates a component that wraps the native bottom sheet to make it easier to use (since it needs to some some crazy stuff to dynamically size its own height based on the content inside). Use it in the dapps screen. This will be used for the revoke phone number work next.

### Test plan

n/a

### Related issues

- Fixes RET-717

### Backwards compatibility

Y
