### PR TITLE
fix(analytics): invoke ValoraAnalytics.init correctly

### DIFF
--- a/src/app/saga.ts
+++ b/src/app/saga.ts
@@ -131,7 +131,7 @@ export function* appInit() {
 
   yield all([
     call(initializeSentry),
-    call(ValoraAnalytics.init),
+    call([ValoraAnalytics, 'init']),
     call(
       initI18n,
       language || bestLanguage || DEFAULT_APP_LANGUAGE,


### PR DESCRIPTION
### Description

`this` object was not bound correctly causing analytics events to not fire since https://github.com/valora-inc/wallet/pull/3672 which went in on 1.57.0

### Test plan

Manually, by enabling analytics on dev build

Before, ValoraAnalytics.track was bailing here https://github.com/valora-inc/wallet/blob/ffb97d37a158a78b61dd4a507b3d7dad5b168fa5/src/analytics/ValoraAnalytics.ts#L249-L252

After the fix, confirmed with logs that events are successfully sent to segment

### Related issues

N/A

### Backwards compatibility

N/A
