### PR TITLE
test(e2e): use nft viewer instead of impactMarket in dapp display tests

### DIFF
--- a/e2e/src/usecases/DappListDisplay.js
+++ b/e2e/src/usecases/DappListDisplay.js
@@ -1,7 +1,6 @@
 import { fetchDappList, navigateToDappList } from '../utils/dappList'
 import { reloadReactNative } from '../utils/retries'
-import { getElementTextList, sleep, waitForElementId } from '../utils/utils'
-import { scrollToDapp } from '../utils/dappList'
+import { getElementTextList, sleep, scrollIntoView, waitForElementId } from '../utils/utils'
 
 jestExpect = require('expect')
 
@@ -41,8 +40,9 @@ export default DappListDisplay = () => {
   })
 
   it('should show dapp bottom sheet when dapp is selected', async () => {
-    await scrollToDapp(dappToTest.index)
-    await element(by.id('DappCard')).atIndex(dappToTest.index).tap()
+    await sleep(2000)
+    await scrollIntoView(dappToTest.dapp.name, 'DAppsExplorerScreen/DappsList')
+    await element(by.text(dappToTest.dapp.name)).tap()
     await waitForElementId('ConfirmDappButton')
     await waitFor(element(by.text(`Go to ${dappToTest.dapp.name}`)))
       .toBeVisible()

--- a/e2e/src/usecases/DappListDisplay.js
+++ b/e2e/src/usecases/DappListDisplay.js
@@ -1,6 +1,7 @@
 import { fetchDappList, navigateToDappList } from '../utils/dappList'
 import { reloadReactNative } from '../utils/retries'
 import { getElementTextList, sleep, waitForElementId } from '../utils/utils'
+import { scrollToDapp } from '../utils/dappList'
 
 jestExpect = require('expect')
 
@@ -11,10 +12,10 @@ export default DappListDisplay = () => {
   beforeAll(async () => {
     dappList = await fetchDappList()
     dappToTest = {
-      dapp: dappList.applications.find((dapp) => dapp.id === 'impactmarket'),
+      dapp: dappList.applications.find((dapp) => dapp.id === 'nftviewer'),
       index: dappList.applications
         .filter((dapp) => dapp[device.getPlatform() === 'ios' ? 'listOnIos' : 'listOnAndroid'])
-        .findIndex((dapp) => dapp.id === 'impactmarket'),
+        .findIndex((dapp) => dapp.id === 'nftviewer'),
     }
   })
 
@@ -40,6 +41,7 @@ export default DappListDisplay = () => {
   })
 
   it('should show dapp bottom sheet when dapp is selected', async () => {
+    await scrollToDapp(dappToTest.index)
     await element(by.id('DappCard')).atIndex(dappToTest.index).tap()
     await waitForElementId('ConfirmDappButton')
     await waitFor(element(by.text(`Go to ${dappToTest.dapp.name}`)))


### PR DESCRIPTION
### Description

Follow up to https://github.com/valora-inc/wallet/pull/3937, where impactMarket was used in all the Dapp tests; however, that domain appears slow to load and is causing failures in our e2e test suites. Instead we should test again a domain we control such as the NFT viewer.

### Test plan

Tested locally on Android and in CI.

### Related issues

N/A

### Backwards compatibility

Yes