### PR TITLE
fix(wc): use symkey presence to determine pairing uri

### DIFF
--- a/src/app/saga.test.ts
+++ b/src/app/saga.test.ts
@@ -224,7 +224,7 @@ describe('WalletConnect deeplinks', () => {
   })
 
   const connectionString = encodeURIComponent(
-    'wc:79a02f869d0f921e435a5e0643304548ebfa4a0430f9c66fe8b1a9254db7ef77@1?controller=false&publicKey=f661b0a9316a4ce0b6892bdce42bea0f45037f2c1bee9e118a3a4bc868a32a39&relay={"protocol":"waku"}'
+    'wc:79a02f869d0f921e435a5e0643304548ebfa4a0430f9c66fe8b1a9254db7ef77@2?relay-protocol=irn&symKey=f661b0a9316a4ce0b6892bdce42bea0f45037f2c1bee9e118a3a4bc868a32a39'
   )
   const connectionLinks = [
     {

--- a/src/walletConnect/walletConnect.ts
+++ b/src/walletConnect/walletConnect.ts
@@ -1,6 +1,7 @@
+import { parseUri } from '@walletconnect/utils'
 import { WalletConnectEvents } from 'src/analytics/Events'
-import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import { WalletConnectPairingOrigin } from 'src/analytics/types'
+import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import { getDappRequestOrigin } from 'src/app/utils'
 import { activeDappSelector } from 'src/dapps/selectors'
 import { ActiveDapp } from 'src/dapps/types'
@@ -47,8 +48,9 @@ export function* handleWalletConnectDeepLink(deepLink: string) {
     yield* fork(handleLoadingWithTimeout, WalletConnectPairingOrigin.Deeplink)
   }
 
-  // connection request
-  if (link.includes('?')) {
+  // pairing request
+  // https://docs.walletconnect.com/2.0/specs/clients/core/pairing/pairing-uri
+  if (parseUri(link).symKey) {
     yield* call(initialiseWalletConnect, link, WalletConnectPairingOrigin.Deeplink)
   }
 


### PR DESCRIPTION
### Description

Previously the presence or absence of `?` was used to determine if a walletconnect deeplink was a pairing request or not; however, this is not the case for v2 urls. Instead we should use the presence or absence of the `symKey`.

### Test plan

Tested locally on Android with the following dapps:

- [x] [StakedCelo](https://app.stcelo.xyz/connect)
- [x] [Curve](https://curve.fi/#/celo/swap)
- [x] [Mento](https://app.mento.org)
### Related issues

- Fixes RET-818

### Backwards compatibility

Yes