### PR TITLE
fix(deps): add dotenv as dev dependency for balance and fund task

### DIFF
--- a/package.json
+++ b/package.json
@@ -251,6 +251,7 @@
     "babel-plugin-module-resolver": "^4.1.0",
     "depcheck": "^1.4.3",
     "detox": "^19.13.0",
+    "dotenv": "^16.3.1",
     "escape-string-regexp": "^1.0.5",
     "eslint": "^7.32.0",
     "eslint-plugin-import": "^2.23.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7101,6 +7101,11 @@ dotenv@^10.0.0:
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-10.0.0.tgz#3d4227b8fb95f81096cdd2b66653fb2c7085ba81"
   integrity sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==
 
+dotenv@^16.3.1:
+  version "16.3.1"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.3.1.tgz#369034de7d7e5b120972693352a3bf112172cc3e"
+  integrity sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==
+
 dotenv@^8.2.0:
   version "8.6.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.6.0.tgz#061af664d19f7f4d8fc6e4ff9b584ce237adcb8b"


### PR DESCRIPTION
### Description

The balance and fund task for the e2e test wallet was failing because dotenv was removed as a dev dependency. This PR adds it back; task [failing previously](https://github.com/valora-inc/wallet/actions/workflows/e2e-faucet-balance.yml).

### Test plan

- Tested locally
- Tested in CI

### Related issues

- Fixes [ENG-78](https://linear.app/valora/issue/ENG-78/fix-balance-and-fund-task-for-e2e-tests)

### Backwards compatibility

Yes