### PR TITLE
feat(wallet): Genericize ValoraWallet interface

### DIFF
--- a/src/account/saga.ts
+++ b/src/account/saga.ts
@@ -1,6 +1,6 @@
 import { ContractKit } from '@celo/contractkit'
 import { parsePhoneNumber } from '@celo/phone-utils'
-import { ValoraWallet } from 'src/web3/types'
+import { PrimaryValoraWallet } from 'src/web3/types'
 import firebase from '@react-native-firebase/app'
 import { Platform } from 'react-native'
 import DeviceInfo from 'react-native-device-info'
@@ -150,7 +150,7 @@ function* handlePreviouslyVerifiedPhoneNumber() {
 
 export function* generateSignedMessage() {
   try {
-    const wallet: ValoraWallet = yield call(getWallet)
+    const wallet: PrimaryValoraWallet = yield call(getWallet)
     const address: string = yield select(walletAddressSelector)
     yield call(unlockAccount, address)
 

--- a/src/ethers/ValoraEthersWallet.ts
+++ b/src/ethers/ValoraEthersWallet.ts
@@ -1,13 +1,12 @@
 import { normalizeAddressWith0x } from '@celo/utils/lib/address'
 import { Chain } from 'src/ethers/types'
 import { DEFAULT_FORNO_URL } from 'src/config'
-import { ValoraWallet } from 'src/web3/types'
+import { ValoraWallet, WalletTxType } from 'src/web3/types'
 import { TypedDataDomain, TypedDataField } from 'ethers'
 import KeychainAccountManager from 'src/web3/KeychainAccountManager'
 import { KeychainAccount } from 'src/web3/types'
-import { ethers } from 'ethers'
+import { ethers, TransactionRequest } from 'ethers'
 import { ErrorMessages } from 'src/app/ErrorMessages'
-import { CeloTx, EncodedTransaction } from '@celo/connect'
 
 const providerUrlForChain: Record<Chain, string> = {
   [Chain.Celo]: DEFAULT_FORNO_URL,
@@ -23,7 +22,7 @@ const providerUrlForChain: Record<Chain, string> = {
  * Ideally, this responsibility would be enforced programatically. The current approach
  * was opted for out of simplicity and to reduce changes needed on existing critical code.
  */
-class ValoraEthersWallet implements ValoraWallet {
+class ValoraEthersWallet implements ValoraWallet<WalletTxType.Ethers> {
   walletMap: Record<string, ethers.Wallet> // keys are lowercase account addresses
 
   constructor(protected chain: Chain, private keychainAccountManager: KeychainAccountManager) {
@@ -52,7 +51,7 @@ class ValoraEthersWallet implements ValoraWallet {
     throw new Error('Not implemented')
   }
 
-  async signTransaction(tx: CeloTx): Promise<EncodedTransaction> {
+  async signTransaction(tx: TransactionRequest): Promise<string> {
     if (!tx.from || !this.isAccountUnlocked(tx.from.toString())) {
       throw new Error('Authentication needed')
     }

--- a/src/fiatconnect/clients.ts
+++ b/src/fiatconnect/clients.ts
@@ -1,5 +1,5 @@
 import { ensureLeading0x } from '@celo/utils/lib/address'
-import { ValoraWallet } from 'src/web3/types'
+import { PrimaryValoraWallet } from 'src/web3/types'
 import { FiatConnectApiClient, FiatConnectClient } from '@fiatconnect/fiatconnect-sdk'
 import { networkTimeoutSecondsSelector } from 'src/app/selectors'
 import { FIATCONNECT_NETWORK } from 'src/config'
@@ -18,7 +18,9 @@ const fiatConnectClients: Record<
  *
  * @param wallet
  */
-export function getSiweSigningFunction(wallet: ValoraWallet): (message: string) => Promise<string> {
+export function getSiweSigningFunction(
+  wallet: PrimaryValoraWallet
+): (message: string) => Promise<string> {
   return async function (message: string): Promise<string> {
     const [account] = wallet.getAccounts()
     if (!wallet.isAccountUnlocked(account)) {
@@ -39,7 +41,7 @@ export async function getFiatConnectClient(
     fiatConnectClients[providerId].url !== providerBaseUrl ||
     fiatConnectClients[providerId].apiKey !== providerApiKey
   ) {
-    const wallet = (await getWalletAsync()) as ValoraWallet
+    const wallet = (await getWalletAsync()) as PrimaryValoraWallet
     const [account] = wallet.getAccounts()
     fiatConnectClients[providerId] = {
       url: providerBaseUrl,

--- a/src/fiatconnect/index.ts
+++ b/src/fiatconnect/index.ts
@@ -1,4 +1,4 @@
-import { ValoraWallet } from 'src/web3/types'
+import { PrimaryValoraWallet } from 'src/web3/types'
 import { CreateQuoteParams, FiatConnectApiClient } from '@fiatconnect/fiatconnect-sdk'
 import { FiatType, QuoteErrorResponse, QuoteResponse } from '@fiatconnect/fiatconnect-types'
 import { WALLET_CRYPTO_TO_FIATCONNECT_CRYPTO } from 'src/fiatconnect/consts'
@@ -69,7 +69,7 @@ export async function getFiatConnectProviders(
  * If the user's wallet is currently locked, will prompt for PIN entry.
  */
 export async function loginWithFiatConnectProvider(
-  wallet: ValoraWallet,
+  wallet: PrimaryValoraWallet,
   fiatConnectClient: FiatConnectApiClient,
   forceLogin: boolean = false
 ): Promise<void> {

--- a/src/walletConnect/request.ts
+++ b/src/walletConnect/request.ts
@@ -10,7 +10,7 @@ import { SupportedActions } from 'src/walletConnect/constants'
 import { getContractKit, getWallet, getWeb3 } from 'src/web3/contracts'
 import { getWalletAddress, unlockAccount } from 'src/web3/saga'
 import { applyChainIdWorkaround, buildTxo } from 'src/web3/utils'
-import { ValoraWallet } from 'src/web3/types'
+import { PrimaryValoraWallet } from 'src/web3/types'
 import Web3 from 'web3'
 
 const TAG = 'WalletConnect/handle-request'
@@ -26,7 +26,7 @@ export interface WalletResponseSuccess {
 
 export function* handleRequest({ method, params }: { method: string; params: any[] }) {
   const account: string = yield call(getWalletAddress)
-  const wallet: ValoraWallet = yield call(getWallet)
+  const wallet: PrimaryValoraWallet = yield call(getWallet)
   yield call(unlockAccount, account)
   // Call Sentry performance monitoring after entering pin if required
   SentryTransactionHub.startTransaction(SentryTransaction.wallet_connect_transaction)

--- a/src/web3/ValoraCeloWallet.ts
+++ b/src/web3/ValoraCeloWallet.ts
@@ -1,4 +1,4 @@
-import { ValoraWallet } from 'src/web3/types'
+import { ValoraWallet, WalletTxType } from 'src/web3/types'
 import { KeychainWallet } from 'src/web3/KeychainWallet'
 import { ImportMnemonicAccount } from 'src/web3/KeychainSigner'
 import { TypedDataDomain, TypedDataField } from 'ethers'
@@ -6,7 +6,7 @@ import { omitBy, isNil } from 'lodash'
 import KeychainAccountManager from 'src/web3/KeychainAccountManager'
 import { CeloTx, EncodedTransaction } from '@celo/connect'
 
-class ValoraCeloWallet implements ValoraWallet {
+class ValoraCeloWallet implements ValoraWallet<WalletTxType.ContractKit> {
   private keychainWallet: KeychainWallet
 
   constructor(

--- a/src/web3/contracts.ts
+++ b/src/web3/contracts.ts
@@ -20,13 +20,13 @@ import { getHttpProvider } from 'src/web3/providers'
 import { walletAddressSelector } from 'src/web3/selectors'
 import Web3 from 'web3'
 import WalletManager from 'src/web3/WalletManager'
-import { ValoraWallet } from 'src/web3/types'
+import { PrimaryValoraWallet } from 'src/web3/types'
 
 const TAG = 'web3/contracts'
 const WAIT_FOR_CONTRACT_KIT_RETRIES = 10
 
 let walletManager: WalletManager | undefined
-let wallet: ValoraWallet | undefined
+let wallet: PrimaryValoraWallet | undefined
 let contractKit: ContractKit | undefined
 
 const initContractKitLock = new Lock()

--- a/src/web3/dataEncryptionKey.ts
+++ b/src/web3/dataEncryptionKey.ts
@@ -52,7 +52,7 @@ import {
   walletAddressSelector,
 } from 'src/web3/selectors'
 import { estimateGas } from 'src/web3/utils'
-import { ValoraWallet } from 'src/web3/types'
+import { PrimaryValoraWallet } from 'src/web3/types'
 
 const TAG = 'web3/dataEncryptionKey'
 const PLACEHOLDER_DEK = '0x02c9cacca8c5c5ebb24dc6080a933f6d52a072136a069083438293d71da36049dc'
@@ -346,7 +346,7 @@ export function* getAuthSignerForAccount(accountAddress: string, walletAddress: 
   return walletKeySigner
 }
 
-export function* importDekIfNecessary(wallet: ValoraWallet | undefined) {
+export function* importDekIfNecessary(wallet: PrimaryValoraWallet | undefined) {
   const privateDataKey: string | null = yield select(dataEncryptionKeySelector)
   if (!privateDataKey) {
     throw new Error('No data key in store. Should never happen.')

--- a/src/web3/saga.ts
+++ b/src/web3/saga.ts
@@ -26,7 +26,7 @@ import {
   walletAddressSelector,
 } from 'src/web3/selectors'
 import { RootState } from '../redux/reducers'
-import { ValoraWallet } from 'src/web3/types'
+import { PrimaryValoraWallet } from 'src/web3/types'
 
 const TAG = 'web3/saga'
 
@@ -106,7 +106,7 @@ export function* getOrCreateAccount() {
 export function* assignAccountFromPrivateKey(privateKey: string, mnemonic: string) {
   try {
     const account = privateKeyToAddress(privateKey)
-    const wallet: ValoraWallet = yield call(getWallet)
+    const wallet: PrimaryValoraWallet = yield call(getWallet)
     const password: string = yield call(getPasswordSaga, account, false, true)
 
     try {
@@ -188,7 +188,7 @@ export enum UnlockResult {
 export function* unlockAccount(account: string, force: boolean = false) {
   Logger.debug(TAG + '@unlockAccount', `Unlocking account: ${account}`)
 
-  const wallet: ValoraWallet = yield call(getWallet)
+  const wallet: PrimaryValoraWallet = yield call(getWallet)
   if (!force && wallet.isAccountUnlocked(account)) {
     return UnlockResult.SUCCESS
   }

--- a/src/web3/types.ts
+++ b/src/web3/types.ts
@@ -1,5 +1,16 @@
-import { TypedDataDomain, TypedDataField } from 'ethers'
+import { TypedDataDomain, TypedDataField, TransactionRequest } from 'ethers'
 import { CeloTx, EncodedTransaction } from '@celo/connect'
+
+export enum WalletTxType {
+  Ethers = 'Ethers',
+  ContractKit = 'ContractKit',
+}
+type SignTransactionInputType<T extends WalletTxType> = T extends WalletTxType.Ethers
+  ? TransactionRequest
+  : CeloTx
+type SignTransactionOutputType<T extends WalletTxType> = T extends WalletTxType.Ethers
+  ? string
+  : EncodedTransaction
 
 // Generic wrapper interface for implementation-agnostic, lockable wallets used in Valora.
 // A "wallet" is responsible for managing an arbitrary number of "accounts" (i.e.,
@@ -7,10 +18,12 @@ import { CeloTx, EncodedTransaction } from '@celo/connect'
 // all the functionality currently expected of a "wallet" by the application.
 //
 // The types used for these methods are largely taken from Ethers where it was straightforward
-// to modify callsites to adhere to the new types. signTransaction is a notable deviation from
-// this due to its complexity.
-// TODO: Update signTransaction to use Ethers types.
-export interface ValoraWallet {
+// to modify callsites to adhere to the new types. Since it's not simple to transform the current
+// input/output types of signTransaction to adhere to Ethers types (or vice-versa), this class is
+// generic in order to support either set of types. This genericization means that when transitioning
+// from a ContractKit wallet to an Ethers wallet, the only  method signature that needs to change is
+// signTransaction.
+export interface ValoraWallet<T extends WalletTxType> {
   // Sign EIP712 typed data
   signTypedData(
     address: string,
@@ -19,7 +32,7 @@ export interface ValoraWallet {
     value: Record<string, any>,
     primaryType: string
   ): Promise<string>
-  signTransaction(tx: CeloTx): Promise<EncodedTransaction>
+  signTransaction(tx: SignTransactionInputType<T>): Promise<SignTransactionOutputType<T>>
   // Sign a personal message with the given account, without hashing it
   signPersonalMessage(address: string, data: string): Promise<string>
   // Decrypt generic ciphertext Buffer for the given accountq
@@ -38,6 +51,12 @@ export interface ValoraWallet {
   // Update an account password
   updateAccount(address: string, oldPassword: string, newPassword: string): Promise<boolean>
 }
+
+// This is a convenience type to control the type of wallet used throughout the app.
+// Switching the transaction type here will modify the expected signature of the signTransaction
+// method throughout the app.
+// TODO: Switch this to WalletTxType.Ethers when we're ready to make the switch to using Ethers globally
+export type PrimaryValoraWallet = ValoraWallet<WalletTxType.ContractKit>
 
 export interface KeychainAccount {
   address: string

--- a/test/values.ts
+++ b/test/values.ts
@@ -52,7 +52,7 @@ import { TransactionDataInput } from 'src/send/SendAmount'
 import { StoredTokenBalance } from 'src/tokens/slice'
 import { CiCoCurrency, Currency } from 'src/utils/currencies'
 import { ONE_DAY_IN_MILLIS } from 'src/utils/time'
-import { ValoraWallet } from 'src/web3/types'
+import { PrimaryValoraWallet } from 'src/web3/types'
 
 export const nullAddress = '0x0'
 
@@ -442,7 +442,7 @@ export const mockRecipientInfo: RecipientInfo = {
   addressToDisplayName: {},
 }
 
-export const mockWallet: ValoraWallet = {
+export const mockWallet: PrimaryValoraWallet = {
   unlockAccount: jest.fn(),
   isAccountUnlocked: jest.fn(),
   addAccount: jest.fn(),


### PR DESCRIPTION
### Description

Currently, the `ValoraWallet` interface expects Celo-specific types to be used for the `signTransaction` method. The input/output types are not easily transformed between Ethers/Celo-specific types, however, which means that we will not be able to implement `ValoraEthersWallet` using the Celo types (or modify `ValoraCeloWallet` to use Ethers types). To sidestep this, this PR genericizes the `ValoraWallet` interface such that either Celo _or_ Ethers types can be used for `signTransaction`. When we decide to switch the primary wallet within the app to a `ValoraEthersWallet` implementation, all we'll need to do is change a single type (`PrimaryValoraWallet`) and update the call sites of `signTransaction` throughout the app to use Ethers-specific types. Since all the other method signatures are shared between `ValoraCeloWallet` and `ValoraEthersWallet`, these are the only changes we'll need to make.

### Test plan

Manual tested

### Related issues

### Backwards compatibility

Yes.
