### PR TITLE
docs: remove react-celo and update walletconnect v2 link

### DIFF
--- a/docs/connecting-dapps.md
+++ b/docs/connecting-dapps.md
@@ -2,13 +2,13 @@
 
 Valora supports [WalletConnect v2](https://docs.walletconnect.com/2.0/) for connecting Dapps to Valora. [WalletConnect v1 is end-of-life](https://docs.walletconnect.com/2.0/advanced/migration-from-v1.x/overview) and not supported.
 
-If you're building a Dapp we recommend [react-celo](https://github.com/celo-org/react-celo) to make it easy to connect your Dapp to Valora via WalletConnect. [cLabs](https://clabs.co/) supports react-celo and it includes a complete example to help you get started.
+If you're building a Dapp we recommend [@celo/rainbowkit-celo](https://github.com/celo-org/rainbowkit-celo) or [Web3Modal](https://github.com/WalletConnect/web3modal)to make it easy to connect your Dapp to Valora via WalletConnect. [cLabs](https://clabs.co/) supports @celo/rainbowkit-celo and it includes a [complete example](https://docs.celo.org/developer/rainbowkit-celo) to help you get started.
 
 ## WalletConnect details
 
 Supported actions: <https://github.com/celo-org/wallet/blob/main/src/walletConnect/constants.ts#L3>
 
-Docs for WalletConnect v2: <https://docs.walletconnect.com/2.0/javascript/sign/dapp-usage>
+Docs for WalletConnect v2: <https://docs.walletconnect.com/2.0>
 
 ## Troubleshooting tips
 


### PR DESCRIPTION
### Description

Removes outdated recommendation for dapps to use react-celo which is now end of life and instead recommends @celo/rainbowkit-celo and web3modal. Also replaces a dead link for WalletConnect Docs.

### Test plan

N/A

### Related issues

[react-celo end-of-life (EOL) process #364
](https://github.com/celo-org/react-celo/issues/364)

### Backwards compatibility

Yes