### PR TITLE
fix: reorder the dapp featured actions cards

### DIFF
--- a/src/dappsExplorer/DappFeaturedActions.tsx
+++ b/src/dappsExplorer/DappFeaturedActions.tsx
@@ -74,22 +74,22 @@ export function DappFeaturedActions({
       showsHorizontalScrollIndicator={false}
       scrollEnabled={scrollEnabled}
     >
-      {showDappRankings && (
-        <FeaturedAction
-          title={t('dappRankings.title')}
-          description={t('dappRankings.description')}
-          onPress={onPressShowDappRankings}
-          Image={<Trophy />}
-          style={scrollEnabled ? styles.reducedWidthCard : undefined}
-        />
-      )}
-
       {showClaimRewards && (
         <FeaturedAction
           title={t('dappShortcuts.rewards.title')}
           description={t('dappShortcuts.rewards.description')}
           Image={<Wallet />}
           onPress={handleShowRewardsShortcuts}
+          style={scrollEnabled ? styles.reducedWidthCard : undefined}
+        />
+      )}
+
+      {showDappRankings && (
+        <FeaturedAction
+          title={t('dappRankings.title')}
+          description={t('dappRankings.description')}
+          onPress={onPressShowDappRankings}
+          Image={<Trophy />}
           style={
             scrollEnabled
               ? [


### PR DESCRIPTION
### Description

As the title - i implemented this before Reed updated the designs so the order was wrong.

### Test plan

n/a

### Related issues

- Fixes RET-733

### Backwards compatibility

Y
