### PR TITLE
feat(keyless-backup): show spinner on google sign in

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -30,7 +30,7 @@ export interface ButtonProps {
   onPress: () => void
   style?: StyleProp<ViewStyle>
   text: string | ReactNode
-  showLoading?: boolean
+  showLoading?: boolean // shows activity indicator on the button, but doesn't disable it. disabled must explicitly be set to disable the button
   loadingColor?: string
   accessibilityLabel?: string
   type?: BtnTypes

--- a/src/keylessBackup/SignInWithEmail.test.tsx
+++ b/src/keylessBackup/SignInWithEmail.test.tsx
@@ -68,6 +68,7 @@ describe('SignInWithEmail', () => {
     expect(ValoraAnalytics.track).toHaveBeenCalledWith('cab_sign_in_with_google', {
       keylessBackupFlow: KeylessBackupFlow.Setup,
     })
+    expect(getByTestId('Button/Loading')).toBeTruthy()
     await waitFor(() => expect(navigate).toHaveBeenCalledTimes(1))
     expect(navigate).toHaveBeenCalledWith(Screens.KeylessBackupPhoneInput, {
       keylessBackupFlow: KeylessBackupFlow.Setup,
@@ -85,9 +86,10 @@ describe('SignInWithEmail', () => {
 
   it('pressing button invokes authorize and logs warning if authorize fails', async () => {
     mockAuthorize.mockRejectedValue(new Error('auth failed'))
-    const { getByTestId } = renderComponent()
+    const { getByTestId, queryByTestId } = renderComponent()
     const continueButton = getByTestId('SignInWithEmail/Google')
     fireEvent.press(continueButton)
+    expect(getByTestId('Button/Loading')).toBeTruthy()
     expect(ValoraAnalytics.track).toHaveBeenCalledWith('cab_sign_in_with_google', {
       keylessBackupFlow: KeylessBackupFlow.Setup,
     })
@@ -98,13 +100,15 @@ describe('SignInWithEmail', () => {
     expect(mockGetCredentials).not.toHaveBeenCalled()
     expect(store.getActions()).toEqual([])
     expect(ValoraAnalytics.track).toHaveBeenCalledTimes(1)
+    expect(queryByTestId('Button/Loading')).toBeNull()
   })
 
   it('pressing button invokes authorize and logs warning if idToken is not present in credentials', async () => {
     mockGetCredentials.mockResolvedValue({})
-    const { getByTestId } = renderComponent()
+    const { getByTestId, queryByTestId } = renderComponent()
     const continueButton = getByTestId('SignInWithEmail/Google')
     fireEvent.press(continueButton)
+    expect(getByTestId('Button/Loading')).toBeTruthy()
     expect(ValoraAnalytics.track).toHaveBeenCalledWith('cab_sign_in_with_google', {
       keylessBackupFlow: KeylessBackupFlow.Setup,
     })
@@ -115,13 +119,15 @@ describe('SignInWithEmail', () => {
     expect(mockGetCredentials).toHaveBeenCalledTimes(1)
     expect(store.getActions()).toEqual([])
     expect(ValoraAnalytics.track).toHaveBeenCalledTimes(1)
+    expect(queryByTestId('Button/Loading')).toBeNull()
   })
 
   it('pressing button invokes authorize and logs debug message if login is cancelled (empty credentials)', async () => {
     mockGetCredentials.mockResolvedValue(undefined)
-    const { getByTestId } = renderComponent()
+    const { getByTestId, queryByTestId } = renderComponent()
     const continueButton = getByTestId('SignInWithEmail/Google')
     fireEvent.press(continueButton)
+    expect(getByTestId('Button/Loading')).toBeTruthy()
     expect(ValoraAnalytics.track).toHaveBeenCalledWith('cab_sign_in_with_google', {
       keylessBackupFlow: KeylessBackupFlow.Setup,
     })
@@ -135,6 +141,7 @@ describe('SignInWithEmail', () => {
     expect(store.getActions()).toEqual([])
     expect(ValoraAnalytics.track).toHaveBeenCalledTimes(1)
     expect(logWarnSpy).not.toHaveBeenCalled()
+    expect(queryByTestId('Button/Loading')).toBeNull()
   })
 
   it.each([

--- a/src/keylessBackup/SignInWithEmail.tsx
+++ b/src/keylessBackup/SignInWithEmail.tsx
@@ -1,5 +1,5 @@
 import { NativeStackScreenProps } from '@react-navigation/native-stack'
-import React from 'react'
+import React, { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { SafeAreaView, ScrollView, StyleSheet, Text } from 'react-native'
 import { useAuth0 } from 'react-native-auth0'
@@ -28,8 +28,10 @@ function SignInWithEmail({ route }: Props) {
   const dispatch = useDispatch()
   const { authorize, getCredentials, clearCredentials } = useAuth0()
   const { keylessBackupFlow } = route.params
+  const [loading, setLoading] = useState(false)
 
   const onPressGoogle = async () => {
+    setLoading(true)
     ValoraAnalytics.track(KeylessBackupEvents.cab_sign_in_with_google, { keylessBackupFlow })
     try {
       // clear any existing saved credentials
@@ -42,6 +44,7 @@ function SignInWithEmail({ route }: Props) {
 
       if (!credentials) {
         Logger.debug(TAG, 'login cancelled')
+        setLoading(false)
         return
       }
 
@@ -53,8 +56,13 @@ function SignInWithEmail({ route }: Props) {
       ValoraAnalytics.track(KeylessBackupEvents.cab_sign_in_with_google_success, {
         keylessBackupFlow,
       })
+      setTimeout(() => {
+        // to avoid screen flash
+        setLoading(false)
+      }, 1000)
     } catch (err) {
       Logger.warn(TAG, 'login failed', err)
+      setLoading(false)
     }
   }
 
@@ -77,7 +85,9 @@ function SignInWithEmail({ route }: Props) {
         style={styles.button}
         icon={<GoogleIcon />}
         iconMargin={12}
-        touchableStyle={styles.buttonTouchable}
+        touchableStyle={loading ? undefined : styles.buttonTouchable}
+        showLoading={loading}
+        disabled={loading}
       />
     </SafeAreaView>
   )


### PR DESCRIPTION
### Description

Show a spinner on google sign in during the period when auth0 flow completes and credentials are loading

### Test plan

iOS:

https://github.com/valora-inc/wallet/assets/5062591/9b6edbbb-3518-4f48-948d-078eed0d7126

Android:

https://github.com/valora-inc/wallet/assets/5062591/779e387b-aaac-420c-b4a2-6b97015cea5e



### Related issues

- Fixes ACT-822

### Backwards compatibility

Yes
