### PR TITLE
fix(nft-image): use unique key in dependency array and remove use memo

### DIFF
--- a/src/nfts/NftImage.tsx
+++ b/src/nfts/NftImage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { View } from 'react-native'
 import FastImage from 'react-native-fast-image'
 import { NftEvents } from 'src/analytics/Events'
@@ -59,10 +59,7 @@ export default function NftImage({
   const [status, setStatus] = useState<Status>(!nft.metadata ? 'error' : 'loading')
   const [scaledHeight, setScaledHeight] = useState(DEFAULT_IMAGE_HEIGHT)
 
-  const imageUrl = useMemo(
-    () => nft.media.find((media) => media.raw === nft.metadata?.image)?.gateway,
-    [nft]
-  )
+  const imageUrl = nft.media.find((media) => media.raw === nft.metadata?.image)?.gateway
 
   useEffect(() => {
     if (nft.metadata) {
@@ -71,7 +68,7 @@ export default function NftImage({
       sendImageLoadEvent('No nft metadata')
       setStatus('error')
     }
-  }, [nft])
+  }, [`${nft.contractAddress}-${nft.tokenId}`])
 
   function sendImageLoadEvent(error?: string) {
     const { contractAddress, tokenId } = nft


### PR DESCRIPTION
### Description

Nft images in the transaction feed could get into a persisted loading state on Android.

#### Android Before

https://github.com/valora-inc/wallet/assets/26950305/c867fb86-2cff-4dd4-bc56-06da9ebc766d



#### Android After

https://github.com/valora-inc/wallet/assets/26950305/af022787-6784-45f0-a97b-de4142035e89



### Test plan

Tested locally on Android 

### Related issues

- #3903

### Backwards compatibility

Yes