### PR TITLE
feat(actions): Hide swap action when disabled

### DIFF
--- a/src/home/ActionsCarousel.test.tsx
+++ b/src/home/ActionsCarousel.test.tsx
@@ -9,18 +9,49 @@ import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import { CloseIcon } from 'src/navigator/types'
 import { mocked } from 'ts-jest/utils'
+import { MockStoreEnhanced } from 'redux-mock-store'
+import { createMockStore } from 'test/utils'
+import { Provider } from 'react-redux'
+
+function getStore(shouldShowSwapAction: boolean) {
+  return createMockStore({
+    app: {
+      showSwapMenuInDrawerMenu: shouldShowSwapAction,
+    },
+  })
+}
 
 describe('ActionsCarousel', () => {
+  let store: MockStoreEnhanced<{}>
+  beforeEach(() => {
+    store = getStore(true)
+  })
+
   afterEach(() => {
     jest.clearAllMocks()
   })
 
   it('renders all actions', () => {
-    const { getAllByTestId } = render(<ActionsCarousel />)
+    const { getAllByTestId } = render(
+      <Provider store={store}>
+        <ActionsCarousel />
+      </Provider>
+    )
 
     expect(getAllByTestId(/HomeAction-/)).toHaveLength(6)
   })
 
+  it('does not render swap action when disabled', () => {
+    store = getStore(false)
+    const { queryByTestId, getAllByTestId } = render(
+      <Provider store={store}>
+        <ActionsCarousel />
+      </Provider>
+    )
+
+    expect(getAllByTestId(/HomeAction-/)).toHaveLength(5)
+    expect(queryByTestId(`HomeAction/Title-Swap`)).toBeFalsy()
+  })
   it.each([
     [HomeActionName.Send, 'send', Screens.Send, { closeIcon: CloseIcon.BackChevron }],
     [
@@ -41,7 +72,12 @@ describe('ActionsCarousel', () => {
   ])(
     'renders title and navigates to appropriate screen for %s',
     (name, title, screen, screenOptions) => {
-      const { getByTestId } = render(<ActionsCarousel />)
+      const { getByTestId } = render(
+        <Provider store={store}>
+          <ActionsCarousel />
+        </Provider>
+      )
+
       expect(
         within(getByTestId(`HomeAction/Title-${name}`)).getByText(`homeActions.${title}`)
       ).toBeTruthy()

--- a/src/home/ActionsCarousel.tsx
+++ b/src/home/ActionsCarousel.tsx
@@ -18,9 +18,13 @@ import { Screens } from 'src/navigator/Screens'
 import { CloseIcon } from 'src/navigator/types'
 import Colors from 'src/styles/colors'
 import fontStyles from 'src/styles/fonts'
+import { useSelector } from 'react-redux'
+import { isAppSwapsEnabledSelector } from 'src/navigator/selectors'
 
 function ActionsCarousel() {
   const { t } = useTranslation()
+
+  const shouldShowSwapAction = useSelector(isAppSwapsEnabledSelector)
 
   const actions = [
     {
@@ -59,6 +63,7 @@ function ActionsCarousel() {
       onPress: () => {
         navigate(Screens.SwapScreenWithBack)
       },
+      hidden: !shouldShowSwapAction,
     },
     {
       name: HomeActionName.Request,
@@ -85,25 +90,27 @@ function ActionsCarousel() {
       contentContainerStyle={styles.carouselContainer}
       testID={'HomeActionsCarousel'}
     >
-      {actions.map(({ name, title, icon, onPress }) => (
-        <Card style={styles.card} shadow={null} key={`HomeAction-${name}`}>
-          <Touchable
-            onPress={() => {
-              ValoraAnalytics.track(HomeEvents.home_action_pressed, { action: name })
-              onPress()
-            }}
-            style={styles.touchable}
-            testID={`HomeAction-${name}`}
-          >
-            <>
-              {icon}
-              <Text style={styles.name} testID={`HomeAction/Title-${name}`}>
-                {title}
-              </Text>
-            </>
-          </Touchable>
-        </Card>
-      ))}
+      {actions.map(({ name, title, icon, onPress, hidden }) =>
+        hidden ? undefined : (
+          <Card style={styles.card} shadow={null} key={`HomeAction-${name}`}>
+            <Touchable
+              onPress={() => {
+                ValoraAnalytics.track(HomeEvents.home_action_pressed, { action: name })
+                onPress()
+              }}
+              style={styles.touchable}
+              testID={`HomeAction-${name}`}
+            >
+              <>
+                {icon}
+                <Text style={styles.name} testID={`HomeAction/Title-${name}`}>
+                  {title}
+                </Text>
+              </>
+            </Touchable>
+          </Card>
+        )
+      )}
     </ScrollView>
   )
 }

--- a/src/home/ActionsCarousel.tsx
+++ b/src/home/ActionsCarousel.tsx
@@ -90,8 +90,9 @@ function ActionsCarousel() {
       contentContainerStyle={styles.carouselContainer}
       testID={'HomeActionsCarousel'}
     >
-      {actions.map(({ name, title, icon, onPress, hidden }) =>
-        hidden ? undefined : (
+      {actions
+        .filter(({ hidden }) => !hidden)
+        .map(({ name, title, icon, onPress }) => (
           <Card style={styles.card} shadow={null} key={`HomeAction-${name}`}>
             <Touchable
               onPress={() => {
@@ -109,8 +110,7 @@ function ActionsCarousel() {
               </>
             </Touchable>
           </Card>
-        )
-      )}
+        ))}
     </ScrollView>
   )
 }


### PR DESCRIPTION
### Description

For ACT-810. Hides the swap action for home screen actions experiment when it's disabled. This check uses the same flag that we use to [determine swap eligibility on the drawer navigator](https://github.com/valora-inc/wallet/blob/main/src/navigator/DrawerNavigator.tsx#L224).

### Test plan

Unit and manual tested.

### Related issues

- Fixes ACT-810.

### Backwards compatibility

Yes.
