### PR TITLE
feat: enable trigger shortcuts

### DIFF
--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -1347,7 +1347,8 @@
       "description": "Now you can claim rewards from open dapp positions directly in {{appName}}!",
       "claimButton": "Claim",
       "claimedLabel": "Claimed",
-      "rewardLabel": "Available reward"
+      "rewardLabel": "Available reward",
+      "claimSuccess": "Success! You claimed a reward"
     },
     "claimRewardFailure": "There was an error claiming your reward, please try again later"
   },

--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -1346,6 +1346,7 @@
       "title": "Your rewards",
       "description": "Now you can claim rewards from open dapp positions directly in {{appName}}!",
       "claimButton": "Claim",
+      "claimedLabel": "Claimed",
       "rewardLabel": "Available reward"
     }
   },

--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -1348,7 +1348,8 @@
       "claimButton": "Claim",
       "claimedLabel": "Claimed",
       "rewardLabel": "Available reward"
-    }
+    },
+    "claimRewardFailure": "There was an error claiming your reward, please try again later"
   },
   "dappsScreenHelpDialog": {
     "title": "What are dapps?",

--- a/src/app/ErrorMessages.ts
+++ b/src/app/ErrorMessages.ts
@@ -69,4 +69,5 @@ export enum ErrorMessages {
   KYC_TRY_AGAIN_FAILED = 'fiatConnectKycStatusScreen.tryAgainFailed',
   INSUFFICIENT_BALANCE_STABLE = 'insufficientBalanceStable',
   HOOKS_INVALID_PREVIEW_API_URL = 'hooksPreview.invalidApiUrl',
+  SHORTCUT_CLAIM_REWARD_FAILED = 'dappShortcuts.claimRewardFailure',
 }

--- a/src/dapps/DappShortcutsRewards.test.tsx
+++ b/src/dapps/DappShortcutsRewards.test.tsx
@@ -190,7 +190,7 @@ describe('DappShortcutsRewards', () => {
     expect(getByTestId('Button/Loading')).toBeTruthy()
   })
 
-  it('should show a claimed reward correctly', () => {
+  it('should show a claimed reward when it is no longer claimable in redux', () => {
     const { getByTestId, getByText, queryByText, rerender } = render(
       <Provider store={mockStore}>
         <DappShortcutsRewards />
@@ -201,6 +201,7 @@ describe('DappShortcutsRewards', () => {
     expect(queryByText('dappShortcuts.claimRewardsScreen.claimedLabel')).toBeFalsy()
     expect(getByText('dappShortcuts.claimRewardsScreen.claimButton')).toBeTruthy()
 
+    // simulate data refresh after a successful claim
     const updatedStore = createMockStore({
       ...defaultState,
       positions: {
@@ -230,6 +231,7 @@ describe('DappShortcutsRewards', () => {
     expect(queryByText('dappShortcuts.claimRewardsScreen.claimedLabel')).toBeFalsy()
     expect(getByText('dappShortcuts.claimRewardsScreen.claimButton')).toBeTruthy()
 
+    // simulate data refresh after a successful claim, for a continuously claimable reward
     const updatedStore = createMockStore({
       ...defaultState,
       positions: {

--- a/src/dapps/DappShortcutsRewards.test.tsx
+++ b/src/dapps/DappShortcutsRewards.test.tsx
@@ -1,7 +1,8 @@
-import { render, within } from '@testing-library/react-native'
+import { fireEvent, render, within } from '@testing-library/react-native'
 import React from 'react'
 import { Provider } from 'react-redux'
 import DappShortcutsRewards from 'src/dapps/DappShortcutsRewards'
+import { Position } from 'src/positions/types'
 import { createMockStore } from 'test/utils'
 import { mockCusdAddress, mockPositions, mockShortcuts } from 'test/values'
 
@@ -12,48 +13,117 @@ jest.mock('src/statsig', () => ({
 const mockCeloAddress = '0x471ece3750da237f93b8e339c536989b8978a438'
 const mockUbeAddress = '0x00be915b9dcf56a3cbe739d9b9c202ca692409ec'
 
+const getPositionWithClaimableBalance = (balance?: string): Position => ({
+  type: 'contract-position',
+  network: 'celo',
+  address: '0xda7f463c27ec862cfbf2369f3f74c364d050d93f',
+  appId: 'ubeswap',
+  appName: 'Ubeswap',
+  displayProps: {
+    title: 'CELO / cUSD',
+    description: 'Farm',
+    imageUrl: '',
+  },
+  tokens: [
+    {
+      type: 'app-token',
+      network: 'celo',
+      address: '0x1e593f1fe7b61c53874b54ec0c59fd0d5eb8621e',
+      appId: 'ubeswap',
+      symbol: 'ULP',
+      decimals: 18,
+      appName: 'Ubeswap',
+      displayProps: {
+        title: 'CELO / cUSD',
+        description: 'Pool',
+        imageUrl: '',
+      },
+      tokens: [
+        {
+          type: 'base-token',
+          network: 'celo',
+          address: '0x471ece3750da237f93b8e339c536989b8978a438',
+          symbol: 'CELO',
+          decimals: 18,
+          priceUsd: '0.6959536890241361',
+          balance: balance ?? '0.950545800159603456',
+          category: 'claimable',
+        },
+        {
+          type: 'base-token',
+          network: 'celo',
+          address: '0x765de816845861e75a25fca122bb6898b8b1282a',
+          symbol: 'cUSD',
+          decimals: 18,
+          priceUsd: '1',
+          balance: '0.659223169268731392',
+        },
+      ],
+      pricePerShare: ['2.827719585853931', '1.961082008754231'],
+      priceUsd: '3.9290438860550765',
+      balance: '0.336152780111169400',
+      supply: '42744.727037884449180591',
+      availableShortcutIds: [],
+    },
+    {
+      priceUsd: '0.00904673476946796903',
+      type: 'base-token',
+      category: 'claimable',
+      decimals: 18,
+      network: 'celo',
+      balance: balance ?? '0.098322815093446616',
+      symbol: 'UBE',
+      address: '0x00be915b9dcf56a3cbe739d9b9c202ca692409ec',
+    },
+  ],
+  balanceUsd: '1.3207590254762067',
+  availableShortcutIds: ['claim-reward'],
+})
+
+const defaultState = {
+  positions: {
+    positions: [...mockPositions.slice(0, 2), getPositionWithClaimableBalance()],
+    shortcuts: mockShortcuts,
+  },
+  tokens: {
+    tokenBalances: {
+      [mockCeloAddress]: {
+        address: mockCeloAddress,
+        symbol: 'CELO',
+        usdPrice: '0.6959536890241361', // matches data in mockPositions
+        balance: '10',
+        priceFetchedAt: Date.now(),
+        isCoreToken: true,
+      },
+      [mockUbeAddress]: {
+        address: mockUbeAddress,
+        symbol: 'UBE',
+        usdPrice: '0.00904673476946796903', // matches data in mockPositions
+        balance: '10',
+        priceFetchedAt: Date.now(),
+      },
+      [mockCusdAddress]: {
+        address: mockCusdAddress,
+        symbol: 'cUSD',
+        usdPrice: '1',
+        balance: '10',
+        priceFetchedAt: Date.now(),
+        isCoreToken: true,
+      },
+    },
+  },
+}
+const mockStore = createMockStore(defaultState)
+
 describe('DappShortcutsRewards', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    mockStore.clearActions()
   })
 
   it('should render claimable rewards correctly', () => {
     const { getByText, getAllByTestId } = render(
-      <Provider
-        store={createMockStore({
-          positions: {
-            positions: mockPositions,
-            shortcuts: mockShortcuts,
-          },
-          tokens: {
-            tokenBalances: {
-              [mockCeloAddress]: {
-                address: mockCeloAddress,
-                symbol: 'CELO',
-                usdPrice: '0.6959536890241361', // matches data in mockPositions
-                balance: '10',
-                priceFetchedAt: Date.now(),
-                isCoreToken: true,
-              },
-              [mockUbeAddress]: {
-                address: mockUbeAddress,
-                symbol: 'UBE',
-                usdPrice: '0.00904673476946796903', // matches data in mockPositions
-                balance: '10',
-                priceFetchedAt: Date.now(),
-              },
-              [mockCusdAddress]: {
-                address: mockCusdAddress,
-                symbol: 'cUSD',
-                usdPrice: '1',
-                balance: '10',
-                priceFetchedAt: Date.now(),
-                isCoreToken: true,
-              },
-            },
-          },
-        })}
-      >
+      <Provider store={mockStore}>
         <DappShortcutsRewards />
       </Provider>
     )
@@ -70,5 +140,89 @@ describe('DappShortcutsRewards', () => {
       within(rewardCard).getByTestId('DappShortcutsRewards/RewardAmountFiat')
     ).toHaveTextContent('₱0.88') // USD value $0.66, mocked exchange rate 1.33
     expect(within(rewardCard).getByTestId('DappShortcutsRewards/ClaimButton')).toBeTruthy()
+  })
+
+  it('should dispatch the correct action on claim', () => {
+    const { getAllByTestId } = render(
+      <Provider store={mockStore}>
+        <DappShortcutsRewards />
+      </Provider>
+    )
+
+    fireEvent.press(getAllByTestId('DappShortcutsRewards/ClaimButton')[0])
+
+    expect(mockStore.getActions()).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "payload": Object {
+            "address": "0x0000000000000000000000000000000000007e57",
+            "appId": "ubeswap",
+            "id": "claim-reward-0xda7f463c27ec862cfbf2369f3f74c364d050d93f-1.048868615253050072",
+            "network": "celo",
+            "positionAddress": "0xda7f463c27ec862cfbf2369f3f74c364d050d93f",
+            "shortcutId": "claim-reward",
+          },
+          "type": "positions/triggerShortcut",
+        },
+      ]
+    `)
+  })
+
+  it('should show a claimed reward correctly', () => {
+    const { getByTestId, getByText, queryByText, rerender } = render(
+      <Provider store={mockStore}>
+        <DappShortcutsRewards />
+      </Provider>
+    )
+
+    expect(getByTestId('DappShortcutsRewards/ClaimButton')).toBeEnabled()
+    expect(queryByText('dappShortcuts.claimRewardsScreen.claimedLabel')).toBeFalsy()
+    expect(getByText('dappShortcuts.claimRewardsScreen.claimButton')).toBeTruthy()
+
+    const updatedStore = createMockStore({
+      ...defaultState,
+      positions: {
+        ...defaultState.positions,
+        positions: [...mockPositions.slice(0, 2), getPositionWithClaimableBalance('0')],
+      },
+    })
+    rerender(
+      <Provider store={updatedStore}>
+        <DappShortcutsRewards />
+      </Provider>
+    )
+
+    expect(getByTestId('DappShortcutsRewards/ClaimButton')).toBeDisabled()
+    expect(queryByText('dappShortcuts.claimRewardsScreen.claimButton')).toBeFalsy()
+    expect(getByText('dappShortcuts.claimRewardsScreen.claimedLabel')).toBeTruthy()
+  })
+
+  it('should show a claimed, updated reward correctly', () => {
+    const { getByTestId, getByText, queryByText, rerender } = render(
+      <Provider store={mockStore}>
+        <DappShortcutsRewards />
+      </Provider>
+    )
+
+    expect(getByTestId('DappShortcutsRewards/ClaimButton')).toBeEnabled()
+    expect(queryByText('dappShortcuts.claimRewardsScreen.claimedLabel')).toBeFalsy()
+    expect(getByText('dappShortcuts.claimRewardsScreen.claimButton')).toBeTruthy()
+
+    const updatedStore = createMockStore({
+      ...defaultState,
+      positions: {
+        ...defaultState.positions,
+        positions: [...mockPositions.slice(0, 2), getPositionWithClaimableBalance('0.01')],
+      },
+    })
+    rerender(
+      <Provider store={updatedStore}>
+        <DappShortcutsRewards />
+      </Provider>
+    )
+
+    expect(getByTestId('DappShortcutsRewards/ClaimButton')).toBeEnabled()
+    expect(queryByText('dappShortcuts.claimRewardsScreen.claimedLabel')).toBeFalsy()
+    expect(getByText('dappShortcuts.claimRewardsScreen.claimButton')).toBeTruthy()
   })
 })

--- a/src/dapps/DappShortcutsRewards.test.tsx
+++ b/src/dapps/DappShortcutsRewards.test.tsx
@@ -168,6 +168,28 @@ describe('DappShortcutsRewards', () => {
     `)
   })
 
+  it('should show a reward being claimed', () => {
+    const { getByTestId } = render(
+      <Provider
+        store={createMockStore({
+          ...defaultState,
+          positions: {
+            ...defaultState.positions,
+            triggeredShortcutsStatus: {
+              'claim-reward-0xda7f463c27ec862cfbf2369f3f74c364d050d93f-1.048868615253050072':
+                'loading',
+            },
+          },
+        })}
+      >
+        <DappShortcutsRewards />
+      </Provider>
+    )
+
+    expect(getByTestId('DappShortcutsRewards/ClaimButton')).toBeDisabled()
+    expect(getByTestId('Button/Loading')).toBeTruthy()
+  })
+
   it('should show a claimed reward correctly', () => {
     const { getByTestId, getByText, queryByText, rerender } = render(
       <Provider store={mockStore}>

--- a/src/dapps/DappShortcutsRewards.tsx
+++ b/src/dapps/DappShortcutsRewards.tsx
@@ -116,7 +116,7 @@ function DappShortcutsRewards() {
                 : t('dappShortcuts.claimRewardsScreen.claimButton')
             }
             showLoading={item.status === 'loading'}
-            disabled={item.status === 'success'}
+            disabled={item.status === 'success' || item.status === 'loading'}
             size={BtnSizes.SMALL}
             touchableStyle={styles.claimButton}
             testID="DappShortcutsRewards/ClaimButton"

--- a/src/dapps/DappShortcutsRewards.tsx
+++ b/src/dapps/DappShortcutsRewards.tsx
@@ -7,7 +7,10 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useDispatch, useSelector } from 'react-redux'
 import Button, { BtnSizes } from 'src/components/Button'
 import TokenDisplay from 'src/components/TokenDisplay'
-import { positionsWithClaimableRewardsSelector } from 'src/positions/selectors'
+import {
+  getClaimableRewardId,
+  positionsWithClaimableRewardsSelector,
+} from 'src/positions/selectors'
 import { triggerShortcut } from 'src/positions/slice'
 import { ClaimablePosition } from 'src/positions/types'
 import Colors from 'src/styles/colors'
@@ -56,6 +59,7 @@ function DappShortcutsRewards() {
 
     dispatch(
       triggerShortcut({
+        id: getClaimableRewardId(position.address, position.claimableShortcut),
         address,
         appId: position.appId,
         network: 'celo',

--- a/src/dapps/DappShortcutsRewards.tsx
+++ b/src/dapps/DappShortcutsRewards.tsx
@@ -110,7 +110,7 @@ function DappShortcutsRewards() {
           <Button
             onPress={handleClaimReward(item)}
             text={
-              item.status === 'loading'
+              item.status === 'success'
                 ? t('dappShortcuts.claimRewardsScreen.claimedLabel')
                 : t('dappShortcuts.claimRewardsScreen.claimButton')
             }

--- a/src/dapps/DappShortcutsRewards.tsx
+++ b/src/dapps/DappShortcutsRewards.tsx
@@ -155,6 +155,7 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderColor: Colors.gray2,
     borderRadius: 12,
+    marginBottom: Spacing.Regular16,
   },
   rewardInfoContainer: {
     flexDirection: 'row',

--- a/src/dapps/DappShortcutsRewards.tsx
+++ b/src/dapps/DappShortcutsRewards.tsx
@@ -1,27 +1,68 @@
 import { BigNumber } from 'bignumber.js'
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Image, StyleSheet, Text, View } from 'react-native'
 import Animated from 'react-native-reanimated'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
-import { useSelector } from 'react-redux'
+import { useDispatch, useSelector } from 'react-redux'
 import Button, { BtnSizes } from 'src/components/Button'
 import TokenDisplay from 'src/components/TokenDisplay'
 import { positionsWithClaimableRewardsSelector } from 'src/positions/selectors'
+import { triggerShortcut } from 'src/positions/slice'
 import { ClaimablePosition } from 'src/positions/types'
 import Colors from 'src/styles/colors'
 import fontStyles from 'src/styles/fonts'
 import { Spacing } from 'src/styles/styles'
 import { Currency } from 'src/utils/currencies'
+import Logger from 'src/utils/Logger'
+import { walletAddressSelector } from 'src/web3/selectors'
 
 function DappShortcutsRewards() {
   const { t } = useTranslation()
   const insets = useSafeAreaInsets()
+  const dispatch = useDispatch()
 
+  const address = useSelector(walletAddressSelector)
   const positionsWithClaimableRewards = useSelector(positionsWithClaimableRewardsSelector)
 
+  const [rewards, setRewards] = useState(positionsWithClaimableRewards)
+
+  useEffect(() => {
+    setRewards((prev) => {
+      // update the displayed rewards in place, so they do not change order and
+      // claimed rewards can remain on the screen even if the data is refreshed
+      const updatedRewards = prev.map((reward) => ({
+        ...reward,
+        status:
+          positionsWithClaimableRewards.find((position) => position.address === reward.address)
+            ?.status ?? 'success',
+      }))
+
+      // add any new rewards to the end of the list
+      const newClaimablePositions = positionsWithClaimableRewards.filter(
+        (position) => !rewards.find((reward) => reward.address === position.address)
+      )
+
+      return [...updatedRewards, ...newClaimablePositions]
+    })
+  }, [positionsWithClaimableRewards])
+
   const handleClaimReward = (position: ClaimablePosition) => () => {
-    // do something
+    if (!address) {
+      // should never happen
+      Logger.error('dapps/DappShortcutsRewards', 'No wallet address found when claiming reward')
+      return
+    }
+
+    dispatch(
+      triggerShortcut({
+        address,
+        appId: position.appId,
+        network: 'celo',
+        positionAddress: position.address,
+        shortcutId: position.claimableShortcut.id,
+      })
+    )
   }
 
   const renderItem = ({ item }: { item: ClaimablePosition }) => {
@@ -64,7 +105,13 @@ function DappShortcutsRewards() {
           </View>
           <Button
             onPress={handleClaimReward(item)}
-            text={t('dappShortcuts.claimRewardsScreen.claimButton')}
+            text={
+              item.status === 'loading'
+                ? t('dappShortcuts.claimRewardsScreen.claimedLabel')
+                : t('dappShortcuts.claimRewardsScreen.claimButton')
+            }
+            showLoading={item.status === 'loading'}
+            disabled={item.status === 'success'}
             size={BtnSizes.SMALL}
             touchableStyle={styles.claimButton}
             testID="DappShortcutsRewards/ClaimButton"
@@ -96,7 +143,7 @@ function DappShortcutsRewards() {
         }}
         scrollEventThrottle={16}
         renderItem={renderItem}
-        data={positionsWithClaimableRewards}
+        data={rewards}
         ListHeaderComponent={renderHeader}
       />
     </>

--- a/src/dapps/DappShortcutsRewards.tsx
+++ b/src/dapps/DappShortcutsRewards.tsx
@@ -28,25 +28,26 @@ function DappShortcutsRewards() {
   const address = useSelector(walletAddressSelector)
   const positionsWithClaimableRewards = useSelector(positionsWithClaimableRewardsSelector)
 
-  const [rewards, setRewards] = useState(positionsWithClaimableRewards)
+  const [claimablePositions, setClaimablePositions] = useState(positionsWithClaimableRewards)
 
   useEffect(() => {
-    setRewards((prev) => {
+    setClaimablePositions((prev) => {
       // update the displayed rewards in place, so they do not change order and
-      // claimed rewards can remain on the screen even if the data is refreshed
-      const updatedRewards = prev.map((reward) => ({
+      // claimed rewards can remain on the screen even if the reward disappears
+      // after being claimed on data is refreshed
+      const updatedPositions = prev.map((reward) => ({
         ...reward,
         status:
           positionsWithClaimableRewards.find((position) => position.address === reward.address)
             ?.status ?? 'success',
       }))
 
-      // add any new rewards to the end of the list
+      // add any new claimable positions to the end of the list
       const newClaimablePositions = positionsWithClaimableRewards.filter(
-        (position) => !rewards.find((reward) => reward.address === position.address)
+        (position) => !claimablePositions.find((reward) => reward.address === position.address)
       )
 
-      return [...updatedRewards, ...newClaimablePositions]
+      return [...updatedPositions, ...newClaimablePositions]
     })
   }, [positionsWithClaimableRewards])
 
@@ -147,7 +148,7 @@ function DappShortcutsRewards() {
         }}
         scrollEventThrottle={16}
         renderItem={renderItem}
-        data={rewards}
+        data={claimablePositions}
         ListHeaderComponent={renderHeader}
       />
     </>

--- a/src/home/saga.ts
+++ b/src/home/saga.ts
@@ -16,6 +16,7 @@ import { Actions, refreshAllBalances, setLoading, updateNotifications } from 'sr
 import { IdToNotification } from 'src/home/reducers'
 import { fetchCurrentRate } from 'src/localCurrency/actions'
 import { shouldFetchCurrentRate } from 'src/localCurrency/selectors'
+import { triggerShortcutSuccess } from 'src/positions/slice'
 import { withTimeout } from 'src/redux/sagas-helpers'
 import { shouldUpdateBalance } from 'src/redux/selectors'
 import { fetchTokenBalances } from 'src/tokens/slice'
@@ -71,7 +72,7 @@ export function* autoRefreshWatcher() {
 export function* watchRefreshBalances() {
   yield call(refreshBalances)
   yield takeLeading(
-    Actions.REFRESH_BALANCES,
+    [Actions.REFRESH_BALANCES, triggerShortcutSuccess.type],
     safely(withLoading(withTimeout(REFRESH_TIMEOUT, refreshBalances)))
   )
   yield takeLeading(

--- a/src/positions/saga.test.ts
+++ b/src/positions/saga.test.ts
@@ -268,7 +268,6 @@ describe(triggerShortcutSaga, () => {
     await expectSaga(triggerShortcutSaga, triggerShortcut(shortcut))
       .provide(defaultProviders)
       .put(triggerShortcutSuccess('someId'))
-      .put(refreshAllBalances())
       .not.put(triggerShortcutFailure(expect.anything()))
       .run()
 

--- a/src/positions/saga.test.ts
+++ b/src/positions/saga.test.ts
@@ -68,6 +68,7 @@ const contractKit = {
     chainId: jest.fn(() => '42220'),
     nonce: jest.fn(),
     gasPrice: jest.fn(),
+    estimateGas: jest.fn(() => '1234'),
   },
 }
 
@@ -254,7 +255,6 @@ describe(triggerShortcutSaga, () => {
       from: mockAccount,
       to: '0x43d72ff17701b2da814620735c39c620ce0ea4a1',
       data: '0x4e71d92d',
-      gas: '1234', //check why the tests don't pass without this
     }
     mockFetch.mockResponse(
       JSON.stringify({

--- a/src/positions/saga.test.ts
+++ b/src/positions/saga.test.ts
@@ -1,12 +1,16 @@
 import { FetchMock } from 'jest-fetch-mock/types'
 import { Platform } from 'react-native'
+import Toast from 'react-native-simple-toast'
 import { expectSaga } from 'redux-saga-test-plan'
+import { EffectProviders, StaticProvider } from 'redux-saga-test-plan/providers'
 import { call, select } from 'redux-saga/effects'
 import { HooksEnablePreviewOrigin } from 'src/analytics/types'
+import { refreshAllBalances } from 'src/home/actions'
 import {
   fetchPositionsSaga,
   fetchShortcutsSaga,
   handleEnableHooksPreviewDeepLink,
+  triggerShortcutSaga,
   _confirmEnableHooksPreview,
 } from 'src/positions/saga'
 import {
@@ -21,10 +25,16 @@ import {
   fetchShortcutsFailure,
   fetchShortcutsSuccess,
   previewModeEnabled,
+  triggerShortcut,
+  triggerShortcutFailure,
+  triggerShortcutSuccess,
 } from 'src/positions/slice'
 import { getFeatureGate } from 'src/statsig'
+import { sendTransaction } from 'src/transactions/send'
 import Logger from 'src/utils/Logger'
+import { getContractKit } from 'src/web3/contracts'
 import networkConfig from 'src/web3/networkConfig'
+import { getConnectedUnlockedAccount } from 'src/web3/saga'
 import { walletAddressSelector } from 'src/web3/selectors'
 import { mockAccount, mockPositions, mockShortcuts } from 'test/values'
 import { mocked } from 'ts-jest/utils'
@@ -32,6 +42,10 @@ import { mocked } from 'ts-jest/utils'
 jest.mock('src/sentry/SentryTransactionHub')
 jest.mock('src/statsig')
 jest.mock('src/utils/Logger')
+jest.mock('src/transactions/send', () => ({
+  sendTransaction: jest.fn(() => ({ transactionHash: '0x123' })),
+}))
+jest.mock('react-native-simple-toast')
 
 const MOCK_RESPONSE = {
   message: 'OK',
@@ -46,6 +60,16 @@ const MOCK_SHORTCUTS_RESPONSE = {
 const mockFetch = fetch as FetchMock
 
 const originalPlatform = Platform.OS
+
+const contractKit = {
+  getWallet: jest.fn(),
+  getAccounts: jest.fn(),
+  connection: {
+    chainId: jest.fn(() => '42220'),
+    nonce: jest.fn(),
+    gasPrice: jest.fn(),
+  },
+}
 
 beforeEach(() => {
   jest.clearAllMocks()
@@ -206,5 +230,84 @@ describe(handleEnableHooksPreviewDeepLink, () => {
       .provide([[call(_confirmEnableHooksPreview), false]])
       .not.put.actionType(previewModeEnabled.type)
       .run()
+  })
+})
+
+describe(triggerShortcutSaga, () => {
+  const shortcut = {
+    id: 'someId',
+    address: mockAccount,
+    appId: 'gooddollar',
+    network: 'celo',
+    positionAddress: '0x43d72Ff17701B2DA814620735C39C620Ce0ea4A1',
+    shortcutId: 'claim-reward',
+  }
+  const defaultProviders: (EffectProviders | StaticProvider)[] = [
+    [select(hooksApiUrlSelector), networkConfig.hooksApiUrl],
+    [call(getContractKit), contractKit],
+    [call(getConnectedUnlockedAccount), mockAccount],
+  ]
+
+  it('should successfully trigger a shortcut and send the transaction', async () => {
+    const mockTransaction = {
+      network: 'celo',
+      from: mockAccount,
+      to: '0x43d72ff17701b2da814620735c39c620ce0ea4a1',
+      data: '0x4e71d92d',
+      gas: '1234', //check why the tests don't pass without this
+    }
+    mockFetch.mockResponse(
+      JSON.stringify({
+        message: 'OK',
+        data: {
+          transactions: [mockTransaction],
+        },
+      })
+    )
+
+    await expectSaga(triggerShortcutSaga, triggerShortcut(shortcut))
+      .provide(defaultProviders)
+      .put(triggerShortcutSuccess('someId'))
+      .put(refreshAllBalances())
+      .not.put(triggerShortcutFailure(expect.anything()))
+      .run()
+
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+    expect(mockFetch).toHaveBeenCalledWith(`${networkConfig.hooksApiUrl}/triggerShortcut`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(shortcut),
+    })
+    // TODO how to check that the transaction was correctly formed?
+    expect(sendTransaction).toHaveBeenCalledWith(expect.anything(), mockAccount, expect.anything())
+    expect(Toast.showWithGravity).toHaveBeenCalledWith(
+      'dappShortcuts.claimRewardsScreen.claimSuccess',
+      undefined,
+      undefined // these values do not matter so much
+    )
+  })
+
+  it('should handle shortcut trigger failure', async () => {
+    mockFetch.mockResponse(JSON.stringify({ message: 'something went wrong' }), { status: 500 })
+
+    await expectSaga(triggerShortcutSaga, triggerShortcut(shortcut))
+      .provide(defaultProviders)
+      .not.put(triggerShortcutSuccess(expect.anything()))
+      .not.put(refreshAllBalances())
+      .put(triggerShortcutFailure('someId'))
+      .run()
+
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+    expect(mockFetch).toHaveBeenCalledWith(`${networkConfig.hooksApiUrl}/triggerShortcut`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(shortcut),
+    })
+    expect(sendTransaction).not.toHaveBeenCalled()
+    expect(Toast.showWithGravity).not.toHaveBeenCalled()
   })
 })

--- a/src/positions/saga.ts
+++ b/src/positions/saga.ts
@@ -12,6 +12,7 @@ import { HooksEnablePreviewOrigin } from 'src/analytics/types'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import { ErrorMessages } from 'src/app/ErrorMessages'
 import { DEFAULT_TESTNET } from 'src/config'
+import { refreshAllBalances } from 'src/home/actions'
 import i18n from 'src/i18n'
 import {
   hooksApiUrlSelector,
@@ -250,6 +251,7 @@ export function* triggerShortcutSaga({ payload }: ReturnType<typeof triggerShort
       Toast.SHORT,
       Toast.BOTTOM
     )
+    yield put(refreshAllBalances())
   } catch (error) {
     yield put(triggerShortcutFailure(payload.id))
     // TODO customise error message when there are more shortcut types

--- a/src/positions/saga.ts
+++ b/src/positions/saga.ts
@@ -252,14 +252,14 @@ export function* triggerShortcutSaga({ payload }: ReturnType<typeof triggerShort
       Logger.debug(`${TAG}/triggerShortcutSaga`, 'Claimed reward successful', receipt)
     }
 
-    yield put(triggerShortcutSuccess(payload.positionAddress))
+    yield put(triggerShortcutSuccess(payload.id))
     Toast.showWithGravity(
       i18n.t('dappShortcuts.claimRewardsScreen.claimSuccess'),
       Toast.SHORT,
       Toast.BOTTOM
     )
   } catch (error) {
-    yield put(triggerShortcutFailure(payload.positionAddress))
+    yield put(triggerShortcutFailure(payload.id))
     // TODO customise error message when there are more shortcut types
     yield put(showError(ErrorMessages.SHORTCUT_CLAIM_REWARD_FAILED))
     Logger.warn(`${TAG}/triggerShortcutSaga`, 'Failed to claim reward', error)

--- a/src/positions/saga.ts
+++ b/src/positions/saga.ts
@@ -1,7 +1,11 @@
+import { CeloTx, CeloTxReceipt } from '@celo/connect'
+import { TxParamsNormalizer } from '@celo/connect/lib/utils/tx-params-normalizer'
+import { ContractKit } from '@celo/contractkit'
 import isIP from 'is-ip'
 import path from 'path'
 import { Alert, Platform } from 'react-native'
-import { call, put, select, spawn, takeLeading } from 'redux-saga/effects'
+import Toast from 'react-native-simple-toast'
+import { call, put, select, spawn, takeEvery, takeLeading } from 'redux-saga/effects'
 import { showError } from 'src/alert/actions'
 import { BuilderHooksEvents } from 'src/analytics/Events'
 import { HooksEnablePreviewOrigin } from 'src/analytics/types'
@@ -23,6 +27,9 @@ import {
   fetchShortcutsSuccess,
   previewModeDisabled,
   previewModeEnabled,
+  triggerShortcut,
+  triggerShortcutFailure,
+  triggerShortcutSuccess,
 } from 'src/positions/slice'
 import { Position, Shortcut } from 'src/positions/types'
 import { SentryTransactionHub } from 'src/sentry/SentryTransactionHub'
@@ -30,10 +37,15 @@ import { SentryTransaction } from 'src/sentry/SentryTransactions'
 import { getFeatureGate } from 'src/statsig'
 import { StatsigFeatureGates } from 'src/statsig/types'
 import { fetchTokenBalances } from 'src/tokens/slice'
+import { sendTransaction } from 'src/transactions/send'
+import { newTransactionContext } from 'src/transactions/types'
 import { fetchWithTimeout } from 'src/utils/fetchWithTimeout'
 import Logger from 'src/utils/Logger'
 import { safely } from 'src/utils/safely'
+import { getContractKit } from 'src/web3/contracts'
+import { getConnectedUnlockedAccount } from 'src/web3/saga'
 import { walletAddressSelector } from 'src/web3/selectors'
+import { applyChainIdWorkaround, buildTxo } from 'src/web3/utils'
 
 const TAG = 'positions/saga'
 
@@ -188,6 +200,72 @@ export function* handleEnableHooksPreviewDeepLink(
   }
 }
 
+export function* triggerShortcutSaga({ payload }: ReturnType<typeof triggerShortcut>) {
+  Logger.debug(`${TAG}/triggerShortcutSaga`, 'Initiating request to claim reward', payload)
+
+  const hooksApiUrl = yield select(hooksApiUrlSelector)
+
+  try {
+    const response = yield call(fetchWithTimeout, `${hooksApiUrl}/triggerShortcut`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    })
+    if (!response.ok) {
+      throw new Error(`Unable to trigger shortcut: ${response.status} ${response.statusText}`)
+    }
+
+    const { data } = yield call([response, 'json'])
+
+    console.log('=====data', data)
+
+    const kit: ContractKit = yield call(getContractKit)
+    const walletAddress: string = yield call(getConnectedUnlockedAccount)
+    const normalizer = new TxParamsNormalizer(kit.connection)
+
+    Logger.debug(`${TAG}/triggerShortcutSaga`, 'Starting to claim reward(s)', data.transactions)
+
+    for (const transaction of data.transactions) {
+      applyChainIdWorkaround(transaction, yield call([kit.connection, 'chainId'], 42220))
+
+      console.log('=====transaction', transaction)
+      const tx: CeloTx = yield call([normalizer, 'populate'], {
+        to: transaction.to,
+        from: transaction.from,
+        data: transaction.data,
+        chainId: 42220,
+        gas: 112652,
+      })
+      const txo = buildTxo(kit, tx)
+
+      console.log('=====txo', txo)
+
+      const receipt: CeloTxReceipt = yield call(
+        sendTransaction,
+        txo,
+        walletAddress,
+        newTransactionContext(TAG, 'Trigger shortcut')
+      )
+
+      Logger.debug(`${TAG}/triggerShortcutSaga`, 'Claimed reward successful', receipt)
+    }
+
+    yield put(triggerShortcutSuccess(payload.positionAddress))
+    Toast.showWithGravity(
+      i18n.t('dappShortcuts.claimRewardsScreen.claimSuccess'),
+      Toast.SHORT,
+      Toast.BOTTOM
+    )
+  } catch (error) {
+    yield put(triggerShortcutFailure(payload.positionAddress))
+    // TODO customise error message when there are more shortcut types
+    yield put(showError(ErrorMessages.SHORTCUT_CLAIM_REWARD_FAILED))
+    Logger.warn(`${TAG}/triggerShortcutSaga`, 'Failed to claim reward', error)
+  }
+}
+
 export function* watchFetchBalances() {
   // Refresh positions/shortcuts when fetching token balances
   // or when preview mode is enabled/disabled
@@ -201,6 +279,11 @@ export function* watchFetchBalances() {
   )
 }
 
+export function* watchShortcuts() {
+  yield takeEvery(triggerShortcut, safely(triggerShortcutSaga))
+}
+
 export function* positionsSaga() {
   yield spawn(watchFetchBalances)
+  yield spawn(watchShortcuts)
 }

--- a/src/positions/saga.ts
+++ b/src/positions/saga.ts
@@ -228,7 +228,7 @@ export function* triggerShortcutSaga({ payload }: ReturnType<typeof triggerShort
     Logger.debug(`${TAG}/triggerShortcutSaga`, 'Starting to claim reward(s)', data.transactions)
 
     for (const transaction of data.transactions) {
-      applyChainIdWorkaround(transaction, yield call([kit.connection, 'chainId'], 42220))
+      applyChainIdWorkaround(transaction, yield call([kit.connection, 'chainId']))
 
       console.log('=====transaction', transaction)
       const tx: CeloTx = yield call([normalizer, 'populate'], {

--- a/src/positions/selectors.test.ts
+++ b/src/positions/selectors.test.ts
@@ -97,6 +97,7 @@ describe('positionsWithClaimableRewardsSelector', () => {
       positions: {
         positions: mockPositions,
         shortcuts: mockShortcuts,
+        triggeredShortcutsStatus: {},
       },
     }
     const positions = positionsWithClaimableRewardsSelector(state)

--- a/src/positions/selectors.ts
+++ b/src/positions/selectors.ts
@@ -56,7 +56,9 @@ export const claimableShortcutSelector = createSelector([shortcutsSelector], (sh
 })
 
 function getAllClaimableTokens(tokens: Token[]): Token[] {
-  const claimableTokens = tokens.filter((token) => token.category === 'claimable')
+  const claimableTokens = tokens.filter(
+    (token) => token.category === 'claimable' && BigNumber(token.balance).gt(0)
+  )
   const nestedTokens = tokens
     .filter((token): token is AppTokenPosition => 'tokens' in token)
     .flatMap((token) => getAllClaimableTokens(token.tokens))
@@ -73,12 +75,13 @@ export const positionsWithClaimableRewardsSelector = createSelector(
 
       appShortcuts.forEach((shortcut) => {
         const { availableShortcutIds, tokens, ...rest } = position
-        if (availableShortcutIds.includes(shortcut.id)) {
+        const claimableTokens = getAllClaimableTokens(tokens)
+        if (availableShortcutIds.includes(shortcut.id) && claimableTokens.length > 0) {
           claimablePositions.push({
             ...rest,
             claimableShortcut: {
               ...shortcut,
-              claimableTokens: getAllClaimableTokens(tokens),
+              claimableTokens,
             },
             status: triggeredShortcuts[position.address] ?? 'idle',
           })

--- a/src/positions/selectors.ts
+++ b/src/positions/selectors.ts
@@ -48,6 +48,9 @@ export const shortcutsSelector = (state: RootState) => state.positions.shortcuts
 
 export const shortcutsStatusSelector = (state: RootState) => state.positions.shortcutsStatus
 
+export const triggeredShortcutsStatusSelector = (state: RootState) =>
+  state.positions.triggeredShortcutsStatus
+
 export const claimableShortcutSelector = createSelector([shortcutsSelector], (shortcuts) => {
   return shortcuts.filter((shortcut) => shortcut.category === 'claim')
 })
@@ -62,8 +65,8 @@ function getAllClaimableTokens(tokens: Token[]): Token[] {
 }
 
 export const positionsWithClaimableRewardsSelector = createSelector(
-  [positionsSelector, claimableShortcutSelector],
-  (positions, shortcuts) => {
+  [positionsSelector, claimableShortcutSelector, triggeredShortcutsStatusSelector],
+  (positions, shortcuts, triggeredShortcuts) => {
     const claimablePositions: ClaimablePosition[] = []
     positions.forEach((position) => {
       const appShortcuts = shortcuts.filter((shortcut) => shortcut.appId === position.appId)
@@ -77,6 +80,7 @@ export const positionsWithClaimableRewardsSelector = createSelector(
               ...shortcut,
               claimableTokens: getAllClaimableTokens(tokens),
             },
+            status: triggeredShortcuts[position.address] ?? 'idle',
           })
         }
       })

--- a/src/positions/slice.ts
+++ b/src/positions/slice.ts
@@ -11,6 +11,7 @@ export interface State {
   shortcuts: Shortcut[]
   shortcutsStatus: Status
   previewApiUrl: string | null
+  triggeredShortcutsStatus: Record<string, Status>
 }
 
 const initialState: State = {
@@ -19,6 +20,15 @@ const initialState: State = {
   shortcuts: [],
   shortcutsStatus: 'idle',
   previewApiUrl: null,
+  triggeredShortcutsStatus: {},
+}
+
+interface TriggerShortcut {
+  network: string
+  address: string
+  appId: string
+  positionAddress: string
+  shortcutId: string
 }
 
 const slice = createSlice({
@@ -67,6 +77,15 @@ const slice = createSlice({
       shortcuts: [],
       shortcutsStatus: 'idle',
     }),
+    triggerShortcut: (state, action: PayloadAction<TriggerShortcut>) => {
+      state.triggeredShortcutsStatus[action.payload.positionAddress] = 'loading'
+    },
+    triggerShortcutSuccess: (state, action: PayloadAction<string>) => {
+      state.triggeredShortcutsStatus[action.payload] = 'success'
+    },
+    triggerShortcutFailure: (state, action: PayloadAction<string>) => {
+      state.triggeredShortcutsStatus[action.payload] = 'error'
+    },
   },
   extraReducers: (builder) => {
     builder.addCase(REHYDRATE, (state, action: RehydrateAction) => ({
@@ -74,6 +93,7 @@ const slice = createSlice({
       ...getRehydratePayload(action, 'positions'),
       status: 'idle',
       shortcutsStatus: 'idle',
+      triggeredShortcutsStatus: {},
     }))
   },
 })
@@ -87,6 +107,9 @@ export const {
   fetchShortcutsFailure,
   previewModeEnabled,
   previewModeDisabled,
+  triggerShortcut,
+  triggerShortcutSuccess,
+  triggerShortcutFailure,
 } = slice.actions
 
 export default slice.reducer

--- a/src/positions/slice.ts
+++ b/src/positions/slice.ts
@@ -24,6 +24,7 @@ const initialState: State = {
 }
 
 interface TriggerShortcut {
+  id: string // only used in the app to display the execution status of the shortcut
   network: string
   address: string
   appId: string
@@ -78,7 +79,7 @@ const slice = createSlice({
       shortcutsStatus: 'idle',
     }),
     triggerShortcut: (state, action: PayloadAction<TriggerShortcut>) => {
-      state.triggeredShortcutsStatus[action.payload.positionAddress] = 'loading'
+      state.triggeredShortcutsStatus[action.payload.id] = 'loading'
     },
     triggerShortcutSuccess: (state, action: PayloadAction<string>) => {
       state.triggeredShortcutsStatus[action.payload] = 'success'

--- a/src/positions/types.ts
+++ b/src/positions/types.ts
@@ -68,4 +68,5 @@ export interface ClaimablePosition extends Omit<Position, 'availableShortcutIds'
   claimableShortcut: Shortcut & {
     claimableTokens: Token[]
   }
+  status: 'idle' | 'loading' | 'success' | 'error'
 }

--- a/src/positions/types.ts
+++ b/src/positions/types.ts
@@ -65,8 +65,6 @@ export type ClaimableShortcut = Shortcut & {
 }
 
 export interface ClaimablePosition extends Omit<Position, 'availableShortcutIds' | 'tokens'> {
-  claimableShortcut: Shortcut & {
-    claimableTokens: Token[]
-  }
+  claimableShortcut: ClaimableShortcut
   status: 'idle' | 'loading' | 'success' | 'error'
 }

--- a/src/redux/migrations.ts
+++ b/src/redux/migrations.ts
@@ -1181,4 +1181,5 @@ export const migrations = {
       previewApiUrl: null,
     },
   }),
+  135: (state: any) => state,
 }

--- a/src/redux/store.test.ts
+++ b/src/redux/store.test.ts
@@ -99,7 +99,7 @@ describe('store state', () => {
       Object {
         "_persist": Object {
           "rehydrated": true,
-          "version": 134,
+          "version": 135,
         },
         "account": Object {
           "acceptedTerms": false,
@@ -312,6 +312,7 @@ describe('store state', () => {
           "shortcuts": Array [],
           "shortcutsStatus": "idle",
           "status": "idle",
+          "triggeredShortcutsStatus": Object {},
         },
         "recipients": Object {
           "coinbasePaySenders": Array [],

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -23,7 +23,7 @@ const persistConfig: PersistConfig<RootState> = {
   key: 'root',
   // default is -1, increment as we make migrations
   // See https://github.com/valora-inc/wallet/tree/main/WALLET.md#redux-state-migration
-  version: 134,
+  version: 135,
   keyPrefix: `reduxStore-`, // the redux-persist default is `persist:` which doesn't work with some file systems.
   storage: FSStorage(),
   blacklist: ['networkInfo', 'alert', 'imports', 'keylessBackup'],

--- a/test/RootStateSchema.json
+++ b/test/RootStateSchema.json
@@ -203,6 +203,7 @@
                                 "contractKitInitFailed",
                                 "corruptedChainDeleted",
                                 "countryNotAvailable",
+                                "dappShortcuts.claimRewardFailure",
                                 "deleteBankAccountFail",
                                 "errorRefreshingRate",
                                 "exchangeFailed",
@@ -2288,6 +2289,10 @@
             ],
             "type": "object"
         },
+        "Record<string,Status>": {
+            "additionalProperties": false,
+            "type": "object"
+        },
         "Record<string,[string,...string[]]>": {
             "additionalProperties": false,
             "type": "object"
@@ -4083,6 +4088,9 @@
                 },
                 "status": {
                     "$ref": "#/definitions/Status"
+                },
+                "triggeredShortcutsStatus": {
+                    "$ref": "#/definitions/Record<string,Status>"
                 }
             },
             "required": [
@@ -4090,7 +4098,8 @@
                 "previewApiUrl",
                 "shortcuts",
                 "shortcutsStatus",
-                "status"
+                "status",
+                "triggeredShortcutsStatus"
             ],
             "type": "object"
         },

--- a/test/schemas.ts
+++ b/test/schemas.ts
@@ -2350,6 +2350,18 @@ export const v134Schema = {
   },
 }
 
+export const v135Schema = {
+  ...v134Schema,
+  _persist: {
+    ...v134Schema._persist,
+    version: 135,
+  },
+  positions: {
+    ...v134Schema.positions,
+    triggeredShortcutsStatus: {},
+  },
+}
+
 export function getLatestSchema(): Partial<RootState> {
-  return v134Schema as Partial<RootState>
+  return v135Schema as Partial<RootState>
 }


### PR DESCRIPTION
### Description

This PR does 2 things (that made sense to test together)
1. add a saga for triggering a shortcut
2. add some redux state management to display available / claiming / claimed statuses on the rewards screen

The logic for 2 is a little more hefty than I originally planned, i may have overthought the scenario. What i wanted to cater for is:
1. a user claims a reward successfully
2. their balance and positions are refreshed in the background while the user remains on the rewards screen
3. they should see that their reward was claimed, but the positions may refresh and the claimable parts removed. so the screen essentially tracks all the data it was loaded with, and if any rewards go "missing" from the redux store then we mark it as "claimed".
4. to make this a little robust for rewards that can be continuously claimed (i.e. on successful claim, the reward remains but the reward amount changes) i made up a reward id that relies on a combination of reward amount and reward address.

### Test plan


https://github.com/valora-inc/wallet/assets/20150449/595bb6ae-26fc-426f-aede-12356929022f


### Related issues

- Fixes RET-733

### Backwards compatibility

Y
