### PR TITLE
fix(keyless-backup): remove extra padding on phone input screen

### DIFF
--- a/src/keylessBackup/KeylessBackupPhoneInput.tsx
+++ b/src/keylessBackup/KeylessBackupPhoneInput.tsx
@@ -127,8 +127,7 @@ KeylessBackupPhoneInput.navigationOptions = () => ({
   ...emptyHeader,
   headerLeft: () => (
     <TopBarIconButton
-      style={styles.cancelButton}
-      icon={<Times height={16} />}
+      icon={<Times />}
       onPress={navigateBack} // TODO: handle in ACT-770
     />
   ),
@@ -144,9 +143,6 @@ const styles = StyleSheet.create({
   scrollContainer: {
     padding: 24,
     paddingTop: 36,
-  },
-  cancelButton: {
-    marginLeft: 16,
   },
   title: {
     ...fontStyles.h2,


### PR DESCRIPTION
### Description

Remove extra padding on the back button to make it consistent with other screens

### Test plan

| Before | After |
|--------|--------|
| <img src="https://github.com/valora-inc/wallet/assets/5062591/efafd843-13f4-4840-ba84-0a74183d984a" width="270" /> | <img src="https://github.com/valora-inc/wallet/assets/5062591/c625a3b3-7804-4888-a68f-b73282eef9c3" width="270" /> | 

### Related issues

N/A

### Backwards compatibility

yes