### PR TITLE
feat(nav-drawer): upgrade to v6 and enable freeze

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "@react-native-masked-view/masked-view": "^0.2.9",
     "@react-native-picker/picker": "^2.5.0",
     "@react-navigation/devtools": "^6.0.19",
-    "@react-navigation/drawer": "^5.12.9",
+    "@react-navigation/drawer": "^6.6.3",
     "@react-navigation/elements": "^1.3.18",
     "@react-navigation/material-top-tabs": "^5.3.19",
     "@react-navigation/native": "^6.1.7",

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -7,7 +7,7 @@ import { Auth0Provider } from 'react-native-auth0'
 import { GestureHandlerRootView } from 'react-native-gesture-handler'
 import { getNumberFormatSettings } from 'react-native-localize'
 import { SafeAreaProvider } from 'react-native-safe-area-context'
-import { enableScreens } from 'react-native-screens'
+import { enableFreeze, enableScreens } from 'react-native-screens'
 import { Provider } from 'react-redux'
 import { PersistGate } from 'redux-persist/integration/react'
 import { apolloClient } from 'src/apollo/index'
@@ -23,6 +23,8 @@ Logger.debug('App/init', 'Current Language: ' + i18n.language)
 
 // Explicitly enable screens for react-native-screens
 enableScreens(true)
+// Prevent inactive screens from rerendering https://reactnavigation.org/docs/native-stack-navigator#freezeonblur
+enableFreeze(true)
 
 const ignoreWarnings = [
   'componentWillReceiveProps',

--- a/src/navigator/DrawerNavigator.tsx
+++ b/src/navigator/DrawerNavigator.tsx
@@ -1,7 +1,6 @@
 import {
   createDrawerNavigator,
   DrawerContentComponentProps,
-  DrawerContentOptions,
   DrawerContentScrollView,
 } from '@react-navigation/drawer'
 import {
@@ -80,7 +79,10 @@ const TAG = 'NavigationService'
 
 const Drawer = createDrawerNavigator()
 
-type CustomDrawerItemListProps = Omit<DrawerContentOptions, 'contentContainerStyle' | 'style'> & {
+type CustomDrawerItemListProps = Omit<
+  DrawerContentComponentProps,
+  'contentContainerStyle' | 'style'
+> & {
   state: DrawerNavigationState<ParamListBase>
   navigation: DrawerNavigationHelpers
   descriptors: DrawerDescriptorMap
@@ -97,7 +99,6 @@ function CustomDrawerItemList({
   state,
   navigation,
   descriptors,
-  itemStyle,
   protectedRoutes,
   ...passThroughProps
 }: CustomDrawerItemListProps) {
@@ -149,7 +150,11 @@ function CustomDrawerItemList({
         label={drawerLabel !== undefined ? drawerLabel : title !== undefined ? title : route.name}
         icon={drawerIcon}
         focused={focused}
-        style={itemStyle}
+        labelStyle={[
+          fontStyles.regular,
+          { color: colors.dark, marginLeft: -20, fontWeight: 'normal' },
+        ]}
+        style={focused && { backgroundColor: colors.gray2 }}
         to={buildLink(route.name, route.params)}
         onPress={onPress}
       />
@@ -157,7 +162,7 @@ function CustomDrawerItemList({
   }) as React.ReactNode as React.ReactElement
 }
 
-function CustomDrawerContent(props: DrawerContentComponentProps<DrawerContentOptions>) {
+function CustomDrawerContent(props: DrawerContentComponentProps) {
   const { t } = useTranslation()
   const displayName = useSelector(nameSelector)
   const e164PhoneNumber = useSelector(e164NumberSelector)
@@ -218,9 +223,7 @@ export default function DrawerNavigator({ route }: Props) {
     ExperimentConfigs[StatsigExperiments.DAPP_MENU_ITEM_COPY]
   )
 
-  const drawerContent = (props: DrawerContentComponentProps<DrawerContentOptions>) => (
-    <CustomDrawerContent {...props} />
-  )
+  const drawerContent = (props: DrawerContentComponentProps) => <CustomDrawerContent {...props} />
 
   const shouldShowSwapMenuInDrawerMenu = useSelector(isAppSwapsEnabledSelector) && showSwapOnMenu
 
@@ -245,13 +248,10 @@ export default function DrawerNavigator({ route }: Props) {
       initialRouteName={initialScreen}
       drawerContent={drawerContent}
       backBehavior={'initialRoute'}
-      drawerContentOptions={{
-        labelStyle: [fontStyles.regular, { marginLeft: -20, fontWeight: 'normal' }],
-        activeBackgroundColor: colors.gray2,
-      }}
-      // Reloads the screen when the user comes back to it - resetting navigation state
       screenOptions={{
-        unmountOnBlur: true,
+        unmountOnBlur: true, // Reloads the screen when the user comes back to it - resetting navigation
+        headerShown: false, // Hide the default header on v6
+        drawerType: 'front', // Makes the drawer overlay the content
       }}
       // Whether inactive screens should be detached from the view hierarchy to save memory.
       // Defaults to true, but also explicitly set here.

--- a/src/navigator/DrawerNavigator.tsx
+++ b/src/navigator/DrawerNavigator.tsx
@@ -260,7 +260,12 @@ export default function DrawerNavigator({ route }: Props) {
       <Drawer.Screen
         name={Screens.WalletHome}
         component={WalletHome}
-        options={{ title: t('home') ?? undefined, drawerIcon: Home, unmountOnBlur: false }}
+        options={{
+          title: t('home') ?? undefined,
+          drawerIcon: Home,
+          unmountOnBlur: false,
+          freezeOnBlur: false,
+        }}
       />
       {shouldShowNftGallery && (
         <Drawer.Screen

--- a/src/qrcode/QRScanner.tsx
+++ b/src/qrcode/QRScanner.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native'
+import { Keyboard, StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native'
 import { RNCamera } from 'react-native-camera'
 import DeviceInfo from 'react-native-device-info'
 import { useSafeAreaFrame, useSafeAreaInsets } from 'react-native-safe-area-context'
@@ -69,6 +69,7 @@ export default function QRScanner({ onBarCodeDetected }: QRScannerProps) {
   }
 
   const submitModal = () => {
+    Keyboard.dismiss()
     onBarCodeDetected({ type: '', data: value })
     closeModal()
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3033,13 +3033,14 @@
     nanoid "^3.1.23"
     stacktrace-parser "^0.1.10"
 
-"@react-navigation/drawer@^5.12.9":
-  version "5.12.9"
-  resolved "https://registry.yarnpkg.com/@react-navigation/drawer/-/drawer-5.12.9.tgz#b07d7391a6fea4ce07cd7a7421fdbaea37cdbb46"
-  integrity sha512-SYb2BCEAn+BiEwC6WBfCzs1VlWD+ZdQbxmsim6vo1o+ndPW2e+kiq7FXKRs0vUXhQRZVl2oOB3vBn0c3YCllQg==
+"@react-navigation/drawer@^6.6.3":
+  version "6.6.3"
+  resolved "https://registry.yarnpkg.com/@react-navigation/drawer/-/drawer-6.6.3.tgz#ad48b3e0a2d2771e7fc8bc46a8b269ef2ae11e54"
+  integrity sha512-oQzHqH6svtSIun6+rikQtku6ye2CyyxT4xf3RQLVsBvK7+g4tDdKKLcjgoJmuT1zBZC3SSu3wNeqp8cg4cr2PQ==
   dependencies:
-    color "^3.1.3"
-    react-native-iphone-x-helper "^1.3.0"
+    "@react-navigation/elements" "^1.3.18"
+    color "^4.2.3"
+    warn-once "^0.1.0"
 
 "@react-navigation/elements@^1.3.18":
   version "1.3.18"
@@ -6348,7 +6349,7 @@ color-name@^1.0.0, color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
-color-string@^1.5.4:
+color-string@^1.5.4, color-string@^1.9.0:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/color-string/-/color-string-1.9.1.tgz#4467f9146f036f855b764dfb5bf8582bf342c7a4"
   integrity sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==
@@ -6363,6 +6364,14 @@ color@^3.1.3:
   dependencies:
     color-convert "^1.9.1"
     color-string "^1.5.4"
+
+color@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/color/-/color-4.2.3.tgz#d781ecb5e57224ee43ea9627560107c0e0c6463a"
+  integrity sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==
+  dependencies:
+    color-convert "^2.0.1"
+    color-string "^1.9.0"
 
 colorette@^1.0.7:
   version "1.2.2"
@@ -14026,11 +14035,6 @@ react-native-in-app-review@^4.3.3:
   version "4.3.3"
   resolved "https://registry.yarnpkg.com/react-native-in-app-review/-/react-native-in-app-review-4.3.3.tgz#61f09f110de18f0a470a9bb55b9f49600390085f"
   integrity sha512-Q9sXBtK8tCBYFPCGmMgeMlkxXC5e6vAyPZK26OC1oOKUuKUd0QORnryk/qbwnuN4fLshHQN8UKlLgyHLGRuK3A==
-
-react-native-iphone-x-helper@^1.3.0:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/react-native-iphone-x-helper/-/react-native-iphone-x-helper-1.3.1.tgz#20c603e9a0e765fd6f97396638bdeb0e5a60b010"
-  integrity sha512-HOf0jzRnq2/aFUcdCJ9w9JGzN3gdEg0zFE4FyYlp4jtidqU03D5X7ZegGKfT1EWteR0gPBGp9ye5T5FvSWi9Yg==
 
 react-native-keychain@8.0.0:
   version "8.0.0"


### PR DESCRIPTION
### Description

Updates @react-navigation/drawer to v6 and enables freeze for performance improvements. Some prop changes were needed to maintain existing styles and behavior.

Freeze works as follows:
> ...Using Suspense mechanism introduced in React 17. The main use case of this library is to avoid unnecessary re-renders of parts of the app that are not visible to the user at a given moment. The frozen components are not unmounted when they are replaced with a placeholder view, so their React state and corresponding native view instances are retained during the freeze (DOM elements for react-dom or platform-native views for React Native apps) keeping things like scroll position, input state, or loaded images (for <img> components) unchanged. [source](https://github.com/software-mansion/react-freeze).

| iOS Before | iOS After | Android Before | Android After |
| :---: | :---: | :---: | :---: |
| ![](https://github.com/valora-inc/wallet/assets/26950305/3375b1e1-193c-4f84-b653-b17db439262f "iOS Before") | ![](https://github.com/valora-inc/wallet/assets/26950305/804d2ddf-7fff-461a-82f0-288944ca5b63 "iOS After")| ![](https://github.com/valora-inc/wallet/assets/26950305/81d12fc3-fa9b-4467-9143-b429946b538d "Android Before") | ![](https://github.com/valora-inc/wallet/assets/26950305/5bcd5206-3713-47a7-841d-3b7407978e71 "Android After") |

### Test plan

- Tested locally on Android & iOS

### Related issues

N/A

### Backwards compatibility

Yes