### PR TITLE
refactor: remove all external usage of `localCurrencyExchangeRatesSelector`

### DIFF
--- a/src/exchange/CeloGoldHistoryChart.tsx
+++ b/src/exchange/CeloGoldHistoryChart.tsx
@@ -10,16 +10,12 @@ import { exchangeHistorySelector } from 'src/exchange/reducer'
 import { withTranslation } from 'src/i18n'
 import { LocalCurrencyCode } from 'src/localCurrency/consts'
 import { convertDollarsToLocalAmount } from 'src/localCurrency/convert'
-import {
-  getLocalCurrencyCode,
-  localCurrencyExchangeRatesSelector,
-} from 'src/localCurrency/selectors'
+import { getLocalCurrencyCode, usdToLocalCurrencyRateSelector } from 'src/localCurrency/selectors'
 import useSelector from 'src/redux/useSelector'
 import colors from 'src/styles/colors'
 import { Spacing } from 'src/styles/styles'
 import variables from 'src/styles/variables'
 import { tokensBySymbolSelector } from 'src/tokens/selectors'
-import { Currency } from 'src/utils/currencies'
 import { getLocalCurrencyDisplayValue } from 'src/utils/formatting'
 import { formatFeedDate } from 'src/utils/time'
 import { VictoryGroup, VictoryLine, VictoryScatter } from 'victory-native'
@@ -183,7 +179,7 @@ function CeloGoldHistoryChart({ testID, i18n }: Props) {
       getLocalCurrencyDisplayValue(amount, localCurrencyCode || LocalCurrencyCode.USD, true),
     [localCurrencyCode]
   )
-  const localExchangeRate = useSelector(localCurrencyExchangeRatesSelector)?.[Currency.Dollar]
+  const localExchangeRate = useSelector(usdToLocalCurrencyRateSelector)
   const dollarsToLocal = useCallback(
     (amount: BigNumber.Value | null) =>
       convertDollarsToLocalAmount(amount, localCurrencyCode ? localExchangeRate : 1),

--- a/src/exchange/ExchangeHomeScreen.tsx
+++ b/src/exchange/ExchangeHomeScreen.tsx
@@ -15,10 +15,7 @@ import { exchangeHistorySelector } from 'src/exchange/reducer'
 import InfoIcon from 'src/icons/InfoIcon'
 import { LocalCurrencyCode } from 'src/localCurrency/consts'
 import { convertDollarsToLocalAmount } from 'src/localCurrency/convert'
-import {
-  getLocalCurrencyCode,
-  localCurrencyExchangeRatesSelector,
-} from 'src/localCurrency/selectors'
+import { getLocalCurrencyCode, usdToLocalCurrencyRateSelector } from 'src/localCurrency/selectors'
 import DrawerTopBar from 'src/navigator/DrawerTopBar'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
@@ -28,7 +25,6 @@ import colors from 'src/styles/colors'
 import fontStyles from 'src/styles/fonts'
 import variables from 'src/styles/variables'
 import { tokensBySymbolSelector } from 'src/tokens/selectors'
-import { Currency } from 'src/utils/currencies'
 import { getLocalCurrencyDisplayValue } from 'src/utils/formatting'
 
 function navigateToGuide() {
@@ -75,7 +71,7 @@ function ExchangeHomeScreen() {
 
   const tokensBySymbol = useSelector(tokensBySymbolSelector)
   const localCurrencyCode = useSelector(getLocalCurrencyCode)
-  const localExchangeRate = useSelector(localCurrencyExchangeRatesSelector)?.[Currency.Dollar]
+  const localExchangeRate = useSelector(usdToLocalCurrencyRateSelector)
   const exchangeHistory = useSelector(exchangeHistorySelector)
 
   const exchangeHistoryLength = exchangeHistory.aggregatedExchangeRates.length

--- a/src/fiatExchanges/FiatExchangeAmount.tsx
+++ b/src/fiatExchanges/FiatExchangeAmount.tsx
@@ -32,8 +32,8 @@ import { attemptReturnUserFlow } from 'src/fiatconnect/slice'
 import i18n from 'src/i18n'
 import { LocalCurrencyCode, LocalCurrencySymbol } from 'src/localCurrency/consts'
 import { useLocalCurrencyCode } from 'src/localCurrency/hooks'
-import { localCurrencyExchangeRatesSelector } from 'src/localCurrency/selectors'
-import { HeaderTitleWithTokenBalance, emptyHeader } from 'src/navigator/Headers'
+import { usdToLocalCurrencyRateSelector } from 'src/localCurrency/selectors'
+import { emptyHeader, HeaderTitleWithTokenBalance } from 'src/navigator/Headers'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import { StackParamList } from 'src/navigator/types'
@@ -48,9 +48,9 @@ import {
   useTokenInfoBySymbol,
   useTokenToLocalAmount,
 } from 'src/tokens/hooks'
-import Logger from 'src/utils/Logger'
-import { CiCoCurrency, Currency, currencyForAnalytics } from 'src/utils/currencies'
+import { CiCoCurrency, currencyForAnalytics } from 'src/utils/currencies'
 import { roundUp } from 'src/utils/formatting'
+import Logger from 'src/utils/Logger'
 import { CICOFlow, isUserInputCrypto } from './utils'
 
 const TAG = 'FiatExchangeAmount'
@@ -85,7 +85,7 @@ function FiatExchangeAmount({ route }: Props) {
   const inputConvertedToLocalCurrency =
     useTokenToLocalAmount(parsedInputAmount, address) || new BigNumber(0)
   const localCurrencyCode = useLocalCurrencyCode()
-  const exchangeRates = useSelector(localCurrencyExchangeRatesSelector)
+  const usdToLocalRate = useSelector(usdToLocalCurrencyRateSelector)
   const cachedFiatAccountUses = useSelector(cachedFiatAccountUsesSelector)
   const attemptReturnUserFlowLoading = useSelector(attemptReturnUserFlowLoadingSelector)
 
@@ -274,7 +274,7 @@ function FiatExchangeAmount({ route }: Props) {
       )}
       <Button
         onPress={onPressContinue}
-        showLoading={exchangeRates[Currency.Dollar] === null || attemptReturnUserFlowLoading}
+        showLoading={usdToLocalRate === null || attemptReturnUserFlowLoading}
         text={t('next')}
         type={BtnTypes.PRIMARY}
         accessibilityLabel={t('next') ?? undefined}

--- a/src/fiatExchanges/PaymentMethodSection.tsx
+++ b/src/fiatExchanges/PaymentMethodSection.tsx
@@ -15,10 +15,7 @@ import { getSettlementTimeString } from 'src/fiatExchanges/quotes/utils'
 import { ProviderSelectionAnalyticsData } from 'src/fiatExchanges/types'
 import { CICOFlow, PaymentMethod } from 'src/fiatExchanges/utils'
 import InfoIcon from 'src/icons/InfoIcon'
-import {
-  getLocalCurrencyCode,
-  localCurrencyExchangeRatesSelector,
-} from 'src/localCurrency/selectors'
+import { getLocalCurrencyCode, usdToLocalCurrencyRateSelector } from 'src/localCurrency/selectors'
 import { getFeatureGate } from 'src/statsig'
 import { StatsigFeatureGates } from 'src/statsig/types'
 import colors from 'src/styles/colors'
@@ -59,7 +56,7 @@ export function PaymentMethodSection({
   const sectionQuotes = normalizedQuotes.filter(
     (quote) => quote.getPaymentMethod() === paymentMethod
   )
-  const exchangeRates = useSelector(localCurrencyExchangeRatesSelector)!
+  const exchangeRates = useSelector(usdToLocalCurrencyRateSelector)!
   const tokenInfo = useTokenInfoBySymbol(cryptoType)
   const localCurrency = useSelector(getLocalCurrencyCode)
 

--- a/src/fiatExchanges/SelectProvider.tsx
+++ b/src/fiatExchanges/SelectProvider.tsx
@@ -1,5 +1,6 @@
 import { RouteProp } from '@react-navigation/native'
 import { NativeStackScreenProps } from '@react-navigation/native-stack'
+import _ from 'lodash'
 import React, { useEffect, useMemo, useState } from 'react'
 import { useAsync } from 'react-async-hook'
 import { Trans, useTranslation } from 'react-i18next'
@@ -15,19 +16,6 @@ import BackButton from 'src/components/BackButton'
 import Dialog from 'src/components/Dialog'
 import TextButton from 'src/components/TextButton'
 import Touchable from 'src/components/Touchable'
-import { CoinbasePaymentSection } from 'src/fiatExchanges/CoinbasePaymentSection'
-import { ExternalExchangeProvider } from 'src/fiatExchanges/ExternalExchanges'
-import {
-  PaymentMethodSection,
-  PaymentMethodSectionMethods,
-} from 'src/fiatExchanges/PaymentMethodSection'
-import { CryptoAmount, FiatAmount } from 'src/fiatExchanges/amount'
-import { normalizeQuotes } from 'src/fiatExchanges/quotes/normalizeQuotes'
-import {
-  ProviderSelectionAnalyticsData,
-  SelectProviderExchangesLink,
-  SelectProviderExchangesText,
-} from 'src/fiatExchanges/types'
 import {
   fiatConnectProvidersSelector,
   fiatConnectQuotesErrorSelector,
@@ -36,12 +24,25 @@ import {
   selectFiatConnectQuoteLoadingSelector,
 } from 'src/fiatconnect/selectors'
 import { fetchFiatConnectProviders, fetchFiatConnectQuotes } from 'src/fiatconnect/slice'
+import { CryptoAmount, FiatAmount } from 'src/fiatExchanges/amount'
+import { CoinbasePaymentSection } from 'src/fiatExchanges/CoinbasePaymentSection'
+import { ExternalExchangeProvider } from 'src/fiatExchanges/ExternalExchanges'
+import {
+  PaymentMethodSection,
+  PaymentMethodSectionMethods,
+} from 'src/fiatExchanges/PaymentMethodSection'
+import { normalizeQuotes } from 'src/fiatExchanges/quotes/normalizeQuotes'
+import {
+  ProviderSelectionAnalyticsData,
+  SelectProviderExchangesLink,
+  SelectProviderExchangesText,
+} from 'src/fiatExchanges/types'
 import { readOnceFromFirebase } from 'src/firebase/firebase'
 import i18n from 'src/i18n'
 import {
   getDefaultLocalCurrencyCode,
   getLocalCurrencyCode,
-  localCurrencyExchangeRatesSelector,
+  usdToLocalCurrencyRateSelector,
 } from 'src/localCurrency/selectors'
 import { emptyHeader } from 'src/navigator/Headers'
 import { navigate } from 'src/navigator/NavigationService'
@@ -56,9 +57,9 @@ import fontStyles from 'src/styles/fonts'
 import { Spacing } from 'src/styles/styles'
 import variables from 'src/styles/variables'
 import { useTokenInfoBySymbol } from 'src/tokens/hooks'
-import Logger from 'src/utils/Logger'
 import { CiCoCurrency } from 'src/utils/currencies'
 import { navigateToURI } from 'src/utils/linking'
+import Logger from 'src/utils/Logger'
 import { currentAccountSelector } from 'src/web3/selectors'
 import {
   CICOFlow,
@@ -73,7 +74,6 @@ import {
   PaymentMethod,
   resolveCloudFunctionDigitalAsset,
 } from './utils'
-import _ from 'lodash'
 
 const TAG = 'SelectProviderScreen'
 
@@ -107,7 +107,7 @@ export default function SelectProviderScreen({ route, navigation }: Props) {
   const fiatConnectQuotesError = useSelector(fiatConnectQuotesErrorSelector)
   const fiatConnectProviders = useSelector(fiatConnectProvidersSelector)
   const selectFiatConnectQuoteLoading = useSelector(selectFiatConnectQuoteLoadingSelector)
-  const exchangeRates = useSelector(localCurrencyExchangeRatesSelector)
+  const usdToLocalRate = useSelector(usdToLocalCurrencyRateSelector)
   const tokenInfo = useTokenInfoBySymbol(digitalAsset)
 
   const { t } = useTranslation()
@@ -217,7 +217,7 @@ export default function SelectProviderScreen({ route, navigation }: Props) {
   const analyticsData = getProviderSelectionAnalyticsData({
     normalizedQuotes,
     legacyMobileMoneyProviders,
-    exchangeRates,
+    usdToLocalRate: usdToLocalRate,
     tokenInfo,
     centralizedExchanges: exchanges,
     coinbasePayAvailable: coinbasePayVisible,

--- a/src/fiatExchanges/quotes/ExternalQuote.test.ts
+++ b/src/fiatExchanges/quotes/ExternalQuote.test.ts
@@ -11,11 +11,7 @@ import { mockCusdAddress, mockProviders, mockProviderSelectionAnalyticsData } fr
 
 jest.mock('src/analytics/ValoraAnalytics')
 
-const mockExchangeRates = {
-  cGLD: '2',
-  cUSD: '2',
-  cEUR: '2',
-}
+const mockUsdToLocalRate = '2'
 
 const mockTokenInfo = {
   balance: new BigNumber('10'),
@@ -89,7 +85,7 @@ describe('ExternalQuote', () => {
         provider: mockProviders[0],
         flow: CICOFlow.CashIn,
       })
-      expect(quote.getFeeInCrypto(mockExchangeRates, mockTokenInfo)).toEqual(new BigNumber(3))
+      expect(quote.getFeeInCrypto(mockUsdToLocalRate, mockTokenInfo)).toEqual(new BigNumber(3))
     })
     it('returns converted fee for other', () => {
       const quote = new ExternalQuote({
@@ -97,7 +93,7 @@ describe('ExternalQuote', () => {
         provider: mockProviders[1],
         flow: CICOFlow.CashIn,
       })
-      expect(quote.getFeeInCrypto(mockExchangeRates, mockTokenInfo)).toEqual(new BigNumber(2.5))
+      expect(quote.getFeeInCrypto(mockUsdToLocalRate, mockTokenInfo)).toEqual(new BigNumber(2.5))
     })
     it('returns null when fee is unspecified', () => {
       const quote = new ExternalQuote({
@@ -108,7 +104,7 @@ describe('ExternalQuote', () => {
         provider: mockProviders[1],
         flow: CICOFlow.CashIn,
       })
-      expect(quote.getFeeInCrypto(mockExchangeRates, mockTokenInfo)).toEqual(null)
+      expect(quote.getFeeInCrypto(mockUsdToLocalRate, mockTokenInfo)).toEqual(null)
     })
   })
 
@@ -119,7 +115,7 @@ describe('ExternalQuote', () => {
         provider: mockProviders[0],
         flow: CICOFlow.CashIn,
       })
-      expect(quote.getFeeInFiat(mockExchangeRates, mockTokenInfo)).toEqual(new BigNumber(6))
+      expect(quote.getFeeInFiat(mockUsdToLocalRate, mockTokenInfo)).toEqual(new BigNumber(6))
     })
     it('returns fee for other', () => {
       const quote = new ExternalQuote({
@@ -127,7 +123,7 @@ describe('ExternalQuote', () => {
         provider: mockProviders[1],
         flow: CICOFlow.CashIn,
       })
-      expect(quote.getFeeInFiat(mockExchangeRates, mockTokenInfo)).toEqual(new BigNumber(5))
+      expect(quote.getFeeInFiat(mockUsdToLocalRate, mockTokenInfo)).toEqual(new BigNumber(5))
     })
     it('returns null when fee is unspecified', () => {
       const quote = new ExternalQuote({
@@ -138,7 +134,7 @@ describe('ExternalQuote', () => {
         provider: mockProviders[1],
         flow: CICOFlow.CashIn,
       })
-      expect(quote.getFeeInFiat(mockExchangeRates, mockTokenInfo)).toEqual(null)
+      expect(quote.getFeeInFiat(mockUsdToLocalRate, mockTokenInfo)).toEqual(null)
     })
   })
 

--- a/src/fiatExchanges/quotes/ExternalQuote.ts
+++ b/src/fiatExchanges/quotes/ExternalQuote.ts
@@ -17,7 +17,7 @@ import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import { TokenBalance } from 'src/tokens/slice'
 import { convertLocalToTokenAmount } from 'src/tokens/utils'
-import { CiCoCurrency, Currency, resolveCICOCurrency } from 'src/utils/currencies'
+import { CiCoCurrency, resolveCICOCurrency } from 'src/utils/currencies'
 import { navigateToURI } from 'src/utils/linking'
 
 const strings = {
@@ -71,22 +71,16 @@ export default class ExternalQuote extends NormalizedQuote {
       : resolveCICOCurrency(this.quote.digitalAsset)!
   }
 
-  getFeeInCrypto(
-    exchangeRates: { [token in Currency]: string | null },
-    tokenInfo: TokenBalance
-  ): BigNumber | null {
-    const fee = this.getFeeInFiat(exchangeRates, tokenInfo)
+  getFeeInCrypto(usdToLocalRate: string | null, tokenInfo: TokenBalance): BigNumber | null {
+    const fee = this.getFeeInFiat(usdToLocalRate, tokenInfo)
     return convertLocalToTokenAmount({
       localAmount: fee,
-      exchangeRates,
+      usdToLocalRate: usdToLocalRate,
       tokenInfo,
     })
   }
 
-  getFeeInFiat(
-    _exchangeRates: { [token in Currency]: string | null },
-    _tokenInfo: TokenBalance
-  ): BigNumber | null {
+  getFeeInFiat(_usdToLocalRate: string | null, _tokenInfo: TokenBalance): BigNumber | null {
     if (isSimplexQuote(this.quote)) {
       return new BigNumber(this.quote.fiat_money.total_amount).minus(
         new BigNumber(this.quote.fiat_money.base_amount)

--- a/src/fiatExchanges/quotes/FiatConnectQuote.test.ts
+++ b/src/fiatExchanges/quotes/FiatConnectQuote.test.ts
@@ -47,11 +47,7 @@ jest.mock('src/fiatExchanges/quotes/constants', () => {
   }
 })
 
-const mockExchangeRates = {
-  cGLD: '2',
-  cUSD: '2',
-  cEUR: '2',
-}
+const mockUsdToLocalRate = '2'
 
 const mockTokenInfo = {
   balance: new BigNumber('10'),
@@ -172,7 +168,7 @@ describe('FiatConnectQuote', () => {
         quote: quoteData,
         fiatAccountType: FiatAccountType.BankAccount,
       })
-      expect(quote.getFeeInCrypto(mockExchangeRates, mockTokenInfo)).toBeNull()
+      expect(quote.getFeeInCrypto(mockUsdToLocalRate, mockTokenInfo)).toBeNull()
     })
     it('returns fee directly for cash out', () => {
       const quote = new FiatConnectQuote({
@@ -180,7 +176,7 @@ describe('FiatConnectQuote', () => {
         quote: mockFiatConnectQuotes[1] as FiatConnectQuoteSuccess,
         fiatAccountType: FiatAccountType.BankAccount,
       })
-      expect(quote.getFeeInCrypto(mockExchangeRates, mockTokenInfo)).toEqual(new BigNumber(0.53))
+      expect(quote.getFeeInCrypto(mockUsdToLocalRate, mockTokenInfo)).toEqual(new BigNumber(0.53))
     })
     it('returns converted fee for cash in', () => {
       const quote = new FiatConnectQuote({
@@ -188,7 +184,7 @@ describe('FiatConnectQuote', () => {
         quote: mockFiatConnectQuotes[1] as FiatConnectQuoteSuccess,
         fiatAccountType: FiatAccountType.BankAccount,
       })
-      expect(quote.getFeeInCrypto(mockExchangeRates, mockTokenInfo)).toEqual(new BigNumber(0.265))
+      expect(quote.getFeeInCrypto(mockUsdToLocalRate, mockTokenInfo)).toEqual(new BigNumber(0.265))
     })
   })
 
@@ -201,7 +197,7 @@ describe('FiatConnectQuote', () => {
         quote: quoteData,
         fiatAccountType: FiatAccountType.BankAccount,
       })
-      expect(quote.getFeeInFiat(mockExchangeRates, mockTokenInfo)).toBeNull()
+      expect(quote.getFeeInFiat(mockUsdToLocalRate, mockTokenInfo)).toBeNull()
     })
     it('returns fee directly for cash in', () => {
       const quote = new FiatConnectQuote({
@@ -209,7 +205,7 @@ describe('FiatConnectQuote', () => {
         quote: mockFiatConnectQuotes[1] as FiatConnectQuoteSuccess,
         fiatAccountType: FiatAccountType.BankAccount,
       })
-      expect(quote.getFeeInFiat(mockExchangeRates, mockTokenInfo)).toEqual(new BigNumber(0.53))
+      expect(quote.getFeeInFiat(mockUsdToLocalRate, mockTokenInfo)).toEqual(new BigNumber(0.53))
     })
     it('returns converted fee for cash out', () => {
       const quote = new FiatConnectQuote({
@@ -217,7 +213,7 @@ describe('FiatConnectQuote', () => {
         quote: mockFiatConnectQuotes[1] as FiatConnectQuoteSuccess,
         fiatAccountType: FiatAccountType.BankAccount,
       })
-      expect(quote.getFeeInFiat(mockExchangeRates, mockTokenInfo)).toEqual(new BigNumber(1.06))
+      expect(quote.getFeeInFiat(mockUsdToLocalRate, mockTokenInfo)).toEqual(new BigNumber(1.06))
     })
   })
 

--- a/src/fiatExchanges/quotes/FiatConnectQuote.ts
+++ b/src/fiatExchanges/quotes/FiatConnectQuote.ts
@@ -169,10 +169,7 @@ export default class FiatConnectQuote extends NormalizedQuote {
     return feeString !== undefined ? new BigNumber(feeString) : null
   }
   // FiatConnect quotes denominate fees in fiat & crypto for CashIn & CashOut respectively
-  getFeeInCrypto(
-    exchangeRates: { cGLD: string | null; cUSD: string | null; cEUR: string | null },
-    tokenInfo: TokenBalance
-  ): BigNumber | null {
+  getFeeInCrypto(usdToLocalRate: string | null, tokenInfo: TokenBalance): BigNumber | null {
     const fee = this._getFee()
     if (this.flow === CICOFlow.CashOut) {
       return fee
@@ -180,15 +177,12 @@ export default class FiatConnectQuote extends NormalizedQuote {
     return convertLocalToTokenAmount({
       localAmount: fee,
       tokenInfo,
-      exchangeRates,
+      usdToLocalRate,
     })
   }
 
   // FiatConnect quotes denominate fees in fiat & crypto for CashIn & CashOut respectively
-  getFeeInFiat(
-    exchangeRates: { cGLD: string | null; cUSD: string | null; cEUR: string | null },
-    tokenInfo: TokenBalance
-  ): BigNumber | null {
+  getFeeInFiat(usdToLocalRate: string | null, tokenInfo: TokenBalance): BigNumber | null {
     const fee = this._getFee()
     if (this.flow === CICOFlow.CashIn) {
       return fee
@@ -196,7 +190,7 @@ export default class FiatConnectQuote extends NormalizedQuote {
     return convertTokenToLocalAmount({
       tokenAmount: fee,
       tokenInfo,
-      exchangeRates,
+      usdToLocalRate,
     })
   }
 

--- a/src/fiatExchanges/quotes/NormalizedQuote.ts
+++ b/src/fiatExchanges/quotes/NormalizedQuote.ts
@@ -6,18 +6,12 @@ import { SettlementEstimation } from 'src/fiatExchanges/quotes/constants'
 import { ProviderSelectionAnalyticsData } from 'src/fiatExchanges/types'
 import { CICOFlow, PaymentMethod } from 'src/fiatExchanges/utils'
 import { TokenBalance } from 'src/tokens/slice'
-import { CiCoCurrency, Currency } from 'src/utils/currencies'
+import { CiCoCurrency } from 'src/utils/currencies'
 
 export default abstract class NormalizedQuote {
   abstract getPaymentMethod(): PaymentMethod
-  abstract getFeeInFiat(
-    exchangeRates: { [token in Currency]: string | null },
-    tokenInfo: TokenBalance
-  ): BigNumber | null
-  abstract getFeeInCrypto(
-    exchangeRates: { [token in Currency]: string | null },
-    tokenInfo: TokenBalance
-  ): BigNumber | null
+  abstract getFeeInFiat(usdToLocalRate: string | null, tokenInfo: TokenBalance): BigNumber | null
+  abstract getFeeInCrypto(usdToLocalRate: string | null, tokenInfo: TokenBalance): BigNumber | null
   abstract getCryptoType(): CiCoCurrency
   abstract getKycInfo(): string | null
   abstract getTimeEstimation(): SettlementEstimation

--- a/src/fiatExchanges/quotes/normalizeQuotes.test.ts
+++ b/src/fiatExchanges/quotes/normalizeQuotes.test.ts
@@ -37,16 +37,7 @@ describe('normalizeQuotes', () => {
     expect(
       normalizedQuotes.map((quote) => [
         quote.getProviderId(),
-        quote
-          .getFeeInCrypto(
-            {
-              cGLD: '1',
-              cUSD: '1',
-              cEUR: '1',
-            },
-            { usdPrice: BigNumber('1') } as TokenBalance
-          )
-          ?.toNumber(),
+        quote.getFeeInCrypto('1', { usdPrice: BigNumber('1') } as TokenBalance)?.toNumber(),
       ])
     ).toEqual([
       ['Ramp', 0],
@@ -91,16 +82,7 @@ describe('normalizeQuotes', () => {
     expect(
       normalizedQuotes.map((quote) => [
         quote.getProviderId(),
-        quote
-          .getFeeInCrypto(
-            {
-              cGLD: '1',
-              cUSD: '1',
-              cEUR: '1',
-            },
-            { usdPrice: BigNumber('1') } as TokenBalance
-          )
-          ?.toNumber(),
+        quote.getFeeInCrypto('1', { usdPrice: BigNumber('1') } as TokenBalance)?.toNumber(),
       ])
     ).toEqual([
       ['provider-one', 0.97],

--- a/src/fiatExchanges/quotes/normalizeQuotes.ts
+++ b/src/fiatExchanges/quotes/normalizeQuotes.ts
@@ -13,7 +13,7 @@ import {
 import { getFeatureGate } from 'src/statsig'
 import { StatsigFeatureGates } from 'src/statsig/types'
 import { TokenBalance } from 'src/tokens/slice'
-import { CiCoCurrency, Currency } from 'src/utils/currencies'
+import { CiCoCurrency } from 'src/utils/currencies'
 import Logger from 'src/utils/Logger'
 
 const TAG = 'NormalizeQuotes'
@@ -37,19 +37,15 @@ export function normalizeQuotes(
 
 export const quotesByFeeComparator = (quote1: NormalizedQuote, quote2: NormalizedQuote) => {
   // We can use a dummy exchange rate value here since its just a comparator
-  const exchangeRates = {
-    [Currency.Celo]: '1',
-    [Currency.Dollar]: '1',
-    [Currency.Euro]: '1',
-  }
+  const usdToLocalRate = '1'
   // also dummy token info. all we need is the usdPrice
   const dummyTokenInfo = {
     usdPrice: new BigNumber('1'),
   }
   const providerFee1 =
-    quote1.getFeeInFiat(exchangeRates, dummyTokenInfo as TokenBalance) ?? new BigNumber(Infinity)
+    quote1.getFeeInFiat(usdToLocalRate, dummyTokenInfo as TokenBalance) ?? new BigNumber(Infinity)
   const providerFee2 =
-    quote2.getFeeInFiat(exchangeRates, dummyTokenInfo as TokenBalance) ?? new BigNumber(Infinity)
+    quote2.getFeeInFiat(usdToLocalRate, dummyTokenInfo as TokenBalance) ?? new BigNumber(Infinity)
 
   return providerFee1.isGreaterThan(providerFee2) ? 1 : -1
 }

--- a/src/fiatExchanges/utils.test.ts
+++ b/src/fiatExchanges/utils.test.ts
@@ -5,9 +5,9 @@ import {
   mockLegacyMobileMoneyProvider,
   mockTokenBalances,
 } from '../../test/values'
-import { CiCoCurrency, Currency } from '../utils/currencies'
+import { CiCoCurrency } from '../utils/currencies'
 import NormalizedQuote from './quotes/NormalizedQuote'
-import { PaymentMethod, getProviderSelectionAnalyticsData } from './utils'
+import { getProviderSelectionAnalyticsData, PaymentMethod } from './utils'
 
 class MockNormalizedQuote extends NormalizedQuote {
   getCryptoType = jest.fn()
@@ -29,11 +29,7 @@ describe('fiatExchanges utils', () => {
   const mockNormalizedQuote1 = new MockNormalizedQuote()
   const mockNormalizedQuote2 = new MockNormalizedQuote()
   const mockNormalizedQuote3 = new MockNormalizedQuote()
-  const exchangeRates: { [token in Currency]: string | null } = {
-    cUSD: '1',
-    cGLD: '2',
-    cEUR: '1.5',
-  } // not important because NormalizedQuote class is mocked
+  const usdToLocalRate = '1' // not important because NormalizedQuote class is mocked
   const normalizedQuotes = [mockNormalizedQuote1, mockNormalizedQuote2, mockNormalizedQuote3]
 
   mockNormalizedQuote1.getFeeInCrypto.mockReturnValue(new BigNumber(1))
@@ -59,7 +55,7 @@ describe('fiatExchanges utils', () => {
     it('returns analytics data aggregating all available payment methods', () => {
       const analyticsOutput = getProviderSelectionAnalyticsData({
         normalizedQuotes,
-        exchangeRates,
+        usdToLocalRate,
         legacyMobileMoneyProviders: [mockLegacyMobileMoneyProvider],
         centralizedExchanges: mockExchanges,
         coinbasePayAvailable: true,
@@ -96,7 +92,7 @@ describe('fiatExchanges utils', () => {
     it('returns correct count when some payment methods are unavailable', () => {
       const analyticsOutput = getProviderSelectionAnalyticsData({
         normalizedQuotes,
-        exchangeRates,
+        usdToLocalRate,
         legacyMobileMoneyProviders: [],
         centralizedExchanges: [],
         coinbasePayAvailable: false,

--- a/src/fiatExchanges/utils.tsx
+++ b/src/fiatExchanges/utils.tsx
@@ -11,7 +11,7 @@ import { getDynamicConfigParams } from 'src/statsig'
 import { DynamicConfigs } from 'src/statsig/constants'
 import { StatsigDynamicConfigs } from 'src/statsig/types'
 import { TokenBalance } from 'src/tokens/slice'
-import { CiCoCurrency, Currency } from 'src/utils/currencies'
+import { CiCoCurrency } from 'src/utils/currencies'
 import { fetchWithTimeout } from 'src/utils/fetchWithTimeout'
 import Logger from 'src/utils/Logger'
 import networkConfig from 'src/web3/networkConfig'
@@ -336,7 +336,7 @@ export function resolveCloudFunctionDigitalAsset(
  */
 export function getProviderSelectionAnalyticsData({
   normalizedQuotes,
-  exchangeRates,
+  usdToLocalRate,
   tokenInfo,
   legacyMobileMoneyProviders,
   centralizedExchanges,
@@ -345,7 +345,7 @@ export function getProviderSelectionAnalyticsData({
   cryptoType,
 }: {
   normalizedQuotes: NormalizedQuote[]
-  exchangeRates: { [token in Currency]: string | null }
+  usdToLocalRate: string | null
   tokenInfo?: TokenBalance
   legacyMobileMoneyProviders?: LegacyMobileMoneyProvider[]
   centralizedExchanges?: ExternalExchangeProvider[]
@@ -370,7 +370,7 @@ export function getProviderSelectionAnalyticsData({
   for (const quote of normalizedQuotes) {
     paymentMethodsAvailable[quote.getPaymentMethod()] = true
     if (tokenInfo) {
-      const fee = quote.getFeeInCrypto(exchangeRates, tokenInfo)
+      const fee = quote.getFeeInCrypto(usdToLocalRate, tokenInfo)
       if (fee && (lowestFeeCryptoAmount === null || fee.isLessThan(lowestFeeCryptoAmount))) {
         lowestFeeCryptoAmount = fee
         lowestFeePaymentMethod = quote.getPaymentMethod()

--- a/src/fiatconnect/ReviewScreen.tsx
+++ b/src/fiatconnect/ReviewScreen.tsx
@@ -30,7 +30,7 @@ import { CICOFlow } from 'src/fiatExchanges/utils'
 import i18n from 'src/i18n'
 import {
   getDefaultLocalCurrencyCode,
-  localCurrencyExchangeRatesSelector,
+  usdToLocalCurrencyRateSelector,
 } from 'src/localCurrency/selectors'
 import { emptyHeader } from 'src/navigator/Headers'
 import { navigate, navigateBack } from 'src/navigator/NavigationService'
@@ -299,12 +299,12 @@ function ReceiveAmount({
   networkFee: BigNumber
 }) {
   const { t } = useTranslation()
-  const exchangeRates = useSelector(localCurrencyExchangeRatesSelector)!
+  const usdToLocalRate = useSelector(usdToLocalCurrencyRateSelector)
   const tokenInfo = useTokenInfoBySymbol(normalizedQuote.getCryptoType())!
   const { receiveDisplay } = getDisplayAmounts({
     flow,
     normalizedQuote,
-    exchangeRates,
+    usdToLocalRate,
     networkFee,
     tokenInfo,
   })
@@ -323,17 +323,13 @@ function ReceiveAmount({
 function getDisplayAmounts({
   flow,
   normalizedQuote,
-  exchangeRates,
+  usdToLocalRate,
   networkFee,
   tokenInfo,
 }: {
   flow: CICOFlow
   normalizedQuote: FiatConnectQuote
-  exchangeRates: {
-    cGLD: string | null
-    cUSD: string | null
-    cEUR: string | null
-  }
+  usdToLocalRate: string | null
   networkFee: BigNumber
   tokenInfo: TokenBalance | undefined
 }) {
@@ -341,7 +337,7 @@ function getDisplayAmounts({
   const fiatType = normalizedQuote.getFiatType()
   if (flow === CICOFlow.CashOut) {
     const providerFee =
-      (!!tokenInfo && normalizedQuote.getFeeInCrypto(exchangeRates, tokenInfo)) || new BigNumber(0)
+      (!!tokenInfo && normalizedQuote.getFeeInCrypto(usdToLocalRate, tokenInfo)) || new BigNumber(0)
     const receive = Number(normalizedQuote.getFiatAmount())
     const total = Number(
       new BigNumber(normalizedQuote.getCryptoAmount()).plus(networkFee).toString()
@@ -383,7 +379,7 @@ function getDisplayAmounts({
     const receive = normalizedQuote.getCryptoAmount()
     const total = normalizedQuote.getFiatAmount()
     const fee =
-      (!!tokenInfo && normalizedQuote.getFeeInFiat(exchangeRates, tokenInfo)) || new BigNumber(0)
+      (!!tokenInfo && normalizedQuote.getFeeInFiat(usdToLocalRate, tokenInfo)) || new BigNumber(0)
     const totalMinusFee = Number(total) - Number(fee || 0)
     const exchangeRate = totalMinusFee / Number(receive)
 
@@ -426,14 +422,14 @@ function TransactionDetails({
   networkFee: BigNumber
   feeEstimate: FeeEstimateState | undefined
 }) {
-  const exchangeRates = useSelector(localCurrencyExchangeRatesSelector)!
+  const usdToLocalRate = useSelector(usdToLocalCurrencyRateSelector)
   const tokenInfo = useTokenInfoBySymbol(normalizedQuote.getCryptoType())
 
   const { receiveDisplay, totalDisplay, feeDisplay, exchangeRateDisplay, totalMinusFeeDisplay } =
     getDisplayAmounts({
       flow,
       normalizedQuote,
-      exchangeRates,
+      usdToLocalRate,
       networkFee,
       tokenInfo,
     })

--- a/src/localCurrency/hooks.test.tsx
+++ b/src/localCurrency/hooks.test.tsx
@@ -1,0 +1,113 @@
+import { render } from '@testing-library/react-native'
+import React from 'react'
+import { Provider } from 'react-redux'
+import { MoneyAmount } from 'src/apollo/types'
+import * as localCurrencyHooks from 'src/localCurrency/hooks'
+import { Currency } from 'src/utils/currencies'
+import { createMockStore } from 'test/utils'
+
+const useLocalCurrencyToShowSpy = jest.spyOn(localCurrencyHooks, 'useLocalCurrencyToShow')
+
+function TestComponent({ amount }: { amount: MoneyAmount }) {
+  localCurrencyHooks.useLocalCurrencyToShow(amount)
+
+  return null
+}
+
+function createStore(dollarExchange: string | null = '2') {
+  return createMockStore({
+    tokens: {
+      tokenBalances: {
+        '0xcUSD': {
+          symbol: 'cUSD',
+          balance: '0',
+          usdPrice: '1',
+          priceFetchedAt: Date.now(),
+        },
+        '0xT1': {
+          symbol: 'T1',
+          balance: '0',
+          usdPrice: '5',
+          priceFetchedAt: Date.now(),
+        },
+        '0xT2': {
+          symbol: 'T2',
+          usdPrice: '5',
+          balance: null,
+          priceFetchedAt: Date.now(),
+        },
+      },
+    },
+    localCurrency: {
+      exchangeRates: {
+        [Currency.Dollar]: dollarExchange,
+      },
+    },
+  })
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe(localCurrencyHooks.useLocalCurrencyToShow, () => {
+  it('returns the expect value when the currency is known', async () => {
+    render(
+      <Provider store={createStore()}>
+        <TestComponent amount={{ value: 15, currencyCode: 'cUSD' }} />
+      </Provider>
+    )
+
+    expect(useLocalCurrencyToShowSpy).toHaveReturnedTimes(1)
+    expect(useLocalCurrencyToShowSpy).toHaveReturnedWith({
+      amountCurrency: 'cUSD',
+      localCurrencyCode: 'PHP',
+      localCurrencyExchangeRate: '2',
+    })
+  })
+
+  it('returns the expect value when the currency is unknown', async () => {
+    render(
+      <Provider store={createStore()}>
+        <TestComponent amount={{ value: 15, currencyCode: 'cSomething' }} />
+      </Provider>
+    )
+
+    expect(useLocalCurrencyToShowSpy).toHaveReturnedTimes(1)
+    expect(useLocalCurrencyToShowSpy).toHaveReturnedWith({
+      amountCurrency: 'cSomething',
+      localCurrencyCode: 'PHP',
+      localCurrencyExchangeRate: null,
+    })
+  })
+
+  it('returns the expect value when the token is known', async () => {
+    render(
+      <Provider store={createStore()}>
+        <TestComponent amount={{ value: 15, currencyCode: 'T1' }} />
+      </Provider>
+    )
+
+    expect(useLocalCurrencyToShowSpy).toHaveReturnedTimes(1)
+    expect(useLocalCurrencyToShowSpy).toHaveReturnedWith({
+      amountCurrency: 'T1',
+      localCurrencyCode: 'PHP',
+      localCurrencyExchangeRate: '10',
+    })
+  })
+
+  it('returns the expect value when the token is unknown', async () => {
+    render(
+      <Provider store={createStore()}>
+        <TestComponent amount={{ value: 15, currencyCode: 'SOMETHING' }} />
+      </Provider>
+    )
+
+    expect(useLocalCurrencyToShowSpy).toHaveReturnedTimes(1)
+    expect(useLocalCurrencyToShowSpy).toHaveReturnedWith({
+      amountCurrency: 'SOMETHING',
+      localCurrencyCode: 'PHP',
+      localCurrencyExchangeRate: null,
+    })
+  })
+})

--- a/src/localCurrency/hooks.ts
+++ b/src/localCurrency/hooks.ts
@@ -1,29 +1,29 @@
 import BigNumber from 'bignumber.js'
-import { useMemo } from 'react'
 import { MoneyAmount } from 'src/apollo/types'
 import { LocalCurrencyCode } from 'src/localCurrency/consts'
-import {
-  convertCurrencyToLocalAmount,
-  convertDollarsToLocalAmount,
-  convertLocalAmountToCurrency,
-} from 'src/localCurrency/convert'
+import { convertDollarsToLocalAmount } from 'src/localCurrency/convert'
 import {
   getLocalCurrencyCode,
   getLocalCurrencySymbol,
-  localCurrencyExchangeRatesSelector,
+  usdToLocalCurrencyRateSelector,
 } from 'src/localCurrency/selectors'
 import { CurrencyInfo } from 'src/localCurrency/types'
 import useSelector from 'src/redux/useSelector'
+import { useTokenInfoBySymbol } from 'src/tokens/hooks'
+import { convertTokenToLocalAmount } from 'src/tokens/utils'
 import { Currency } from 'src/utils/currencies'
-
-export function useDollarToLocalRate() {
-  return useSelector(localCurrencyExchangeRatesSelector)?.[Currency.Dollar]
-}
 
 export function useLocalCurrencyToShow(amount: MoneyAmount, currencyInfo?: CurrencyInfo) {
   let localCurrencyCode = useSelector(getLocalCurrencyCode)
   const amountCurrency = amount.currencyCode as Currency
-  let localCurrencyExchangeRate = useSelector(localCurrencyExchangeRatesSelector)[amountCurrency]
+  const tokenInfo = useTokenInfoBySymbol(amountCurrency)
+  const usdToLocalRate = useSelector(usdToLocalCurrencyRateSelector)
+  let localCurrencyExchangeRate =
+    convertTokenToLocalAmount({
+      tokenAmount: new BigNumber(1),
+      tokenInfo,
+      usdToLocalRate,
+    })?.toString() ?? null
   if (currencyInfo) {
     localCurrencyCode = currencyInfo.localCurrencyCode
     localCurrencyExchangeRate = currencyInfo.localExchangeRate
@@ -36,8 +36,8 @@ export function useLocalCurrencyToShow(amount: MoneyAmount, currencyInfo?: Curre
 }
 
 export function useDollarsToLocalAmount(amount: BigNumber.Value | null) {
-  const exchangeRate = useDollarToLocalRate()
-  const convertedAmount = convertDollarsToLocalAmount(amount, exchangeRate)
+  const usdToLocalRate = useSelector(usdToLocalCurrencyRateSelector)
+  const convertedAmount = convertDollarsToLocalAmount(amount, usdToLocalRate)
   if (!convertedAmount) {
     return null
   }
@@ -50,38 +50,4 @@ export function useLocalCurrencyCode() {
 
 export function useLocalCurrencySymbol() {
   return useSelector(getLocalCurrencySymbol)
-}
-
-export function useLocalAmountToCurrency(amount: BigNumber, currency: Currency): BigNumber | null {
-  const exchangeRate = useSelector(localCurrencyExchangeRatesSelector)[currency]
-  return useMemo(() => convertLocalAmountToCurrency(amount, exchangeRate), [amount, exchangeRate])
-}
-
-export function useCurrencyToLocalAmount(amount: BigNumber, currency: Currency): BigNumber | null {
-  const exchangeRate = useSelector(localCurrencyExchangeRatesSelector)[currency]
-  return useMemo(() => convertCurrencyToLocalAmount(amount, exchangeRate), [amount, exchangeRate])
-}
-
-export function convertBetweenCurrencies(
-  amount: BigNumber,
-  from: Currency,
-  to: Currency,
-  exchangeRates: { [currency in Currency]: string | null }
-) {
-  const localAmount = convertCurrencyToLocalAmount(amount, exchangeRates[from])
-  return convertLocalAmountToCurrency(localAmount, exchangeRates[to])
-}
-
-export function useConvertBetweenCurrencies(amount: BigNumber, from: Currency, to: Currency) {
-  const exchangeRates = useSelector(localCurrencyExchangeRatesSelector)
-  return useMemo(() => {
-    if (from === to) {
-      return amount
-    }
-    return convertBetweenCurrencies(amount, from, to, exchangeRates)
-  }, [amount, exchangeRates, from, to])
-}
-
-export function useCurrencyToLocalAmountExchangeRate(currency: Currency) {
-  return useSelector(localCurrencyExchangeRatesSelector)[currency]
 }

--- a/src/localCurrency/selectors.ts
+++ b/src/localCurrency/selectors.ts
@@ -51,7 +51,8 @@ export function getLocalCurrencySymbol(state: RootState): LocalCurrencySymbol | 
   return LocalCurrencySymbol[getLocalCurrencyCode(state)]
 }
 
-export const localCurrencyExchangeRatesSelector = createSelector(
+// Deprecated, will be removed as we'll only store the USD to local currency rate
+const localCurrencyExchangeRatesSelector = createSelector(
   (state: RootState) => state.localCurrency.exchangeRates,
   (state: RootState) => state.localCurrency.fetchedCurrencyCode,
   getLocalCurrencyCode,

--- a/src/merchantPayment/FeeContainer.tsx
+++ b/src/merchantPayment/FeeContainer.tsx
@@ -6,8 +6,7 @@ import FeeDrawer from 'src/components/FeeDrawer'
 import TokenTotalLineItem from 'src/components/TokenTotalLineItem'
 import { estimateFee, FeeType } from 'src/fees/reducer'
 import { feeEstimatesSelector } from 'src/fees/selectors'
-import { useCurrencyToLocalAmount } from 'src/localCurrency/hooks'
-import { getLocalCurrencyCode } from 'src/localCurrency/selectors'
+import { getLocalCurrencyCode, usdToLocalCurrencyRateSelector } from 'src/localCurrency/selectors'
 import { BASE_TAG } from 'src/merchantPayment/constants'
 import { useTokenInfoBySymbol } from 'src/tokens/hooks'
 import { fetchTokenBalances } from 'src/tokens/slice'
@@ -23,10 +22,10 @@ export default function FeeContainer({ amount }: { amount: BigNumber }) {
   const tokenInfo = useTokenInfoBySymbol(Currency.Dollar)
   const isDekRegistered = useSelector(isDekRegisteredSelector) ?? false
   const localCurrencyCode = useSelector(getLocalCurrencyCode)
-  const localToFeeExchangeRate = useCurrencyToLocalAmount(new BigNumber(1), Currency.Dollar)
+  const usdToLocalRate = useSelector(usdToLocalCurrencyRateSelector)
   const currencyInfo = {
     localCurrencyCode,
-    localExchangeRate: localToFeeExchangeRate?.toString() ?? '',
+    localExchangeRate: usdToLocalRate,
   }
   const tokenAddress = tokenInfo?.address
 

--- a/src/tokens/hooks.ts
+++ b/src/tokens/hooks.ts
@@ -1,5 +1,5 @@
 import BigNumber from 'bignumber.js'
-import { localCurrencyExchangeRatesSelector } from 'src/localCurrency/selectors'
+import { usdToLocalCurrencyRateSelector } from 'src/localCurrency/selectors'
 import useSelector from 'src/redux/useSelector'
 import {
   tokensByAddressSelector,
@@ -30,11 +30,11 @@ export function useLocalToTokenAmount(
   tokenAddress: string
 ): BigNumber | null {
   const tokenInfo = useTokenInfo(tokenAddress)
-  const exchangeRates = useSelector(localCurrencyExchangeRatesSelector)
+  const usdToLocalRate = useSelector(usdToLocalCurrencyRateSelector)
   return convertLocalToTokenAmount({
     localAmount,
     tokenInfo,
-    exchangeRates,
+    usdToLocalRate,
   })
 }
 
@@ -43,11 +43,11 @@ export function useTokenToLocalAmount(
   tokenAddress: string
 ): BigNumber | null {
   const tokenInfo = useTokenInfo(tokenAddress)
-  const exchangeRates = useSelector(localCurrencyExchangeRatesSelector)
+  const usdToLocalRate = useSelector(usdToLocalCurrencyRateSelector)
   return convertTokenToLocalAmount({
     tokenAmount,
     tokenInfo,
-    exchangeRates,
+    usdToLocalRate,
   })
 }
 

--- a/src/tokens/selectors.ts
+++ b/src/tokens/selectors.ts
@@ -6,7 +6,7 @@ import {
   TIME_UNTIL_TOKEN_INFO_BECOMES_STALE,
   TOKEN_MIN_AMOUNT,
 } from 'src/config'
-import { localCurrencyExchangeRatesSelector } from 'src/localCurrency/selectors'
+import { usdToLocalCurrencyRateSelector } from 'src/localCurrency/selectors'
 import { RootState } from 'src/redux/reducers'
 import { TokenBalance, TokenBalances } from 'src/tokens/slice'
 import { Currency } from 'src/utils/currencies'
@@ -181,10 +181,9 @@ export const defaultTokenToSendSelector = createSelector(
 )
 
 export const lastKnownTokenBalancesSelector = createSelector(
-  [tokensListSelector, tokensWithLastKnownUsdValueSelector, localCurrencyExchangeRatesSelector],
-  (tokensList, tokensWithLastKnownUsdValue, exchangeRate) => {
-    const usdRate = exchangeRate[Currency.Dollar]
-    if (!usdRate || tokensList.length === 0) {
+  [tokensListSelector, tokensWithLastKnownUsdValueSelector, usdToLocalCurrencyRateSelector],
+  (tokensList, tokensWithLastKnownUsdValue, usdToLocalRate) => {
+    if (!usdToLocalRate || tokensList.length === 0) {
       return null
     }
 
@@ -192,7 +191,7 @@ export const lastKnownTokenBalancesSelector = createSelector(
     for (const token of tokensWithLastKnownUsdValue) {
       const tokenAmount = new BigNumber(token.balance)
         .multipliedBy(token.lastKnownUsdPrice ?? 0)
-        .multipliedBy(usdRate)
+        .multipliedBy(usdToLocalRate)
       totalBalance = totalBalance.plus(tokenAmount)
     }
 
@@ -204,17 +203,16 @@ export const totalTokenBalanceSelector = createSelector(
   [
     tokensListSelector,
     tokensWithUsdValueSelector,
-    localCurrencyExchangeRatesSelector,
+    usdToLocalCurrencyRateSelector,
     tokenFetchErrorSelector,
     tokenFetchLoadingSelector,
   ],
-  (tokensList, tokensWithUsdValue, exchangeRate, tokenFetchError, tokenFetchLoading) => {
+  (tokensList, tokensWithUsdValue, usdToLocalRate, tokenFetchError, tokenFetchLoading) => {
     if (tokenFetchError || tokenFetchLoading) {
       return null
     }
 
-    const usdRate = exchangeRate[Currency.Dollar]
-    if (!usdRate || tokensList.length === 0) {
+    if (!usdToLocalRate || tokensList.length === 0) {
       return null
     }
     let totalBalance = new BigNumber(0)
@@ -222,7 +220,7 @@ export const totalTokenBalanceSelector = createSelector(
     for (const token of tokensWithUsdValue) {
       const tokenAmount = new BigNumber(token.balance)
         .multipliedBy(token.usdPrice)
-        .multipliedBy(usdRate)
+        .multipliedBy(usdToLocalRate)
       totalBalance = totalBalance.plus(tokenAmount)
     }
 

--- a/src/tokens/utils.test.tsx
+++ b/src/tokens/utils.test.tsx
@@ -116,15 +116,11 @@ describe(convertLocalToTokenAmount, () => {
   const tokenInfo = {
     usdPrice: BigNumber(2),
   } as TokenBalance
-  const exchangeRates = {
-    [Currency.Dollar]: '20',
-    [Currency.Celo]: null,
-    [Currency.Euro]: null,
-  }
+  const usdToLocalRate = '20'
   it('returns null if there is no token usd price', () => {
     const tokenAmount = convertLocalToTokenAmount({
       localAmount: BigNumber(10),
-      exchangeRates,
+      usdToLocalRate,
       tokenInfo: undefined,
     })
     expect(tokenAmount).toEqual(null)
@@ -133,10 +129,7 @@ describe(convertLocalToTokenAmount, () => {
   it('returns null if there is no usd exchange rate', () => {
     const tokenAmount = convertLocalToTokenAmount({
       localAmount: BigNumber(10),
-      exchangeRates: {
-        ...exchangeRates,
-        [Currency.Dollar]: null,
-      },
+      usdToLocalRate: null,
       tokenInfo,
     })
     expect(tokenAmount).toEqual(null)
@@ -145,7 +138,7 @@ describe(convertLocalToTokenAmount, () => {
   it('returns null if localAmount is null', () => {
     const tokenAmount = convertLocalToTokenAmount({
       localAmount: null,
-      exchangeRates,
+      usdToLocalRate,
       tokenInfo,
     })
     expect(tokenAmount).toEqual(null)
@@ -154,7 +147,7 @@ describe(convertLocalToTokenAmount, () => {
   it('converts a local amount to a token amount', () => {
     const tokenAmount = convertLocalToTokenAmount({
       localAmount: BigNumber(10),
-      exchangeRates,
+      usdToLocalRate,
       tokenInfo,
     })
     expect(tokenAmount).toEqual(new BigNumber(0.25))
@@ -165,15 +158,11 @@ describe(convertTokenToLocalAmount, () => {
   const tokenInfo = {
     usdPrice: BigNumber(2),
   } as TokenBalance
-  const exchangeRates = {
-    [Currency.Dollar]: '20',
-    [Currency.Celo]: null,
-    [Currency.Euro]: null,
-  }
+  const usdToLocalRate = '20'
   it('returns null if there is no token usd price', () => {
     const localAmount = convertTokenToLocalAmount({
       tokenAmount: BigNumber(10),
-      exchangeRates,
+      usdToLocalRate,
       tokenInfo: undefined,
     })
     expect(localAmount).toEqual(null)
@@ -182,10 +171,7 @@ describe(convertTokenToLocalAmount, () => {
   it('returns null if there is no usd exchange rate', () => {
     const localAmount = convertTokenToLocalAmount({
       tokenAmount: BigNumber(10),
-      exchangeRates: {
-        ...exchangeRates,
-        [Currency.Dollar]: null,
-      },
+      usdToLocalRate: null,
       tokenInfo,
     })
     expect(localAmount).toEqual(null)
@@ -194,16 +180,16 @@ describe(convertTokenToLocalAmount, () => {
   it('returns null if localAmount is null', () => {
     const localAmount = convertTokenToLocalAmount({
       tokenAmount: null,
-      exchangeRates,
+      usdToLocalRate,
       tokenInfo,
     })
     expect(localAmount).toEqual(null)
   })
 
-  it('converts a local amount to a token amount', () => {
+  it('converts a token amount to a local amount', () => {
     const localAmount = convertTokenToLocalAmount({
       tokenAmount: BigNumber(10),
-      exchangeRates,
+      usdToLocalRate,
       tokenInfo,
     })
     expect(localAmount).toEqual(new BigNumber(400))

--- a/src/tokens/utils.ts
+++ b/src/tokens/utils.ts
@@ -84,35 +84,33 @@ function usdBalance(token: TokenBalance): BigNumber {
 export function convertLocalToTokenAmount({
   localAmount,
   tokenInfo,
-  exchangeRates,
+  usdToLocalRate,
 }: {
   localAmount: BigNumber | null
   tokenInfo: TokenBalance | undefined
-  exchangeRates: { [token in Currency]: string | null }
+  usdToLocalRate: string | null
 }) {
   const tokenUsdPrice = tokenInfo?.usdPrice
-  const localFiatPerDollar = exchangeRates[Currency.Dollar]
-  if (!tokenUsdPrice || !localFiatPerDollar || !localAmount) {
+  if (!tokenUsdPrice || !usdToLocalRate || !localAmount) {
     return null
   }
 
-  return localAmount.dividedBy(localFiatPerDollar).dividedBy(tokenUsdPrice)
+  return localAmount.dividedBy(usdToLocalRate).dividedBy(tokenUsdPrice)
 }
 
 export function convertTokenToLocalAmount({
   tokenAmount,
   tokenInfo,
-  exchangeRates,
+  usdToLocalRate,
 }: {
   tokenAmount: BigNumber | null
   tokenInfo: TokenBalance | undefined
-  exchangeRates: { [token in Currency]: string | null }
+  usdToLocalRate: string | null
 }) {
   const tokenUsdPrice = tokenInfo?.usdPrice
-  const localFiatPerDollar = exchangeRates[Currency.Dollar]
-  if (!tokenUsdPrice || !localFiatPerDollar || !tokenAmount) {
+  if (!tokenUsdPrice || !usdToLocalRate || !tokenAmount) {
     return null
   }
 
-  return tokenAmount.multipliedBy(tokenUsdPrice).multipliedBy(localFiatPerDollar)
+  return tokenAmount.multipliedBy(tokenUsdPrice).multipliedBy(usdToLocalRate)
 }


### PR DESCRIPTION
### Description

`localCurrencyExchangeRatesSelector` was meant to be removed since the multi token switch.
Almost all places were only reading the `Currency.Dollar` to local rate already.

There will be a follow up PR where the last consumer (`usdToLocalCurrencyRateSelector`) will be updated to read the needed rate from a different place from the redux store. We'll also fetch the USD to local rate, instead of cUSD to local rate.

### Test plan

- Updated tests

### Related issues

- Fixes RET-830

### Backwards compatibility

Yes
