### PR TITLE
fix(cash-in-bottom-sheet): only show when home is in focus

### DIFF
--- a/e2e/src/FiatConnectTransferOut.spec.js
+++ b/e2e/src/FiatConnectTransferOut.spec.js
@@ -18,10 +18,7 @@ describe('FiatConnect Transfer Out', () => {
   })
 
   const platform = device.getPlatform()
-  // disable test for android until we fix the bottom sheet issue
-  if (platform === 'ios') {
-    describe('Non KYC', fiatConnectNonKycTransferOut)
-  }
+  describe('Non KYC', fiatConnectNonKycTransferOut)
 
   // KYC test needs to be on iOS and needs Mock Provider info
   if (platform == 'ios' && MOCK_PROVIDER_BASE_URL && MOCK_PROVIDER_API_KEY) {

--- a/src/home/WalletHome.tsx
+++ b/src/home/WalletHome.tsx
@@ -1,3 +1,4 @@
+import { useIsFocused } from '@react-navigation/native'
 import _ from 'lodash'
 import React, { useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -8,6 +9,7 @@ import { useDispatch } from 'react-redux'
 import { showMessage } from 'src/alert/actions'
 import { AppState } from 'src/app/actions'
 import { appStateSelector, phoneNumberVerifiedSelector } from 'src/app/selectors'
+import QrScanButton from 'src/components/QrScanButton'
 import { HomeTokenBalance } from 'src/components/TokenBalance'
 import {
   ALERT_BANNER_DURATION,
@@ -37,12 +39,12 @@ import { celoAddressSelector, coreTokensSelector } from 'src/tokens/selectors'
 import TransactionFeed from 'src/transactions/feed/TransactionFeed'
 import { userInSanctionedCountrySelector } from 'src/utils/countryFeatures'
 import { checkContactsPermission } from 'src/utils/permissions'
-import QrScanButton from 'src/components/QrScanButton'
 
 const AnimatedSectionList = Animated.createAnimatedComponent(SectionList)
 
 function WalletHome() {
   const { t } = useTranslation()
+  const isFocused = useIsFocused()
 
   const appState = useSelector(appStateSelector)
   const isLoading = useSelector((state) => state.home.loading)
@@ -115,6 +117,9 @@ function WalletHome() {
   }
 
   const shouldShowCashInBottomSheet = () => {
+    if (!isFocused) {
+      return false
+    }
     // If user is in a sanctioned country do not show the cash in bottom sheet
     if (userInSanctionedCountry) {
       return false


### PR DESCRIPTION
### Description

Makes is so the cash in bottom sheet is only displayed when the `wallethome.tsx` is in focus and re-enables the fiat connect cash out tests: [Related Slack Thread](https://github.com/valora-inc/wallet/pull/3923#:~:text=See%20here%20for%20more%20context).

### Test plan

Tested locally on Android after the tests are enabled.

### Related issues

- #3923

### Backwards compatibility

Yes