### PR TITLE
fix(cico): avoid wrapping 'new' tag on select providers screen

### DIFF
--- a/src/fiatExchanges/PaymentMethodSection.tsx
+++ b/src/fiatExchanges/PaymentMethodSection.tsx
@@ -305,7 +305,7 @@ const styles = StyleSheet.create({
     marginTop: 4,
     marginLeft: 'auto',
     flexDirection: 'row',
-    width: 65,
+    width: 'auto',
   },
   newLabelText: {
     ...fontStyles.label,


### PR DESCRIPTION
### Description

otherwise languages with longer words for 'new' look bad

before:
English:
![simulator_screenshot_9BE4F0D1-C5C6-475D-9C64-AA93DF2DFA99](https://github.com/valora-inc/wallet/assets/7979215/7c522038-d2d6-4e17-bb84-cf3033ca6be0)

Portuguese:
![Simulator Screenshot - iPhone 14 - 2023-05-18 at 14 46 20](https://github.com/valora-inc/wallet/assets/7979215/0e9888fd-6e22-41e9-aa29-6076aac97e4d)

after:
English:
![simulator_screenshot_0E82F567-F80F-4CB6-8CCC-D2FA7343ED96](https://github.com/valora-inc/wallet/assets/7979215/b5f9eea8-6a1b-4a2a-82c9-8e35d0836694)

Portuguese:
![Simulator Screenshot - iPhone 14 - 2023-05-18 at 14 49 46](https://github.com/valora-inc/wallet/assets/7979215/b9069328-0843-4a81-a9ea-bedf23b07066)


### Test plan

<!-- Demonstrate the change is solid, or why it doesn't need testing.
Example: add any manual testing steps or scenarios (if not obvious), screenshots / videos if the pull request changes the user interface.
-->

### Related issues

- Fixes #[issue number here]

### Backwards compatibility

<!-- Brief explanation of why these changes are/are not backwards compatible. -->
