### PR TITLE
feat: phone number keyboard suggestion on iOS

### DIFF
--- a/src/components/PhoneNumberInput.tsx
+++ b/src/components/PhoneNumberInput.tsx
@@ -120,6 +120,7 @@ export default function PhoneNumberInput({
           value={internationalPhoneNumber}
           placeholder={numberPlaceholder}
           keyboardType="phone-pad"
+          textContentType="telephoneNumber"
           testID="PhoneNumberField"
           validator={ValidatorKind.Phone}
           countryCallingCode={countryCallingCode}

--- a/src/components/__snapshots__/PhoneNumberInput.test.tsx.snap
+++ b/src/components/__snapshots__/PhoneNumberInput.test.tsx.snap
@@ -175,6 +175,7 @@ exports[`PhoneNumberInput renders and behaves correctly 1`] = `
             ]
           }
           testID="PhoneNumberField"
+          textContentType="telephoneNumber"
           underlineColorAndroid="transparent"
           validator="phone"
           value=""


### PR DESCRIPTION
### Description

This is my "perennial problems" hackathon project.

On iOS, the user's phone number is now suggested, when prompted to enter it. Tapping it above the keyboard fills the input.
This is something I wanted to do for as long as I can remember.

This one line change was made possible following the fixes made by @kathaypacific in https://github.com/valora-inc/wallet/pull/3507

### Test plan

- Tested locally

<img src="https://github.com/valora-inc/wallet/assets/57791/4357aed4-9619-4544-b753-d67df4ec520c" width="50%" /> 

### Related issues

- N/A

### Backwards compatibility

Yes
