### PR TITLE
chore: disable fiatconnect kyc test

### DIFF
--- a/e2e/src/FiatConnectTransferOut.spec.js
+++ b/e2e/src/FiatConnectTransferOut.spec.js
@@ -21,6 +21,6 @@ describe('FiatConnect Transfer Out', () => {
   const platform = device.getPlatform()
   // KYC test needs to be on iOS and needs Mock Provider info
   if (platform == 'ios' && MOCK_PROVIDER_BASE_URL && MOCK_PROVIDER_API_KEY) {
-    describe('KYC', fiatConnectKycTransferOut)
+    describe.skip('KYC', fiatConnectKycTransferOut)
   }
 })


### PR DESCRIPTION
### Description

Temporarily disable this test while we are addressing blockscout issues. https://valora-app.slack.com/archives/C025V1D6F3J/p1687186166841559

### Test plan

n/a

### Related issues

n/a

### Backwards compatibility

n/a
