### PR TITLE
refactor: take button component out of BottomSheet

### DIFF
--- a/src/RevokePhoneNumber.tsx
+++ b/src/RevokePhoneNumber.tsx
@@ -6,6 +6,7 @@ import { defaultCountryCodeSelector, e164NumberSelector } from 'src/account/sele
 import { SettingsEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import BottomSheet, { BottomSheetRefType } from 'src/components/BottomSheet'
+import Button, { BtnSizes, BtnTypes } from 'src/components/Button'
 import PhoneNumberWithFlag from 'src/components/PhoneNumberWithFlag'
 import ToastWithCTA from 'src/components/ToastWithCTA'
 import AttentionIcon from 'src/icons/Attention'
@@ -65,9 +66,6 @@ export const RevokePhoneNumber = ({ forwardedRef }: Props) => {
       <BottomSheet
         forwardedRef={forwardedRef}
         title={t('revokePhoneNumber.bottomSheetTitle')}
-        buttonLabel={t('revokePhoneNumber.confirmButton')}
-        buttonOnPress={handleRevokePhoneNumber}
-        buttonLoading={revokeNumberAsync.loading}
         testId="RevokePhoneNumberBottomSheet"
       >
         {e164PhoneNumber && (
@@ -80,6 +78,14 @@ export const RevokePhoneNumber = ({ forwardedRef }: Props) => {
           <AttentionIcon />
           <Text style={styles.warningText}>{t('revokePhoneNumber.description')}</Text>
         </View>
+        <Button
+          text={t('revokePhoneNumber.confirmButton')}
+          onPress={handleRevokePhoneNumber}
+          size={BtnSizes.FULL}
+          type={BtnTypes.PRIMARY}
+          showLoading={revokeNumberAsync.loading}
+          testID="RevokePhoneNumberBottomSheet/PrimaryAction"
+        />
       </BottomSheet>
       <ToastWithCTA
         showToast={showRevokeSuccess}

--- a/src/components/BottomSheet.tsx
+++ b/src/components/BottomSheet.tsx
@@ -6,7 +6,6 @@ import { BottomSheetDefaultBackdropProps } from '@gorhom/bottom-sheet/lib/typesc
 import React, { useCallback, useMemo } from 'react'
 import { StyleSheet, Text, View } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
-import Button, { BtnSizes, BtnTypes } from 'src/components/Button'
 import Colors from 'src/styles/colors'
 import fontStyles from 'src/styles/fonts'
 import { Spacing } from 'src/styles/styles'
@@ -14,10 +13,6 @@ import { Spacing } from 'src/styles/styles'
 interface Props {
   forwardedRef: React.RefObject<GorhomBottomSheet>
   title: string
-  buttonLabel: string
-  buttonOnPress: () => void
-  buttonType?: BtnTypes
-  buttonLoading?: boolean
   description?: string | null
   children?: React.ReactNode
   testId: string
@@ -25,17 +20,7 @@ interface Props {
 
 export type BottomSheetRefType = GorhomBottomSheet
 
-const BottomSheet = ({
-  forwardedRef,
-  title,
-  buttonLabel,
-  buttonOnPress,
-  buttonType = BtnTypes.PRIMARY,
-  buttonLoading = false,
-  description,
-  children,
-  testId,
-}: Props) => {
+const BottomSheet = ({ forwardedRef, title, description, children, testId }: Props) => {
   const insets = useSafeAreaInsets()
   const paddingBottom = Math.max(insets.bottom, Spacing.Thick24)
 
@@ -69,14 +54,6 @@ const BottomSheet = ({
         <Text style={styles.title}>{title}</Text>
         {description && <Text style={styles.description}>{description}</Text>}
         {children}
-        <Button
-          text={buttonLabel}
-          onPress={buttonOnPress}
-          size={BtnSizes.FULL}
-          type={buttonType}
-          showLoading={buttonLoading}
-          testID={`${testId}/PrimaryAction`}
-        />
       </View>
     </GorhomBottomSheet>
   )

--- a/src/dappsExplorer/useDappInfoBottomSheet.tsx
+++ b/src/dappsExplorer/useDappInfoBottomSheet.tsx
@@ -4,7 +4,7 @@ import { Keyboard } from 'react-native'
 import { DappExplorerEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import BottomSheet, { BottomSheetRefType } from 'src/components/BottomSheet'
-import { BtnTypes } from 'src/components/Button'
+import Button, { BtnSizes, BtnTypes } from 'src/components/Button'
 import { DAPPS_LEARN_MORE } from 'src/config'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
@@ -32,11 +32,16 @@ const useDappInfoBottomSheet = () => {
         forwardedRef={bottomSheetRef}
         title={t('dappsScreenInfoSheet.title')}
         description={t('dappsScreenInfoSheet.description')}
-        buttonLabel={t('dappsScreenInfoSheet.buttonLabel')}
-        buttonOnPress={onPressMore}
-        buttonType={BtnTypes.SECONDARY}
         testId="DAppsExplorerScreen/InfoBottomSheet"
-      />
+      >
+        <Button
+          text={t('dappsScreenInfoSheet.buttonLabel')}
+          onPress={onPressMore}
+          size={BtnSizes.FULL}
+          type={BtnTypes.SECONDARY}
+          testID="DAppsExplorerScreen/InfoBottomSheet/PrimaryAction"
+        />
+      </BottomSheet>
     ),
     []
   )


### PR DESCRIPTION
### Description

Not all bottom sheets need to have a button.

### Test plan

n/a

### Related issues

- Fixes RET-698

### Backwards compatibility

Y
