### PR TITLE
chore: dispatch in app review on successful swap and reward claim

### DIFF
--- a/src/app/saga.ts
+++ b/src/app/saga.ts
@@ -55,6 +55,7 @@ import {
   DYNAMIC_LINK_DOMAIN_URI_PREFIX,
   FETCH_TIMEOUT_DURATION,
 } from 'src/config'
+import { claimRewardsSuccess } from 'src/consumerIncentives/slice'
 import { SuperchargeTokenConfigByToken } from 'src/consumerIncentives/types'
 import { handleDappkitDeepLink } from 'src/dappkit/dappkit'
 import { DappConnectInfo } from 'src/dapps/types'
@@ -88,6 +89,7 @@ import { SentryTransactionHub } from 'src/sentry/SentryTransactionHub'
 import { SentryTransaction } from 'src/sentry/SentryTransactions'
 import { getFeatureGate, patchUpdateStatsigUser } from 'src/statsig'
 import { StatsigFeatureGates } from 'src/statsig/types'
+import { swapSuccess } from 'src/swap/slice'
 import { isDeepLink, navigateToURI } from 'src/utils/linking'
 import Logger from 'src/utils/Logger'
 import { safely } from 'src/utils/safely'
@@ -540,9 +542,11 @@ export function* requestInAppReview() {
 }
 
 export function* watchAppReview() {
-  // TODO: add more actions to trigger app review
-  // non liquidating transaction (to include dapp tx, sends, cash ins, celo buy/sell, swap) and/or supercharge claim
-  yield takeLatest([SendActions.SEND_PAYMENT_SUCCESS], safely(requestInAppReview))
+  // Triggers on successful payment, swap, or rewards claim
+  yield takeLatest(
+    [SendActions.SEND_PAYMENT_SUCCESS, swapSuccess, claimRewardsSuccess],
+    safely(requestInAppReview)
+  )
 }
 
 export function* appSaga() {


### PR DESCRIPTION
### Description

Adds the additional trigger actions of `swapSuccess` and `claimRewardsSuccess` for In App Review. I opted to excluded dapp tx as the action in-app review would likely disrupt the dapp action flow and this is against [best practices](https://developer.apple.com/design/human-interface-guidelines/ratings-and-reviews).

> Avoid interrupting people while they’re performing a task or playing a game. Asking for feedback can disrupt the user experience and feel like a burden. Look for natural breaks or stopping points in your app or game where a rating request is less likely to be bothersome.



### Test plan

Tested locally on iOS.

### Related issues

- Fixes RET-15

### Backwards compatibility

Yes