### PR TITLE
test(e2e): fix recently used dapps test

### DIFF
--- a/e2e/src/usecases/DappListRecent.js
+++ b/e2e/src/usecases/DappListRecent.js
@@ -5,11 +5,13 @@ import {
   getElementTextList,
   scrollIntoView,
 } from '../utils/utils'
-import { navigateToDappList, scrollToDapp, navigateToHome } from '../utils/dappList'
+import { navigateToDappList, navigateToHome } from '../utils/dappList'
 
 const jestExpect = require('expect')
 
 export default DappListRecent = () => {
+  const dappToTest = 'impactMarket'
+
   it('should show most recently used dapp leftmost on home screen :ios:', async () => {
     // Get recently used dapps at start of test
     const startRecentlyUsedDapps = await getElementTextList('RecentlyUsedDapps/Name')
@@ -27,8 +29,8 @@ export default DappListRecent = () => {
     await navigateToDappList()
 
     // Scroll to impact market dapp
-    await scrollIntoView('impactMarket', 'DAppsExplorerScreen/DappsList')
-    await element(by.text('impactMarket')).tap()
+    await scrollIntoView(dappToTest, 'DAppsExplorerScreen/DappsList')
+    await element(by.text(dappToTest)).tap()
 
     // Get dapp name in confirmation dialog
     const dappPressed = await element(by.id('ConfirmDappButton')).getAttributes()
@@ -58,8 +60,8 @@ export default DappListRecent = () => {
     await navigateToDappList()
 
     // Scroll to impact market dapp
-    await scrollIntoView('impactMarket', 'DAppsExplorerScreen/DappsList')
-    await element(by.text('impactMarket')).tap()
+    await scrollIntoView(dappToTest, 'DAppsExplorerScreen/DappsList')
+    await element(by.text(dappToTest)).tap()
 
     // Get dapp name in confirmation dialog
     const dappPressed = await element(by.id('ConfirmDappTitle')).getAttributes()

--- a/e2e/src/usecases/DappListRecent.js
+++ b/e2e/src/usecases/DappListRecent.js
@@ -26,10 +26,8 @@ export default DappListRecent = () => {
     // Navigate to DappList reload and navigate again - ci issue
     await navigateToDappList()
 
-    // Scroll to first dapp or next after most recent dapp
-    await scrollToDapp(startRecentDappCount + 1)
-    // The E2E test wallet always receives a non-shuffled dapp list which is controlled by Statsig
-    // Unless Bidali or impactMarket are removed impactMarket will always be second in the list
+    // Scroll to impact market dapp
+    await scrollIntoView('impactMarket', 'DAppsExplorerScreen/DappsList')
     await element(by.text('impactMarket')).tap()
 
     // Get dapp name in confirmation dialog
@@ -59,8 +57,9 @@ export default DappListRecent = () => {
     // Navigate to DappList reload and navigate again - ci issue
     await navigateToDappList()
 
-    // Scroll doesn't work well for android so we just tap the second dapp
-    await element(by.id('DappCard')).atIndex(1).tap()
+    // Scroll to impact market dapp
+    await scrollIntoView('impactMarket', 'DAppsExplorerScreen/DappsList')
+    await element(by.text('impactMarket')).tap()
 
     // Get dapp name in confirmation dialog
     const dappPressed = await element(by.id('ConfirmDappTitle')).getAttributes()

--- a/e2e/src/utils/dappList.js
+++ b/e2e/src/utils/dappList.js
@@ -29,21 +29,6 @@ export async function navigateToHome() {
 }
 
 /**
- * Scroll to a dapp in the dapp - iOS only
- * @param {number} dappIndex: index of dapp to scroll to
- */
-export async function scrollToDapp(dappIndex = 0) {
-  try {
-    await waitFor(element(by.id('DappCard')).atIndex(dappIndex))
-      .toBeVisible(100)
-      .whileElement(by.id('DAppsExplorerScreen/DappsList'))
-      .scroll(250, 'down')
-  } catch {
-    console.log('Catch of scrollToDapp')
-  }
-}
-
-/**
  * Fetch the Dapp list from the cloud function using node-fetch
  * @param {string} userAgent: user agent to use for dapp list fetch
  * @returns {object|null} dappList: list of dapps


### PR DESCRIPTION
### Description

Dapp e2e tests broke again with https://github.com/valora-inc/dapp-list/pull/485, which made Moola the first dapp and broke assumptions about the position of `impactMarket` dapp. This updates the recently used dapps test to always scroll to and pick impactMarket

### Test plan

CI

### Related issues

N/A

### Backwards compatibility

Yes
