### PR TITLE
test(e2e): prevent empty test suite on android

### DIFF
--- a/e2e/src/FiatConnectTransferOut.spec.js
+++ b/e2e/src/FiatConnectTransferOut.spec.js
@@ -5,7 +5,7 @@ import {
 import { MOCK_PROVIDER_BASE_URL, MOCK_PROVIDER_API_KEY } from 'react-native-dotenv'
 import { launchApp } from './utils/retries'
 
-describe('FiatConnect Transfer Out', () => {
+describe(':ios: FiatConnect Transfer Out', () => {
   // deliberately not doing onboarding in beforeEach, since we'll want to re-use accounts, use fresh accounts, etc for these tests
   beforeEach(async () => {
     // uninstall and reinstall to obtain a fresh account
@@ -19,12 +19,10 @@ describe('FiatConnect Transfer Out', () => {
 
   const platform = device.getPlatform()
   // disable test for android until we fix the bottom sheet issue
-  if (platform === 'ios') {
-    describe('Non KYC', fiatConnectNonKycTransferOut)
-  }
+  describe('Non KYC', fiatConnectNonKycTransferOut)
 
   // KYC test needs to be on iOS and needs Mock Provider info
-  if (platform == 'ios' && MOCK_PROVIDER_BASE_URL && MOCK_PROVIDER_API_KEY) {
+  if (MOCK_PROVIDER_BASE_URL && MOCK_PROVIDER_API_KEY) {
     describe('KYC', fiatConnectKycTransferOut)
   }
 })

--- a/e2e/src/FiatConnectTransferOut.spec.js
+++ b/e2e/src/FiatConnectTransferOut.spec.js
@@ -17,7 +17,6 @@ describe(':ios: FiatConnect Transfer Out', () => {
     })
   })
 
-  const platform = device.getPlatform()
   // disable test for android until we fix the bottom sheet issue
   describe('Non KYC', fiatConnectNonKycTransferOut)
 


### PR DESCRIPTION
### Description

#3923 added conditional test logic that creates an empty suite on Android which causes a test fail, but CI still passes. This PR skips those tests on android instead of conditionally excluding them on Android: [action run](https://github.com/valora-inc/wallet/actions/runs/5397315841/jobs/9802794612).

### Android Passing CI Run

```
FAIL e2e/src/FiatConnectTransferOut.spec.js
  ● Test suite failed to run

    Your test suite must contain at least one test.
```

### Test plan

Tested locally on Android

### Related issues

https://github.com/valora-inc/wallet/pull/3411

### Backwards compatibility

Yes