### PR TITLE
feat: hooks preview mode banner

### DIFF
--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -1774,6 +1774,7 @@
       "cancel": "Cancel",
       "confirm": "Confirm"
     },
-    "invalidApiUrl": "Invalid hooks preview API URL"
+    "invalidApiUrl": "Invalid hooks preview API URL",
+    "bannerTitle": "Hooks preview enabled, tap to disable"
   }
 }

--- a/src/navigator/NavigatorWrapper.tsx
+++ b/src/navigator/NavigatorWrapper.tsx
@@ -25,6 +25,7 @@ import {
 import Navigator from 'src/navigator/Navigator'
 import { Screens } from 'src/navigator/Screens'
 import PincodeLock from 'src/pincode/PincodeLock'
+import HooksPreviewModeBanner from 'src/positions/HooksPreviewModeBanner'
 import useTypedSelector from 'src/redux/useSelector'
 import { sentryRoutingInstrumentation } from 'src/sentry/Sentry'
 import { getExperimentParams } from 'src/statsig'
@@ -186,6 +187,7 @@ export const NavigatorWrapper = () => {
     >
       <View style={styles.container}>
         <Navigator />
+        <HooksPreviewModeBanner />
         {(appLocked || updateRequired) && (
           <View style={styles.locked}>{updateRequired ? <UpgradeScreen /> : <PincodeLock />}</View>
         )}

--- a/src/positions/HooksPreviewModeBanner.test.tsx
+++ b/src/positions/HooksPreviewModeBanner.test.tsx
@@ -1,0 +1,56 @@
+import { fireEvent, render } from '@testing-library/react-native'
+import * as React from 'react'
+import { Provider } from 'react-redux'
+import HooksPreviewModeBanner from 'src/positions/HooksPreviewModeBanner'
+import { previewModeDisabled } from 'src/positions/slice'
+import { createMockStore } from 'test/utils'
+
+describe(HooksPreviewModeBanner, () => {
+  it('should render when hooks preview is enabled', () => {
+    const tree = render(
+      <Provider
+        store={createMockStore({
+          positions: {
+            previewApiUrl: 'https://example.com',
+          },
+        })}
+      >
+        <HooksPreviewModeBanner />)
+      </Provider>
+    )
+
+    expect(tree.getByText('hooksPreview.bannerTitle')).toBeTruthy()
+  })
+
+  it('should render when hooks preview is disabled', () => {
+    const tree = render(
+      <Provider
+        store={createMockStore({
+          positions: {
+            previewApiUrl: null,
+          },
+        })}
+      >
+        <HooksPreviewModeBanner />)
+      </Provider>
+    )
+
+    expect(tree.queryByText('hooksPreview.bannerTitle')).toBeFalsy()
+  })
+
+  it('should disable hooks preview when tapped', () => {
+    const store = createMockStore({
+      positions: {
+        previewApiUrl: 'https://example.com',
+      },
+    })
+    const tree = render(
+      <Provider store={store}>
+        <HooksPreviewModeBanner />)
+      </Provider>
+    )
+
+    fireEvent.press(tree.getByText('hooksPreview.bannerTitle'))
+    expect(store.getActions()).toEqual([previewModeDisabled()])
+  })
+})

--- a/src/positions/HooksPreviewModeBanner.test.tsx
+++ b/src/positions/HooksPreviewModeBanner.test.tsx
@@ -22,7 +22,7 @@ describe(HooksPreviewModeBanner, () => {
     expect(tree.getByText('hooksPreview.bannerTitle')).toBeTruthy()
   })
 
-  it('should render when hooks preview is disabled', () => {
+  it("shouldn't render when hooks preview is disabled", () => {
     const tree = render(
       <Provider
         store={createMockStore({

--- a/src/positions/HooksPreviewModeBanner.tsx
+++ b/src/positions/HooksPreviewModeBanner.tsx
@@ -1,26 +1,37 @@
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 import { StyleSheet, Text } from 'react-native'
 import Animated, { SlideInUp, SlideOutUp } from 'react-native-reanimated'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { useDispatch, useSelector } from 'react-redux'
 import Touchable from 'src/components/Touchable'
-import { hooksPreviewApiUrlSelector } from 'src/positions/selectors'
+import { hooksPreviewApiUrlSelector, hooksPreviewStatusSelector } from 'src/positions/selectors'
 import { previewModeDisabled } from 'src/positions/slice'
+import colors from 'src/styles/colors'
+import fonts from 'src/styles/fonts'
 
 const AnimatedSafeAreaView = Animated.createAnimatedComponent(SafeAreaView)
+
+const STATUS_COLORS = {
+  idle: 'gray',
+  loading: 'gray',
+  success: colors.greenUI,
+  error: '#d01a26',
+}
 
 export default function HooksPreviewModeBanner() {
   const hooksPreviewApiUrl = useSelector(hooksPreviewApiUrlSelector)
   const dispatch = useDispatch()
+  const { t } = useTranslation()
+  const status = useSelector(hooksPreviewStatusSelector)
 
   if (!hooksPreviewApiUrl) {
     return null
   }
 
   return (
-    // <View
     <AnimatedSafeAreaView
-      style={styles.container}
+      style={[styles.container, { backgroundColor: STATUS_COLORS[status] }]}
       edges={['top']}
       entering={SlideInUp}
       exiting={SlideOutUp}
@@ -29,7 +40,9 @@ export default function HooksPreviewModeBanner() {
         onPress={() => dispatch(previewModeDisabled())}
         hitSlop={{ top: 10, right: 10, bottom: 10, left: 10 }}
       >
-        <Text style={styles.text}>Hooks Preview enabled, tap to disable</Text>
+        <Text style={styles.text} numberOfLines={1}>
+          {t('hooksPreview.bannerTitle')}
+        </Text>
       </Touchable>
     </AnimatedSafeAreaView>
   )
@@ -42,13 +55,11 @@ const styles = StyleSheet.create({
     left: 0,
     right: 0,
     backgroundColor: 'orange',
-    // padding: 10,
   },
   text: {
-    // color: 'white',
-    // color: colors.white,
-    // fontSize: 16,
-    // fontWeight: '500',
+    ...fonts.xsmall500,
+    color: colors.white,
     textAlign: 'center',
+    paddingHorizontal: 10,
   },
 })

--- a/src/positions/HooksPreviewModeBanner.tsx
+++ b/src/positions/HooksPreviewModeBanner.tsx
@@ -1,0 +1,54 @@
+import React from 'react'
+import { StyleSheet, Text } from 'react-native'
+import Animated, { SlideInUp, SlideOutUp } from 'react-native-reanimated'
+import { SafeAreaView } from 'react-native-safe-area-context'
+import { useDispatch, useSelector } from 'react-redux'
+import Touchable from 'src/components/Touchable'
+import { hooksPreviewApiUrlSelector } from 'src/positions/selectors'
+import { previewModeDisabled } from 'src/positions/slice'
+
+const AnimatedSafeAreaView = Animated.createAnimatedComponent(SafeAreaView)
+
+export default function HooksPreviewModeBanner() {
+  const hooksPreviewApiUrl = useSelector(hooksPreviewApiUrlSelector)
+  const dispatch = useDispatch()
+
+  if (!hooksPreviewApiUrl) {
+    return null
+  }
+
+  return (
+    // <View
+    <AnimatedSafeAreaView
+      style={styles.container}
+      edges={['top']}
+      entering={SlideInUp}
+      exiting={SlideOutUp}
+    >
+      <Touchable
+        onPress={() => dispatch(previewModeDisabled())}
+        hitSlop={{ top: 10, right: 10, bottom: 10, left: 10 }}
+      >
+        <Text style={styles.text}>Hooks Preview enabled, tap to disable</Text>
+      </Touchable>
+    </AnimatedSafeAreaView>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    position: 'absolute',
+    top: -10,
+    left: 0,
+    right: 0,
+    backgroundColor: 'orange',
+    // padding: 10,
+  },
+  text: {
+    // color: 'white',
+    // color: colors.white,
+    // fontSize: 16,
+    // fontWeight: '500',
+    textAlign: 'center',
+  },
+})

--- a/src/positions/saga.ts
+++ b/src/positions/saga.ts
@@ -15,6 +15,7 @@ import {
   fetchPositionsStart,
   fetchPositionsSuccess,
   fetchShortcutsFailure,
+  fetchShortcutsStart,
   fetchShortcutsSuccess,
   previewModeDisabled,
   previewModeEnabled,
@@ -74,6 +75,7 @@ export function* fetchShortcutsSaga() {
       return
     }
 
+    yield put(fetchShortcutsStart())
     const hooksApiUrl = yield select(hooksApiUrlSelector)
     const response = yield call(
       fetchWithTimeout,

--- a/src/positions/selectors.ts
+++ b/src/positions/selectors.ts
@@ -4,10 +4,13 @@ import { AppTokenPosition, ClaimablePosition, Position, Token } from 'src/positi
 import { RootState } from 'src/redux/reducers'
 import { getFeatureGate } from 'src/statsig'
 import { StatsigFeatureGates } from 'src/statsig/types'
+import { isPresent } from 'src/utils/typescript'
 import networkConfig from 'src/web3/networkConfig'
 import { getPositionBalanceUsd } from './getPositionBalanceUsd'
 
 export const showPositionsSelector = () => getFeatureGate(StatsigFeatureGates.SHOW_POSITIONS)
+export const showClaimShortcutsSelector = () =>
+  getFeatureGate(StatsigFeatureGates.SHOW_CLAIM_SHORTCUTS)
 export const allowHooksPreviewSelector = () =>
   getFeatureGate(StatsigFeatureGates.ALLOW_HOOKS_PREVIEW)
 
@@ -90,18 +93,20 @@ export const hooksApiUrlSelector = (state: RootState) =>
   hooksPreviewApiUrlSelector(state) || networkConfig.hooksApiUrl
 
 export const hooksPreviewStatusSelector = (state: RootState) => {
-  const positionsStatus = positionsStatusSelector(state)
-  const shortcutsStatus = shortcutsStatusSelector(state)
+  const statuses = [
+    showPositionsSelector() ? positionsStatusSelector(state) : undefined,
+    showClaimShortcutsSelector() ? shortcutsStatusSelector(state) : undefined,
+  ].filter(isPresent)
 
-  if (positionsStatus === 'loading' || shortcutsStatus === 'loading') {
+  if (statuses.includes('loading')) {
     return 'loading'
   }
 
-  if (positionsStatus === 'error' || shortcutsStatus === 'error') {
+  if (statuses.includes('error')) {
     return 'error'
   }
 
-  if (positionsStatus === 'success' && shortcutsStatus === 'success') {
+  if (statuses.every((status) => status === 'success')) {
     return 'success'
   }
 

--- a/src/positions/selectors.ts
+++ b/src/positions/selectors.ts
@@ -88,3 +88,22 @@ export const hooksPreviewApiUrlSelector = (state: RootState) =>
 
 export const hooksApiUrlSelector = (state: RootState) =>
   hooksPreviewApiUrlSelector(state) || networkConfig.hooksApiUrl
+
+export const hooksPreviewStatusSelector = (state: RootState) => {
+  const positionsStatus = positionsStatusSelector(state)
+  const shortcutsStatus = shortcutsStatusSelector(state)
+
+  if (positionsStatus === 'loading' || shortcutsStatus === 'loading') {
+    return 'loading'
+  }
+
+  if (positionsStatus === 'error' || shortcutsStatus === 'error') {
+    return 'error'
+  }
+
+  if (positionsStatus === 'success' && shortcutsStatus === 'success') {
+    return 'success'
+  }
+
+  return 'idle'
+}

--- a/src/positions/slice.ts
+++ b/src/positions/slice.ts
@@ -3,11 +3,13 @@ import { REHYDRATE, RehydrateAction } from 'redux-persist'
 import { getRehydratePayload } from 'src/redux/persist-helper'
 import { Position, Shortcut } from './types'
 
+type Status = 'idle' | 'loading' | 'success' | 'error'
+
 export interface State {
   positions: Position[]
-  status: 'idle' | 'loading' | 'success' | 'error'
+  status: Status
   shortcuts: Shortcut[]
-  shortcutsStatus: 'idle' | 'loading' | 'success' | 'error'
+  shortcutsStatus: Status
   previewApiUrl: string | null
 }
 

--- a/src/positions/slice.ts
+++ b/src/positions/slice.ts
@@ -7,7 +7,7 @@ export interface State {
   positions: Position[]
   status: 'idle' | 'loading' | 'success' | 'error'
   shortcuts: Shortcut[]
-  shortcutsStatus: 'idle' | 'success' | 'error'
+  shortcutsStatus: 'idle' | 'loading' | 'success' | 'error'
   previewApiUrl: string | null
 }
 
@@ -35,6 +35,10 @@ const slice = createSlice({
     fetchPositionsFailure: (state, action: PayloadAction<Error>) => ({
       ...state,
       status: 'error',
+    }),
+    fetchShortcutsStart: (state) => ({
+      ...state,
+      shortcutsStatus: 'loading',
     }),
     fetchShortcutsSuccess: (state, action: PayloadAction<Shortcut[]>) => ({
       ...state,
@@ -76,6 +80,7 @@ export const {
   fetchPositionsStart,
   fetchPositionsSuccess,
   fetchPositionsFailure,
+  fetchShortcutsStart,
   fetchShortcutsSuccess,
   fetchShortcutsFailure,
   previewModeEnabled,

--- a/test/RootStateSchema.json
+++ b/test/RootStateSchema.json
@@ -4084,6 +4084,7 @@
                     "enum": [
                         "error",
                         "idle",
+                        "loading",
                         "success"
                     ],
                     "type": "string"

--- a/test/RootStateSchema.json
+++ b/test/RootStateSchema.json
@@ -4081,22 +4081,10 @@
                     "type": "array"
                 },
                 "shortcutsStatus": {
-                    "enum": [
-                        "error",
-                        "idle",
-                        "loading",
-                        "success"
-                    ],
-                    "type": "string"
+                    "$ref": "#/definitions/Status"
                 },
                 "status": {
-                    "enum": [
-                        "error",
-                        "idle",
-                        "loading",
-                        "success"
-                    ],
-                    "type": "string"
+                    "$ref": "#/definitions/Status"
                 }
             },
             "required": [
@@ -4505,6 +4493,15 @@
                 "walletToAccountAddress"
             ],
             "type": "object"
+        },
+        "Status": {
+            "enum": [
+                "error",
+                "idle",
+                "loading",
+                "success"
+            ],
+            "type": "string"
         },
         "StoredTokenBalance": {
             "additionalProperties": false,


### PR DESCRIPTION
### Description

This adds a banner when hooks preview mode is enabled.
Tapping it allows to disable preview mode.

The background color changes based on the fetch status for hooks (both positions and shortcuts)
- idle/loading -> grey
- success -> green
- error -> red

### Test plan

https://github.com/valora-inc/wallet/assets/57791/c0cfa79e-c95a-46d7-a426-e54d384e11d9

### Related issues

- Fixes RET-750

### Backwards compatibility

Yes