### PR TITLE
chore(e2e): Don't run QR Scanner e2e tests on Android

### DIFF
--- a/e2e/src/QRScanner.spec.js
+++ b/e2e/src/QRScanner.spec.js
@@ -1,7 +1,9 @@
 import { reloadReactNative } from './utils/retries'
 import { quickOnboarding, waitForElementId } from './utils/utils'
 
-describe('Given QR Scanner', () => {
+// Re-enable when react-native-reanimated is updated to v3
+// https://linear.app/valora/issue/ENG-76/[wallet]-update-react-native-reanimated-to-v3
+describe.skip('Given QR Scanner', () => {
   beforeAll(async () => {
     await quickOnboarding()
   })

--- a/e2e/src/QRScanner.spec.js
+++ b/e2e/src/QRScanner.spec.js
@@ -1,9 +1,9 @@
 import { reloadReactNative } from './utils/retries'
 import { quickOnboarding, waitForElementId } from './utils/utils'
 
-// Re-enable when react-native-reanimated is updated to v3
+// Re-enable for android when react-native-reanimated is updated to v3
 // https://linear.app/valora/issue/ENG-76/[wallet]-update-react-native-reanimated-to-v3
-describe.skip('Given QR Scanner', () => {
+describe(':ios: Given QR Scanner', () => {
   beforeAll(async () => {
     await quickOnboarding()
   })


### PR DESCRIPTION
### Description

Skip e2e QR scanner tests on android until we tackle some [tech debt with upgrading react-native-animated.](https://linear.app/valora/issue/ENG-76/[wallet]-update-react-native-reanimated-to-v3)

### Related issues

https://linear.app/valora/issue/ACT-821/update-qr-tab-bar-e2e-tests
https://linear.app/valora/issue/ENG-76/[wallet]-update-react-native-reanimated-to-v3

