### PR TITLE
feat(keyless-backup): add feature gate

### DIFF
--- a/src/account/Settings.test.tsx
+++ b/src/account/Settings.test.tsx
@@ -17,10 +17,11 @@ import {
   setNumberVerified,
 } from 'src/app/actions'
 import { PRIVACY_LINK, TOS_LINK } from 'src/brandingConfig'
-import { getKeylessBackupGate, isBackupComplete } from 'src/keylessBackup/utils'
+import { isBackupComplete } from 'src/keylessBackup/utils'
 import { ensurePincode, navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import { removeStoredPin, setPincodeWithBiometry } from 'src/pincode/authentication'
+import { getFeatureGate } from 'src/statsig/index'
 import { navigateToURI } from 'src/utils/linking'
 import Logger from 'src/utils/Logger'
 import networkConfig from 'src/web3/networkConfig'
@@ -41,10 +42,11 @@ mockedKeychain.getGenericPassword.mockResolvedValue({
 jest.mock('src/analytics/ValoraAnalytics')
 jest.mock('src/utils/Logger')
 jest.mock('src/keylessBackup/utils')
+jest.mock('src/statsig')
 
 describe('Account', () => {
   beforeEach(() => {
-    mocked(getKeylessBackupGate).mockReturnValue(false)
+    mocked(getFeatureGate).mockReturnValue(false)
     mocked(isBackupComplete).mockReturnValue(false)
     jest.clearAllMocks()
   })
@@ -285,7 +287,7 @@ describe('Account', () => {
   })
 
   it('shows keyless backup setup when flag is enabled and not already backed up', async () => {
-    mocked(getKeylessBackupGate).mockReturnValue(true)
+    mocked(getFeatureGate).mockReturnValue(true)
     mocked(isBackupComplete).mockReturnValue(false)
     mockedEnsurePincode.mockImplementation(() => Promise.resolve(true))
     const store = createMockStore()
@@ -306,7 +308,7 @@ describe('Account', () => {
   })
 
   it('shows keyless backup delete when flag is enabled and already backed up', () => {
-    mocked(getKeylessBackupGate).mockReturnValue(true)
+    mocked(getFeatureGate).mockReturnValue(true)
     mocked(isBackupComplete).mockReturnValue(true)
     const store = createMockStore()
     const { getByTestId, getByText } = render(

--- a/src/account/Settings.test.tsx
+++ b/src/account/Settings.test.tsx
@@ -275,7 +275,6 @@ describe('Account', () => {
     expect(navigate).not.toHaveBeenCalled()
   })
 
-  // TODO(ACT-771): update these tests to mock statsig instead of helper function
   it('does not show keyless backup', () => {
     const store = createMockStore()
     const { queryByTestId } = render(

--- a/src/account/Settings.tsx
+++ b/src/account/Settings.tsx
@@ -57,7 +57,7 @@ import {
 import { PRIVACY_LINK, TOS_LINK } from 'src/config'
 import { currentLanguageSelector } from 'src/i18n/selectors'
 import { revokeVerification } from 'src/identity/actions'
-import { getKeylessBackupGate, isBackupComplete } from 'src/keylessBackup/utils'
+import { isBackupComplete } from 'src/keylessBackup/utils'
 import { getLocalCurrencyCode } from 'src/localCurrency/selectors'
 import DrawerTopBar from 'src/navigator/DrawerTopBar'
 import { ensurePincode, navigate } from 'src/navigator/NavigationService'
@@ -65,6 +65,8 @@ import { Screens } from 'src/navigator/Screens'
 import { StackParamList } from 'src/navigator/types'
 import { removeStoredPin, setPincodeWithBiometry } from 'src/pincode/authentication'
 import RevokePhoneNumber from 'src/RevokePhoneNumber'
+import { getFeatureGate } from 'src/statsig/index'
+import { StatsigFeatureGates } from 'src/statsig/types'
 import colors from 'src/styles/colors'
 import fontStyles from 'src/styles/fonts'
 import { navigateToURI } from 'src/utils/linking'
@@ -373,8 +375,7 @@ export const Account = ({ navigation, route }: Props) => {
     }
   }
 
-  // TODO(ACT-771): get from Statsig
-  const showKeylessBackup = getKeylessBackupGate()
+  const showKeylessBackup = getFeatureGate(StatsigFeatureGates.SHOW_CLOUD_ACCOUNT_BACKUP_SETUP)
 
   // TODO(ACT-684, ACT-766, ACT-767): get from redux, and also handle in progress state
   const isKeylessBackupComplete = isBackupComplete()

--- a/src/keylessBackup/utils.ts
+++ b/src/keylessBackup/utils.ts
@@ -1,7 +1,4 @@
 // helper functions that default to false, but allows testing by mocking
 
-// TODO(ACT-771): remove when status taken from statsig
-export const getKeylessBackupGate = () => false
-
 // TODO(ACT-684, ACT-766, ACT-767): remove when status taken from redux
 export const isBackupComplete = () => false

--- a/src/navigator/DrawerNavigator.test.tsx
+++ b/src/navigator/DrawerNavigator.test.tsx
@@ -3,7 +3,7 @@ import * as React from 'react'
 import 'react-native'
 import { Provider } from 'react-redux'
 import DrawerNavigator from 'src/navigator/DrawerNavigator'
-import { getExperimentParams } from 'src/statsig'
+import { getExperimentParams, getFeatureGate } from 'src/statsig'
 import MockedNavigator from 'test/MockedNavigator'
 import { createMockStore } from 'test/utils'
 import { mocked } from 'ts-jest/utils'
@@ -107,6 +107,56 @@ describe('DrawerNavigator', () => {
       </Provider>
     )
     expect(queryByTestId('DrawerItem/swapScreen.title')).toBeNull()
+  })
+
+  it('shows recovery phrase if backup is not complete and cloud backup feature gate is false', () => {
+    mocked(getFeatureGate).mockReturnValue(false)
+    const store = createMockStore({
+      account: {
+        backupCompleted: false,
+      },
+    })
+    const { queryByTestId } = render(
+      <Provider store={store}>
+        <MockedNavigator component={DrawerNavigator}></MockedNavigator>
+      </Provider>
+    )
+    expect(queryByTestId('DrawerItem/accountKey')).toBeTruthy()
+    expect(queryByTestId('DrawerItem/walletSecurity')).toBeNull()
+  })
+
+  it('shows wallet security if backup is not complete and cloud backup feature gate is true', () => {
+    mocked(getFeatureGate).mockReturnValue(true)
+    const store = createMockStore({
+      account: {
+        backupCompleted: false,
+      },
+    })
+    const { queryByTestId } = render(
+      <Provider store={store}>
+        <MockedNavigator component={DrawerNavigator}></MockedNavigator>
+      </Provider>
+    )
+    expect(queryByTestId('DrawerItem/accountKey')).toBeNull()
+    expect(queryByTestId('DrawerItem/walletSecurity')).toBeTruthy()
+  })
+
+  it('hides wallet security and recovery phrase if backup is complete', () => {
+    const store = createMockStore({
+      app: {
+        shouldShowRecoveryPhraseInSettings: true,
+      },
+      account: {
+        backupCompleted: true,
+      },
+    })
+    const { queryByTestId } = render(
+      <Provider store={store}>
+        <MockedNavigator component={DrawerNavigator}></MockedNavigator>
+      </Provider>
+    )
+    expect(queryByTestId('DrawerItem/accountKey')).toBeNull()
+    expect(queryByTestId('DrawerItem/walletSecurity')).toBeNull()
   })
 
   describe('phone number in drawer', () => {

--- a/src/navigator/DrawerNavigator.test.tsx
+++ b/src/navigator/DrawerNavigator.test.tsx
@@ -143,9 +143,6 @@ describe('DrawerNavigator', () => {
 
   it('hides wallet security and recovery phrase if backup is complete', () => {
     const store = createMockStore({
-      app: {
-        shouldShowRecoveryPhraseInSettings: true,
-      },
       account: {
         backupCompleted: true,
       },

--- a/src/navigator/DrawerNavigator.tsx
+++ b/src/navigator/DrawerNavigator.tsx
@@ -203,11 +203,6 @@ function CustomDrawerContent(props: DrawerContentComponentProps<DrawerContentOpt
 
 type Props = NativeStackScreenProps<StackParamList, Screens.DrawerNavigator>
 
-// TODO(ACT-771): get from Statsig
-function showKeylessBackup() {
-  return false
-}
-
 export default function DrawerNavigator({ route }: Props) {
   const { t } = useTranslation()
   const initialScreen = route.params?.initialScreen ?? Screens.WalletHome
@@ -228,6 +223,10 @@ export default function DrawerNavigator({ route }: Props) {
   const shouldShowSwapMenuInDrawerMenu = useSelector(isAppSwapsEnabledSelector) && showSwapOnMenu
 
   const shouldShowNftGallery = getFeatureGate(StatsigFeatureGates.SHOW_IN_APP_NFT_GALLERY)
+
+  const shouldShowKeylessBackup = getFeatureGate(
+    StatsigFeatureGates.SHOW_CLOUD_ACCOUNT_BACKUP_SETUP
+  )
 
   // ExchangeHomeScreen
   const celoMenuItem = (
@@ -296,7 +295,7 @@ export default function DrawerNavigator({ route }: Props) {
       )}
 
       {!backupCompleted &&
-        (showKeylessBackup() ? (
+        (shouldShowKeylessBackup ? (
           <Drawer.Screen
             // NOTE: this needs to be a different screen name from the screen
             // accessed from the settings which shows the back button instead of

--- a/src/statsig/constants.ts
+++ b/src/statsig/constants.ts
@@ -32,6 +32,8 @@ export const FeatureGates = {
   [StatsigFeatureGates.SHOW_RECEIVE_AMOUNT_IN_SELECT_PROVIDER]: false,
   [StatsigFeatureGates.SHOW_IN_APP_NFT_GALLERY]: false,
   [StatsigFeatureGates.SHOW_NOTIFICATION_CENTER]: false,
+  [StatsigFeatureGates.SHOW_CLOUD_ACCOUNT_BACKUP_SETUP]: false,
+  [StatsigFeatureGates.SHOW_CLOUD_ACCOUNT_BACKUP_RESTORE]: false,
 }
 
 export const ExperimentConfigs = {

--- a/src/statsig/types.ts
+++ b/src/statsig/types.ts
@@ -27,6 +27,8 @@ export enum StatsigFeatureGates {
   SHOW_RECEIVE_AMOUNT_IN_SELECT_PROVIDER = 'show_receive_amount_in_select_provider',
   SHOW_IN_APP_NFT_GALLERY = 'show_in_app_nft_gallery',
   SHOW_NOTIFICATION_CENTER = 'show_notification_center',
+  SHOW_CLOUD_ACCOUNT_BACKUP_SETUP = 'show_cloud_account_backup_setup',
+  SHOW_CLOUD_ACCOUNT_BACKUP_RESTORE = 'show_cloud_account_backup_restore',
 }
 
 export enum StatsigExperiments {


### PR DESCRIPTION
### Description

Setup two feature gates, one for [setup](https://console.statsig.com/4plizaPmWwPL21ASV4QAO0/gates/show_cloud_account_backup_setup) and one for [restore](https://console.statsig.com/4plizaPmWwPL21ASV4QAO0/gates/show_cloud_account_backup_restore) and used the setup feature gate to show / hide backup. restore feature gate will be used eventually when recovery flow is implemented

### Test plan

Manually by using statsig overrides and unit tests

### Related issues

- Fixes ACT-771

### Backwards compatibility

N/A
