### PR TITLE
feat(SelectProvider): show receive amount instead of fees

### DIFF
--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -1416,7 +1416,8 @@
     },
     "cashOut": {
       "amountSpentInfo": "You'll withdraw <0></0> including fees"
-    }
+    },
+    "receiveAmount": "Receive <0></0>"
   },
   "fiatConnectLinkAccountScreen": {
     "bankAccount": {

--- a/src/fiatExchanges/CoinbasePaymentSection.tsx
+++ b/src/fiatExchanges/CoinbasePaymentSection.tsx
@@ -87,10 +87,10 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
   category: {
-    ...fontStyles.small500,
+    ...fontStyles.small,
   },
   fee: {
-    ...fontStyles.regular500,
+    ...fontStyles.small600,
     marginTop: 4,
   },
 })

--- a/src/fiatExchanges/SelectProvider.tsx
+++ b/src/fiatExchanges/SelectProvider.tsx
@@ -579,10 +579,10 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
   categoryHeader: {
-    ...fontStyles.small500,
+    ...fontStyles.small,
   },
   categoryText: {
-    ...fontStyles.regular500,
+    ...fontStyles.small600,
     marginTop: 4,
   },
   linkToOtherScreen: {

--- a/src/fiatExchanges/quotes/ExternalQuote.test.ts
+++ b/src/fiatExchanges/quotes/ExternalQuote.test.ts
@@ -261,4 +261,37 @@ describe('ExternalQuote', () => {
       expect(quote.isProviderNew()).toEqual(false)
     })
   })
+
+  describe('.getReceiveAmount', () => {
+    it('returns amount for simplex quote', () => {
+      const quote = new ExternalQuote({
+        quote: mockProviders[0].quote as SimplexQuote,
+        provider: mockProviders[0],
+        flow: CICOFlow.CashIn,
+      })
+      expect(quote.getReceiveAmount()).toEqual(new BigNumber(25))
+    })
+
+    it('returns amount for other quotes', () => {
+      const quote = new ExternalQuote({
+        quote: {
+          paymentMethod: PaymentMethod.Bank,
+          digitalAsset: CiCoCurrency.CELO,
+          returnedAmount: 20,
+        },
+        provider: mockProviders[1],
+        flow: CICOFlow.CashIn,
+      })
+      expect(quote.getReceiveAmount()).toEqual(new BigNumber(20))
+    })
+
+    it('returns null if returned amount is not set in quote', () => {
+      const quote = new ExternalQuote({
+        quote: { paymentMethod: PaymentMethod.Bank, digitalAsset: CiCoCurrency.CELO },
+        provider: mockProviders[1],
+        flow: CICOFlow.CashIn,
+      })
+      expect(quote.getReceiveAmount()).toBeNull()
+    })
+  })
 })

--- a/src/fiatExchanges/quotes/ExternalQuote.ts
+++ b/src/fiatExchanges/quotes/ExternalQuote.ts
@@ -31,6 +31,7 @@ export const isSimplexQuote = (quote: RawProviderQuote | SimplexQuote): quote is
 export default class ExternalQuote extends NormalizedQuote {
   quote: RawProviderQuote | SimplexQuote
   provider: FetchProvidersOutput
+  flow: CICOFlow
   constructor({
     quote,
     provider,
@@ -57,6 +58,7 @@ export default class ExternalQuote extends NormalizedQuote {
     }
     this.quote = quote
     this.provider = provider
+    this.flow = flow
   }
 
   getPaymentMethod(): PaymentMethod {
@@ -131,5 +133,20 @@ export default class ExternalQuote extends NormalizedQuote {
 
   isProviderNew(): boolean {
     return false
+  }
+
+  getReceiveAmount(): BigNumber | null {
+    if (isSimplexQuote(this.quote)) {
+      if (this.flow === CICOFlow.CashIn) {
+        return new BigNumber(this.quote.digital_money.amount)
+      } else {
+        // simplex is cash in only, this should never be reached
+        return null
+      }
+    }
+
+    return typeof this.quote.returnedAmount !== 'undefined'
+      ? new BigNumber(this.quote.returnedAmount)
+      : null
   }
 }

--- a/src/fiatExchanges/quotes/FiatConnectQuote.test.ts
+++ b/src/fiatExchanges/quotes/FiatConnectQuote.test.ts
@@ -651,4 +651,23 @@ describe('FiatConnectQuote', () => {
       expect(quote.isProviderNew()).toEqual(false)
     })
   })
+
+  describe('.getReceiveAmount', () => {
+    it('returns crypto amount for cash ins', () => {
+      const quote = new FiatConnectQuote({
+        flow: CICOFlow.CashIn,
+        quote: mockFiatConnectQuotes[1] as FiatConnectQuoteSuccess,
+        fiatAccountType: FiatAccountType.BankAccount,
+      })
+      expect(quote.getReceiveAmount()).toEqual(new BigNumber(quote.getCryptoAmount()))
+    })
+    it('returns fiat amount for cash out', () => {
+      const quote = new FiatConnectQuote({
+        flow: CICOFlow.CashOut,
+        quote: mockFiatConnectQuotes[1] as FiatConnectQuoteSuccess,
+        fiatAccountType: FiatAccountType.BankAccount,
+      })
+      expect(quote.getReceiveAmount()).toEqual(new BigNumber(quote.getFiatAmount()))
+    })
+  })
 })

--- a/src/fiatExchanges/quotes/FiatConnectQuote.ts
+++ b/src/fiatExchanges/quotes/FiatConnectQuote.ts
@@ -329,4 +329,10 @@ export default class FiatConnectQuote extends NormalizedQuote {
   getGuaranteedUntil(): Date {
     return new Date(this.quote.quote.guaranteedUntil)
   }
+
+  getReceiveAmount(): BigNumber {
+    return new BigNumber(
+      this.flow === CICOFlow.CashIn ? this.getCryptoAmount() : this.getFiatAmount()
+    )
+  }
 }

--- a/src/fiatExchanges/quotes/NormalizedQuote.ts
+++ b/src/fiatExchanges/quotes/NormalizedQuote.ts
@@ -25,6 +25,7 @@ export default abstract class NormalizedQuote {
   abstract getProviderLogo(): string
   abstract getProviderId(): string
   abstract isProviderNew(): boolean
+  abstract getReceiveAmount(): BigNumber | null
 
   abstract navigate(dispatch: Dispatch): void
   onPress(

--- a/src/fiatExchanges/utils.test.ts
+++ b/src/fiatExchanges/utils.test.ts
@@ -21,6 +21,7 @@ class MockNormalizedQuote extends NormalizedQuote {
   getTimeEstimation = jest.fn()
   navigate = jest.fn()
   isProviderNew = jest.fn()
+  getReceiveAmount = jest.fn()
 }
 
 describe('fiatExchanges utils', () => {


### PR DESCRIPTION
### Description

Show receive amount instead of fees on the SelectProvider page, behind a statsig feature gate. Includes some styling changes to match new designs, which aren't behind the gate.

### Test plan

Unit tests, manual

#### Cash In

With feature gate false:

https://github.com/valora-inc/wallet/assets/5062591/f15793b7-0a30-48bb-855e-1e04d83a3e84


With feature gate true:

https://github.com/valora-inc/wallet/assets/5062591/3fa3ed00-ccc3-4063-b5f1-465c3e4c5967


#### Cash Out

With feature gate false:

https://github.com/valora-inc/wallet/assets/5062591/1e25fee1-6310-4a2f-8fbc-b19b36a605b1

With feature gate true:

https://github.com/valora-inc/wallet/assets/5062591/09d2040a-e5b0-4b3a-80b2-d41e94575c96



### Related issues

- Fixes ACT-842

### Backwards compatibility

Yes
