### PR TITLE
feat(positions): update display of positions with 0 or negative balance

### DIFF
--- a/src/tokens/AssetItem.test.tsx
+++ b/src/tokens/AssetItem.test.tsx
@@ -33,6 +33,45 @@ describe('PositionItem', () => {
       title: 'MOO / CELO',
     })
   })
+
+  it('shows the correct info for a position', () => {
+    const { getByText, queryByText } = render(
+      <Provider store={createMockStore({})}>
+        <PositionItem position={mockPositions[0]} />
+      </Provider>
+    )
+
+    expect(getByText('MOO / CELO')).toBeTruthy()
+    expect(getByText('Pool')).toBeTruthy()
+    expect(getByText('₱3.34')).toBeTruthy()
+    expect(getByText('11.90')).toBeTruthy()
+  })
+
+  it('shows the correct info for a position with a negative balance', () => {
+    const { getByText, queryByText } = render(
+      <Provider store={createMockStore({})}>
+        <PositionItem position={{ ...mockPositions[0], balance: `-${mockPositions[0].balance}` }} />
+      </Provider>
+    )
+
+    expect(getByText('MOO / CELO')).toBeTruthy()
+    expect(getByText('Pool')).toBeTruthy()
+    expect(getByText('-₱3.34')).toBeTruthy()
+    expect(getByText('-11.90')).toBeTruthy()
+  })
+
+  it('shows the correct info for a position with a 0 price', () => {
+    const { getByText, queryByText } = render(
+      <Provider store={createMockStore({})}>
+        <PositionItem position={{ ...mockPositions[0], priceUsd: '0' }} />
+      </Provider>
+    )
+
+    expect(getByText('MOO / CELO')).toBeTruthy()
+    expect(getByText('Pool')).toBeTruthy()
+    expect(getByText('-')).toBeTruthy()
+    expect(getByText('11.90')).toBeTruthy()
+  })
 })
 
 describe('TokenBalanceItem', () => {

--- a/src/tokens/AssetItem.test.tsx
+++ b/src/tokens/AssetItem.test.tsx
@@ -4,6 +4,7 @@ import React from 'react'
 import { Provider } from 'react-redux'
 import { AssetsEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
+import { AppTokenPosition } from 'src/positions/types'
 import { PositionItem, TokenBalanceItem } from 'src/tokens/AssetItem'
 import { createMockStore } from 'test/utils'
 import { mockCusdAddress, mockPositions } from 'test/values'
@@ -35,7 +36,7 @@ describe('PositionItem', () => {
   })
 
   it('shows the correct info for a position', () => {
-    const { getByText, queryByText } = render(
+    const { getByText } = render(
       <Provider store={createMockStore({})}>
         <PositionItem position={mockPositions[0]} />
       </Provider>
@@ -48,9 +49,10 @@ describe('PositionItem', () => {
   })
 
   it('shows the correct info for a position with a negative balance', () => {
-    const { getByText, queryByText } = render(
+    const mockPosition = mockPositions[0] as AppTokenPosition
+    const { getByText } = render(
       <Provider store={createMockStore({})}>
-        <PositionItem position={{ ...mockPositions[0], balance: `-${mockPositions[0].balance}` }} />
+        <PositionItem position={{ ...mockPosition, balance: `-${mockPosition.balance}` }} />
       </Provider>
     )
 
@@ -61,9 +63,10 @@ describe('PositionItem', () => {
   })
 
   it('shows the correct info for a position with a 0 price', () => {
-    const { getByText, queryByText } = render(
+    const mockPosition = mockPositions[0] as AppTokenPosition
+    const { getByText } = render(
       <Provider store={createMockStore({})}>
-        <PositionItem position={{ ...mockPositions[0], priceUsd: '0' }} />
+        <PositionItem position={{ ...mockPosition, priceUsd: '0' }} />
       </Provider>
     )
 

--- a/src/tokens/AssetItem.tsx
+++ b/src/tokens/AssetItem.tsx
@@ -51,8 +51,12 @@ export const PositionItem = ({ position }: { position: Position }) => {
         </View>
       </View>
       <View style={styles.balances}>
-        {balanceUsd.gt(0) && (
+        {balanceUsd.gt(0) || balanceUsd.lt(0) ? (
           <TokenDisplay amount={balanceUsd} currency={Currency.Dollar} style={styles.tokenAmt} />
+        ) : (
+          // If the balance is 0 / NaN, display a dash instead
+          // as it means we don't have a price for at least one of the underlying tokens
+          <Text style={styles.tokenAmt}>-</Text>
         )}
         {balanceInDecimal && (
           <TokenDisplay


### PR DESCRIPTION
### Description

This updates the display of positions with a negative balance (upcoming Moola position hook), or 0 balance.
- show the negative balance
- positions with a 0 balance show a `-` (dash). 
  - This can happen if a position has an underlying token for which we have no USD price yet. 
  - Also this way the placement of the token amount remains stable when available, as a sub text.

### Test plan

**before/after**

<img src="https://github.com/valora-inc/wallet/assets/57791/4f3d6b94-5531-4805-b24a-2e1879a64ebf" width="50%" /><img src="https://github.com/valora-inc/wallet/assets/57791/2aa5d769-ca09-4e7a-bbc4-de493f180fbf" width="50%" />

(Faking the negative and 0 positions here).

- Updated unit tests

### Related issues

- Fixes RET-739

### Backwards compatibility

Yes
