### PR TITLE
feat(keyless-backup): show wallet security on drawer

### DIFF
--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -557,6 +557,7 @@
   "close": "Close",
   "home": "Home",
   "accountKey": "Recovery Phrase",
+  "walletSecurity": "Wallet Security",
   "addAndWithdraw": "Add & Withdraw",
   "settings": "Settings",
   "help": "Help",

--- a/src/keylessBackup/WalletSecurityPrimer.test.tsx
+++ b/src/keylessBackup/WalletSecurityPrimer.test.tsx
@@ -5,10 +5,29 @@ import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import WalletSecurityPrimer from 'src/keylessBackup/WalletSecurityPrimer'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
+import { getMockStackScreenProps } from 'test/utils'
 
 describe('WalletSecurityPrimer', () => {
+  it('renders drawer if prop is set', () => {
+    const { getByTestId } = render(
+      <WalletSecurityPrimer
+        {...getMockStackScreenProps(Screens.WalletSecurityPrimerDrawer, { showDrawerTopBar: true })}
+      />
+    )
+    expect(getByTestId('WalletSecurityPrimer/DrawerTopBar')).toBeTruthy()
+  })
+
+  it('hides drawer if prop is not set', () => {
+    const { queryByTestId } = render(
+      <WalletSecurityPrimer {...getMockStackScreenProps(Screens.WalletSecurityPrimer)} />
+    )
+    expect(queryByTestId('WalletSecurityPrimer/DrawerTopBar')).toBeFalsy()
+  })
+
   it('pressing get started button emits analytics event and navigates to next screen', () => {
-    const { getByTestId } = render(<WalletSecurityPrimer />)
+    const { getByTestId } = render(
+      <WalletSecurityPrimer {...getMockStackScreenProps(Screens.WalletSecurityPrimer)} />
+    )
     const continueButton = getByTestId('WalletSecurityPrimer/GetStarted')
     fireEvent.press(continueButton)
     expect(ValoraAnalytics.track).toHaveBeenCalledTimes(1)

--- a/src/keylessBackup/WalletSecurityPrimer.tsx
+++ b/src/keylessBackup/WalletSecurityPrimer.tsx
@@ -1,15 +1,19 @@
+import { NativeStackScreenProps } from '@react-navigation/native-stack'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
-import { SafeAreaView, ScrollView, StyleSheet, Text } from 'react-native'
+import { ScrollView, StyleSheet, Text } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
 import { KeylessBackupEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import Button, { BtnSizes, BtnTypes } from 'src/components/Button'
 import BackChevron from 'src/icons/BackChevron'
 import Chain from 'src/icons/Chain'
+import DrawerTopBar from 'src/navigator/DrawerTopBar'
 import { emptyHeader } from 'src/navigator/Headers'
 import { navigate, navigateBack } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import { TopBarIconButton } from 'src/navigator/TopBarButton'
+import { StackParamList } from 'src/navigator/types'
 import fontStyles from 'src/styles/fonts'
 
 function onPressContinue() {
@@ -17,10 +21,16 @@ function onPressContinue() {
   navigate(Screens.SetUpKeylessBackup)
 }
 
-function WalletSecurityPrimer() {
+type Props =
+  | NativeStackScreenProps<StackParamList, Screens.WalletSecurityPrimer>
+  | NativeStackScreenProps<StackParamList, Screens.WalletSecurityPrimerDrawer>
+
+function WalletSecurityPrimer({ route }: Props) {
   const { t } = useTranslation()
+  const showDrawerTopBar = route.params?.showDrawerTopBar
   return (
-    <SafeAreaView style={styles.container}>
+    <SafeAreaView style={styles.container} edges={showDrawerTopBar ? undefined : ['bottom']}>
+      {showDrawerTopBar && <DrawerTopBar testID="WalletSecurityPrimer/DrawerTopBar" />}
       <ScrollView style={styles.scrollContainer}>
         <Chain style={styles.chainIcon} />
         <Text style={styles.title}>{t('walletSecurityPrimer.title')}</Text>

--- a/src/navigator/DrawerNavigator.tsx
+++ b/src/navigator/DrawerNavigator.tsx
@@ -56,6 +56,7 @@ import { NFT } from 'src/icons/navigator/NFT'
 import { Settings } from 'src/icons/navigator/Settings'
 import { Swap } from 'src/icons/navigator/Swap'
 import Invite from 'src/invite/Invite'
+import WalletSecurityPrimer from 'src/keylessBackup/WalletSecurityPrimer'
 import DrawerItem from 'src/navigator/DrawerItem'
 import { ensurePincode } from 'src/navigator/NavigationService'
 import { getActiveRouteName } from 'src/navigator/NavigatorWrapper'
@@ -202,6 +203,11 @@ function CustomDrawerContent(props: DrawerContentComponentProps<DrawerContentOpt
 
 type Props = NativeStackScreenProps<StackParamList, Screens.DrawerNavigator>
 
+// TODO(ACT-771): get from Statsig
+function showKeylessBackup() {
+  return false
+}
+
 export default function DrawerNavigator({ route }: Props) {
   const { t } = useTranslation()
   const initialScreen = route.params?.initialScreen ?? Screens.WalletHome
@@ -289,28 +295,57 @@ export default function DrawerNavigator({ route }: Props) {
           }}
         />
       )}
-      {(!backupCompleted || !shouldShowRecoveryPhraseInSettings) && (
-        <Drawer.Screen
-          name={Screens.BackupIntroduction}
-          // @ts-expect-error component type in native-stack v6
-          component={BackupIntroduction}
-          options={{
-            drawerLabel: !backupCompleted
-              ? () => (
-                  <View style={styles.itemStyle}>
-                    <Text style={styles.itemTitle}>{t('accountKey')}</Text>
-                    <View style={styles.drawerItemIcon}>
-                      <ExclamationCircleIcon />
+
+      {(!backupCompleted || !shouldShowRecoveryPhraseInSettings) &&
+        (showKeylessBackup() ? (
+          <Drawer.Screen
+            // NOTE: this needs to be a different screen name from the screen
+            // accessed from the settings which shows the back button instead of
+            // the drawer. Otherwise the settings item will navigate to the
+            // screen with the drawer. This wasn't needed for the
+            // BackupIntroduction screen because it navigates to the pin screen
+            // first.
+            name={Screens.WalletSecurityPrimerDrawer}
+            // @ts-expect-error component type in native-stack v6
+            component={WalletSecurityPrimer}
+            options={{
+              drawerLabel: !backupCompleted
+                ? () => (
+                    <View style={styles.itemStyle}>
+                      <Text style={styles.itemTitle}>{t('walletSecurity')}</Text>
+                      <View style={styles.drawerItemIcon}>
+                        <ExclamationCircleIcon />
+                      </View>
                     </View>
-                  </View>
-                )
-              : t('accountKey') ?? undefined,
-            title: t('accountKey') ?? undefined,
-            drawerIcon: AccountKey,
-          }}
-          initialParams={{ showDrawerTopBar: true }}
-        />
-      )}
+                  )
+                : t('walletSecurity') ?? undefined,
+              title: t('walletSecurity') ?? undefined,
+              drawerIcon: AccountKey,
+            }}
+            initialParams={{ showDrawerTopBar: true }}
+          />
+        ) : (
+          <Drawer.Screen
+            name={Screens.BackupIntroduction}
+            // @ts-expect-error component type in native-stack v6
+            component={BackupIntroduction}
+            options={{
+              drawerLabel: !backupCompleted
+                ? () => (
+                    <View style={styles.itemStyle}>
+                      <Text style={styles.itemTitle}>{t('accountKey')}</Text>
+                      <View style={styles.drawerItemIcon}>
+                        <ExclamationCircleIcon />
+                      </View>
+                    </View>
+                  )
+                : t('accountKey') ?? undefined,
+              title: t('accountKey') ?? undefined,
+              drawerIcon: AccountKey,
+            }}
+            initialParams={{ showDrawerTopBar: true }}
+          />
+        ))}
       {showAddWithdrawOnMenu && (
         <Drawer.Screen
           name={Screens.FiatExchange}

--- a/src/navigator/Screens.tsx
+++ b/src/navigator/Screens.tsx
@@ -104,6 +104,7 @@ export enum Screens {
   WalletConnectRequest = 'WalletConnectRequest',
   WalletConnectSessions = 'WalletConnectSessions',
   WalletSecurityPrimer = 'WalletSecurityPrimer',
+  WalletSecurityPrimerDrawer = 'WalletSecurityPrimerDrawer',
   WebViewScreen = 'WebViewScreen',
   Welcome = 'Welcome',
   WithdrawCeloQrScannerScreen = 'WithdrawCeloQrScannerScreen',

--- a/src/navigator/types.tsx
+++ b/src/navigator/types.tsx
@@ -350,6 +350,7 @@ export type StackParamList = {
   [Screens.WalletConnectSessions]: undefined
   [Screens.WalletHome]: undefined
   [Screens.WalletSecurityPrimer]: undefined
+  [Screens.WalletSecurityPrimerDrawer]: { showDrawerTopBar: boolean }
   [Screens.WebViewScreen]: { uri: string; dappkitDeeplink?: string }
   [Screens.Welcome]: undefined
   [Screens.WithdrawCeloQrScannerScreen]: {

--- a/test/RootStateSchema.json
+++ b/test/RootStateSchema.json
@@ -2430,6 +2430,7 @@
                 "WalletConnectSessions",
                 "WalletHome",
                 "WalletSecurityPrimer",
+                "WalletSecurityPrimerDrawer",
                 "WebViewScreen",
                 "Welcome",
                 "WithdrawCeloQrScannerScreen",


### PR DESCRIPTION
### Description

Change the "Recovery Phrase" drawer item to "Wallet Security" and navigate to the WalletSecurityPrimer screen. Currently behind a dummy flag

### Test plan

Manual


https://github.com/valora-inc/wallet/assets/5062591/89df7565-3e0b-469f-98ab-5c735849d70e


### Related issues

- Fixes ACT-836

### Backwards compatibility

Yes
