### PR TITLE
feat: show P0 notifications only on the home screen

### DIFF
--- a/src/components/SimpleMessagingCard.tsx
+++ b/src/components/SimpleMessagingCard.tsx
@@ -10,6 +10,7 @@ export interface Props {
   icon?: ImageSourcePropType | React.ReactNode
   callToActions: CallToAction[]
   priority: number
+  showOnHomeScreen?: boolean
   testID?: string
 }
 

--- a/src/home/NotificationBox.test.tsx
+++ b/src/home/NotificationBox.test.tsx
@@ -133,7 +133,7 @@ describe('NotificationBox', () => {
     })
     const tree = render(
       <Provider store={store}>
-        <NotificationBox />
+        <NotificationBox showOnlyHomeScreenNotifications={false} />
       </Provider>
     )
     expect(tree).toMatchSnapshot()
@@ -149,7 +149,7 @@ describe('NotificationBox', () => {
     })
     const { getByText } = render(
       <Provider store={store}>
-        <NotificationBox />
+        <NotificationBox showOnlyHomeScreenNotifications={false} />
       </Provider>
     )
 
@@ -171,7 +171,7 @@ describe('NotificationBox', () => {
     })
     const { getByText } = render(
       <Provider store={store}>
-        <NotificationBox />
+        <NotificationBox showOnlyHomeScreenNotifications={false} />
       </Provider>
     )
     expect(getByText('whatIsGold')).toBeTruthy()
@@ -191,7 +191,7 @@ describe('NotificationBox', () => {
     })
     const { getByTestId } = render(
       <Provider store={store}>
-        <NotificationBox />
+        <NotificationBox showOnlyHomeScreenNotifications={false} />
       </Provider>
     )
 
@@ -217,7 +217,7 @@ describe('NotificationBox', () => {
     })
     const { getByText } = render(
       <Provider store={store}>
-        <NotificationBox />
+        <NotificationBox showOnlyHomeScreenNotifications={false} />
       </Provider>
     )
     expect(getByText(/incomingPaymentRequestsSummaryTitle/)).toBeTruthy()
@@ -235,7 +235,7 @@ describe('NotificationBox', () => {
     })
     const { getByText } = render(
       <Provider store={store}>
-        <NotificationBox />
+        <NotificationBox showOnlyHomeScreenNotifications={false} />
       </Provider>
     )
     expect(getByText(/outgoingPaymentRequestsSummaryTitle/)).toBeTruthy()
@@ -253,7 +253,7 @@ describe('NotificationBox', () => {
     })
     const { getByTestId } = render(
       <Provider store={store}>
-        <NotificationBox />
+        <NotificationBox showOnlyHomeScreenNotifications={false} />
       </Provider>
     )
 
@@ -279,7 +279,7 @@ describe('NotificationBox', () => {
     })
     const { getByText } = render(
       <Provider store={store}>
-        <NotificationBox />
+        <NotificationBox showOnlyHomeScreenNotifications={false} />
       </Provider>
     )
     expect(getByText('notification.body')).toBeTruthy()
@@ -291,7 +291,7 @@ describe('NotificationBox', () => {
     })
     const { queryByText } = render(
       <Provider store={store}>
-        <NotificationBox />
+        <NotificationBox showOnlyHomeScreenNotifications={false} />
       </Provider>
     )
     expect(queryByText('notification.body')).toBeFalsy()
@@ -336,7 +336,7 @@ describe('NotificationBox', () => {
     })
     const { queryByText, getByText } = render(
       <Provider store={store}>
-        <NotificationBox />
+        <NotificationBox showOnlyHomeScreenNotifications={false} />
       </Provider>
     )
     expect(queryByText('Notification 1')).toBeFalsy()
@@ -383,7 +383,7 @@ describe('NotificationBox', () => {
     })
     const { queryByText, getByText } = render(
       <Provider store={store}>
-        <NotificationBox />
+        <NotificationBox showOnlyHomeScreenNotifications={false} />
       </Provider>
     )
     expect(queryByText('Notification 1')).toBeTruthy()
@@ -408,7 +408,7 @@ describe('NotificationBox', () => {
     const store = createMockStore(superchargeSetUp)
     const { queryByTestId, getByTestId } = render(
       <Provider store={store}>
-        <NotificationBox />
+        <NotificationBox showOnlyHomeScreenNotifications={false} />
       </Provider>
     )
 
@@ -431,7 +431,7 @@ describe('NotificationBox', () => {
     })
     const { queryByTestId, getByTestId } = render(
       <Provider store={store}>
-        <NotificationBox />
+        <NotificationBox showOnlyHomeScreenNotifications={false} />
       </Provider>
     )
 
@@ -457,7 +457,7 @@ describe('NotificationBox', () => {
     })
     const { queryByTestId } = render(
       <Provider store={store}>
-        <NotificationBox />
+        <NotificationBox showOnlyHomeScreenNotifications={false} />
       </Provider>
     )
 
@@ -479,7 +479,7 @@ describe('NotificationBox', () => {
     })
     const { queryByTestId, getByTestId } = render(
       <Provider store={store}>
-        <NotificationBox />
+        <NotificationBox showOnlyHomeScreenNotifications={false} />
       </Provider>
     )
 
@@ -502,7 +502,7 @@ describe('NotificationBox', () => {
     })
     const { queryByTestId, getByTestId } = render(
       <Provider store={store}>
-        <NotificationBox />
+        <NotificationBox showOnlyHomeScreenNotifications={false} />
       </Provider>
     )
 
@@ -528,12 +528,60 @@ describe('NotificationBox', () => {
     })
     const { queryByTestId } = render(
       <Provider store={store}>
-        <NotificationBox />
+        <NotificationBox showOnlyHomeScreenNotifications={false} />
       </Provider>
     )
 
     expect(queryByTestId('NotificationView/claimSuperchargeRewards')).toBeFalsy()
     expect(queryByTestId('NotificationView/keepSupercharging')).toBeFalsy()
     expect(queryByTestId('NotificationView/startSupercharging')).toBeFalsy()
+  })
+
+  it('only renders notification marked for the home screen when showOnlyHomeScreenNotifications is true', () => {
+    const store = createMockStore({
+      ...storeDataNotificationsDisabled,
+      home: {
+        notifications: {
+          notification1: {
+            ...testNotification,
+            dismissed: true,
+            showOnHomeScreen: true,
+            content: {
+              en: {
+                ...testNotification.content.en,
+                body: 'Notification 1',
+              },
+            },
+          },
+          notification2: {
+            ...testNotification,
+            showOnHomeScreen: true, // This is the only one that should show
+            content: {
+              en: {
+                ...testNotification.content.en,
+                body: 'Notification 2',
+              },
+            },
+          },
+          notification3: {
+            ...testNotification,
+            content: {
+              en: {
+                ...testNotification.content.en,
+                body: 'Notification 3',
+              },
+            },
+          },
+        },
+      },
+    })
+    const { queryByText } = render(
+      <Provider store={store}>
+        <NotificationBox showOnlyHomeScreenNotifications={true} />
+      </Provider>
+    )
+    expect(queryByText('Notification 1')).toBeFalsy()
+    expect(queryByText('Notification 2')).toBeTruthy()
+    expect(queryByText('Notification 3')).toBeFalsy()
   })
 })

--- a/src/home/NotificationBox.test.tsx
+++ b/src/home/NotificationBox.test.tsx
@@ -537,7 +537,7 @@ describe('NotificationBox', () => {
     expect(queryByTestId('NotificationView/startSupercharging')).toBeFalsy()
   })
 
-  it('only renders notification marked for the home screen when showOnlyHomeScreenNotifications is true', () => {
+  it('only renders notifications marked for the home screen when showOnlyHomeScreenNotifications is true', () => {
     const store = createMockStore({
       ...storeDataNotificationsDisabled,
       home: {

--- a/src/home/NotificationCenter.test.tsx
+++ b/src/home/NotificationCenter.test.tsx
@@ -593,7 +593,7 @@ describe('NotificationCenter', () => {
   })
 
   describe('remote notifications', () => {
-    it('renders all remote notifications that were not dismissed', () => {
+    it('renders all remote notifications that were not dismissed and not for the home screen', () => {
       const store = createMockStore({
         ...storeDataNotificationsDisabled,
         home: {
@@ -610,6 +610,7 @@ describe('NotificationCenter', () => {
             },
             notification2: {
               ...testNotification,
+              showOnHomeScreen: true,
               content: {
                 en: {
                   ...testNotification.content.en,
@@ -636,7 +637,7 @@ describe('NotificationCenter', () => {
         </Provider>
       )
       expect(queryByText('Notification 1')).toBeFalsy()
-      expect(queryByText('Notification 2')).toBeTruthy()
+      expect(queryByText('Notification 2')).toBeFalsy()
       expect(queryByText('Notification 3')).toBeTruthy()
 
       expect(store.getActions()).toEqual([fetchAvailableRewards()])

--- a/src/home/NotificationCenter.tsx
+++ b/src/home/NotificationCenter.tsx
@@ -113,11 +113,17 @@ export function useNotifications() {
     ...simpleActions.map((notification) => ({
       element: <SimpleMessagingCard testID={notification.id} {...notification} />,
       priority: notification.priority,
+      showOnHomeScreen: notification.showOnHomeScreen,
       id: notification.id,
     }))
   )
 
-  return notifications.sort((n1, n2) => n2.priority - n1.priority)
+  return (
+    notifications
+      .sort((n1, n2) => n2.priority - n1.priority)
+      // Hide notifications that should only be shown on the home screen
+      .filter((n) => !n.showOnHomeScreen)
+  )
 }
 
 export default function Notifications({ navigation }: NotificationsProps) {

--- a/src/home/WalletHome.tsx
+++ b/src/home/WalletHome.tsx
@@ -18,13 +18,13 @@ import {
   STABLE_TRANSACTION_MIN_AMOUNT,
 } from 'src/config'
 import useOpenDapp from 'src/dappsExplorer/useOpenDapp'
+import { refreshAllBalances, visitHome } from 'src/home/actions'
 import ActionsCarousel from 'src/home/ActionsCarousel'
 import CashInBottomSheet from 'src/home/CashInBottomSheet'
 import DappsCarousel from 'src/home/DappsCarousel'
 import NotificationBell from 'src/home/NotificationBell'
 import NotificationBox from 'src/home/NotificationBox'
 import SendOrRequestBar from 'src/home/SendOrRequestBar'
-import { refreshAllBalances, visitHome } from 'src/home/actions'
 import Logo from 'src/icons/Logo'
 import { importContacts } from 'src/identity/actions'
 import DrawerTopBar from 'src/navigator/DrawerTopBar'
@@ -156,7 +156,13 @@ function WalletHome() {
 
   const notificationBoxSection = {
     data: [{}],
-    renderItem: () => <NotificationBox key={'NotificationBox'} />,
+    renderItem: () => (
+      <NotificationBox
+        key={'NotificationBox'}
+        // When the notification center is enabled, we only show high priority notifications marked for the home screen
+        showOnlyHomeScreenNotifications={showNotificationCenter}
+      />
+    ),
   }
   const tokenBalanceSection = {
     data: [{}],
@@ -168,7 +174,11 @@ function WalletHome() {
   }
 
   if (showHomeActions) {
-    sections.push(tokenBalanceSection, actionsCarouselSection, notificationBoxSection)
+    if (showNotificationCenter) {
+      sections.push(notificationBoxSection, tokenBalanceSection, actionsCarouselSection)
+    } else {
+      sections.push(tokenBalanceSection, actionsCarouselSection, notificationBoxSection)
+    }
   } else {
     sections.push(notificationBoxSection, tokenBalanceSection)
   }

--- a/src/home/reducers.ts
+++ b/src/home/reducers.ts
@@ -21,6 +21,7 @@ export interface Notification {
   blockedCountries?: string[]
   openExternal?: boolean
   priority?: number
+  showOnHomeScreen?: boolean
 }
 
 export interface IdToNotification {

--- a/test/RootStateSchema.json
+++ b/test/RootStateSchema.json
@@ -1891,6 +1891,9 @@
                 },
                 "priority": {
                     "type": "number"
+                },
+                "showOnHomeScreen": {
+                    "type": "boolean"
                 }
             },
             "required": [


### PR DESCRIPTION
### Description

As the title says.

This ended up requiring very few changes.

Also for now P0 notifications are hidden from the notification center screen. I'll check this is what we want.

### Test plan

**When the notification center is enabled**

With a single notification marked with `showOnHomeScreen: true`:

<img src="https://github.com/valora-inc/wallet/assets/57791/21cd976b-0183-49f7-a88c-101ef8f6d23b" width="50%" /><img src="https://github.com/valora-inc/wallet/assets/57791/ef2d7a88-9209-4dc3-b76d-5cdb6743ed3e" width="50%" /> 

With multiple notifications marked with `showOnHomeScreen: true`:

<img src="https://github.com/valora-inc/wallet/assets/57791/cde8a2f1-7cbe-4d83-a3b2-773e67abee0f" width="50%" /><img src="https://github.com/valora-inc/wallet/assets/57791/116d822d-c3f3-4a84-ba1d-b861a76ae360" width="50%" /> 

Note that this isn't a case we'll do on purpose. But since it allowed to reuse `<NotificationBox />` with minimal changes I left it this way. The highest priority notification is still displayed first.

**When the notification center is disabled**

<img src="https://github.com/valora-inc/wallet/assets/57791/03ac60bf-35f8-4f4c-a6e5-2715f2bf1be0" width="50%" /> 

This is same as before this PR.

### Related issues

- Fixes RET-800

### Backwards compatibility

Yes
