### PR TITLE
ci: fix workflows using new version of google secrets GHA

### DIFF
--- a/.github/workflows/automerge-crowdin.yml
+++ b/.github/workflows/automerge-crowdin.yml
@@ -14,13 +14,16 @@ jobs:
     permissions:
       pull-requests: write
     steps:
+      - uses: google-github-actions/auth@v1
+        with:
+          project_id: celo-mobile-mainnet
+          credentials_json: ${{ secrets.MAINNET_SERVICE_ACCOUNT_KEY }}
       - name: Google Secrets
         id: google-secrets
         uses: google-github-actions/get-secretmanager-secrets@v1.0.1
         with:
           secrets: |-
             VALORA_BOT_TOKEN:projects/1027349420744/secrets/VALORA_BOT_TOKEN
-          credentials: ${{ secrets.MAINNET_SERVICE_ACCOUNT_KEY }}
       - uses: actions/checkout@v3
       - uses: actions/github-script@v5
         with:

--- a/.github/workflows/automerge-translation.yml
+++ b/.github/workflows/automerge-translation.yml
@@ -13,13 +13,16 @@ jobs:
     permissions:
       pull-requests: write
     steps:
+      - uses: google-github-actions/auth@v1
+        with:
+          project_id: celo-mobile-mainnet
+          credentials_json: ${{ secrets.MAINNET_SERVICE_ACCOUNT_KEY }}
       - name: Google Secrets
         id: google-secrets
         uses: google-github-actions/get-secretmanager-secrets@v1.0.1
         with:
           secrets: |-
             VALORA_BOT_TOKEN:projects/1027349420744/secrets/VALORA_BOT_TOKEN
-          credentials: ${{ secrets.MAINNET_SERVICE_ACCOUNT_KEY }}
       - uses: actions/checkout@v3
       - uses: actions/github-script@v5
         with:

--- a/.github/workflows/bump-app-version.yml
+++ b/.github/workflows/bump-app-version.yml
@@ -16,6 +16,10 @@ jobs:
     env:
       BRANCH_NAME: valora-bot/bump-app-version
     steps:
+      - uses: google-github-actions/auth@v1
+        with:
+          project_id: celo-mobile-mainnet
+          credentials_json: ${{ secrets.MAINNET_SERVICE_ACCOUNT_KEY }}
       - name: Google Secrets
         id: google-secrets
         uses: google-github-actions/get-secretmanager-secrets@v1.0.1
@@ -23,7 +27,6 @@ jobs:
           secrets: |-
             BOT_SSH_KEY:projects/1027349420744/secrets/BOT_SSH_PRIVATE_KEY
             VALORA_BOT_TOKEN:projects/1027349420744/secrets/VALORA_BOT_TOKEN
-          credentials: ${{ secrets.MAINNET_SERVICE_ACCOUNT_KEY }}
       - uses: webfactory/ssh-agent@v0.5.3
         with:
           ssh-private-key: ${{ steps.google-secrets.outputs.BOT_SSH_KEY }}

--- a/.github/workflows/update-licenses-disclaimer.yml
+++ b/.github/workflows/update-licenses-disclaimer.yml
@@ -16,6 +16,10 @@ jobs:
     env:
       BRANCH_NAME: valora-bot/update-licenses-disclaimer
     steps:
+      - uses: google-github-actions/auth@v1
+        with:
+          project_id: celo-mobile-mainnet
+          credentials_json: ${{ secrets.MAINNET_SERVICE_ACCOUNT_KEY }}
       - name: Google Secrets
         id: google-secrets
         uses: google-github-actions/get-secretmanager-secrets@v1.0.1
@@ -23,7 +27,6 @@ jobs:
           secrets: |-
             BOT_SSH_KEY:projects/1027349420744/secrets/BOT_SSH_PRIVATE_KEY
             VALORA_BOT_TOKEN:projects/1027349420744/secrets/VALORA_BOT_TOKEN
-          credentials: ${{ secrets.MAINNET_SERVICE_ACCOUNT_KEY }}
       - uses: webfactory/ssh-agent@v0.5.3
         with:
           ssh-private-key: ${{ steps.google-secrets.outputs.BOT_SSH_KEY }}


### PR DESCRIPTION
### Description

These workflows were missed in #3994 
`credentials` is no longer supported in `google-github-actions/get-secretmanager-secrets@v1`

### Test plan

These changes work correctly on the e2e-ios workflow

### Related issues

N/A

### Backwards compatibility

N/A
