### PR TITLE
fix: transaction feed truncated at the bottom when home actions are enabled

### DIFF
--- a/src/home/WalletHome.tsx
+++ b/src/home/WalletHome.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { RefreshControl, RefreshControlProps, SectionList, StyleSheet } from 'react-native'
 import Animated from 'react-native-reanimated'
-import { SafeAreaView } from 'react-native-safe-area-context'
+import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useDispatch } from 'react-redux'
 import { showMessage } from 'src/alert/actions'
 import { AppState } from 'src/app/actions'
@@ -51,6 +51,7 @@ function WalletHome() {
   const celoAddress = useSelector(celoAddressSelector)
   const userInSanctionedCountry = useSelector(userInSanctionedCountrySelector)
 
+  const insets = useSafeAreaInsets()
   const scrollPosition = useRef(new Animated.Value(0)).current
   const onScroll = Animated.event([{ nativeEvent: { contentOffset: { y: scrollPosition } } }])
 
@@ -178,15 +179,22 @@ function WalletHome() {
   })
 
   return (
-    <SafeAreaView testID="WalletHome" style={styles.container}>
+    <SafeAreaView
+      testID="WalletHome"
+      style={styles.container}
+      edges={!showHomeNavBar ? ['top'] : undefined}
+    >
       <DrawerTopBar middleElement={<Logo />} scrollPosition={scrollPosition} />
       <AnimatedSectionList
+        // Workaround iOS setting an incorrect automatic inset at the top
+        scrollIndicatorInsets={{ top: 0.01 }}
         scrollEventThrottle={16}
         onScroll={onScroll}
         refreshControl={refresh}
         onRefresh={onRefresh}
         refreshing={isLoading}
         style={styles.container}
+        contentContainerStyle={!showHomeNavBar ? { paddingBottom: insets.bottom } : undefined}
         sections={sections}
         keyExtractor={keyExtractor}
         testID="WalletHome/SectionList"


### PR DESCRIPTION
### Description

The transaction feed was truncated at the bottom when home actions are enabled.
It now takes the full height.

### Test plan

**before/after**

<img src="https://github.com/valora-inc/wallet/assets/57791/95e00a09-aa73-479f-afc6-da98725e035c" width="50%" /><img src="https://github.com/valora-inc/wallet/assets/57791/5816ff33-99c3-4b22-b9b3-c051d07b0c41" width="50%" />

### Related issues

N/A

### Backwards compatibility

Yes