### PR TITLE
fix: pay deeplinks showing and sending incorrect amounts

### DIFF
--- a/src/send/utils.ts
+++ b/src/send/utils.ts
@@ -1,6 +1,10 @@
 import { SendOrigin } from 'src/analytics/types'
 import { LocalCurrencyCode } from 'src/localCurrency/consts'
-import { convertDollarsToLocalAmount, convertLocalAmountToDollars } from 'src/localCurrency/convert'
+import {
+  convertDollarsToLocalAmount,
+  convertLocalAmountToDollars,
+  convertToMaxSupportedPrecision,
+} from 'src/localCurrency/convert'
 import { fetchExchangeRate } from 'src/localCurrency/saga'
 import { getLocalCurrencyCode, usdToLocalCurrencyRateSelector } from 'src/localCurrency/selectors'
 import { navigate } from 'src/navigator/NavigationService'
@@ -12,6 +16,7 @@ import { canSendTokensSelector } from 'src/send/selectors'
 import { TransactionDataInput } from 'src/send/SendAmount'
 import { tokensListSelector } from 'src/tokens/selectors'
 import { TokenBalanceWithAddress } from 'src/tokens/slice'
+import { convertLocalToTokenAmount } from 'src/tokens/utils'
 import { Currency } from 'src/utils/currencies'
 import Logger from 'src/utils/Logger'
 import { call, put, select } from 'typed-redux-saga'
@@ -60,9 +65,14 @@ export function* handleSendPaymentData(
       : yield* select(getLocalCurrencyCode)
     const exchangeRate = yield* call(fetchExchangeRate, LocalCurrencyCode.USD, currency)
     const dollarAmount = convertLocalAmountToDollars(data.amount, exchangeRate)
-    const localCurrencyExchangeRate: string | null = yield* select(usdToLocalCurrencyRateSelector)
-    const inputAmount = convertDollarsToLocalAmount(dollarAmount, localCurrencyExchangeRate)
-    const tokenAmount = dollarAmount?.times(tokenInfo.priceUsd)
+    const usdToLocalRate = yield* select(usdToLocalCurrencyRateSelector)
+    const localAmount = convertDollarsToLocalAmount(dollarAmount, usdToLocalRate)
+    const inputAmount = localAmount && convertToMaxSupportedPrecision(localAmount)
+    const tokenAmount = convertLocalToTokenAmount({
+      localAmount: inputAmount,
+      tokenInfo,
+      usdToLocalRate,
+    })
     if (!inputAmount || !tokenAmount) {
       Logger.warn(TAG, '@handleSendPaymentData null amount')
       return


### PR DESCRIPTION
### Description

This fixes a regression with `celo://wallet/pay?...` deeplinks which happened when we switched to support multi token a long time ago.

This got uncovered working on https://github.com/valora-inc/wallet/pull/4230, blocking the e2e tests there.

### Test plan

Only the unit tests needed to be updated here.
The e2e tests couldn't uncover this bug because of the hardcoded cUSD price there ([1 cUSD is 1 USD](https://github.com/valora-inc/wallet/blob/2e91e5b8749114ea77fa46d7f969e2ad0223b050/src/tokens/e2eTokens.ts#L18)), and the local currency selected being USD (maybe we should change that?).

With the following deeplink:
```
celo://wallet/pay?address=0xC0509a7dcc69a0B28c7Ca73feD2FF06b9d59E5b9&amount=0.1&currencyCode=USD&token=cUSD&displayName=TestFaucet&comment=sending+usd:+0.1+to+my+wallet
```

The expected effect is that the equivalent of 0.1 USD in cUSD will be sent.
Since this is on Alfajores, where 1 cUSD is 1.5 USD, the sent cUSD amount should be 0.1 / 1.5 = 0.0667.

Note that the screenshots were taken on a device where the local currency is PHP. So it's expected to see most values shown in PHP.

**before/after**
<img src="https://github.com/valora-inc/wallet/assets/57791/134fa15b-1a70-4958-a176-5501e7ea049b" width="50%" /><img src="https://github.com/valora-inc/wallet/assets/57791/28a0a3fb-4f76-41cb-9847-983e803396e7" width="50%" />

With the following deeplink:
```
celo://wallet/pay?address=0xC0509a7dcc69a0B28c7Ca73feD2FF06b9d59E5b9&amount=0.1&token=cUSD&displayName=TestFaucet&comment=sending+usd:+0.1+to+my+wallet
```
The expected effect is that the equivalent of 0.1 PHP (local currency, since `currencyCode` isn't set explicitly) in cUSD will be sent.
Since this is on Alfajores, where 1 USD is 56.931999 PHP and 1 cUSD is 1.5 USD, the sent cUSD amount should be 0.1 / 56.931999 / 1.5  = 0.0012.

Again, the screenshots were taken on a device where the local currency is PHP. So it's expected to see most values shown in PHP.

Please also note that the comment should be "sending local: 0.1 to my wallet" to be correct and less confusing.

**before/after**
<img src="https://github.com/valora-inc/wallet/assets/57791/270ed61f-8faf-4ea1-9938-4b8051e22fcc" width="50%" /><img src="https://github.com/valora-inc/wallet/assets/57791/18bf06b0-47b5-4c17-9727-ead15f21fb55" width="50%" />

Final note, there seem to be another bug with the local amount at the top + fee not adding up to the total displayed. This isn't something new though. We can dig and fix this separately.

### Related issues

- N/A

### Backwards compatibility

Pay deeplinks amounts will now work as [documented](https://github.com/valora-inc/wallet/blob/main/docs/deeplinks.md).
