### PR TITLE
fix: ensure drawer menu header padding is consistent

### DIFF
--- a/src/navigator/DrawerNavigator.tsx
+++ b/src/navigator/DrawerNavigator.tsx
@@ -71,6 +71,7 @@ import { ExperimentConfigs } from 'src/statsig/constants'
 import { StatsigExperiments, StatsigFeatureGates } from 'src/statsig/types'
 import colors from 'src/styles/colors'
 import fontStyles from 'src/styles/fonts'
+import { Spacing } from 'src/styles/styles'
 import SwapScreen from 'src/swap/SwapScreen'
 import Logger from 'src/utils/Logger'
 import { currentAccountSelector } from 'src/web3/selectors'
@@ -389,10 +390,11 @@ const styles = StyleSheet.create({
     width: '100%',
     flexDirection: 'row',
     justifyContent: 'space-between',
+    marginBottom: Spacing.Smallest8,
   },
   nameLabel: {
     ...fontStyles.displayName,
-    marginTop: 8,
+    marginBottom: Spacing.Smallest8,
   },
   border: {
     marginTop: 20,


### PR DESCRIPTION
### Description

As the title. With the revoke phonenumber work, the top padding on the phone number was removed without testing this scenario.

### Test plan

![Simulator Screenshot - iPhone 14 Pro - 2023-07-24 at 09 32 17](https://github.com/valora-inc/wallet/assets/20150449/9f3afae7-066e-476f-9d63-31d1b80cd52b)


### Related issues

n/a

### Backwards compatibility

Y
