### PR TITLE
fix: ensure private keys stored without the 0x prefix can be used for signing

### DIFF
--- a/src/web3/KeychainSigner.ts
+++ b/src/web3/KeychainSigner.ts
@@ -86,7 +86,17 @@ async function getStoredPrivateKey(
     throw new Error('No private key found in storage')
   }
 
-  return await decryptPrivateKey(encryptedPrivateKey, password)
+  const privateKey = await decryptPrivateKey(encryptedPrivateKey, password)
+  if (!privateKey) {
+    return privateKey
+  }
+
+  // There was a bug introduced in https://github.com/valora-inc/wallet/blob/f7b3a2cc7c2689a17b7eb50edfdb1b8743f441d1/src/web3/KeychainAccountManager.ts#L63-L71
+  // which caused the private key to be stored without the 0x prefix
+  // so all accounts created or imported after that change will have the private key stored without the 0x prefix
+  // Later on we reverted the code with the bug and it caused signing issues for these accounts.
+  // Here we make sure that we always return the private key with the 0x prefix
+  return normalizeAddressWith0x(privateKey)
 }
 
 /**


### PR DESCRIPTION
### Description

This fixes always failing transactions for accounts created or imported after #3920 and used after #4098.

The bug was introduced in https://github.com/valora-inc/wallet/blob/f7b3a2cc7c2689a17b7eb50edfdb1b8743f441d1/src/web3/KeychainAccountManager.ts#L63-L71

It caused the private key to be stored without the 0x prefix.

At the time it was harmless because unlocking the account would then normalize the private key https://github.com/valora-inc/wallet/blob/f7b3a2cc7c2689a17b7eb50edfdb1b8743f441d1/src/web3/KeychainAccountManager.ts#L111

But when #4098 was merged, reverting #3920, this wasn't the case anymore and made the problem apparent.

### Test plan

- Added unit test
- Manually confirmed by importing an account with 1d9939fe7615591e1b7c79fcb73583b0c3bc8f70 and ensuring it can still be used after 0ff5faff58fcc5dfb420392ba1159dd8ae42d5c8 when this fix is applied.

### Related issues

- Slack [thread](https://valora-app.slack.com/archives/C04B61SJ6DS/p1693305352039569)

### Backwards compatibility

Yes