### PR TITLE
fix: android release build failure

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -364,9 +364,9 @@ dependencies {
     implementation 'com.clevertap.android:clevertap-android-sdk:4.4.0'
     implementation 'com.google.android.gms:play-services-base:17.4.0'
     implementation "com.google.firebase:firebase-messaging:21.0.0"
-    implementation 'com.google.android.exoplayer:exoplayer:2.11.5'
-    implementation 'com.google.android.exoplayer:exoplayer-hls:2.11.5'
-    implementation 'com.google.android.exoplayer:exoplayer-ui:2.11.5'
+    implementation 'com.google.android.exoplayer:exoplayer:2.17.1'
+    implementation 'com.google.android.exoplayer:exoplayer-hls:2.17.1'
+    implementation 'com.google.android.exoplayer:exoplayer-ui:2.17.1'
     implementation 'com.github.bumptech.glide:glide:4.11.0'
     implementation 'androidx.recyclerview:recyclerview:1.1.0'
     implementation 'androidx.viewpager:viewpager:1.0.0'

--- a/patches/react-native-fast-crypto+2.0.0.patch
+++ b/patches/react-native-fast-crypto+2.0.0.patch
@@ -1,11 +1,85 @@
 diff --git a/node_modules/react-native-fast-crypto/android/build.gradle b/node_modules/react-native-fast-crypto/android/build.gradle
-index dd999fa..79db185 100644
+index dd999fa..1cc7cf6 100644
 --- a/node_modules/react-native-fast-crypto/android/build.gradle
 +++ b/node_modules/react-native-fast-crypto/android/build.gradle
-@@ -47,15 +47,6 @@ android {
-             path "src/main/cpp/CMakeLists.txt"
-         }
+@@ -1,68 +1,48 @@
+-
+ buildscript {
+-    repositories {
+-        jcenter()
+-    }
++  repositories {
++    google()
++    mavenCentral()
++  }
+ 
+-    dependencies {
+-        classpath 'com.android.tools.build:gradle:2.3.3'
+-    }
++  dependencies {
++    classpath 'com.android.tools.build:gradle:3.6.0'
++  }
+ }
+ 
+ apply plugin: 'com.android.library'
+ 
+ def safeExtGet(prop, fallback) {
+-    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
++  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+ }
+ 
+-android {
+-    compileSdkVersion safeExtGet('compileSdkVersion', 26)
+-    buildToolsVersion safeExtGet('buildToolsVersion', '26.0.3')
+-
+-    defaultConfig {
+-        minSdkVersion safeExtGet('minSdkVersion', 16)
+-        targetSdkVersion safeExtGet('targetSdkVersion', 26)
+-        versionCode 1
+-        versionName "1.0"
+-
+-        externalNativeBuild {
+-            cmake {
+-                arguments '-DANDROID_TOOLCHAIN=clang', '-DANDROID_STL=c++_shared'
+-            }
+-        }
+-
+-        ndk {
+-            // Specifies the ABI configurations of your native
+-            // libraries Gradle should build and package with your APK.
+-            abiFilters 'armeabi-v7a', 'arm64-v8a', 'x86', 'x86_64'
+-        }
++def DEFAULT_COMPILE_SDK_VERSION = 28
++def DEFAULT_BUILD_TOOLS_VERSION = '28.0.2'
++def DEFAULT_MIN_SDK_VERSION = 19
++def DEFAULT_TARGET_SDK_VERSION = 27
+ 
++android {
++  compileSdkVersion safeExtGet('compileSdkVersion', DEFAULT_COMPILE_SDK_VERSION)
++  buildToolsVersion safeExtGet('buildToolsVersion', DEFAULT_BUILD_TOOLS_VERSION)
++
++  defaultConfig {
++    minSdkVersion safeExtGet('minSdkVersion', DEFAULT_MIN_SDK_VERSION)
++    targetSdkVersion safeExtGet('targetSdkVersion', DEFAULT_TARGET_SDK_VERSION)
++    versionCode 1
++    versionName '1.0'
++  }
++  lintOptions {
++    abortOnError false
++  }
++  externalNativeBuild {
++    cmake {
++      path "src/main/cpp/CMakeLists.txt"
      }
+-    lintOptions {
+-        abortOnError false
+-    }
+-
+-    externalNativeBuild {
+-        cmake {
+-            path "src/main/cpp/CMakeLists.txt"
+-        }
+-    }
 -
 -    // If you want Gradle to package prebuilt native libraries
 -    // with your APK, modify the default source set configuration
@@ -15,9 +89,18 @@ index dd999fa..79db185 100644
 -            jniLibs.srcDirs 'jni/libs/'
 -        }
 -    }
++  }
  }
  
  repositories {
+-    mavenCentral()
+ }
+ 
+ dependencies {
+-    implementation 'com.facebook.react:react-native:+'
++  implementation 'com.facebook.react:react-native:+'
+ }
+-  
 diff --git a/node_modules/react-native-fast-crypto/react-native-fast-crypto.podspec b/node_modules/react-native-fast-crypto/react-native-fast-crypto.podspec
 index 0745247..ce5333d 100644
 --- a/node_modules/react-native-fast-crypto/react-native-fast-crypto.podspec


### PR DESCRIPTION
### Description

This PR fixes the build issue we see [here](https://github.com/valora-inc/release-automation/actions/runs/5350577625/jobs/9708127671#step:17:95). it seems to indicate that there were some changes in the maven dependencies.

This PR:
- applies https://github.com/EdgeApp/react-native-fast-crypto/commit/35f2106bb6904afc4e936b201ff1c46afd56b3f5 as a patch. unfortunately i tried* but failed to make the latest version of react-native-fast-crypto compatible with android 6 and 7, so in the interest of time the patch seems the best option.
- upgrades the exoplayer versions - after resolving the fast-crypto error, i saw the build error below. the version added here is what is recommended in the clevertap-react-native [docs](https://developer.clevertap.com/docs/react-native-quick-start-guide#add-dependencies) (we didn't update this part when renovate upgraded the project)
```
FAILURE: Build failed with an exception.

* What went wrong:
Could not determine the dependencies of task ':app:compileAlfajoresdevDebugJavaWithJavac'.
> Could not resolve all task dependencies for configuration ':app:alfajoresdevDebugCompileClasspath'.
   > Could not find com.google.android.exoplayer:exoplayer:2.11.5.
     Required by:
         project :app
   > Could not find com.google.android.exoplayer:exoplayer-hls:2.11.5.
     Required by:
         project :app
   > Could not find com.google.android.exoplayer:exoplayer-ui:2.11.5.
     Required by:
         project :app
```

*The things i tried:
- for android API level below 26, use PBKDF2WithHmacSHA1 instead of PBKDF2WithHmacSHA512 - this has security implications so it would have been quick and dirty, but it didn't work anyway (downstream functions did not accept the output)
- for android API level below 26, put back all the code that was remove in [this commit](https://github.com/EdgeApp/react-native-fast-crypto/commit/91b4af45c872f2f23029a600e3d1b243ee2571bf) - maybe i didn't do this well, but it just caused an app crash for me. unfortunately this meant i have no idea what went wrong, crash happens too fast to see anything in live logs and can't send logs to myself because no email client on the emulator.

### Test plan

Did a build locally, verified working on android 7 emulator

### Related issues

n/a

### Backwards compatibility

Y
