### PR TITLE
test(e2e): use impactMarket in dapp tests

### DIFF
--- a/e2e/src/usecases/DappListDisplay.js
+++ b/e2e/src/usecases/DappListDisplay.js
@@ -1,13 +1,21 @@
 import { fetchDappList, navigateToDappList } from '../utils/dappList'
 import { reloadReactNative } from '../utils/retries'
-import { getElementText, getElementTextList, sleep, waitForElementId } from '../utils/utils'
+import { getElementTextList, sleep, waitForElementId } from '../utils/utils'
 
 jestExpect = require('expect')
 
 export default DappListDisplay = () => {
   let dappList = null
+  let dappToTest = null
+
   beforeAll(async () => {
     dappList = await fetchDappList()
+    dappToTest = {
+      dapp: dappList.applications.find((dapp) => dapp.id === 'impactmarket'),
+      index: dappList.applications
+        .filter((dapp) => dapp[device.getPlatform() === 'ios' ? 'listOnIos' : 'listOnAndroid'])
+        .findIndex((dapp) => dapp.id === 'impactmarket'),
+    }
   })
 
   it('should show dapp info icon and subsequent modal', async () => {
@@ -32,19 +40,19 @@ export default DappListDisplay = () => {
   })
 
   it('should show dapp bottom sheet when dapp is selected', async () => {
-    await element(by.id('DappCard')).atIndex(0).tap()
+    await element(by.id('DappCard')).atIndex(dappToTest.index).tap()
     await waitForElementId('ConfirmDappButton')
-    await waitFor(element(by.text(`Go to ${dappList.applications[0].name}`)))
+    await waitFor(element(by.text(`Go to ${dappToTest.dapp.name}`)))
       .toBeVisible()
       .withTimeout(10 * 1000)
   })
 
   it('should open internal webview with correct dapp when dapp opened', async () => {
     await element(by.id('ConfirmDappButton')).tap()
-    await waitFor(element(by.id(`WebViewScreen/${dappList.applications[0].name}`)))
+    await waitFor(element(by.id(`WebViewScreen/${dappToTest.dapp.name}`)))
       .toBeVisible()
       .withTimeout(10 * 1000)
-    const url = new URL(dappList.applications[0].url)
+    const url = new URL(dappToTest.dapp.url)
     // Should show correct hostname in webview
     await waitFor(element(by.text(url.hostname)))
       .toBeVisible()

--- a/e2e/src/usecases/DappListRecent.js
+++ b/e2e/src/usecases/DappListRecent.js
@@ -58,8 +58,8 @@ export default DappListRecent = () => {
     // Navigate to DappList reload and navigate again - ci issue
     await navigateToDappList()
 
-    // Scroll doesn't work well for android so we just tap the first dapp
-    await element(by.id('DappCard')).atIndex(0).tap()
+    // Scroll doesn't work well for android so we just tap the second dapp
+    await element(by.id('DappCard')).atIndex(1).tap()
 
     // Get dapp name in confirmation dialog
     const dappPressed = await element(by.id('ConfirmDappTitle')).getAttributes()

--- a/e2e/src/usecases/DappListRecent.js
+++ b/e2e/src/usecases/DappListRecent.js
@@ -28,7 +28,8 @@ export default DappListRecent = () => {
 
     // Scroll to first dapp or next after most recent dapp
     await scrollToDapp(startRecentDappCount + 1)
-    await element(by.id('DappCard')).atIndex(startRecentDappCount).tap()
+    // Tap impact Market as it is the second dapp in the list
+    await element(by.text('impactMarket')).tap()
 
     // Get dapp name in confirmation dialog
     const dappPressed = await element(by.id('ConfirmDappButton')).getAttributes()

--- a/e2e/src/usecases/DappListRecent.js
+++ b/e2e/src/usecases/DappListRecent.js
@@ -28,7 +28,8 @@ export default DappListRecent = () => {
 
     // Scroll to first dapp or next after most recent dapp
     await scrollToDapp(startRecentDappCount + 1)
-    // Tap impact Market as it is the second dapp in the list
+    // The E2E test wallet always receives a non-shuffled dapp list which is controlled by Statsig
+    // Unless Bidali or impactMarket are removed impactMarket will always be second in the list
     await element(by.text('impactMarket')).tap()
 
     // Get dapp name in confirmation dialog


### PR DESCRIPTION
### Description

Specifies [impactMarket](https://www.impactmarket.com/) as the dapp tested in the recent dapp flow. Bidali became the dapp at the top of list replacing Ubeswap when many dapps were disabled in https://github.com/valora-inc/dapp-list/pull/469 and due to it's unique flow the tests started failing.

### Test plan

Tested locally on iOS and both Android and iOS with CI.

### Related issues

N/A

### Backwards compatibility

Yes