### PR TITLE
fix(home-actions): use X instead of back for some actions

### DIFF
--- a/src/home/ActionsCarousel.test.tsx
+++ b/src/home/ActionsCarousel.test.tsx
@@ -1,5 +1,7 @@
 import { fireEvent, render, within } from '@testing-library/react-native'
 import React from 'react'
+import { Provider } from 'react-redux'
+import { MockStoreEnhanced } from 'redux-mock-store'
 import { HomeEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import { FiatExchangeFlow } from 'src/fiatExchanges/utils'
@@ -7,11 +9,8 @@ import ActionsCarousel from 'src/home/ActionsCarousel'
 import { HomeActionName } from 'src/home/types'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
-import { CloseIcon } from 'src/navigator/types'
-import { mocked } from 'ts-jest/utils'
-import { MockStoreEnhanced } from 'redux-mock-store'
 import { createMockStore } from 'test/utils'
-import { Provider } from 'react-redux'
+import { mocked } from 'ts-jest/utils'
 
 function getStore(shouldShowSwapAction: boolean) {
   return createMockStore({
@@ -53,21 +52,11 @@ describe('ActionsCarousel', () => {
     expect(queryByTestId(`HomeAction/Title-Swap`)).toBeFalsy()
   })
   it.each([
-    [HomeActionName.Send, 'send', Screens.Send, { closeIcon: CloseIcon.BackChevron }],
-    [
-      HomeActionName.Receive,
-      'receive',
-      Screens.QRNavigator,
-      { screen: Screens.QRCode, closeIcon: CloseIcon.BackChevron },
-    ],
+    [HomeActionName.Send, 'send', Screens.Send, undefined],
+    [HomeActionName.Receive, 'receive', Screens.QRNavigator, { screen: Screens.QRCode }],
     [HomeActionName.Add, 'add', Screens.FiatExchangeCurrency, { flow: FiatExchangeFlow.CashIn }],
     [HomeActionName.Swap, 'swap', Screens.SwapScreenWithBack, undefined],
-    [
-      HomeActionName.Request,
-      'request',
-      Screens.Send,
-      { isOutgoingPaymentRequest: true, closeIcon: CloseIcon.BackChevron },
-    ],
+    [HomeActionName.Request, 'request', Screens.Send, { isOutgoingPaymentRequest: true }],
     [HomeActionName.Withdraw, 'withdraw', Screens.WithdrawSpend, undefined],
   ])(
     'renders title and navigates to appropriate screen for %s',

--- a/src/home/ActionsCarousel.tsx
+++ b/src/home/ActionsCarousel.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 import { ScrollView, StyleSheet, Text } from 'react-native'
+import { useSelector } from 'react-redux'
 import { HomeEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import Card from 'src/components/Card'
@@ -15,11 +16,9 @@ import HomeActionsSwap from 'src/icons/home-actions/Swap'
 import HomeActionsWithdraw from 'src/icons/home-actions/Withdraw'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
-import { CloseIcon } from 'src/navigator/types'
+import { isAppSwapsEnabledSelector } from 'src/navigator/selectors'
 import Colors from 'src/styles/colors'
 import fontStyles from 'src/styles/fonts'
-import { useSelector } from 'react-redux'
-import { isAppSwapsEnabledSelector } from 'src/navigator/selectors'
 
 function ActionsCarousel() {
   const { t } = useTranslation()
@@ -32,7 +31,7 @@ function ActionsCarousel() {
       title: t('homeActions.send'),
       icon: <HomeActionsSend />,
       onPress: () => {
-        navigate(Screens.Send, { closeIcon: CloseIcon.BackChevron })
+        navigate(Screens.Send)
       },
     },
     {
@@ -42,7 +41,6 @@ function ActionsCarousel() {
       onPress: () => {
         navigate(Screens.QRNavigator, {
           screen: Screens.QRCode,
-          closeIcon: CloseIcon.BackChevron,
         })
       },
     },
@@ -70,7 +68,7 @@ function ActionsCarousel() {
       title: t('homeActions.request'),
       icon: <HomeActionsRequest />,
       onPress: () => {
-        navigate(Screens.Send, { isOutgoingPaymentRequest: true, closeIcon: CloseIcon.BackChevron })
+        navigate(Screens.Send, { isOutgoingPaymentRequest: true })
       },
     },
     {

--- a/src/icons/BackChevron.tsx
+++ b/src/icons/BackChevron.tsx
@@ -1,19 +1,22 @@
 import * as React from 'react'
-import Animated from 'react-native-reanimated'
 import Svg, { Path } from 'react-native-svg'
 import Colors from 'src/styles/colors'
 
-const AnimatedPath = Animated.createAnimatedComponent(Path)
-
 export interface Props {
   height?: number
-  color?: Colors | Animated.Node<Colors>
+  color?: Colors
 }
 
 function BackChevron({ color, height }: Props) {
   return (
-    <Svg height={height} width={height && height / 2} viewBox="0 0 8 16" testID="BackChevron">
-      <AnimatedPath
+    <Svg
+      height={height}
+      width={height && height / 2}
+      viewBox="0 0 8 16"
+      fill="none"
+      testID="BackChevron"
+    >
+      <Path
         fillRule="evenodd"
         clipRule="evenodd"
         d="M7.707 13.707a1 1 0 0 1-1.414 0l-6-6a1 1 0 0 1 0-1.414l6-6a1 1 0 0 1 1.414 1.414L2.414 7l5.293 5.293a1 1 0 0 1 0 1.414Z"

--- a/src/navigator/QRNavigator.test.tsx
+++ b/src/navigator/QRNavigator.test.tsx
@@ -7,7 +7,6 @@ import QRNavigator, {
   QRCodeProps,
   getExperimentParams,
 } from 'src/navigator/QRNavigator'
-import { CloseIcon } from 'src/navigator/types'
 import QRCode from 'src/qrcode/QRGen'
 import StyledQRCode from 'src/qrcode/StyledQRGen'
 import { QRCodeDataType, QRCodeStyle, StatsigLayers } from 'src/statsig/types'
@@ -115,15 +114,6 @@ describe('QRNavigator', () => {
       expect(queryByTestId('Times')).toBeTruthy()
       expect(queryByText('myCode')).toBeTruthy()
       expect(queryByText('scanCode')).toBeTruthy()
-    })
-    it('renders back button when parameter is set', () => {
-      const { queryByTestId } = render(
-        <Provider store={mockStore}>
-          <MockedNavigator component={QRNavigator} params={{ closeIcon: CloseIcon.BackChevron }} />
-        </Provider>
-      )
-
-      expect(queryByTestId('BackChevron')).toBeTruthy()
     })
     describe('integration tests for usage of experiment parameters', () => {
       it('user with Address data type, New style gets styled qr code with address', async () => {

--- a/src/navigator/QRNavigator.tsx
+++ b/src/navigator/QRNavigator.tsx
@@ -18,7 +18,7 @@ import { ExternalExchangeProvider } from 'src/fiatExchanges/ExternalExchanges'
 import { fetchExchanges } from 'src/fiatExchanges/utils'
 import { noHeader } from 'src/navigator/Headers'
 import { Screens } from 'src/navigator/Screens'
-import { CloseIcon, QRTabParamList, StackParamList } from 'src/navigator/types'
+import { QRTabParamList, StackParamList } from 'src/navigator/types'
 import { userLocationDataSelector } from 'src/networkInfo/selectors'
 import NewQRCode from 'src/qrcode/NewQRCode'
 import QRCode from 'src/qrcode/QRCode'
@@ -221,15 +221,12 @@ const pager: ExtractProps<typeof Tab.Navigator>['pager'] =
 type Props = NativeStackScreenProps<StackParamList, Screens.QRNavigator>
 
 export default function QRNavigator({ route }: Props) {
-  const closeIcon = route.params?.closeIcon ?? CloseIcon.TimesSymbol
   const { qrCodeDataType, qrCodeStyle } = getExperimentParams()
   const position = useRef(new Animated.Value(0)).current
   const qrSvgRef = useRef<SVG>()
   const { t } = useTranslation()
 
-  const tabBar = (props: MaterialTopTabBarProps) => (
-    <QRTabBar {...props} qrSvgRef={qrSvgRef} closeIcon={closeIcon} />
-  )
+  const tabBar = (props: MaterialTopTabBarProps) => <QRTabBar {...props} qrSvgRef={qrSvgRef} />
 
   return (
     <Tab.Navigator

--- a/src/navigator/types.tsx
+++ b/src/navigator/types.tsx
@@ -38,13 +38,6 @@ type NestedNavigatorParams<ParamList> = {
     : { screen: K; params: ParamList[K] }
 }[keyof ParamList]
 
-export enum CloseIcon {
-  BackChevron = 'BackChevron',
-  TimesSymbol = 'TimesSymbol',
-}
-
-type QRNavigatorParams = NestedNavigatorParams<QRTabParamList> & { closeIcon?: CloseIcon }
-
 interface SendConfirmationLegacyParams {
   origin: SendOrigin
   transactionData: TransactionDataInputLegacy
@@ -263,7 +256,7 @@ export type StackParamList = {
   [Screens.ProtectWallet]: undefined
   [Screens.OnboardingRecoveryPhrase]: undefined
   [Screens.Profile]: undefined
-  [Screens.QRNavigator]: QRNavigatorParams | undefined
+  [Screens.QRNavigator]: NestedNavigatorParams<QRTabParamList>
   [Screens.ReclaimPaymentConfirmationScreen]: {
     reclaimPaymentInput: EscrowedPayment
     onCancel?: () => void
@@ -290,7 +283,6 @@ export type StackParamList = {
         skipContactsImport?: boolean
         forceTokenAddress?: boolean
         defaultTokenOverride?: string
-        closeIcon?: CloseIcon
       }
     | undefined
   [Screens.SendAmount]: {

--- a/src/navigator/types.tsx
+++ b/src/navigator/types.tsx
@@ -256,7 +256,7 @@ export type StackParamList = {
   [Screens.ProtectWallet]: undefined
   [Screens.OnboardingRecoveryPhrase]: undefined
   [Screens.Profile]: undefined
-  [Screens.QRNavigator]: NestedNavigatorParams<QRTabParamList>
+  [Screens.QRNavigator]: NestedNavigatorParams<QRTabParamList> | undefined
   [Screens.ReclaimPaymentConfirmationScreen]: {
     reclaimPaymentInput: EscrowedPayment
     onCancel?: () => void

--- a/src/qrcode/QRTabBar.tsx
+++ b/src/qrcode/QRTabBar.tsx
@@ -5,27 +5,17 @@ import Animated from 'react-native-reanimated'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { useDispatch } from 'react-redux'
 import SegmentedControl from 'src/components/SegmentedControl'
-import BackChevron from 'src/icons/BackChevron'
 import Share from 'src/icons/Share'
 import Times from 'src/icons/Times'
 import { TopBarIconButton } from 'src/navigator/TopBarButton'
-import { CloseIcon } from 'src/navigator/types'
 import { SVG, shareQRCode } from 'src/send/actions'
 import colors from 'src/styles/colors'
 
 type Props = MaterialTopTabBarProps & {
   qrSvgRef: React.MutableRefObject<SVG>
-  closeIcon: CloseIcon
 }
 
-export default function QRTabBar({
-  state,
-  descriptors,
-  navigation,
-  position,
-  qrSvgRef,
-  closeIcon,
-}: Props) {
+export default function QRTabBar({ state, descriptors, navigation, position, qrSvgRef }: Props) {
   const dispatch = useDispatch()
 
   const values = useMemo(
@@ -88,16 +78,7 @@ export default function QRTabBar({
   return (
     <SafeAreaView style={styles.container} edges={['top']}>
       <View style={styles.leftContainer}>
-        <TopBarIconButton
-          icon={
-            closeIcon === CloseIcon.BackChevron ? (
-              <BackChevron color={color} />
-            ) : (
-              <Times color={color} />
-            )
-          }
-          onPress={onPressClose}
-        />
+        <TopBarIconButton icon={<Times color={color} />} onPress={onPressClose} />
       </View>
       <SegmentedControl
         values={values}

--- a/src/send/Send.test.tsx
+++ b/src/send/Send.test.tsx
@@ -5,7 +5,6 @@ import { SendOrigin } from 'src/analytics/types'
 import { fetchAddressesAndValidate } from 'src/identity/actions'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
-import { CloseIcon } from 'src/navigator/types'
 import Send from 'src/send/Send'
 import { createMockStore, getMockStackScreenProps } from 'test/utils'
 import {
@@ -24,7 +23,6 @@ const mockScreenProps = (params: {
   skipContactsImport?: boolean
   forceTokenAddress?: boolean
   defaultTokenOverride?: string
-  closeIcon?: CloseIcon
 }) => getMockStackScreenProps(Screens.Send, params)
 
 const defaultStore = {
@@ -195,15 +193,5 @@ describe('Send', () => {
 
     await waitFor(() => expect(getByText('inviteModal.sendInviteButtonLabel')).toBeTruthy())
     expect(navigate).not.toHaveBeenCalled()
-  })
-
-  it('shows back button when parameter is set', () => {
-    const { queryByTestId } = render(
-      <Provider store={createMockStore(defaultStore)}>
-        <Send {...mockScreenProps({ closeIcon: CloseIcon.BackChevron })} />
-      </Provider>
-    )
-
-    expect(queryByTestId('BackChevron')).toBeTruthy()
   })
 })

--- a/src/send/Send.tsx
+++ b/src/send/Send.tsx
@@ -21,7 +21,7 @@ import { RecipientVerificationStatus } from 'src/identity/types'
 import { noHeader } from 'src/navigator/Headers'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
-import { CloseIcon, StackParamList } from 'src/navigator/types'
+import { StackParamList } from 'src/navigator/types'
 import { filterRecipientFactory, Recipient, sortRecipients } from 'src/recipients/recipient'
 import RecipientPicker, { Section } from 'src/recipients/RecipientPicker'
 import { phoneRecipientCacheSelector } from 'src/recipients/reducer'
@@ -45,7 +45,6 @@ type Props = NativeStackScreenProps<StackParamList, Screens.Send>
 function Send({ route }: Props) {
   const skipContactsImport = route.params?.skipContactsImport ?? false
   const isOutgoingPaymentRequest = route.params?.isOutgoingPaymentRequest ?? false
-  const closeIcon = route.params?.closeIcon ?? CloseIcon.TimesSymbol
   const forceTokenAddress = route.params?.forceTokenAddress
   const defaultTokenOverride = route.params?.defaultTokenOverride
   const { t } = useTranslation()
@@ -232,7 +231,7 @@ function Send({ route }: Props) {
 
   return (
     <SafeAreaView style={styles.body} edges={['top']}>
-      <SendHeader isOutgoingPaymentRequest={isOutgoingPaymentRequest} closeIcon={closeIcon} />
+      <SendHeader isOutgoingPaymentRequest={isOutgoingPaymentRequest} />
       <DisconnectBanner />
       <SendSearchInput input={searchQuery} onChangeText={throttledSearch} />
       {inviteRewardsActive && hasGivenContactPermission && <InviteRewardsBanner />}

--- a/src/send/SendHeader.tsx
+++ b/src/send/SendHeader.tsx
@@ -2,23 +2,20 @@ import React, { memo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { StyleSheet } from 'react-native'
 import { RequestEvents, SendEvents } from 'src/analytics/Events'
-import BackButton from 'src/components/BackButton'
 import CustomHeader from 'src/components/header/CustomHeader'
 import QRCodeBorderlessIcon from 'src/icons/QRCodeBorderless'
 import Times from 'src/icons/Times'
 import { navigate, navigateBack } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import { TopBarIconButton } from 'src/navigator/TopBarButton'
-import { CloseIcon } from 'src/navigator/types'
 import colors from 'src/styles/colors'
 import variables from 'src/styles/variables'
 
 interface Props {
   isOutgoingPaymentRequest: boolean
-  closeIcon: CloseIcon
 }
 
-function SendHeader({ isOutgoingPaymentRequest, closeIcon }: Props) {
+function SendHeader({ isOutgoingPaymentRequest }: Props) {
   const { t } = useTranslation()
 
   const goToQRScanner = () =>
@@ -33,7 +30,7 @@ function SendHeader({ isOutgoingPaymentRequest, closeIcon }: Props) {
     <CustomHeader
       left={
         <TopBarIconButton
-          icon={closeIcon === CloseIcon.BackChevron ? <BackButton /> : <Times />}
+          icon={<Times />}
           onPress={navigateBack}
           eventName={
             isOutgoingPaymentRequest ? RequestEvents.request_cancel : SendEvents.send_cancel

--- a/src/send/__snapshots__/SendConfirmation.test.tsx.snap
+++ b/src/send/__snapshots__/SendConfirmation.test.tsx.snap
@@ -81,6 +81,7 @@ exports[`SendConfirmation renders correctly 1`] = `
           onStartShouldSetResponder={[Function]}
         >
           <svg
+            fill="none"
             height={16}
             testID="BackChevron"
             viewBox="0 0 8 16"

--- a/src/send/__snapshots__/SendConfirmationLegacy.test.tsx.snap
+++ b/src/send/__snapshots__/SendConfirmationLegacy.test.tsx.snap
@@ -81,6 +81,7 @@ exports[`SendConfirmationLegacy renders correctly 1`] = `
           onStartShouldSetResponder={[Function]}
         >
           <svg
+            fill="none"
             height={16}
             testID="BackChevron"
             viewBox="0 0 8 16"


### PR DESCRIPTION
### Description

The animation for back chevron is broken on the QR screen. After talking to Nitya, we decided to revert the icon to X on the send, receive (QR) and request actions. Swap, Add and Withdraw still use back. Also reverts the Animated change on the BackChevron component since it wasn't working anyway.

### Test plan

Unit tests, manual

https://github.com/valora-inc/wallet/assets/5062591/cf2e5816-f05d-4246-9047-489f6f6788f2


### Related issues

- Fixes ACT-811

### Backwards compatibility

Yes
