### PR TITLE
fix(tokens): ensure header component is above scrollbar on overscroll

### DIFF
--- a/src/tokens/TokenBalances.tsx
+++ b/src/tokens/TokenBalances.tsx
@@ -312,6 +312,7 @@ function TokenBalancesScreen({ navigation, route }: Props) {
       <AnimatedSectionList
         contentContainerStyle={{
           paddingBottom: insets.bottom,
+          opacity: listHeaderHeight > 0 ? 1 : 0,
         }}
         // Workaround iOS setting an incorrect automatic inset at the top
         scrollIndicatorInsets={{ top: 0.01 }}

--- a/src/tokens/TokenBalances.tsx
+++ b/src/tokens/TokenBalances.tsx
@@ -312,7 +312,7 @@ function TokenBalancesScreen({ navigation, route }: Props) {
           paddingBottom: insets.bottom,
           opacity: listHeaderHeight > 0 ? 1 : 0,
         }}
-        // on ios overscoll, ensure scrollbar is above the header
+        // ensure header is above the scrollbar on ios overscroll
         scrollIndicatorInsets={{ top: listHeaderHeight }}
         // @ts-ignore can't get the SectionList to accept a union type :(
         sections={sections}

--- a/src/tokens/TokenBalances.tsx
+++ b/src/tokens/TokenBalances.tsx
@@ -157,6 +157,8 @@ function TokenBalancesScreen({ navigation, route }: Props) {
         [nonStickyHeaderHeight - 10, nonStickyHeaderHeight + 10],
         ['transparent', 'rgba(48, 46, 37, 0.15)']
       ),
+      backgroundColor: scrollPosition.value > nonStickyHeaderHeight ? Colors.light : 'transparent',
+      zIndex: scrollPosition.value < 0 ? 0 : 1, // on ios overscoll, ensure scrollbar is above the header
     }
   }, [scrollPosition.value, nonStickyHeaderHeight, displayPositions])
 
@@ -355,7 +357,6 @@ const styles = StyleSheet.create({
     ...getShadowStyle(Shadow.SoftLight),
     padding: Spacing.Thick24,
     paddingTop: Spacing.Smallest8,
-    backgroundColor: Colors.light,
     position: 'absolute',
     width: '100%',
     zIndex: 1,

--- a/src/tokens/TokenBalances.tsx
+++ b/src/tokens/TokenBalances.tsx
@@ -157,8 +157,6 @@ function TokenBalancesScreen({ navigation, route }: Props) {
         [nonStickyHeaderHeight - 10, nonStickyHeaderHeight + 10],
         ['transparent', 'rgba(48, 46, 37, 0.15)']
       ),
-      backgroundColor: scrollPosition.value > nonStickyHeaderHeight ? Colors.light : 'transparent',
-      zIndex: scrollPosition.value < 0 ? 0 : 1, // on ios overscoll, ensure scrollbar is above the header
     }
   }, [scrollPosition.value, nonStickyHeaderHeight, displayPositions])
 
@@ -314,8 +312,8 @@ function TokenBalancesScreen({ navigation, route }: Props) {
           paddingBottom: insets.bottom,
           opacity: listHeaderHeight > 0 ? 1 : 0,
         }}
-        // Workaround iOS setting an incorrect automatic inset at the top
-        scrollIndicatorInsets={{ top: 0.01 }}
+        // on ios overscoll, ensure scrollbar is above the header
+        scrollIndicatorInsets={{ top: listHeaderHeight }}
         // @ts-ignore can't get the SectionList to accept a union type :(
         sections={sections}
         renderItem={renderAssetItem}
@@ -360,6 +358,7 @@ const styles = StyleSheet.create({
     paddingTop: Spacing.Smallest8,
     position: 'absolute',
     width: '100%',
+    backgroundColor: Colors.light,
     zIndex: 1,
   },
   positionSectionHeaderContainer: {

--- a/src/tokens/TokenBalances.tsx
+++ b/src/tokens/TokenBalances.tsx
@@ -356,9 +356,9 @@ const styles = StyleSheet.create({
     ...getShadowStyle(Shadow.SoftLight),
     padding: Spacing.Thick24,
     paddingTop: Spacing.Smallest8,
+    backgroundColor: Colors.light,
     position: 'absolute',
     width: '100%',
-    backgroundColor: Colors.light,
     zIndex: 1,
   },
   positionSectionHeaderContainer: {


### PR DESCRIPTION
### Description

Context https://valora-app.slack.com/archives/C029Z1QMD7B/p1684931810127659

### Test plan

https://github.com/valora-inc/wallet/assets/20150449/61937fb0-3ef7-4c40-b0ba-8744cbc8036e


### Related issues

- Fixes RET-732

### Backwards compatibility

Y
