### PR TITLE
fix: swappable tokens should have usd price

### DIFF
--- a/src/swap/SwapScreen.test.tsx
+++ b/src/swap/SwapScreen.test.tsx
@@ -104,9 +104,9 @@ const renderScreen = ({ celoBalance = '10', cUSDBalance = '20.456', showDrawerTo
           balance: celoBalance,
         },
         [mockTestTokenAddress]: {
+          // no usdPrice
           address: mockTestTokenAddress,
           symbol: 'TT',
-          priceFetchedAt: now,
           decimals: 18,
           imageUrl:
             'https://raw.githubusercontent.com/valora-inc/address-metadata/main/assets/tokens/TT.png',
@@ -116,9 +116,9 @@ const renderScreen = ({ celoBalance = '10', cUSDBalance = '20.456', showDrawerTo
           balance: '100',
         },
         [mockPoofAddress]: {
+          // no usdPrice
           address: mockPoofAddress,
           symbol: 'POOF',
-          priceFetchedAt: now,
           decimals: 18,
           imageUrl: `https://raw.githubusercontent.com/valora-inc/address-metadata/main/assets/tokens/POOF.png`,
           isCoreToken: false,
@@ -668,15 +668,15 @@ describe('SwapScreen', () => {
       swappingNonNativeTokensEnabled: true,
     })
 
-    const { swapToContainer, getByPlaceholderText, queryByTestId } = renderScreen({})
+    const { swapToContainer, getByPlaceholderText, getByTestId, queryByTestId } = renderScreen({})
     fireEvent.press(within(swapToContainer).getByTestId('SwapAmountInput/TokenSelect'))
 
     expect(getByPlaceholderText('tokenBottomSheet.searchAssets')).toBeTruthy()
-    expect(queryByTestId('cUSDTouchable')).toBeTruthy()
-    expect(queryByTestId('cEURTouchable')).toBeTruthy()
-    expect(queryByTestId('POOFTouchable')).toBeTruthy()
-    expect(queryByTestId('CELOTouchable')).toBeTruthy()
-    expect(queryByTestId('TTTouchable')).toBeNull()
+    expect(getByTestId('cUSDTouchable')).toBeTruthy()
+    expect(getByTestId('cEURTouchable')).toBeTruthy()
+    expect(getByTestId('CELOTouchable')).toBeTruthy()
+    expect(queryByTestId('POOFTouchable')).toBeFalsy()
+    expect(queryByTestId('TTTouchable')).toBeFalsy()
   })
 
   it('should be able to hide top drawer nav when parameter is set', () => {

--- a/src/swap/SwapScreen.tsx
+++ b/src/swap/SwapScreen.tsx
@@ -75,15 +75,15 @@ export function SwapScreenSection({ showDrawerTopNav }: { showDrawerTopNav: bool
 
   const CELO = useMemo(
     () =>
-      supportedTokens.find(
+      swappableTokens.find(
         (token) => token.symbol === DEFAULT_FROM_TOKEN_SYMBOL && token.isCoreToken
       ),
-    [supportedTokens]
+    [swappableTokens]
   )
 
   const defaultFromToken = useMemo(() => {
     return swappableTokens[0] ?? CELO
-  }, [supportedTokens, swappableTokens])
+  }, [swappableTokens])
 
   const [fromToken, setFromToken] = useState<TokenBalance | undefined>(defaultFromToken)
   const [toToken, setToToken] = useState<TokenBalance | undefined>()
@@ -239,7 +239,7 @@ export function SwapScreenSection({ showDrawerTopNav }: { showDrawerTopNav: bool
   }
 
   const handleSelectToken = (tokenAddress: string) => {
-    const selectedToken = supportedTokens.find((token) => token.address === tokenAddress)
+    const selectedToken = swappableTokens.find((token) => token.address === tokenAddress)
     if (selectedToken && selectingToken) {
       ValoraAnalytics.track(SwapEvents.swap_screen_confirm_token, {
         fieldType: selectingToken,
@@ -411,7 +411,7 @@ export function SwapScreenSection({ showDrawerTopNav }: { showDrawerTopNav: bool
         onTokenSelected={handleSelectToken}
         onClose={handleCloseTokenSelect}
         searchEnabled={swappingNonNativeTokensEnabled}
-        tokens={supportedTokens}
+        tokens={swappableTokens}
         title={
           selectingToken == Field.FROM
             ? t('swapScreen.swapFromTokenSelection')


### PR DESCRIPTION
### Description

Currently we are showing all supported swap tokens in the swap flow, but the original intention was to exclude the tokens we don't have a usd price for. We should be referencing `swappableTokens` rather than `supportedTokens` in the swap screen.

### Test plan

https://github.com/valora-inc/wallet/assets/20150449/00faad28-c42b-4a9e-bc3d-aea1719cca23


### Related issues

n/a

### Backwards compatibility

Y
