### PR TITLE
fix(renovate): schedule

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -9,7 +9,7 @@
 
   // Only automerge when the team is mostly offline
   automergeSchedule: [
-    'after 5pm and before 12am every day', // in central Europe this is 2am to 8am, +/- 1hr when 1 region is on DST and the other isn't
+    'after 5pm', // in central Europe this is 2am to 8am, +/- 1hr when 1 region is on DST and the other isn't
     'on saturday',
   ],
 


### PR DESCRIPTION

### Description
dep dashboard was warning of a failure to parse the schedule

### Test plan

ci and look at dashboard after merge to see if it still errors out

### Related issues

na

### Backwards compatibility

na