### PR TITLE
fix: ensure dapp shortcut rewards value is refreshed

### DIFF
--- a/src/dapps/DappShortcutsRewards.tsx
+++ b/src/dapps/DappShortcutsRewards.tsx
@@ -35,12 +35,17 @@ function DappShortcutsRewards() {
       // update the displayed rewards in place, so they do not change order and
       // claimed rewards can remain on the screen even if the reward disappears
       // after being claimed on data is refreshed
-      const updatedPositions = prev.map((reward) => ({
-        ...reward,
-        status:
-          positionsWithClaimableRewards.find((position) => position.address === reward.address)
-            ?.status ?? 'success',
-      }))
+      const updatedPositions: ClaimablePosition[] = prev.map((reward) => {
+        const updatedReward = positionsWithClaimableRewards.find(
+          (position) => position.address === reward.address
+        )
+        return (
+          updatedReward ?? {
+            ...reward,
+            status: 'success',
+          }
+        )
+      })
 
       // add any new claimable positions to the end of the list
       const newClaimablePositions = positionsWithClaimableRewards.filter(


### PR DESCRIPTION
### Description

When a shortcut is claimed, we refetch the positions. When the positions data is updated, the claimable rewards could either disappear or the value could change (i.e. there is a new reward to claim). In the latter scenario, we need to also refresh the value of the reward displayed on the UI - this change makes the UI rely only on positions data in redux when available, and use the locally stored state only if the claimable position disappears.

### Test plan


https://github.com/valora-inc/wallet/assets/20150449/6a316091-f02c-49e9-9704-61479e7a5fb5



### Related issues

- Fixes RET-733

### Backwards compatibility

Y
