### PR TITLE
fix: allow loading hooks from preview server on Android

### DIFF
--- a/android/app/src/debug/res/xml/network_security_config.xml
+++ b/android/app/src/debug/res/xml/network_security_config.xml
@@ -3,6 +3,8 @@
   <!-- This allows unencrypted communication to these domains, which the bundler needs when running on an emulator -->
   <domain-config cleartextTrafficPermitted="true">
     <domain includeSubdomains="true">localhost</domain>
+    <!-- For Valora hooks preview mode with a local server -->
+    <domain includeSubdomains="true">sslip.io</domain>
     <domain includeSubdomains="true">10.0.1.1</domain>
     <domain includeSubdomains="true">10.0.2.2</domain>
     <domain includeSubdomains="true">10.0.3.2</domain>

--- a/android/app/src/main/res/xml/network_security_config.xml
+++ b/android/app/src/main/res/xml/network_security_config.xml
@@ -2,6 +2,8 @@
   <domain-config cleartextTrafficPermitted="true">
       <domain includeSubdomains="true">10.0.2.2</domain>
       <domain includeSubdomains="true">localhost</domain>
+      <!-- For Valora hooks preview mode with a local server -->
+      <domain includeSubdomains="true">sslip.io</domain>
   </domain-config>
   <debug-overrides> 
     <trust-anchors> 

--- a/package.json
+++ b/package.json
@@ -129,6 +129,7 @@
     "i18next": "^22.4.15",
     "ibantools": "^4.2.2",
     "io-ts": "2.0.1",
+    "is-ip": "^3.1.0",
     "lodash": "^4.17.21",
     "lottie-react-native": "^5.1.6",
     "node-libs-react-native": "^1.2.1",

--- a/src/positions/saga.test.ts
+++ b/src/positions/saga.test.ts
@@ -1,4 +1,5 @@
 import { FetchMock } from 'jest-fetch-mock/types'
+import { Platform } from 'react-native'
 import { expectSaga } from 'redux-saga-test-plan'
 import { call, select } from 'redux-saga/effects'
 import {
@@ -43,9 +44,12 @@ const MOCK_SHORTCUTS_RESPONSE = {
 
 const mockFetch = fetch as FetchMock
 
+const originalPlatform = Platform.OS
+
 beforeEach(() => {
   jest.clearAllMocks()
   mockFetch.resetMocks()
+  Platform.OS = originalPlatform
 })
 
 describe(fetchPositionsSaga, () => {
@@ -170,6 +174,15 @@ describe(handleEnableHooksPreviewDeepLink, () => {
   const deepLink = 'celo://wallet/hooks/enablePreview?hooksApiUrl=http%3A%2F%2F192.168.0.42%3A18000'
 
   it('enables hooks preview if the deep link is valid and the user confirms', async () => {
+    Platform.OS = 'android'
+    await expectSaga(handleEnableHooksPreviewDeepLink, deepLink)
+      .provide([[call(_confirmEnableHooksPreview), true]])
+      .put(previewModeEnabled('http://192.168.0.42.sslip.io:18000/')) // Uses sslip.io for Android
+      .run()
+  })
+
+  it('uses the direct IP on iOS if the deep link is valid and the user confirms', async () => {
+    Platform.OS = 'ios'
     await expectSaga(handleEnableHooksPreviewDeepLink, deepLink)
       .provide([[call(_confirmEnableHooksPreview), true]])
       .put(previewModeEnabled('http://192.168.0.42:18000'))

--- a/yarn.lock
+++ b/yarn.lock
@@ -9150,6 +9150,11 @@ io-ts@2.0.1:
   resolved "https://registry.yarnpkg.com/io-ts/-/io-ts-2.0.1.tgz#1261c12f915c2f48d16393a36966636b48a45aa1"
   integrity sha512-RezD+WcCfW4VkMkEcQWL/Nmy/nqsWTvTYg7oUmTGzglvSSV2P9h2z1PVeREPFf0GWNzruYleAt1XCMQZSg1xxQ==
 
+ip-regex@^4.0.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-4.3.0.tgz#687275ab0f57fa76978ff8f4dddc8a23d5990db5"
+  integrity sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==
+
 ip@^1.1.4, ip@^1.1.5:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.8.tgz#ae05948f6b075435ed3307acce04629da8cdbf48"
@@ -9376,6 +9381,13 @@ is-interactive@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-interactive/-/is-interactive-1.0.0.tgz#cea6e6ae5c870a7b0a0004070b7b587e0252912e"
   integrity sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==
+
+is-ip@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/is-ip/-/is-ip-3.1.0.tgz#2ae5ddfafaf05cb8008a62093cf29734f657c5d8"
+  integrity sha512-35vd5necO7IitFPjd/YBeqwWnyDWbuLH9ZXQdMfDA8TEo7pv5X8yfrvVO3xbJbLUlERCMvf6X0hTUamQxCYJ9Q==
+  dependencies:
+    ip-regex "^4.0.0"
 
 is-map@^2.0.1, is-map@^2.0.2:
   version "2.0.2"


### PR DESCRIPTION
### Description

Unlike iOS, Android doesn't allow loading cleartext content from a local server.
Preventing to load hooks from a local dev server.

To allow this, `*.sslip.io` was added to the exception list.
https://sslip.io/ is a handy DNS service which resolves domains like `192.168.0.42.sslip.io` to `192.168.0.42`.

### Test plan

- Added unit test
- Manual test confirming Android can now load hooks from a local dev server:

<img src="https://github.com/valora-inc/wallet/assets/57791/27ef59f0-f7c4-4e17-8181-cbde8132a59c" width="50%" /> 

### Related issues

- Fixes RET-750

### Backwards compatibility

Yes