### PR TITLE
chore: remove redundant call to register remote messaging

### DIFF
--- a/src/firebase/firebase.test.ts
+++ b/src/firebase/firebase.test.ts
@@ -23,7 +23,6 @@ const onMessageMock = jest.fn(() => null)
 const onNotificationOpenedAppMock = jest.fn(() => null)
 const getInitialNotificationMock = jest.fn(() => null)
 const setBackgroundMessageHandler = jest.fn(() => null)
-const registerDeviceForRemoteMessagesMock = jest.fn(() => null)
 
 const mockFcmToken = 'token'
 
@@ -37,7 +36,6 @@ const app: any = {
     onMessage: onMessageMock,
     onNotificationOpenedApp: onNotificationOpenedAppMock,
     getInitialNotification: getInitialNotificationMock,
-    registerDeviceForRemoteMessages: registerDeviceForRemoteMessagesMock,
   }),
 }
 

--- a/src/firebase/firebase.ts
+++ b/src/firebase/firebase.ts
@@ -190,7 +190,6 @@ export function* initializeCloudMessaging(app: ReactNativeFirebase.Module, addre
   // Emulators can't handle fcm tokens and calling getToken on them will throw an error
   if (!isEmulator) {
     yield* call([CleverTap, 'registerForPush'])
-    yield* call([app.messaging(), 'registerDeviceForRemoteMessages'])
     fcmToken = yield* call([app.messaging(), 'getToken'])
   }
   if (fcmToken) {


### PR DESCRIPTION
### Description

This didn't cause problems but I also see in the logs `Usage of "messaging().registerDeviceForRemoteMessages()" is not required. You only need to register if auto-registration is disabled in your 'firebase.json' configuration file` so removing it in this PR.

### Test plan

Tested push notifications again locally. Seems okay.

### Related issues

n/a

### Backwards compatibility

Y
