### PR TITLE
fix: remove paragraphSpacing as not supported by react native

### DIFF
--- a/src/styles/fonts.tsx
+++ b/src/styles/fonts.tsx
@@ -111,26 +111,22 @@ export const typeScale = StyleSheet.create({
     fontFamily: Inter.Regular,
     fontSize: 18,
     lineHeight: 28,
-    paragraphSpacing: 18,
   },
   bodyMedium: {
     fontFamily: Inter.Regular,
     fontSize: 16,
     lineHeight: 24,
-    paragraphSpacing: 16,
   },
   bodySmall: {
     fontFamily: Inter.Regular,
     fontSize: 14,
     lineHeight: 20,
-    paragraphSpacing: 14,
   },
   bodyXSmall: {
     fontFamily: Inter.Regular,
     fontSize: 12,
     lineHeight: 16,
     letterSpacing: 0.12,
-    paragraphSpacing: 12,
   },
   bodyXXSmall: {
     fontFamily: Inter.Regular,


### PR DESCRIPTION
### Description

Removes the the text style prop `paragraphSpacing` that is not supported by [react-native](https://reactnative.dev/docs/text-style-props).

### Test plan

N/A

### Related issues

N/A

### Backwards compatibility

Yes