### PR TITLE
fix: try to reload nft images that failed to load on data refresh

### DIFF
--- a/src/nfts/NftGallery.tsx
+++ b/src/nfts/NftGallery.tsx
@@ -86,7 +86,7 @@ export default function NftGallery() {
                   </View>
                 }
                 origin={NftOrigin.NftGallery}
-                borderRadius={Spacing.Smallest8}
+                borderRadius={Spacing.Regular16}
               />
             </Touchable>
           )}

--- a/src/nfts/NftImage.test.tsx
+++ b/src/nfts/NftImage.test.tsx
@@ -1,10 +1,12 @@
 import { render } from '@testing-library/react-native'
 import React from 'react'
 import { Text } from 'react-native'
+import { Provider } from 'react-redux'
 import { NftEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import NftImage from 'src/nfts/NftImage'
 import { NftOrigin } from 'src/nfts/types'
+import { createMockStore } from 'test/utils'
 import { mockNftAllFields, mockNftNullMetadata } from 'test/values'
 
 jest.mock('src/analytics/ValoraAnalytics')
@@ -14,12 +16,14 @@ describe('NftImage', () => {
 
   it('should initially display a loading state', () => {
     const { getByTestId, queryByText } = render(
-      <NftImage
-        nft={mockNftAllFields}
-        origin={NftOrigin.NftsInfoCarouselMain}
-        ErrorComponent={ErrorComponent}
-        testID="NftImage"
-      />
+      <Provider store={createMockStore()}>
+        <NftImage
+          nft={mockNftAllFields}
+          origin={NftOrigin.NftsInfoCarouselMain}
+          ErrorComponent={ErrorComponent}
+          testID="NftImage"
+        />
+      </Provider>
     )
 
     expect(getByTestId('NftImage')).toBeTruthy()
@@ -30,12 +34,14 @@ describe('NftImage', () => {
 
   it('should display an error state if there is no nft metadata', () => {
     const { getByText, queryByTestId } = render(
-      <NftImage
-        nft={mockNftNullMetadata}
-        origin={NftOrigin.NftsInfoCarouselMain}
-        ErrorComponent={ErrorComponent}
-        testID="NftImage"
-      />
+      <Provider store={createMockStore()}>
+        <NftImage
+          nft={mockNftNullMetadata}
+          origin={NftOrigin.NftsInfoCarouselMain}
+          ErrorComponent={ErrorComponent}
+          testID="NftImage"
+        />
+      </Provider>
     )
 
     expect(queryByTestId('NftImage')).toBeFalsy()

--- a/src/nfts/NftsInfoCarousel.test.tsx
+++ b/src/nfts/NftsInfoCarousel.test.tsx
@@ -1,10 +1,11 @@
 import { fireEvent, render } from '@testing-library/react-native'
 import * as React from 'react'
+import { Provider } from 'react-redux'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import NftsInfoCarousel from 'src/nfts/NftsInfoCarousel'
 import networkConfig from 'src/web3/networkConfig'
-import { getMockStackScreenProps } from 'test/utils'
+import { createMockStore, getMockStackScreenProps } from 'test/utils'
 import { mockNftAllFields, mockNftMinimumFields, mockNftNullMetadata } from 'test/values'
 
 jest.mock('src/utils/Logger')
@@ -16,9 +17,11 @@ describe('NftsInfoCarousel', () => {
 
   it('renders correctly with one Nft', () => {
     const { queryByTestId, getByTestId, getByText } = render(
-      <NftsInfoCarousel
-        {...getMockStackScreenProps(Screens.NftsInfoCarousel, { nfts: [mockNftAllFields] })}
-      />
+      <Provider store={createMockStore()}>
+        <NftsInfoCarousel
+          {...getMockStackScreenProps(Screens.NftsInfoCarousel, { nfts: [mockNftAllFields] })}
+        />
+      </Provider>
     )
 
     // Correct image source should be rendered
@@ -35,11 +38,13 @@ describe('NftsInfoCarousel', () => {
     const nft1Thumbnail = `NftsInfoCarousel/NftThumbnail/${mockNftAllFields.contractAddress}-${mockNftAllFields.tokenId}`
     const nft2Thumbnail = `NftsInfoCarousel/NftThumbnail/${mockNftMinimumFields.contractAddress}-${mockNftMinimumFields.tokenId}`
     const { getByTestId, getByText } = render(
-      <NftsInfoCarousel
-        {...getMockStackScreenProps(Screens.NftsInfoCarousel, {
-          nfts: [mockNftAllFields, mockNftMinimumFields],
-        })}
-      />
+      <Provider store={createMockStore()}>
+        <NftsInfoCarousel
+          {...getMockStackScreenProps(Screens.NftsInfoCarousel, {
+            nfts: [mockNftAllFields, mockNftMinimumFields],
+          })}
+        />
+      </Provider>
     )
 
     // Carousel should be rendered
@@ -68,7 +73,9 @@ describe('NftsInfoCarousel', () => {
 
   it('renders full screen error when no Nft(s)', () => {
     const { getByTestId, queryByTestId } = render(
-      <NftsInfoCarousel {...getMockStackScreenProps(Screens.NftsInfoCarousel, { nfts: [] })} />
+      <Provider store={createMockStore()}>
+        <NftsInfoCarousel {...getMockStackScreenProps(Screens.NftsInfoCarousel, { nfts: [] })} />
+      </Provider>
     )
 
     expect(getByTestId('NftsInfoCarousel/NftsLoadErrorScreen')).toBeTruthy()
@@ -77,20 +84,24 @@ describe('NftsInfoCarousel', () => {
 
   it('renders error image state on Nft null metadata', () => {
     const { getByText } = render(
-      <NftsInfoCarousel
-        {...getMockStackScreenProps(Screens.NftsInfoCarousel, { nfts: [mockNftNullMetadata] })}
-      />
+      <Provider store={createMockStore()}>
+        <NftsInfoCarousel
+          {...getMockStackScreenProps(Screens.NftsInfoCarousel, { nfts: [mockNftNullMetadata] })}
+        />
+      </Provider>
     )
     expect(getByText('nftInfoCarousel.nftImageLoadError')).toBeTruthy()
   })
 
   it('image carousel should render Nfts with null metadata as red info icon', () => {
     const { getByTestId, getByText, queryByText } = render(
-      <NftsInfoCarousel
-        {...getMockStackScreenProps(Screens.NftsInfoCarousel, {
-          nfts: [mockNftAllFields, mockNftNullMetadata],
-        })}
-      />
+      <Provider store={createMockStore()}>
+        <NftsInfoCarousel
+          {...getMockStackScreenProps(Screens.NftsInfoCarousel, {
+            nfts: [mockNftAllFields, mockNftNullMetadata],
+          })}
+        />
+      </Provider>
     )
 
     // The Nft with null metadata will render with an error icon in carousel and display error text when selected
@@ -109,9 +120,11 @@ describe('NftsInfoCarousel', () => {
 
   it('opens link for Explorer', () => {
     const { getByTestId } = render(
-      <NftsInfoCarousel
-        {...getMockStackScreenProps(Screens.NftsInfoCarousel, { nfts: [mockNftMinimumFields] })}
-      />
+      <Provider store={createMockStore()}>
+        <NftsInfoCarousel
+          {...getMockStackScreenProps(Screens.NftsInfoCarousel, { nfts: [mockNftMinimumFields] })}
+        />
+      </Provider>
     )
 
     fireEvent.press(getByTestId('ViewOnExplorer'))
@@ -124,9 +137,11 @@ describe('NftsInfoCarousel', () => {
     const noTokenId = mockNftMinimumFields
     noTokenId.tokenId = null as unknown as string
     const { queryByTestId } = render(
-      <NftsInfoCarousel
-        {...getMockStackScreenProps(Screens.NftsInfoCarousel, { nfts: [noTokenId] })}
-      />
+      <Provider store={createMockStore()}>
+        <NftsInfoCarousel
+          {...getMockStackScreenProps(Screens.NftsInfoCarousel, { nfts: [noTokenId] })}
+        />
+      </Provider>
     )
 
     expect(queryByTestId('ViewOnExplorer')).toBeNull()


### PR DESCRIPTION
### Description

As the title. Currently on pull to refresh, only the data is refreshed but the images states are not.

Also, fix pet peeve of mine...the error image and nft image had different border radiuses....

### Test plan

(Notice the broken images at the start of the video vs the end)

https://github.com/valora-inc/wallet/assets/20150449/3a74d9b2-33de-456f-acc9-56821526cd14


### Related issues

- Fixes RET-793

### Backwards compatibility

Y
