### PR TITLE
fix: add AD_ID permission for android 12+

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
   <uses-permission android:name="android.permission.CAMERA" />
   <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+  <uses-permission android:name="com.google.android.gms.permission.AD_ID" />
 
   <application android:name=".MainApplication" android:allowBackup="false" android:icon="@mipmap/ic_launcher" android:roundIcon="@mipmap/ic_launcher_round" android:label="@string/app_name" android:theme="@style/AppTheme" android:networkSecurityConfig="@xml/network_security_config">
     <profileable android:shell="@bool/is_profiling_build"/>


### PR DESCRIPTION
### Description

The [nightly build](https://github.com/valora-inc/release-automation/actions/runs/6007413531/job/16293507460) picked up this issue - to continue using Adjust (which uses AD_ID) we need to declare it in the AndroidManifest.xml as well as complete the Advertising ID form in the google play console.

[Apparently we are still using Adjust.](https://valora-app.slack.com/archives/C0257HQBWF8/p1690892743484089)

### Test plan

n/a

### Related issues

- Fixes RET-792

### Backwards compatibility

Y
