### PR TITLE
fix: ensure nft videos are muted by default

### DIFF
--- a/src/nfts/NftMedia.tsx
+++ b/src/nfts/NftMedia.tsx
@@ -157,6 +157,7 @@ export default function NftMedia({
             minLoadRetryCount={3}
             repeat={true}
             resizeMode={shouldAutoScaleHeight ? 'contain' : 'cover'}
+            muted={true}
           />
           {/* This is a hack to get the loading skeleton to overlay the media player while loading, nesting within the player doesn't work */}
           <View style={{ marginTop: -DEFAULT_HEIGHT }}>


### PR DESCRIPTION
### Description

As the title - ensure that videos can also be unmuted. https://github.com/react-native-video/react-native-video/blob/master/API.md#muted

### Test plan

Tested on iOS, in silent and not silent mode, by hard coding some video NFT's to load.

https://github.com/valora-inc/wallet/assets/20150449/4821597c-ec43-4021-b8b6-5ab77fb7c74a


### Related issues

- Fixes RET-811

### Backwards compatibility

Y
