### PR TITLE
fix(swap): Fix swap again flow

### DIFF
--- a/src/swap/SwapExecuteScreen.test.tsx
+++ b/src/swap/SwapExecuteScreen.test.tsx
@@ -201,7 +201,7 @@ describe('SwapExecuteScreen', () => {
       </Provider>
     )
     fireEvent.press(getByText('SwapExecuteScreen.swapActionBar.swapAgain'))
-    expect(navigate).toHaveBeenCalledWith(Screens.SwapScreenWithBack)
+    expect(navigate).toHaveBeenCalledWith(Screens.SwapScreen)
   })
 
   it("should be able to navigate home on press of 'Done'", () => {

--- a/src/swap/SwapExecuteScreen.tsx
+++ b/src/swap/SwapExecuteScreen.tsx
@@ -24,7 +24,7 @@ export function SwapExecuteScreen() {
   const { t } = useTranslation()
 
   const navigateToSwapStart = () => {
-    navigate(Screens.SwapScreenWithBack)
+    navigate(Screens.SwapScreen)
   }
 
   const navigateToReviewScreen = () => {


### PR DESCRIPTION
### Description

After investigating the issue (see [issue](https://linear.app/valora/issue/RET-772/[wallet]-[bug]-swap-again-button-doesnt-work-as-expected)), the problem seems to be that when the app goes again to the `SwapReviewScreen` is reusing the `SwapReviewScreen` component from the previous swap, and then is using the already fetched values.

I'm missing the technical details in react of why this exactly happens, I guessed it was because the swap again button goes to the `SwapScreenWithBack`, keeping the component in the tree? I checked on Flipper, and this was happening.
So, I changed it to use the `SwapScreen` without the back button (which I also think is the best experience) and the bug seems to be fixed.

Another solution could be to change the `SwapReviewScreen` code to support multiple uses. However I think we can keep it simpler if we assume each `SwapReviewScreen` can be used once.


### Test plan

I was able to reproduce the error in the local emulator and after the fix the error is gone.

### Related issues

- Fixes [RET-722](https://linear.app/valora/issue/RET-772/[wallet]-[bug]-swap-again-button-doesnt-work-as-expected)

### Backwards compatibility

Yes
