### PR TITLE
docs(analytics): compile-time enforcement of analytics docs

### DIFF
--- a/src/analytics/Events.tsx
+++ b/src/analytics/Events.tsx
@@ -28,7 +28,7 @@ export enum AppEvents {
 }
 
 export enum HomeEvents {
-  home_send = 'home_send',
+  home_send = 'home_send', // when "send" button is pressed from home screen send or request bar (NOT from home screen actions)
   home_request = 'home_request',
   home_qr = 'home_qr',
   hamburger_tapped = 'hamburger_tapped',
@@ -304,7 +304,7 @@ export enum SendEvents {
 
   send_secure_edit = 'send_secure_edit', // when "edit" address button is pressed to manually initiate secure send flow
 
-  send_tx_start = 'send_tx_start',
+  send_tx_start = 'send_tx_start', // issued from the sendPayment saga, after a user confirms their intent to send and right before we build and send the transaction to the network
   send_tx_complete = 'send_tx_complete', // when a send transaction has successfully completed
   send_tx_error = 'send_tx_error', // when there is an error sending a transaction
 

--- a/src/analytics/Events.tsx
+++ b/src/analytics/Events.tsx
@@ -347,7 +347,6 @@ export enum FeeEvents {
   fetch_tobin_tax_failed = 'fetch_tobin_tax_failed',
 }
 
-// Generic transaction logging to grab tx hashes
 export enum TransactionEvents {
   transaction_start = 'transaction_start',
   transaction_gas_estimated = 'transaction_gas_estimated',
@@ -639,37 +638,3 @@ export enum DappShortcutsEvents {
   dapp_shortcuts_reward_tx_accepted = 'dapp_shortcuts_reward_tx_accepted', // When the user confirms the transaction via the bottom sheet
   dapp_shortcuts_reward_tx_rejected = 'dapp_shortcuts_reward_tx_rejected', // When the user rejects the transaction via the bottom sheet
 }
-
-export type AnalyticsEventType =
-  | AppEvents
-  | HomeEvents
-  | SettingsEvents
-  | KeylessBackupEvents
-  | OnboardingEvents
-  | VerificationEvents
-  | IdentityEvents
-  | AuthenticationEvents
-  | InviteEvents
-  | EscrowEvents
-  | FiatExchangeEvents
-  | SendEvents
-  | RequestEvents
-  | FeeEvents
-  | TransactionEvents
-  | CeloExchangeEvents
-  | PerformanceEvents
-  | NavigationEvents
-  | RewardsEvents
-  | WalletConnectEvents
-  | DappKitEvents
-  | CICOEvents
-  | DappExplorerEvents
-  | WebViewEvents
-  | CoinbasePayEvents
-  | SwapEvents
-  | CeloNewsEvents
-  | TokenBottomSheetEvents
-  | AssetsEvents
-  | NftEvents
-  | BuilderHooksEvents
-  | DappShortcutsEvents

--- a/src/analytics/Events.tsx
+++ b/src/analytics/Events.tsx
@@ -28,7 +28,7 @@ export enum AppEvents {
 }
 
 export enum HomeEvents {
-  home_send = 'home_send',
+  home_send = 'home_send', // when "send" button is pressed from home screen send or request bar (NOT from home screen actions)
   home_request = 'home_request',
   home_qr = 'home_qr',
   hamburger_tapped = 'hamburger_tapped',
@@ -304,7 +304,7 @@ export enum SendEvents {
 
   send_secure_edit = 'send_secure_edit', // when "edit" address button is pressed to manually initiate secure send flow
 
-  send_tx_start = 'send_tx_start',
+  send_tx_start = 'send_tx_start', // issued from the sendPayment saga, after a user confirms their intent to send and right before we build and send the transaction to the network
   send_tx_complete = 'send_tx_complete', // when a send transaction has successfully completed
   send_tx_error = 'send_tx_error', // when there is an error sending a transaction
 
@@ -347,7 +347,6 @@ export enum FeeEvents {
   fetch_tobin_tax_failed = 'fetch_tobin_tax_failed',
 }
 
-// Generic transaction logging to grab tx hashes
 export enum TransactionEvents {
   transaction_start = 'transaction_start',
   transaction_gas_estimated = 'transaction_gas_estimated',

--- a/src/analytics/Events.tsx
+++ b/src/analytics/Events.tsx
@@ -28,7 +28,7 @@ export enum AppEvents {
 }
 
 export enum HomeEvents {
-  home_send = 'home_send', // when "send" button is pressed from home screen send or request bar (NOT from home screen actions)
+  home_send = 'home_send',
   home_request = 'home_request',
   home_qr = 'home_qr',
   hamburger_tapped = 'hamburger_tapped',
@@ -304,7 +304,7 @@ export enum SendEvents {
 
   send_secure_edit = 'send_secure_edit', // when "edit" address button is pressed to manually initiate secure send flow
 
-  send_tx_start = 'send_tx_start', // issued from the sendPayment saga, after a user confirms their intent to send and right before we build and send the transaction to the network
+  send_tx_start = 'send_tx_start',
   send_tx_complete = 'send_tx_complete', // when a send transaction has successfully completed
   send_tx_error = 'send_tx_error', // when there is an error sending a transaction
 
@@ -347,6 +347,7 @@ export enum FeeEvents {
   fetch_tobin_tax_failed = 'fetch_tobin_tax_failed',
 }
 
+// Generic transaction logging to grab tx hashes
 export enum TransactionEvents {
   transaction_start = 'transaction_start',
   transaction_gas_estimated = 'transaction_gas_estimated',

--- a/src/analytics/Properties.tsx
+++ b/src/analytics/Properties.tsx
@@ -1401,3 +1401,5 @@ export type AnalyticsPropertiesList = AppEventsProperties &
   NftsEventsProperties &
   BuilderHooksProperties &
   DappShortcutsProperties
+
+export type AnalyticsEventType = keyof AnalyticsPropertiesList

--- a/src/components/CancelButton.tsx
+++ b/src/components/CancelButton.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import { StyleProp, StyleSheet, TextStyle } from 'react-native'
-import { AnalyticsEventType } from 'src/analytics/Events'
+import { AnalyticsEventType } from 'src/analytics/Properties'
 import Times from 'src/icons/Times'
 import { navigateBack } from 'src/navigator/NavigationService'
 import { TopBarIconButton, TopBarTextButton } from 'src/navigator/TopBarButton'

--- a/src/components/header/HeaderWithBackButton.tsx
+++ b/src/components/header/HeaderWithBackButton.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { AnalyticsEventType } from 'src/analytics/Events'
+import { AnalyticsEventType } from 'src/analytics/Properties'
 import BackButton from 'src/components/BackButton'
 import CustomHeader from 'src/components/header/CustomHeader'
 

--- a/src/navigator/TopBarButton.tsx
+++ b/src/navigator/TopBarButton.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import { StyleProp, StyleSheet, Text, TextStyle, ViewStyle } from 'react-native'
-import { AnalyticsEventType } from 'src/analytics/Events'
-import { AnalyticsPropertiesList } from 'src/analytics/Properties'
+import { AnalyticsPropertiesList, AnalyticsEventType } from 'src/analytics/Properties'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import Touchable from 'src/components/Touchable'
 import colors from 'src/styles/colors'


### PR DESCRIPTION
### Description

Thinking of creating a new analytics event without documenting it and leaving your poor teammates in the dark about what it does? Think again! 😈 

I wrote a script that takes all the comments on Events.tsx and populates an object mapping analytics event types to descriptions of what they are. When an analytics event is added that isn't in the object, a type error results, which prevents us from merging the changes. 

Document your analytics events!!!

... does not attempt to backfill docs on all the analytics events we've done this for in the past.

### Test plan

typescript compiles

### Related issues

na

### Backwards compatibility

na
