### PR TITLE
refactor: remove deprecated `getLocalCurrencyToDollarsExchangeRate` selector

### DIFF
--- a/src/exchange/CeloGoldHistoryChart.tsx
+++ b/src/exchange/CeloGoldHistoryChart.tsx
@@ -12,13 +12,14 @@ import { LocalCurrencyCode } from 'src/localCurrency/consts'
 import { convertDollarsToLocalAmount } from 'src/localCurrency/convert'
 import {
   getLocalCurrencyCode,
-  getLocalCurrencyToDollarsExchangeRate,
+  localCurrencyExchangeRatesSelector,
 } from 'src/localCurrency/selectors'
 import useSelector from 'src/redux/useSelector'
 import colors from 'src/styles/colors'
 import { Spacing } from 'src/styles/styles'
 import variables from 'src/styles/variables'
 import { tokensBySymbolSelector } from 'src/tokens/selectors'
+import { Currency } from 'src/utils/currencies'
 import { getLocalCurrencyDisplayValue } from 'src/utils/formatting'
 import { formatFeedDate } from 'src/utils/time'
 import { VictoryGroup, VictoryLine, VictoryScatter } from 'victory-native'
@@ -182,7 +183,7 @@ function CeloGoldHistoryChart({ testID, i18n }: Props) {
       getLocalCurrencyDisplayValue(amount, localCurrencyCode || LocalCurrencyCode.USD, true),
     [localCurrencyCode]
   )
-  const localExchangeRate = useSelector(getLocalCurrencyToDollarsExchangeRate)
+  const localExchangeRate = useSelector(localCurrencyExchangeRatesSelector)?.[Currency.Dollar]
   const dollarsToLocal = useCallback(
     (amount: BigNumber.Value | null) =>
       convertDollarsToLocalAmount(amount, localCurrencyCode ? localExchangeRate : 1),

--- a/src/exchange/ExchangeHomeScreen.tsx
+++ b/src/exchange/ExchangeHomeScreen.tsx
@@ -17,7 +17,7 @@ import { LocalCurrencyCode } from 'src/localCurrency/consts'
 import { convertDollarsToLocalAmount } from 'src/localCurrency/convert'
 import {
   getLocalCurrencyCode,
-  getLocalCurrencyToDollarsExchangeRate,
+  localCurrencyExchangeRatesSelector,
 } from 'src/localCurrency/selectors'
 import DrawerTopBar from 'src/navigator/DrawerTopBar'
 import { navigate } from 'src/navigator/NavigationService'
@@ -28,6 +28,7 @@ import colors from 'src/styles/colors'
 import fontStyles from 'src/styles/fonts'
 import variables from 'src/styles/variables'
 import { tokensBySymbolSelector } from 'src/tokens/selectors'
+import { Currency } from 'src/utils/currencies'
 import { getLocalCurrencyDisplayValue } from 'src/utils/formatting'
 
 function navigateToGuide() {
@@ -74,7 +75,7 @@ function ExchangeHomeScreen() {
 
   const tokensBySymbol = useSelector(tokensBySymbolSelector)
   const localCurrencyCode = useSelector(getLocalCurrencyCode)
-  const localExchangeRate = useSelector(getLocalCurrencyToDollarsExchangeRate)
+  const localExchangeRate = useSelector(localCurrencyExchangeRatesSelector)?.[Currency.Dollar]
   const exchangeHistory = useSelector(exchangeHistorySelector)
 
   const exchangeHistoryLength = exchangeHistory.aggregatedExchangeRates.length

--- a/src/localCurrency/hooks.ts
+++ b/src/localCurrency/hooks.ts
@@ -10,7 +10,6 @@ import {
 import {
   getLocalCurrencyCode,
   getLocalCurrencySymbol,
-  getLocalCurrencyToDollarsExchangeRate,
   localCurrencyExchangeRatesSelector,
 } from 'src/localCurrency/selectors'
 import { CurrencyInfo } from 'src/localCurrency/types'
@@ -18,7 +17,7 @@ import useSelector from 'src/redux/useSelector'
 import { Currency } from 'src/utils/currencies'
 
 export function useDollarToLocalRate() {
-  return useSelector(getLocalCurrencyToDollarsExchangeRate)
+  return useSelector(localCurrencyExchangeRatesSelector)?.[Currency.Dollar]
 }
 
 export function useLocalCurrencyToShow(amount: MoneyAmount, currencyInfo?: CurrencyInfo) {

--- a/src/localCurrency/selectors.ts
+++ b/src/localCurrency/selectors.ts
@@ -74,12 +74,6 @@ export const localCurrencyToUsdSelector = createSelector(
   (exchangeRates) => exchangeRates[Currency.Dollar]
 )
 
-// deprecated, please use |localCurrencyExchangeRatesSelector| instead.
-export function getLocalCurrencyToDollarsExchangeRate(state: RootState) {
-  const exchangeRates = localCurrencyExchangeRatesSelector(state)
-  return exchangeRates?.[Currency.Dollar]
-}
-
 export function shouldFetchCurrentRate(state: RootState): boolean {
   const { isLoading, lastSuccessfulUpdate } = state.localCurrency
 


### PR DESCRIPTION
### Description

Minor refactor to remove the deprecated `getLocalCurrencyToDollarsExchangeRate` selector.

Note that we'll remove `localCurrencyExchangeRatesSelector` soon too.

### Test plan

- Unit tests pass

### Related issues

- Fixes RET-830

### Backwards compatibility

Yes
