### PR TITLE
fix(wc): better compat with unsupported chains

### DIFF
--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -1060,7 +1060,11 @@
     "sendTransaction": "{{dappName}} would like to send a Celo transaction.",
     "decryptPayload": "{{dappName}} would like to decrypt a data payload.",
     "computeSharedSecret": "{{dappName}} would like to generate secrets.",
-    "transactionDataCopied": "Transaction data copied"
+    "transactionDataCopied": "Transaction data copied",
+    "unsupportedChain": {
+      "title": "Unsupported chain",
+      "description": "{{dappName}} is requesting this action on a chain not supported by {{appName}}. Please make sure Celo is the active chain on the dapp."
+    }
   },
   "sessionInfo": "This application may ask to perform the following actions:",
   "description": {

--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -1063,7 +1063,7 @@
     "transactionDataCopied": "Transaction data copied",
     "unsupportedChain": {
       "title": "Unsupported chain",
-      "description": "{{dappName}} is requesting this action on a chain not supported by {{appName}}. Please make sure Celo is the active chain on the dapp."
+      "description": "{{dappName}} is requesting this action on a chain not supported by {{appName}}. Please make sure Celo is the active chain on the dapp side."
     }
   },
   "sessionInfo": "This application may ask to perform the following actions:",

--- a/src/components/Warning.tsx
+++ b/src/components/Warning.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
-import { useTranslation } from 'react-i18next'
-import { StyleSheet, Text, View } from 'react-native'
+import { StyleProp, StyleSheet, Text, View, ViewStyle } from 'react-native'
 import AttentionIcon from 'src/icons/Attention'
 import Colors from 'src/styles/colors'
 import fontStyles from 'src/styles/fonts'
@@ -10,14 +9,13 @@ interface Props {
   title: string
   description: string
   ctaLabel?: string | null
+  style?: StyleProp<ViewStyle>
   onPressCta?: () => void
 }
 
-export function Warning({ title, description, ctaLabel, onPressCta }: Props) {
-  const { t } = useTranslation()
-
+export function Warning({ title, description, ctaLabel, style, onPressCta }: Props) {
   return (
-    <View style={styles.container}>
+    <View style={[styles.container, style]}>
       <View style={styles.row}>
         <AttentionIcon color={Colors.goldDark} />
         <Text style={styles.titleText}>{title}</Text>
@@ -27,7 +25,7 @@ export function Warning({ title, description, ctaLabel, onPressCta }: Props) {
 
       {ctaLabel && onPressCta && (
         <Text style={styles.learnMoreText} onPress={onPressCta}>
-          {t('swapScreen.maxSwapAmountWarning.learnMore')}
+          {ctaLabel}
         </Text>
       )}
     </View>
@@ -36,7 +34,6 @@ export function Warning({ title, description, ctaLabel, onPressCta }: Props) {
 
 const styles = StyleSheet.create({
   container: {
-    marginTop: Spacing.Thick24,
     paddingHorizontal: Spacing.Thick24,
     paddingVertical: Spacing.Regular16,
     backgroundColor: Colors.yellowFaint,

--- a/src/dappkit/DappKitAccountScreen.tsx
+++ b/src/dappkit/DappKitAccountScreen.tsx
@@ -60,6 +60,7 @@ const DappKitAccountScreen = ({ route, handleContentLayout }: Props) => {
   return (
     <BottomSheetScrollView handleContentLayout={handleContentLayout}>
       <RequestContent
+        type="confirm"
         onAccept={handleAllow}
         onDeny={handleCancel}
         dappImageUrl={dappConnectInfo === DappConnectInfo.Basic ? activeDapp?.iconUrl : undefined}

--- a/src/dappkit/DappKitSignTxScreen.tsx
+++ b/src/dappkit/DappKitSignTxScreen.tsx
@@ -76,6 +76,7 @@ const DappKitSignTxScreen = ({ route, handleContentLayout }: Props) => {
   return (
     <BottomSheetScrollView handleContentLayout={handleContentLayout}>
       <RequestContent
+        type="confirm"
         onAccept={handleAllow}
         onDeny={handleCancel}
         dappName={dappName}

--- a/src/dapps/DappShortcutTransactionRequest.tsx
+++ b/src/dapps/DappShortcutTransactionRequest.tsx
@@ -81,6 +81,7 @@ function DappShortcutTransactionRequest({ route: { params }, handleContentLayout
     <BottomSheetScrollView handleContentLayout={handleContentLayout}>
       {pendingAcceptShortcut?.transactions?.length ? (
         <RequestContent
+          type="confirm"
           onAccept={handleClaimReward}
           onDeny={handleDenyTransaction}
           dappName={pendingAcceptShortcut.appName}

--- a/src/navigator/types.tsx
+++ b/src/navigator/types.tsx
@@ -333,6 +333,7 @@ export type StackParamList = {
         type: WalletConnectRequestType.Action
         version: 2
         pendingAction: Web3WalletTypes.EventArguments['session_request']
+        supportedChains: string[]
       }
     | {
         type: WalletConnectRequestType.Session

--- a/src/swap/SwapScreen.tsx
+++ b/src/swap/SwapScreen.tsx
@@ -15,6 +15,7 @@ import Button, { BtnSizes } from 'src/components/Button'
 import KeyboardAwareScrollView from 'src/components/KeyboardAwareScrollView'
 import KeyboardSpacer from 'src/components/KeyboardSpacer'
 import TokenBottomSheet, { TokenPickerOrigin } from 'src/components/TokenBottomSheet'
+import Warning from 'src/components/Warning'
 import { SWAP_LEARN_MORE } from 'src/config'
 import { useMaxSendAmount } from 'src/fees/hooks'
 import { FeeType } from 'src/fees/reducer'
@@ -33,7 +34,6 @@ import { setSwapUserInput } from 'src/swap/slice'
 import SwapAmountInput from 'src/swap/SwapAmountInput'
 import { Field, SwapAmount } from 'src/swap/types'
 import useSwapQuote from 'src/swap/useSwapQuote'
-import Warning from 'src/swap/Warning'
 import { swappableTokensSelector } from 'src/tokens/selectors'
 import { TokenBalance } from 'src/tokens/slice'
 
@@ -380,6 +380,7 @@ export function SwapScreenSection({ showDrawerTopNav }: { showDrawerTopNav: bool
               title={t('swapScreen.maxSwapAmountWarning.title')}
               description={t('swapScreen.maxSwapAmountWarning.body')}
               ctaLabel={t('swapScreen.maxSwapAmountWarning.learnMore')}
+              style={styles.warning}
               onPressCta={onPressLearnMoreFees}
             />
           )}
@@ -387,6 +388,7 @@ export function SwapScreenSection({ showDrawerTopNav }: { showDrawerTopNav: bool
             <Warning
               title={t('swapScreen.priceImpactWarning.title')}
               description={t('swapScreen.priceImpactWarning.body')}
+              style={styles.warning}
             />
           )}
         </View>
@@ -461,6 +463,9 @@ const styles = StyleSheet.create({
   },
   exchangeRateValueText: {
     ...fontStyles.xsmall600,
+  },
+  warning: {
+    marginTop: Spacing.Thick24,
   },
 })
 

--- a/src/walletConnect/saga.test.ts
+++ b/src/walletConnect/saga.test.ts
@@ -2,18 +2,26 @@ import { CoreTypes, SessionTypes } from '@walletconnect/types'
 import { Web3WalletTypes } from '@walletconnect/web3wallet'
 import { expectSaga } from 'redux-saga-test-plan'
 import { call, select } from 'redux-saga/effects'
+import { showMessage } from 'src/alert/actions'
 import { DappRequestOrigin, WalletConnectPairingOrigin } from 'src/analytics/types'
 import { walletConnectEnabledSelector } from 'src/app/selectors'
 import { activeDappSelector } from 'src/dapps/selectors'
-import { navigate } from 'src/navigator/NavigationService'
+import i18n from 'src/i18n'
+import { isBottomSheetVisible, navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
-import { sessionProposal as sessionProposalAction } from 'src/walletConnect/actions'
 import {
+  acceptSession as acceptSessionAction,
+  Actions,
+  sessionProposal as sessionProposalAction,
+} from 'src/walletConnect/actions'
+import {
+  acceptSession,
   getDefaultSessionTrackedProperties,
   initialiseWalletConnect,
   initialiseWalletConnectV2,
   walletConnectSaga,
   _applyIconFixIfNeeded,
+  _setClientForTesting,
 } from 'src/walletConnect/saga'
 import { WalletConnectRequestType } from 'src/walletConnect/types'
 import { createMockStore } from 'test/utils'
@@ -202,6 +210,123 @@ describe(walletConnectSaga, () => {
       pendingSession: sessionProposal,
       version: 2,
     })
+  })
+})
+
+describe(acceptSession, () => {
+  const sessionProposal = createSessionProposal({
+    url: 'someUrl',
+    icons: ['someIcon'],
+    description: 'someDescription',
+    name: 'someName',
+  })
+  let mockClient: any
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockClient = {
+      approveSession: jest.fn(),
+      getActiveSessions: jest.fn(() => {
+        return Promise.resolve({
+          x: {
+            pairingTopic: sessionProposal.params.pairingTopic,
+          },
+        })
+      }),
+    }
+    _setClientForTesting(mockClient as any)
+  })
+
+  it('successfully accepts the session', async () => {
+    const state = createMockStore({}).getState()
+    await expectSaga(acceptSession, acceptSessionAction(sessionProposal))
+      .withState(state)
+      .provide([[call(isBottomSheetVisible, Screens.WalletConnectRequest), false]])
+      .put.actionType(Actions.SESSION_CREATED)
+      .put(showMessage(i18n.t('connectionSuccess', { dappName: 'someName' })))
+      .run()
+
+    expect(mockClient.approveSession).toHaveBeenCalledTimes(1)
+    expect(mockClient.approveSession.mock.calls[0]).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "id": 1669989187506938,
+          "namespaces": Object {
+            "eip155": Object {
+              "accounts": Array [
+                "eip155:44787:0x0000000000000000000000000000000000007e57",
+              ],
+              "chains": Array [
+                "eip155:44787",
+              ],
+              "events": Array [
+                "accountsChanged",
+                "chainChanged",
+              ],
+              "methods": Array [
+                "eth_sendTransaction",
+                "eth_signTypedData",
+              ],
+            },
+          },
+          "relayProtocol": "irn",
+        },
+      ]
+    `)
+  })
+
+  it('successfully accepts the session when the required chain is unsupported', async () => {
+    const state = createMockStore({}).getState()
+    await expectSaga(
+      acceptSession,
+      acceptSessionAction({
+        ...sessionProposal,
+        params: {
+          ...sessionProposal.params,
+          requiredNamespaces: {
+            ...sessionProposal.params.requiredNamespaces,
+            eip155: {
+              ...sessionProposal.params.requiredNamespaces.eip155,
+              chains: ['eip155:1'], // unsupported chain
+            },
+          },
+        },
+      })
+    )
+      .withState(state)
+      .provide([[call(isBottomSheetVisible, Screens.WalletConnectRequest), false]])
+      .put.actionType(Actions.SESSION_CREATED)
+      .put(showMessage(i18n.t('connectionSuccess', { dappName: 'someName' })))
+      .run()
+
+    expect(mockClient.approveSession).toHaveBeenCalledTimes(1)
+    // Note the approved chain below is now 1, not 44787
+    expect(mockClient.approveSession.mock.calls[0]).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "id": 1669989187506938,
+          "namespaces": Object {
+            "eip155": Object {
+              "accounts": Array [
+                "eip155:1:0x0000000000000000000000000000000000007e57",
+              ],
+              "chains": Array [
+                "eip155:1",
+              ],
+              "events": Array [
+                "accountsChanged",
+                "chainChanged",
+              ],
+              "methods": Array [
+                "eth_sendTransaction",
+                "eth_signTypedData",
+              ],
+            },
+          },
+          "relayProtocol": "irn",
+        },
+      ]
+    `)
   })
 })
 

--- a/src/walletConnect/saga.ts
+++ b/src/walletConnect/saga.ts
@@ -1,9 +1,10 @@
+import { ContractKit } from '@celo/contractkit'
 import { appendPath } from '@celo/utils/lib/string'
 import { formatJsonRpcError, formatJsonRpcResult, JsonRpcResult } from '@json-rpc-tools/utils'
 import { Core } from '@walletconnect/core'
 import '@walletconnect/react-native-compat'
 import { SessionTypes } from '@walletconnect/types'
-import { getSdkError, parseUri } from '@walletconnect/utils'
+import { buildApprovedNamespaces, getSdkError, parseUri } from '@walletconnect/utils'
 import { IWeb3Wallet, Web3Wallet, Web3WalletTypes } from '@walletconnect/web3wallet'
 import { EventChannel, eventChannel } from 'redux-saga'
 import {
@@ -66,10 +67,15 @@ import {
   selectSessions,
 } from 'src/walletConnect/selectors'
 import { WalletConnectRequestType } from 'src/walletConnect/types'
+import { getContractKit } from 'src/web3/contracts'
 import networkConfig from 'src/web3/networkConfig'
 import { getWalletAddress } from 'src/web3/saga'
 
 let client: IWeb3Wallet | null = null
+
+export function _setClientForTesting(newClient: IWeb3Wallet | null) {
+  client = newClient
+}
 
 const TAG = 'WalletConnect/saga'
 
@@ -252,6 +258,13 @@ function* showSessionRequest(session: Web3WalletTypes.EventArguments['session_pr
   })
 }
 
+function* getSupportedChains() {
+  const kit: ContractKit = yield call(getContractKit)
+  const chainId = yield call([kit.connection, 'chainId'])
+
+  return [`eip155:${chainId}`]
+}
+
 function* showActionRequest(request: Web3WalletTypes.EventArguments['session_request']) {
   if (!client) {
     throw new Error('missing client')
@@ -280,9 +293,12 @@ function* showActionRequest(request: Web3WalletTypes.EventArguments['session_req
     return
   }
 
+  const supportedChains = yield call(getSupportedChains)
+
   yield call(navigate, Screens.WalletConnectRequest, {
     type: WalletConnectRequestType.Action,
     pendingAction: request,
+    supportedChains,
     version: 2,
   })
 }
@@ -301,23 +317,47 @@ export function* acceptSession({ session }: AcceptSession) {
 
     const address: string = yield call(getWalletAddress)
     const { requiredNamespaces, relays, proposer } = session.params
-    const namespaces: SessionTypes.Namespaces = {}
-    Object.keys(requiredNamespaces).forEach((key) => {
-      const accounts: string[] = []
-      requiredNamespaces[key].chains?.map((chain) => {
-        accounts.push(`${chain}:${address}`)
-      })
-      namespaces[key] = {
-        accounts,
-        methods: requiredNamespaces[key].methods,
-        events: requiredNamespaces[key].events,
-      }
+
+    // Here we approve all required namespaces, but only for EVM chains.
+    // This is so we don't break existing dapps which don't specify the Celo chain as required.
+    // As of writing this, Curve, Toucan and Cred Protocol do that.
+    // We also add the Celo chain to the list of supported chains if it's not already there.
+    // The goal is to be more flexible and allow the initial connection to succeed, no matter what chain is specified.
+    // If the dapp actually requests an action on an unsupported chain, we will show an error.
+    // See ActionRequest for more details.
+    const requiredEip155Chains = requiredNamespaces.eip155?.chains ?? []
+    const supportedEip155Chains = yield call(getSupportedChains)
+    const approvedEip155Chains = [
+      ...supportedEip155Chains,
+      ...requiredEip155Chains.filter((chainId) => !supportedEip155Chains.includes(chainId)),
+    ]
+
+    // Important: this will still throw if the required namespaces don't overlap with the supported ones
+    // This is ok for now, but ideally we would check that earlier and show a warning to the user
+    // This will be addressed later.
+    const approvedNamespaces = buildApprovedNamespaces({
+      proposal: session.params,
+      supportedNamespaces: {
+        eip155: {
+          chains: approvedEip155Chains,
+          methods: [
+            SupportedActions.eth_sign,
+            SupportedActions.eth_signTransaction,
+            SupportedActions.eth_sendTransaction,
+            SupportedActions.personal_sign,
+            SupportedActions.eth_signTypedData,
+            SupportedActions.eth_signTypedData_v4,
+          ],
+          events: ['accountsChanged', 'chainChanged'],
+          accounts: approvedEip155Chains.map((chain) => `${chain}:${address}`),
+        },
+      },
     })
 
     yield call([client, 'approveSession'], {
       id: session.id,
       relayProtocol: relays[0].protocol,
-      namespaces,
+      namespaces: approvedNamespaces,
     })
 
     ValoraAnalytics.track(WalletConnectEvents.wc_session_approve_success, defaultTrackedProperties)

--- a/src/walletConnect/screens/ActionRequest.test.tsx
+++ b/src/walletConnect/screens/ActionRequest.test.tsx
@@ -97,6 +97,8 @@ describe('ActionRequest with WalletConnect V2', () => {
     },
   }
 
+  const supportedChains = ['eip155:44787']
+
   describe('personal_sign', () => {
     const store = createMockStore({
       walletConnect: {
@@ -114,7 +116,11 @@ describe('ActionRequest with WalletConnect V2', () => {
     it('renders the correct elements', () => {
       const { getByText, getByTestId } = render(
         <Provider store={store}>
-          <ActionRequest version={2} pendingAction={pendingAction} />
+          <ActionRequest
+            version={2}
+            pendingAction={pendingAction}
+            supportedChains={supportedChains}
+          />
         </Provider>
       )
 
@@ -134,7 +140,11 @@ describe('ActionRequest with WalletConnect V2', () => {
     it('copies the request payload', () => {
       const { getByTestId } = render(
         <Provider store={store}>
-          <ActionRequest version={2} pendingAction={pendingAction} />
+          <ActionRequest
+            version={2}
+            pendingAction={pendingAction}
+            supportedChains={supportedChains}
+          />
         </Provider>
       )
 
@@ -146,7 +156,11 @@ describe('ActionRequest with WalletConnect V2', () => {
       pendingAction.params.request.params[0] = 'invalid hex'
       const { getByTestId } = render(
         <Provider store={store}>
-          <ActionRequest version={2} pendingAction={pendingAction} />
+          <ActionRequest
+            version={2}
+            pendingAction={pendingAction}
+            supportedChains={supportedChains}
+          />
         </Provider>
       )
 
@@ -161,7 +175,11 @@ describe('ActionRequest with WalletConnect V2', () => {
       pendingAction.params.request.params[0] = ''
       const { getByTestId } = render(
         <Provider store={store}>
-          <ActionRequest version={2} pendingAction={pendingAction} />
+          <ActionRequest
+            version={2}
+            pendingAction={pendingAction}
+            supportedChains={supportedChains}
+          />
         </Provider>
       )
 
@@ -175,7 +193,11 @@ describe('ActionRequest with WalletConnect V2', () => {
     it('dispatches the correct action on press allow', () => {
       const { getByText } = render(
         <Provider store={store}>
-          <ActionRequest version={2} pendingAction={pendingAction} />
+          <ActionRequest
+            version={2}
+            pendingAction={pendingAction}
+            supportedChains={supportedChains}
+          />
         </Provider>
       )
 
@@ -186,7 +208,11 @@ describe('ActionRequest with WalletConnect V2', () => {
     it('dispatches the correct action on dismiss bottom sheet', () => {
       const { unmount } = render(
         <Provider store={store}>
-          <ActionRequest version={2} pendingAction={pendingAction} />
+          <ActionRequest
+            version={2}
+            pendingAction={pendingAction}
+            supportedChains={supportedChains}
+          />
         </Provider>
       )
 
@@ -197,7 +223,7 @@ describe('ActionRequest with WalletConnect V2', () => {
     })
   })
 
-  describe('displayed dapp name falbacks', () => {
+  describe('displayed dapp name fallbacks', () => {
     const activeDapp: ActiveDapp = {
       id: 'someDappId',
       categories: ['someCategory'],
@@ -234,7 +260,11 @@ describe('ActionRequest with WalletConnect V2', () => {
 
       const { getByText } = render(
         <Provider store={store}>
-          <ActionRequest version={2} pendingAction={pendingAction} />
+          <ActionRequest
+            version={2}
+            pendingAction={pendingAction}
+            supportedChains={supportedChains}
+          />
         </Provider>
       )
 
@@ -270,7 +300,11 @@ describe('ActionRequest with WalletConnect V2', () => {
 
       const { getByText } = render(
         <Provider store={store}>
-          <ActionRequest version={2} pendingAction={pendingAction} />
+          <ActionRequest
+            version={2}
+            pendingAction={pendingAction}
+            supportedChains={supportedChains}
+          />
         </Provider>
       )
 
@@ -306,12 +340,98 @@ describe('ActionRequest with WalletConnect V2', () => {
 
       const { getByText } = render(
         <Provider store={store}>
-          <ActionRequest version={2} pendingAction={pendingAction} />
+          <ActionRequest
+            version={2}
+            pendingAction={pendingAction}
+            supportedChains={supportedChains}
+          />
         </Provider>
       )
 
       expect(getByText('confirmTransaction')).toBeTruthy()
       expect(getByText('walletConnectRequest.signPayload, {"dappName":""}')).toBeTruthy()
+    })
+  })
+
+  describe('unsupported chain', () => {
+    it('should show a warning if the chain is not supported', () => {
+      const store = createMockStore({
+        walletConnect: {
+          sessions: [v2Session],
+        },
+      })
+
+      const { getByText, queryByText } = render(
+        <Provider store={store}>
+          <ActionRequest
+            version={2}
+            pendingAction={{
+              ...pendingAction,
+              params: {
+                ...pendingAction.params,
+                request: {
+                  ...pendingAction.params.request,
+                  method: 'eth_sendTransaction',
+                },
+                chainId: 'eip155:1', // unsupported chain
+              },
+            }}
+            supportedChains={supportedChains}
+          />
+        </Provider>
+      )
+
+      expect(getByText('confirmTransaction')).toBeTruthy()
+      expect(
+        getByText('walletConnectRequest.sendTransaction, {"dappName":"WalletConnect Example"}')
+      ).toBeTruthy()
+      expect(queryByText('allow')).toBeFalsy()
+      expect(getByText('dismiss')).toBeTruthy()
+      expect(
+        getByText(
+          'walletConnectRequest.unsupportedChain.title, {"dappName":"WalletConnect Example","chainId":"eip155:1"}'
+        )
+      ).toBeTruthy()
+    })
+
+    it('should not show a warning if the chain is not supported and the method is personal_sign', () => {
+      const store = createMockStore({
+        walletConnect: {
+          sessions: [v2Session],
+        },
+      })
+
+      const { getByText, queryByText } = render(
+        <Provider store={store}>
+          <ActionRequest
+            version={2}
+            pendingAction={{
+              ...pendingAction,
+              params: {
+                ...pendingAction.params,
+                request: {
+                  ...pendingAction.params.request,
+                  method: 'personal_sign',
+                },
+                chainId: 'eip155:1', // unsupported chain
+              },
+            }}
+            supportedChains={supportedChains}
+          />
+        </Provider>
+      )
+
+      expect(getByText('confirmTransaction')).toBeTruthy()
+      expect(
+        getByText('walletConnectRequest.signPayload, {"dappName":"WalletConnect Example"}')
+      ).toBeTruthy()
+      expect(getByText('allow')).toBeTruthy()
+      expect(queryByText('dismiss')).toBeFalsy()
+      expect(
+        queryByText(
+          'walletConnectRequest.unsupportedChain.title, {"dappName":"WalletConnect Example","chainId":"eip155:1"}'
+        )
+      ).toBeFalsy()
     })
   })
 })

--- a/src/walletConnect/screens/Logos.tsx
+++ b/src/walletConnect/screens/Logos.tsx
@@ -1,0 +1,80 @@
+import React from 'react'
+import { Image, StyleSheet, Text, View } from 'react-native'
+import { useSelector } from 'react-redux'
+import { dappConnectInfoSelector } from 'src/dapps/selectors'
+import { DappConnectInfo } from 'src/dapps/types'
+import Logo from 'src/icons/Logo'
+import { Colors } from 'src/styles/colors'
+import fontStyles from 'src/styles/fonts'
+import { getShadowStyle, Shadow, Spacing } from 'src/styles/styles'
+
+const DAPP_IMAGE_SIZE = 40
+
+interface Props {
+  dappImageUrl?: string
+  dappName: string
+}
+
+export default function Logos({ dappImageUrl, dappName }: Props) {
+  const dappConnectInfo = useSelector(dappConnectInfoSelector)
+  if (!dappImageUrl && dappConnectInfo !== DappConnectInfo.Basic) {
+    return null
+  }
+
+  return (
+    <View style={styles.logoContainer}>
+      <View style={styles.logoShadow}>
+        <View style={styles.logoBackground}>
+          <Logo height={24} />
+        </View>
+      </View>
+      <View style={styles.logoShadow}>
+        {dappImageUrl ? (
+          <Image style={styles.dappImage} source={{ uri: dappImageUrl }} resizeMode="cover" />
+        ) : (
+          <View style={[styles.logoBackground, styles.placeholderLogoBackground]}>
+            <Text allowFontScaling={false} style={styles.placeholderLogoText}>
+              {dappName.charAt(0).toUpperCase()}
+            </Text>
+          </View>
+        )}
+      </View>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  logoContainer: {
+    flexDirection: 'row',
+  },
+  logoShadow: {
+    ...getShadowStyle(Shadow.SoftLight),
+    borderRadius: 100,
+  },
+  logoBackground: {
+    justifyContent: 'center',
+    alignItems: 'center',
+    height: DAPP_IMAGE_SIZE,
+    width: DAPP_IMAGE_SIZE,
+    borderRadius: 100,
+    backgroundColor: Colors.light,
+  },
+  dappImage: {
+    height: DAPP_IMAGE_SIZE,
+    width: DAPP_IMAGE_SIZE,
+    borderRadius: 100,
+    backgroundColor: Colors.light,
+    marginLeft: -4,
+  },
+  placeholderLogoBackground: {
+    backgroundColor: Colors.light,
+    marginRight: -Spacing.Small12,
+    borderColor: Colors.gray2,
+    borderWidth: 1,
+  },
+  placeholderLogoText: {
+    ...fontStyles.h1,
+    lineHeight: undefined,
+    color: Colors.gray4,
+  },
+})

--- a/src/walletConnect/screens/SessionRequest.tsx
+++ b/src/walletConnect/screens/SessionRequest.tsx
@@ -50,6 +50,7 @@ function SessionRequest(props: Props) {
 
   return (
     <RequestContent
+      type="confirm"
       onAccept={handleAcceptSession}
       onDeny={handleDenySession}
       dappName={dappName}


### PR DESCRIPTION
### Description

This improves connecting to dapps which either don't specify the Celo chain in the required namespaces or have it only in the optional namespaces.

Curve, Toucan and Cred Protocol fall into this.
The typical issue was that the dapp was reporting the wallet couldn't switch network.
Specifically with Curve, the Ethereum network was selected in the dropdown and it was impossible to switch it.

Previously we were allowing any chain. Now we only only EVM chains, even if not Celo.
We then clearly warn if the dapp tries to perform an action on an unsupported chain, and reject it.

I've left a note to also update the connect experience to show a warning when the requested chain/method/event aren't supported. This will be done in a follow up PR.

### Test plan

- Updated tests
- Manually tested connecting to all listed dapps.

Example of the new warning when the chain is not supported (note: this isn't a real world example, I manually changed the values to produce this):

<img src="https://github.com/valora-inc/wallet/assets/57791/738bdad2-ef31-4d32-a11b-716b67267977" width="50%" /> 

### Related issues

- Fixes RET-778

### Backwards compatibility

Yes.
