### PR TITLE
feat(viem): implement sendAndMonitorTransaction

### DIFF
--- a/src/transactions/actions.ts
+++ b/src/transactions/actions.ts
@@ -18,6 +18,7 @@ export enum Actions {
   RESET_STANDBY_TRANSACTIONS = 'TRANSACTIONS/RESET_STANDBY_TRANSACTIONS',
   ADD_HASH_TO_STANDBY_TRANSACTIONS = 'TRANSACTIONS/ADD_HASH_TO_STANDBY_TRANSACTIONS',
   TRANSACTION_CONFIRMED = 'TRANSACTIONS/TRANSACTION_CONFIRMED',
+  TRANSACTION_CONFIRMED_VIEM = 'TRANSACTIONS/TRANSACTION_CONFIRMED_VIEM',
   TRANSACTION_FAILED = 'TRANSACTIONS/TRANSACTION_FAILED',
   NEW_TRANSACTIONS_IN_FEED = 'TRANSACTIONS/NEW_TRANSACTIONS_IN_FEED',
   REFRESH_RECENT_TX_RECIPIENTS = 'TRANSACTIONS/REFRESH_RECENT_TX_RECIPIENTS',
@@ -59,6 +60,11 @@ export interface TransactionConfirmedAction {
   receipt: CeloTxReceipt
 }
 
+export interface TransactionConfirmedViemAction {
+  type: Actions.TRANSACTION_CONFIRMED_VIEM
+  txId: string
+}
+
 export interface TransactionFailedAction {
   type: Actions.TRANSACTION_FAILED
   txId: string
@@ -94,6 +100,7 @@ export type ActionTypes =
   | UpdatedRecentTxRecipientsCacheAction
   | UpdateTransactionsAction
   | TransactionConfirmedAction
+  | TransactionConfirmedViemAction
   | UpdateInviteTransactionsAction
 
 export const addStandbyTransactionLegacy = (
@@ -133,6 +140,11 @@ export const transactionConfirmed = (
   type: Actions.TRANSACTION_CONFIRMED,
   txId,
   receipt,
+})
+
+export const transactionConfirmedViem = (txId: string): TransactionConfirmedViemAction => ({
+  type: Actions.TRANSACTION_CONFIRMED_VIEM,
+  txId,
 })
 
 export const transactionFailed = (txId: string): TransactionFailedAction => ({

--- a/src/transactions/reducer.ts
+++ b/src/transactions/reducer.ts
@@ -125,6 +125,16 @@ export const reducer = (
           }
         }),
       }
+    case Actions.TRANSACTION_CONFIRMED_VIEM:
+      return {
+        ...state,
+        standbyTransactions: mapForContextId(state.standbyTransactions, action.txId, (tx) => {
+          return {
+            ...tx,
+            status: TransactionStatus.Complete,
+          }
+        }),
+      }
     case Actions.ADD_HASH_TO_STANDBY_TRANSACTIONS:
       return {
         ...state,

--- a/src/transactions/send.ts
+++ b/src/transactions/send.ts
@@ -20,6 +20,7 @@ import { getGasPrice } from 'src/web3/gas'
 import { walletAddressSelector } from 'src/web3/selectors'
 import { estimateGas } from 'src/web3/utils'
 import { call, cancel, cancelled, delay, fork, join, race, select } from 'typed-redux-saga'
+import { TransactionReceipt, WaitForTransactionReceiptReturnType } from 'viem'
 
 const TAG = 'transactions/send'
 
@@ -255,12 +256,13 @@ export function* sendTransaction(
 }
 
 // SendTransactionMethod is a redux saga generator that takes a nonce and returns a receipt.
-export type SendTransactionMethod = (nonce?: number) => Generator<any, CeloTxReceipt, any>
+export type SendTransactionMethod<
+  T extends CeloTxReceipt | WaitForTransactionReceiptReturnType = CeloTxReceipt
+> = (nonce?: number) => Generator<any, T, any>
 
-export function* wrapSendTransactionWithRetry(
-  sendTxMethod: SendTransactionMethod,
-  context: TransactionContext
-) {
+export function* wrapSendTransactionWithRetry<
+  T extends CeloTxReceipt | TransactionReceipt = CeloTxReceipt
+>(sendTxMethod: SendTransactionMethod<T>, context: TransactionContext) {
   for (let i = 1; i <= TX_NUM_TRIES; i++) {
     try {
       // Spin tx send into a Task so that it does not get cancelled automatically on timeout.

--- a/src/viem/saga.test.ts
+++ b/src/viem/saga.test.ts
@@ -34,6 +34,13 @@ import {
 } from 'test/values'
 import { getAddress } from 'viem'
 
+jest.mock('src/transactions/send', () => ({
+  chooseTxFeeDetails: jest.fn(),
+  wrapSendTransactionWithRetry: jest
+    .fn()
+    .mockImplementation((sendTxMethod, _context) => sendTxMethod()),
+}))
+
 const mockViemFeeInfo = {
   feeCurrency: getAddress(mockCusdAddress),
   gas: BigInt(mockFeeInfo.gas.toNumber()),
@@ -312,10 +319,10 @@ describe('sendAndMonitorTransaction', () => {
           throwError(new Error('wait failed')),
         ],
       ])
-      // .put(addHashToStandbyTransaction('txId', mockTxHash))
-      // .put(removeStandbyTransaction('txId'))
-      // .put(transactionFailed('txId'))
-      // .put(showError(ErrorMessages.TRANSACTION_FAILED))
+      .put(addHashToStandbyTransaction('txId', mockTxHash))
+      .put(removeStandbyTransaction('txId'))
+      .put(transactionFailed('txId'))
+      .put(showError(ErrorMessages.TRANSACTION_FAILED))
       .throws(new Error('wait failed'))
       .run()
   })

--- a/src/viem/saga.test.ts
+++ b/src/viem/saga.test.ts
@@ -2,13 +2,25 @@ import { CeloTransactionObject } from '@celo/connect'
 import BigNumber from 'bignumber.js'
 import { expectSaga } from 'redux-saga-test-plan'
 import * as matchers from 'redux-saga-test-plan/matchers'
+import { throwError } from 'redux-saga-test-plan/providers'
 import erc20 from 'src/abis/IERC20'
 import stableToken from 'src/abis/StableToken'
+import { showError } from 'src/alert/actions'
+import { ErrorMessages } from 'src/app/ErrorMessages'
 import { encryptComment } from 'src/identity/commentEncryption'
 import { buildSendTx } from 'src/send/saga'
+import { fetchTokenBalances } from 'src/tokens/slice'
+import {
+  Actions,
+  addHashToStandbyTransaction,
+  removeStandbyTransaction,
+  transactionConfirmedViem,
+  transactionFailed,
+} from 'src/transactions/actions'
 import { chooseTxFeeDetails } from 'src/transactions/send'
 import { publicClient } from 'src/viem'
-import { getSendTxFeeDetails, sendPayment } from 'src/viem/saga'
+import { ViemWallet } from 'src/viem/getLockableWallet'
+import { getSendTxFeeDetails, sendAndMonitorTransaction, sendPayment } from 'src/viem/saga'
 import { getViemWallet } from 'src/web3/contracts'
 import networkConfig from 'src/web3/networkConfig'
 import { UnlockResult, unlockAccount } from 'src/web3/saga'
@@ -28,12 +40,12 @@ const mockViemFeeInfo = {
   maxFeePerGas: BigInt(mockFeeInfo.gasPrice.toNumber()),
 }
 
+const mockViemWallet = {
+  account: { address: mockAccount },
+  writeContract: jest.fn(),
+} as any as ViemWallet
+
 describe('sendPayment', () => {
-  const mockTxHash = '0x123456789'
-  const mockViemWallet = {
-    account: { address: mockAccount },
-    writeContract: jest.fn(),
-  }
   const simulateContractSpy = jest.spyOn(publicClient.celo, 'simulateContract')
 
   const mockSendPaymentArgs = {
@@ -48,7 +60,6 @@ describe('sendPayment', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     simulateContractSpy.mockResolvedValue({ request: 'req' as any } as any)
-    mockViemWallet.writeContract.mockResolvedValue(mockTxHash)
   })
 
   it('sends a payment successfully for stable token', async () => {
@@ -59,6 +70,7 @@ describe('sendPayment', () => {
         [matchers.call.fn(encryptComment), 'encryptedComment'],
         [matchers.call.fn(getSendTxFeeDetails), mockViemFeeInfo],
         [matchers.call.fn(unlockAccount), UnlockResult.SUCCESS],
+        [matchers.call.fn(sendAndMonitorTransaction), 'txReceipt'],
       ])
       .call(getViemWallet, networkConfig.viemChain.celo)
       .call(encryptComment, 'comment', mockSendPaymentArgs.recipientAddress, mockAccount, true)
@@ -69,7 +81,8 @@ describe('sendPayment', () => {
         feeInfo: mockFeeInfo,
         encryptedComment: 'encryptedComment',
       })
-      .returns(mockTxHash)
+      .put.like({ action: { type: Actions.ADD_STANDBY_TRANSACTION } })
+      .returns('txReceipt')
       .run()
 
     expect(simulateContractSpy).toHaveBeenCalledWith({
@@ -89,6 +102,7 @@ describe('sendPayment', () => {
         [matchers.call.fn(getViemWallet), mockViemWallet],
         [matchers.call.fn(getSendTxFeeDetails), mockViemFeeInfo],
         [matchers.call.fn(unlockAccount), UnlockResult.SUCCESS],
+        [matchers.call.fn(sendAndMonitorTransaction), 'txReceipt'],
       ])
       .call(getViemWallet, networkConfig.viemChain.celo)
       .not.call.fn(encryptComment)
@@ -99,7 +113,8 @@ describe('sendPayment', () => {
         feeInfo: mockFeeInfo,
         encryptedComment: '',
       })
-      .returns(mockTxHash)
+      .put.like({ action: { type: Actions.ADD_STANDBY_TRANSACTION } })
+      .returns('txReceipt')
       .run()
 
     expect(simulateContractSpy).toHaveBeenCalledWith({
@@ -121,21 +136,23 @@ describe('sendPayment', () => {
         [matchers.call.fn(getViemWallet), mockViemWallet],
         [matchers.call.fn(getSendTxFeeDetails), mockViemFeeInfo],
       ])
+      .not.put.like({ action: { type: Actions.ADD_STANDBY_TRANSACTION } })
+      .not.call.fn(unlockAccount)
+      .not.call.fn(sendAndMonitorTransaction)
       .throws(new Error('simulate error'))
       .run()
   })
 
-  it('throws if writeContract fails', async () => {
-    mockViemWallet.writeContract.mockRejectedValue(new Error('write error'))
-
+  it('throws if sendAndMonitorTransaction fails', async () => {
     await expectSaga(sendPayment, { ...mockSendPaymentArgs, tokenAddress: mockCeloAddress })
       .withState(createMockStore().getState())
       .provide([
         [matchers.call.fn(getViemWallet), mockViemWallet],
         [matchers.call.fn(getSendTxFeeDetails), mockViemFeeInfo],
         [matchers.call.fn(unlockAccount), UnlockResult.SUCCESS],
+        [matchers.call.fn(sendAndMonitorTransaction), throwError(new Error('tx failed'))],
       ])
-      .throws(new Error('write error'))
+      .throws(new Error('tx failed'))
       .run()
   })
 })
@@ -224,6 +241,82 @@ describe('getSendTxFeeDetails', () => {
         feeInfo.gasPrice
       )
       .returns(mockViemFeeInfo)
+      .run()
+  })
+})
+
+describe('sendAndMonitorTransaction', () => {
+  const mockTxHash = '0x12345678901234'
+  const mockTxReceipt = { status: 'success' }
+  const mockArgs = {
+    context: { id: 'txId' },
+    wallet: mockViemWallet,
+    request: {} as any,
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+  it('confirms a transaction if successfully executed', async () => {
+    await expectSaga(sendAndMonitorTransaction, mockArgs)
+      .provide([
+        [matchers.call.fn(mockViemWallet.writeContract), mockTxHash],
+        [matchers.call.fn(publicClient.celo.waitForTransactionReceipt), mockTxReceipt],
+      ])
+      .put(addHashToStandbyTransaction('txId', mockTxHash))
+      .put(transactionConfirmedViem('txId'))
+      .put(fetchTokenBalances({ showLoading: true }))
+      .call([mockViemWallet, 'writeContract'], mockArgs.request)
+      .call([publicClient.celo, 'waitForTransactionReceipt'], { hash: mockTxHash })
+      .returns(mockTxReceipt)
+      .run()
+  })
+
+  it('fails a transaction and removes standby tx if receipt status is reverted', async () => {
+    await expectSaga(sendAndMonitorTransaction, mockArgs)
+      .provide([
+        [matchers.call.fn(mockViemWallet.writeContract), mockTxHash],
+        [matchers.call.fn(publicClient.celo.waitForTransactionReceipt), { status: 'reverted' }],
+      ])
+      .put(addHashToStandbyTransaction('txId', mockTxHash))
+      .put(removeStandbyTransaction('txId'))
+      .put(transactionFailed('txId'))
+      .put(showError(ErrorMessages.TRANSACTION_FAILED))
+      .call([mockViemWallet, 'writeContract'], mockArgs.request)
+      .call([publicClient.celo, 'waitForTransactionReceipt'], { hash: mockTxHash })
+      .throws(new Error('transaction reverted'))
+      .run()
+  })
+
+  it('fails a transaction and removes standby tx if writeContract throws', async () => {
+    await expectSaga(sendAndMonitorTransaction, mockArgs)
+      .provide([
+        [matchers.call.fn(mockViemWallet.writeContract), throwError(new Error('write failed'))],
+      ])
+      .not.put(addHashToStandbyTransaction('txId', mockTxHash))
+      .put(removeStandbyTransaction('txId'))
+      .put(transactionFailed('txId'))
+      .put(showError(ErrorMessages.TRANSACTION_FAILED))
+      .call([mockViemWallet, 'writeContract'], mockArgs.request)
+      .not.call.fn(publicClient.celo.waitForTransactionReceipt)
+      .throws(new Error('write failed'))
+      .run()
+  })
+
+  it('fails a transaction and removes standby tx if wait for receipt throws', async () => {
+    await expectSaga(sendAndMonitorTransaction, mockArgs)
+      .provide([
+        [matchers.call.fn(mockViemWallet.writeContract), mockTxHash],
+        [
+          matchers.call.fn(publicClient.celo.waitForTransactionReceipt),
+          throwError(new Error('wait failed')),
+        ],
+      ])
+      // .put(addHashToStandbyTransaction('txId', mockTxHash))
+      // .put(removeStandbyTransaction('txId'))
+      // .put(transactionFailed('txId'))
+      // .put(showError(ErrorMessages.TRANSACTION_FAILED))
+      .throws(new Error('wait failed'))
       .run()
   })
 })


### PR DESCRIPTION
### Description

Implement the equivalent of the existing [sendAndMonitorTransaction](https://github.com/valora-inc/wallet/blob/955ea9dda0c8e9ca8b8e079097c74b307adf45f1/src/transactions/saga.ts#L151) method using contract kit. 

### Test plan

Unit tests, manually by enabling the dummy flag and running through the send flow

### Related issues

- Fixes ACT-786

### Backwards compatibility

N/A
