### PR TITLE
fix: ensure inviter and invitee is present in the same event

### DIFF
--- a/src/analytics/Events.tsx
+++ b/src/analytics/Events.tsx
@@ -193,6 +193,7 @@ export enum PhoneVerificationEvents {
   phone_verification_start = 'phone_verification_start', // when the start button is pressed in the phone number input screen
 
   phone_verification_code_request_success = 'phone_verification_code_request_success', // when the verifyPhoneNumber endpoint returns successfully
+  phone_verification_restore_success = 'phone_verification_restore_success', // when the verifyPhoneNumber endpoint returns that the user is already verified (restore wallet flow)
   phone_verification_code_verify_start = 'phone_verification_code_verify_start', // when the user has entered the sms code and we start to validate on the backend
   phone_verification_code_verify_success = 'phone_verification_code_verify_success', // when the backend confirms that the sms code is successfully validated
   phone_verification_code_verify_error = 'phone_verification_code_verify_error', // when the backend throws an error and the sms code cannot be validated

--- a/src/analytics/Properties.tsx
+++ b/src/analytics/Properties.tsx
@@ -417,7 +417,9 @@ interface PhoneVerificationEventsProperties {
   [PhoneVerificationEvents.phone_verification_code_verify_start]: undefined
   [PhoneVerificationEvents.phone_verification_code_verify_success]: {
     phoneNumberHash: string
+    inviterAddress: string | null
   }
+  [PhoneVerificationEvents.phone_verification_restore_success]: undefined
   [PhoneVerificationEvents.phone_verification_code_verify_error]: undefined
   [PhoneVerificationEvents.phone_verification_input_help]: undefined
   [PhoneVerificationEvents.phone_verification_input_help_continue]: undefined

--- a/src/verify/hooks.ts
+++ b/src/verify/hooks.ts
@@ -77,7 +77,7 @@ export function useVerifyPhoneNumber(phoneNumber: string, countryCallingCode: st
 
     setShouldResendSms(false)
     verificationCodeRequested.current = true
-    ValoraAnalytics.track(PhoneVerificationEvents.phone_verification_code_request_success)
+    ValoraAnalytics.track(PhoneVerificationEvents.phone_verification_restore_success)
 
     setVerificationStatus(PhoneNumberVerificationStatus.SUCCESSFUL)
     dispatch(phoneNumberVerificationCompleted(phoneNumber, countryCallingCode))
@@ -199,6 +199,7 @@ export function useVerifyPhoneNumber(phoneNumber: string, countryCallingCode: st
 
         ValoraAnalytics.track(PhoneVerificationEvents.phone_verification_code_verify_success, {
           phoneNumberHash: getPhoneHash(phoneNumber),
+          inviterAddress,
         })
         Logger.debug(`${TAG}/validateVerificationCode`, 'Successfully verified phone number')
         setVerificationStatus(PhoneNumberVerificationStatus.SUCCESSFUL)


### PR DESCRIPTION
### Description

The firebase dynamic link (referral link) is consumed on app open, which is (mostly) before there is a wallet address created.  To make the association between invitee and inviter more reliably, add the inviter address to the verification success event.

### Test plan

n/a

### Related issues

n/a

### Backwards compatibility

Y
