### PR TITLE
fix(positions): don't include positions in total balance if the feature is disabled

### DIFF
--- a/src/components/TokenBalance.test.tsx
+++ b/src/components/TokenBalance.test.tsx
@@ -5,10 +5,14 @@ import { FiatExchangeTokenBalance, HomeTokenBalance } from 'src/components/Token
 import { LocalCurrencyCode } from 'src/localCurrency/consts'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
+import { getFeatureGate } from 'src/statsig'
 import { Currency } from 'src/utils/currencies'
 import { ONE_DAY_IN_MILLIS } from 'src/utils/time'
 import { createMockStore, getElementText } from 'test/utils'
 import { mockPositions, mockTokenBalances } from 'test/values'
+import { mocked } from 'ts-jest/utils'
+
+jest.mock('src/statsig')
 
 const defaultStore = {
   tokens: {
@@ -27,6 +31,8 @@ const defaultStore = {
     },
   },
 }
+
+mocked(getFeatureGate).mockReturnValue(true)
 
 describe('FiatExchangeTokenBalance and HomeTokenBalance', () => {
   it.each([HomeTokenBalance, FiatExchangeTokenBalance])(

--- a/src/home/WalletHome.test.tsx
+++ b/src/home/WalletHome.test.tsx
@@ -101,6 +101,7 @@ jest.mock('src/statsig', () => ({
     showHomeActions: false,
     cashInBottomSheetEnabled: true,
   })),
+  getFeatureGate: jest.fn().mockReturnValue(false),
 }))
 
 jest.mock('src/fiatExchanges/utils', () => ({

--- a/src/navigator/DrawerNavigator.test.tsx
+++ b/src/navigator/DrawerNavigator.test.tsx
@@ -10,6 +10,7 @@ import { mocked } from 'ts-jest/utils'
 
 jest.mock('src/statsig', () => ({
   getExperimentParams: jest.fn(),
+  getFeatureGate: jest.fn().mockReturnValue(false),
 }))
 
 // TODO avoid rendering WalletHome as we're mostly interested in testing the menu here

--- a/src/positions/selectors.test.ts
+++ b/src/positions/selectors.test.ts
@@ -1,6 +1,15 @@
 import BigNumber from 'bignumber.js'
 import { totalPositionsBalanceUsdSelector } from 'src/positions/selectors'
+import { getFeatureGate } from 'src/statsig'
 import { mockPositions } from 'test/values'
+import { mocked } from 'ts-jest/utils'
+
+jest.mock('src/statsig')
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  mocked(getFeatureGate).mockReturnValue(true)
+})
 
 describe(totalPositionsBalanceUsdSelector, () => {
   it('returns the total balance of all positions', () => {
@@ -14,6 +23,17 @@ describe(totalPositionsBalanceUsdSelector, () => {
   })
 
   it('returns null if there are no positions', () => {
+    const state: any = {
+      positions: {
+        positions: [],
+      },
+    }
+    const total = totalPositionsBalanceUsdSelector(state)
+    expect(total).toBeNull()
+  })
+
+  it("returns null if the feature isn't enabled", () => {
+    mocked(getFeatureGate).mockReturnValue(false)
     const state: any = {
       positions: {
         positions: [],

--- a/src/positions/selectors.ts
+++ b/src/positions/selectors.ts
@@ -1,26 +1,33 @@
 import BigNumber from 'bignumber.js'
 import { createSelector } from 'reselect'
 import { RootState } from 'src/redux/reducers'
+import { getFeatureGate } from 'src/statsig'
+import { StatsigFeatureGates } from 'src/statsig/types'
+
+export const showPositionsSelector = () => getFeatureGate(StatsigFeatureGates.SHOW_POSITIONS)
 
 export const positionsSelector = (state: RootState) => state.positions.positions
 export const positionsStatusSelector = (state: RootState) => state.positions.status
 
-export const totalPositionsBalanceUsdSelector = createSelector([positionsSelector], (positions) => {
-  if (positions.length === 0) {
-    return null
-  }
-
-  let totalBalanceUsd = new BigNumber(0)
-  for (const position of positions) {
-    let balanceUsd
-    if (position.type === 'app-token') {
-      const balance = new BigNumber(position.balance)
-      balanceUsd = balance.multipliedBy(position.priceUsd)
-    } else {
-      balanceUsd = new BigNumber(position.balanceUsd)
+export const totalPositionsBalanceUsdSelector = createSelector(
+  [showPositionsSelector, positionsSelector],
+  (showPositions, positions) => {
+    if (!showPositions || positions.length === 0) {
+      return null
     }
-    totalBalanceUsd = totalBalanceUsd.plus(balanceUsd)
-  }
 
-  return totalBalanceUsd
-})
+    let totalBalanceUsd = new BigNumber(0)
+    for (const position of positions) {
+      let balanceUsd
+      if (position.type === 'app-token') {
+        const balance = new BigNumber(position.balance)
+        balanceUsd = balance.multipliedBy(position.priceUsd)
+      } else {
+        balanceUsd = new BigNumber(position.balanceUsd)
+      }
+      totalBalanceUsd = totalBalanceUsd.plus(balanceUsd)
+    }
+
+    return totalBalanceUsd
+  }
+)


### PR DESCRIPTION
### Description

I noticed the total balance was still including the positions after enabling and then disabling the feature flag for positions.
This fixes it.

### Test plan

- Updated tests

### Related issues

N/A

### Backwards compatibility

Yes
