### PR TITLE
chore(dependencies): auto-open renovate PRs

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -5,11 +5,12 @@
   // Set a status check pending for 3 days from release timestamp to guard against unpublishing
   stabilityDays: 3,
   // Limit number of concurrent renovate branches/PRs, to avoid spamming the repo
-  prConcurrentLimit: 5,
-  // For now require manual approval from within the Dependency Dashboard issue
-  // for all packages before opening the renovate PR.
-  // We can relax this (using specific packageRules) as we catch up with package updates.
-  dependencyDashboardApproval: true,
+  prConcurrentLimit: 2,
+
+  // Do not require manual approval from within the Dependency Dashboard issue before opening a PR.
+  // An alternative would be to require manual approval again, or to use specific packageRules
+  dependencyDashboardApproval: false,
+
   // Disable vulnerability updates for now
   // Dependabot is handling them instead because Renovate is not yet able to update transitive dependencies
   // See https://github.com/renovatebot/renovate/issues/3080


### PR DESCRIPTION
### Description

following up on our eng team discussion about keeping up with dependencies. drops `prConcurrentLimit` to 2 and enables automatic PR opening by setting `dependencyDashboardApproval` to false

### Test plan

ci

### Related issues

na

### Backwards compatibility

na
