### PR TITLE
fix(radio-button): use none for unselected instead of undefined

### DIFF
--- a/src/components/__snapshots__/SelectionOption.test.tsx.snap
+++ b/src/components/__snapshots__/SelectionOption.test.tsx.snap
@@ -139,6 +139,7 @@ exports[`renders unselected correctly 1`] = `
         <circle
           cx="10"
           cy="10"
+          fill="none"
           r="6"
           style={Object {}}
         />

--- a/src/icons/RadioButton.tsx
+++ b/src/icons/RadioButton.tsx
@@ -27,7 +27,7 @@ export default class RadioButton extends React.PureComponent<Props> {
     } else if (!this.props.selected) {
       stroke = colors.gray3
     }
-    const fill = this.props.selected && !this.props.disabled ? this.props.color : undefined
+    const fill = this.props.selected && !this.props.disabled ? this.props.color : 'none'
     return (
       <Svg
         xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
### Description

Fixes the Android only issue where the button is filled with black color when unselected

### Test plan

Before:

https://github.com/valora-inc/wallet/assets/5062591/1381e584-38b3-45a6-816b-4856e5032676


After:


https://github.com/valora-inc/wallet/assets/5062591/a1c3de43-2183-48e4-aa6c-4977f5b77059


### Related issues

- N/A

### Backwards compatibility

Yes
