### PR TITLE
fix: unexpected non primitive analytics properties

### DIFF
--- a/src/analytics/ValoraAnalytics.ts
+++ b/src/analytics/ValoraAnalytics.ts
@@ -333,7 +333,7 @@ class ValoraAnalytics {
       // Prefixed super props
       ...prefixedSuperProps,
       // Statsig prop, won't be read properly by Statsig if prefixed
-      statsigEnvironment: STATSIG_ENV,
+      statsigEnvironment: STATSIG_ENV.tier,
     }
   }
 }

--- a/src/analytics/selectors.ts
+++ b/src/analytics/selectors.ts
@@ -126,7 +126,7 @@ export const getCurrentUserTraits = createSelector(
         ? getRegionCodeFromCountryCode(phoneCountryCallingCode)
         : undefined,
       countryCodeAlpha2: countryCodeAlpha2 ?? undefined,
-      language: language ?? null,
+      language: language ?? undefined,
       deviceLanguage: RNLocalize.getLocales()[0]?.languageTag, // Example: "en-GB"
       netWorthUsd: new BigNumber(totalBalanceUsd).plus(totalPositionsBalanceUsd).toNumber(), // Tokens + positions
       totalBalanceUsd: totalBalanceUsd?.toNumber(), // Only tokens (with a USD price), no positions

--- a/src/analytics/selectors.ts
+++ b/src/analytics/selectors.ts
@@ -125,8 +125,8 @@ export const getCurrentUserTraits = createSelector(
       phoneCountryCodeAlpha2: phoneCountryCallingCode
         ? getRegionCodeFromCountryCode(phoneCountryCallingCode)
         : undefined,
-      countryCodeAlpha2,
-      language,
+      countryCodeAlpha2: countryCodeAlpha2 ?? undefined,
+      language: language ?? null,
       deviceLanguage: RNLocalize.getLocales()[0]?.languageTag, // Example: "en-GB"
       netWorthUsd: new BigNumber(totalBalanceUsd).plus(totalPositionsBalanceUsd).toNumber(), // Tokens + positions
       totalBalanceUsd: totalBalanceUsd?.toNumber(), // Only tokens (with a USD price), no positions


### PR DESCRIPTION
### Description

While digging into the Clevertap missing events issue, I noticed some logs complaining about non primitive values. I'm not sure what effect they're having in the end - the logs do say "New event processed" but there is also a "wzrk_error" and it's unclear if the event is actually processed. I thought it doesn't hurt to fix anyway. i'll give a heads up to the team that some fields that could be null can now be undefined.
`
2023-08-02 15:24:48.438918+0200 celo[68492:4526235] [CleverTap]: CleverTap.46W-4W9-4K6Z: New event processed: {"s":1690982683,"n":"_bg","dsync":true,"pg":1,"ep":1690982688,"wzrk_error":{"c":512,"d":"For event \"app_launched\": Property value for property sCountryCodeAlpha2 wasn't a primitive (<null>)"},"type":"profile","lsl":715,"f":false,"profile":{"Carrier":"--","totalPositionsBalanceUsd":0,"deviceLanguage":"en-NZ","phoneCountryCallingCode":"+64","Identity":"0xbd7172dc3b4c48e66f54186f81390e6a2f4781aa","topTenPositions":"","totalBalanceUsd":196.1935559708578,"countryCodeAlpha2":"NL","crealBalance":0,"appVersion":"1.64.0","walletAddress":"0xbd7172dc3b4c48e66f54186f81390e6a2f4781aa","cusdBalance":57.31787889816772,"superchargingAmountInUsd":113.72615675637601,"pincodeType":"PhoneAuth","appBuildNumber":"129","cc":"--","deviceId":"76DFFF49-6F13-4AB1-B7AA-186A378C6AB7","appBundleId":"org.celo.mobile.alfajores","positionsAppsCount":0,"localCurrencyCode":"USD","hasVerifiedNumberCPV":false,"ceurBalance":51.932072082921891,"celoBalance":33.13116614936898,"netWorthUsd":196.1935559708578,"hasCompletedBackup":true,"accountAddress":"0xbd7172dc3b4c48e66f54186f81390e6a2f4781aa","tz":"Europe\/Amsterdam","positionsTopTenApps":"","phoneCountryCodeAlpha2":"NZ","tokenCount":5,"positionsCount":0,"hasVerifiedNumber":false,"language":"en-US","hooksPreviewEnabled":false,"superchargingToken":"cEUR","otherTenTokens":"cUSD_CELO_FP:2.51958,cEUR_CELO_FP:0.31618"}}
`

### Test plan

n/a

### Related issues

- Fixes RET-746

### Backwards compatibility

Y
