### PR TITLE
fix(QRTabBar): remove animation for close icon

### DIFF
--- a/src/icons/BackChevron.tsx
+++ b/src/icons/BackChevron.tsx
@@ -1,19 +1,22 @@
 import * as React from 'react'
-import Animated from 'react-native-reanimated'
 import Svg, { Path } from 'react-native-svg'
 import Colors from 'src/styles/colors'
 
-const AnimatedPath = Animated.createAnimatedComponent(Path)
-
 export interface Props {
   height?: number
-  color?: Colors | Animated.Node<Colors>
+  color?: Colors
 }
 
 function BackChevron({ color, height }: Props) {
   return (
-    <Svg height={height} width={height && height / 2} viewBox="0 0 8 16" testID="BackChevron">
-      <AnimatedPath
+    <Svg
+      height={height}
+      width={height && height / 2}
+      viewBox="0 0 8 16"
+      fill="none"
+      testID="BackChevron"
+    >
+      <Path
         fillRule="evenodd"
         clipRule="evenodd"
         d="M7.707 13.707a1 1 0 0 1-1.414 0l-6-6a1 1 0 0 1 0-1.414l6-6a1 1 0 0 1 1.414 1.414L2.414 7l5.293 5.293a1 1 0 0 1 0 1.414Z"

--- a/src/qrcode/QRTabBar.tsx
+++ b/src/qrcode/QRTabBar.tsx
@@ -1,6 +1,6 @@
 import { MaterialTopTabBarProps } from '@react-navigation/material-top-tabs'
 import React, { useMemo } from 'react'
-import { Platform, StyleSheet, View } from 'react-native'
+import { StyleSheet, View } from 'react-native'
 import Animated from 'react-native-reanimated'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { useDispatch } from 'react-redux'
@@ -43,20 +43,7 @@ export default function QRTabBar({
     outputRange: [1, 0],
   })
 
-  const animatedColor = Animated.interpolateColors(position, {
-    inputRange: [0.9, 1],
-    outputColorRange: [colors.dark, colors.light],
-  })
-
-  // using `animatedColor` with animated svg causes android crash since
-  // upgrading react-native-svg to v13. there are some suggested solutions
-  // linked below, but none that i could get to work after many attempts. since
-  // this is a relatively low impact feature, i'm going to leave it as is for
-  // now.
-  // https://github.com/software-mansion/react-native-svg/issues/1976
-  // https://github.com/software-mansion/react-native-reanimated/issues/3775
-  const color =
-    Platform.OS === 'ios' ? animatedColor : state.index === 0 ? colors.dark : colors.light
+  const color = state.index === 0 ? colors.dark : colors.light
 
   const onPressClose = () => {
     navigation.getParent()?.goBack()

--- a/src/qrcode/QRTabBar.tsx
+++ b/src/qrcode/QRTabBar.tsx
@@ -1,6 +1,6 @@
 import { MaterialTopTabBarProps } from '@react-navigation/material-top-tabs'
 import React, { useMemo } from 'react'
-import { StyleSheet, View } from 'react-native'
+import { Platform, StyleSheet, View } from 'react-native'
 import Animated from 'react-native-reanimated'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { useDispatch } from 'react-redux'
@@ -43,7 +43,12 @@ export default function QRTabBar({
     outputRange: [1, 0],
   })
 
-  const color = state.index === 0 ? colors.dark : colors.light
+  const animatedColor = Animated.interpolateColors(position, {
+    inputRange: [0.9, 1],
+    outputColorRange: [colors.dark, colors.light],
+  })
+
+  const defaultColor = state.index === 0 ? colors.dark : colors.light
 
   const onPressClose = () => {
     navigation.getParent()?.goBack()
@@ -78,9 +83,17 @@ export default function QRTabBar({
         <TopBarIconButton
           icon={
             closeIcon === CloseIcon.BackChevron ? (
-              <BackChevron color={color} />
+              // BackChevron doesn't support Animated color
+              <BackChevron color={defaultColor} />
             ) : (
-              <Times color={color} />
+              // using `animatedColor` with animated svg causes android crash since
+              // upgrading react-native-svg to v13. there are some suggested solutions
+              // linked below, but none that i could get to work after many attempts. since
+              // this is a relatively low impact feature, i'm going to leave it as is for
+              // now.
+              // https://github.com/software-mansion/react-native-svg/issues/1976
+              // https://github.com/software-mansion/react-native-reanimated/issues/3775
+              <Times color={Platform.OS === 'ios' ? animatedColor : defaultColor} />
             )
           }
           onPress={onPressClose}

--- a/src/send/__snapshots__/SendConfirmation.test.tsx.snap
+++ b/src/send/__snapshots__/SendConfirmation.test.tsx.snap
@@ -81,6 +81,7 @@ exports[`SendConfirmation renders correctly 1`] = `
           onStartShouldSetResponder={[Function]}
         >
           <svg
+            fill="none"
             height={16}
             testID="BackChevron"
             viewBox="0 0 8 16"

--- a/src/send/__snapshots__/SendConfirmationLegacy.test.tsx.snap
+++ b/src/send/__snapshots__/SendConfirmationLegacy.test.tsx.snap
@@ -81,6 +81,7 @@ exports[`SendConfirmationLegacy renders correctly 1`] = `
           onStartShouldSetResponder={[Function]}
         >
           <svg
+            fill="none"
             height={16}
             testID="BackChevron"
             viewBox="0 0 8 16"


### PR DESCRIPTION
### Description

The animated color option on BackChevron is broken and doesn't seem to have a simple fix. The animated color was already only working on iOS. This just removes the animated color option for BackChevron.

### Test plan

before

https://github.com/valora-inc/wallet/assets/5062591/f8591e9f-e9ce-42cc-bb5e-1a061253da30


after

https://github.com/valora-inc/wallet/assets/5062591/6431e288-8e4b-41b9-b68d-f84843392212


### Related issues

- Fixes ACT-811

### Backwards compatibility

Yes
