### PR TITLE
fix(multichain): Filter out non-Celo tokens in legacy token selectors

### DIFF
--- a/src/analytics/ValoraAnalytics.test.ts
+++ b/src/analytics/ValoraAnalytics.test.ts
@@ -8,11 +8,16 @@ import { Statsig } from 'statsig-react-native'
 import { getMockStoreData } from 'test/utils'
 import {
   mockCeloAddress,
+  mockCeloTokenId,
   mockCeurAddress,
+  mockCeurTokenId,
   mockCusdAddress,
+  mockCusdTokenId,
   mockPositions,
   mockTestTokenAddress,
+  mockTestTokenTokenId,
 } from 'test/values'
+import { NetworkId } from 'src/transactions/types'
 
 jest.mock('@segment/analytics-react-native')
 jest.mock('@segment/analytics-react-native-plugin-adjust')
@@ -27,6 +32,17 @@ jest.mock('src/config', () => ({
 }))
 jest.mock('statsig-react-native')
 jest.mock('src/statsig')
+jest.mock('src/web3/networkConfig', () => {
+  const originalModule = jest.requireActual('src/web3/networkConfig')
+  return {
+    ...originalModule,
+    __esModule: true,
+    default: {
+      ...originalModule.default,
+      defaultNetworkId: 'celo-alfajores',
+    },
+  }
+})
 
 const mockDeviceId = 'abc-def-123' // mocked in __mocks__/react-native-device-info.ts (but importing from that file causes weird errors)
 const expectedSessionId = '205ac8350460ad427e35658006b409bbb0ee86c22c57648fe69f359c2da648'
@@ -38,45 +54,57 @@ const mockStore = jest.mocked(store)
 const state = getMockStoreData({
   tokens: {
     tokenBalances: {
-      [mockCusdAddress]: {
+      [mockCusdTokenId]: {
         address: mockCusdAddress,
+        tokenId: mockCusdTokenId,
+        networkId: NetworkId['celo-alfajores'],
         symbol: 'cUSD',
         priceUsd: '1',
         balance: '10',
         priceFetchedAt: Date.now(),
         isCoreToken: true,
       },
-      [mockCeurAddress]: {
+      [mockCeurTokenId]: {
         address: mockCeurAddress,
+        tokenId: mockCeurTokenId,
+        networkId: NetworkId['celo-alfajores'],
         symbol: 'cEUR',
         priceUsd: '1.2',
         balance: '20',
         priceFetchedAt: Date.now(),
         isCoreToken: true,
       },
-      [mockCeloAddress]: {
+      [mockCeloTokenId]: {
         address: mockCeloAddress,
+        tokenId: mockCeloTokenId,
+        networkId: NetworkId['celo-alfajores'],
         symbol: 'CELO',
         priceUsd: '5',
         balance: '0',
         priceFetchedAt: Date.now(),
         isCoreToken: true,
       },
-      [mockTestTokenAddress]: {
+      [mockTestTokenTokenId]: {
         address: mockTestTokenAddress,
+        tokenId: mockTestTokenTokenId,
+        networkId: NetworkId['celo-alfajores'],
         symbol: 'TT',
         balance: '10',
         priceFetchedAt: Date.now(),
       },
-      '0xMOO': {
+      'celo-alfajores:0xMOO': {
         address: '0xMOO',
+        tokenId: 'celo-alfajores:0xMOO',
+        networkId: NetworkId['celo-alfajores'],
         symbol: 'MOO',
         priceUsd: '4',
         balance: '0',
         priceFetchedAt: Date.now(),
       },
-      '0xUBE': {
+      'celo-alfajores:0xUBE': {
         address: '0xUBE',
+        tokenId: 'celo-alfajores:0xUBE',
+        networkId: NetworkId['celo-alfajores'],
         symbol: 'UBE',
         priceUsd: '2',
         balance: '1',

--- a/src/components/TokenBalance.test.tsx
+++ b/src/components/TokenBalance.test.tsx
@@ -13,8 +13,25 @@ import { getFeatureGate } from 'src/statsig'
 import { ONE_DAY_IN_MILLIS } from 'src/utils/time'
 import { createMockStore, getElementText } from 'test/utils'
 import { mockPositions, mockTokenBalances } from 'test/values'
+import { NetworkId } from 'src/transactions/types'
 
 jest.mock('src/statsig')
+
+jest.mock('src/web3/networkConfig', () => {
+  const originalModule = jest.requireActual('src/web3/networkConfig')
+  return {
+    __esModule: true,
+    ...originalModule,
+    default: {
+      ...originalModule.default,
+      networkToNetworkId: {
+        celo: 'celo-alfajores',
+        ethereum: 'ethereuim-sepolia',
+      },
+      defaultNetworkId: 'celo-alfajores',
+    },
+  }
+})
 
 const defaultStore = {
   tokens: {
@@ -40,22 +57,28 @@ describe('FiatExchangeTokenBalance and HomeTokenBalance', () => {
         ...defaultStore,
         tokens: {
           tokenBalances: {
-            '0x00400FcbF0816bebB94654259de7273f4A05c762': {
+            'celo-alfajores:0x00400FcbF0816bebB94654259de7273f4A05c762': {
               priceUsd: '0.1',
               address: '0x00400FcbF0816bebB94654259de7273f4A05c762',
+              tokenId: 'celo-alfajores:0x00400FcbF0816bebB94654259de7273f4A05c762',
+              networkId: NetworkId['celo-alfajores'],
               symbol: 'POOF',
               balance: '5',
               priceFetchedAt: Date.now(),
             },
-            '0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F': {
+            'celo-alfajores:0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F': {
               priceUsd: '1.16',
               address: '0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F',
+              tokenId: 'celo-alfajores:0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F',
+              networkId: NetworkId['celo-alfajores'],
               symbol: 'cEUR',
               balance: '7',
               priceFetchedAt: Date.now(),
             },
-            '0x048F47d358EC521a6cf384461d674750a3cB58C8': {
+            'celo-alfajores:0x048F47d358EC521a6cf384461d674750a3cB58C8': {
               address: '0x048F47d358EC521a6cf384461d674750a3cB58C8',
+              tokenId: 'celo-alfajores:0x048F47d358EC521a6cf384461d674750a3cB58C8',
+              networkId: NetworkId['celo-alfajores'],
               symbol: 'TT',
               balance: '10',
               priceFetchedAt: Date.now(),
@@ -83,16 +106,20 @@ describe('FiatExchangeTokenBalance and HomeTokenBalance', () => {
         tokens: {
           // FiatExchangeTokenBalance requires 2 balances to display the View Balances button
           tokenBalances: {
-            '0x00400FcbF0816bebB94654259de7273f4A05c762': {
+            'celo-alfajores:0x00400FcbF0816bebB94654259de7273f4A05c762': {
               priceUsd: '0.1',
               address: '0x00400FcbF0816bebB94654259de7273f4A05c762',
+              tokenId: 'celo-alfajores:0x00400FcbF0816bebB94654259de7273f4A05c762',
+              networkId: NetworkId['celo-alfajores'],
               symbol: 'POOF',
               balance: '5',
               priceFetchedAt: Date.now(),
             },
-            '0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F': {
+            'celo-alfajores:0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F': {
               priceUsd: '1.16',
               address: '0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F',
+              tokenId: 'celo-alfajores:0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F',
+              networkId: NetworkId['celo-alfajores'],
               symbol: 'cEUR',
               balance: '7',
               priceFetchedAt: Date.now(),
@@ -199,15 +226,19 @@ describe('FiatExchangeTokenBalance and HomeTokenBalance', () => {
         ...defaultStore,
         tokens: {
           tokenBalances: {
-            '0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F': {
+            'celo-alfajores:0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F': {
               priceUsd: '1.16',
               address: '0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F',
+              tokenId: 'celo-alfajores:0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F',
+              networkId: NetworkId['celo-alfajores'],
               symbol: 'cEUR',
               balance: '7',
               priceFetchedAt: Date.now(),
             },
-            '0x048F47d358EC521a6cf384461d674750a3cB58C8': {
+            'celo-alfajores:0x048F47d358EC521a6cf384461d674750a3cB58C8': {
               address: '0x048F47d358EC521a6cf384461d674750a3cB58C8',
+              tokenId: 'celo-alfajores:0x048F47d358EC521a6cf384461d674750a3cB58C8',
+              networkId: NetworkId['celo-alfajores'],
               symbol: 'TT',
               balance: '10',
             },
@@ -236,15 +267,19 @@ describe('FiatExchangeTokenBalance and HomeTokenBalance', () => {
         ...defaultStore,
         tokens: {
           tokenBalances: {
-            '0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F': {
+            'celo-alfajores:0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F': {
               priceUsd: '1.16',
               address: '0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F',
+              tokenId: 'celo-alfajores:0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F',
+              networkId: NetworkId['celo-alfajores'],
               symbol: 'cEUR',
               balance: '7',
               priceFetchedAt: Date.now(),
             },
-            '0x048F47d358EC521a6cf384461d674750a3cB58C8': {
+            'celo-alfajores:0x048F47d358EC521a6cf384461d674750a3cB58C8': {
               address: '0x048F47d358EC521a6cf384461d674750a3cB58C8',
+              tokenId: 'celo-alfajores:0x048F47d358EC521a6cf384461d674750a3cB58C8',
+              networkId: NetworkId['celo-alfajores'],
               symbol: 'TT',
               balance: '10',
             },
@@ -312,17 +347,21 @@ describe('FiatExchangeTokenBalance and HomeTokenBalance', () => {
       const store = createMockStore({
         tokens: {
           tokenBalances: {
-            '0xcelo': {
+            'celo-alfajores:0xcelo': {
               name: 'Celo',
               address: '0xcelo',
+              tokenId: 'celo-alfajores:0xcelo',
+              networkId: NetworkId['celo-alfajores'],
               symbol: 'CELO',
               balance: '1',
               priceUsd: '0.90',
               priceFetchedAt: Date.now() - ONE_DAY_IN_MILLIS,
               isCoreToken: true,
             },
-            '0x048F47d358EC521a6cf384461d674750a3cB58C8': {
+            'celo-alfajores:0x048F47d358EC521a6cf384461d674750a3cB58C8': {
               address: '0x048F47d358EC521a6cf384461d674750a3cB58C8',
+              tokenId: 'celo-alfajores:0x048F47d358EC521a6cf384461d674750a3cB58C8',
+              networkId: NetworkId['celo-alfajores'],
               symbol: 'TT',
               balance: '10',
             },
@@ -350,17 +389,21 @@ describe('FiatExchangeTokenBalance and HomeTokenBalance', () => {
       const store = createMockStore({
         tokens: {
           tokenBalances: {
-            '0xcelo': {
+            'celo-alfajores:0xcelo': {
               name: 'Celo',
               address: '0xcelo',
+              tokenId: 'celo-alfajores:0xcelo',
+              networkId: NetworkId['celo-alfajores'],
               symbol: 'CELO',
               balance: '1',
               priceUsd: '0.90',
               priceFetchedAt: Date.now() - ONE_DAY_IN_MILLIS,
               isCoreToken: true,
             },
-            '0x048F47d358EC521a6cf384461d674750a3cB58C8': {
+            'celo-alfajores:0x048F47d358EC521a6cf384461d674750a3cB58C8': {
               address: '0x048F47d358EC521a6cf384461d674750a3cB58C8',
+              tokenId: 'celo-alfajores:0x048F47d358EC521a6cf384461d674750a3cB58C8',
+              networkId: NetworkId['celo-alfajores'],
               symbol: 'TT',
               balance: '10',
             },

--- a/src/components/TokenDisplay.test.tsx
+++ b/src/components/TokenDisplay.test.tsx
@@ -9,10 +9,22 @@ import { RootState } from 'src/redux/reducers'
 import { getFeatureGate } from 'src/statsig'
 import { Currency } from 'src/utils/currencies'
 import { createMockStore, getElementText, RecursivePartial } from 'test/utils'
+import { NetworkId } from 'src/transactions/types'
 
 jest.mock('src/statsig', () => ({
   getFeatureGate: jest.fn(() => false),
 }))
+jest.mock('src/web3/networkConfig', () => {
+  const originalModule = jest.requireActual('src/web3/networkConfig')
+  return {
+    ...originalModule,
+    __esModule: true,
+    default: {
+      ...originalModule.default,
+      defaultNetworkId: 'celo-alfajores',
+    },
+  }
+})
 
 describe('TokenDisplay', () => {
   function store(storeOverrides?: RecursivePartial<RootState>) {
@@ -24,22 +36,28 @@ describe('TokenDisplay', () => {
       },
       tokens: {
         tokenBalances: {
-          ['0xusd']: {
+          ['celo-alfajores:0xusd']: {
             address: '0xusd',
+            tokenId: 'celo-alfajores:0xusd',
+            networkId: NetworkId['celo-alfajores'],
             symbol: 'cUSD',
             balance: '50',
             priceUsd: '1',
             priceFetchedAt: Date.now(),
           },
-          ['0xeur']: {
+          ['celo-alfajores:0xeur']: {
             address: '0xeur',
+            tokenId: 'celo-alfajores:0xeur',
+            networkId: NetworkId['celo-alfajores'],
             symbol: 'cEUR',
             balance: '50',
             priceUsd: '1.2',
             priceFetchedAt: Date.now(),
           },
-          ['0xcelo']: {
+          ['celo-alfajores:0xcelo']: {
             address: '0xcelo',
+            tokenId: 'celo-alfajores:0xcelo',
+            networkId: NetworkId['celo-alfajores'],
             symbol: 'CELO',
             balance: '10',
             priceUsd: '5',

--- a/src/dapps/DappShortcutsRewards.test.tsx
+++ b/src/dapps/DappShortcutsRewards.test.tsx
@@ -6,14 +6,28 @@ import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import { Position } from 'src/positions/types'
 import { createMockStore } from 'test/utils'
-import { mockCusdAddress, mockPositions, mockShortcuts } from 'test/values'
+import { mockCusdAddress, mockCusdTokenId, mockPositions, mockShortcuts } from 'test/values'
+import { NetworkId } from 'src/transactions/types'
 
 jest.mock('src/statsig', () => ({
   getFeatureGate: jest.fn(() => true),
 }))
+jest.mock('src/web3/networkConfig', () => {
+  const originalModule = jest.requireActual('src/web3/networkConfig')
+  return {
+    ...originalModule,
+    __esModule: true,
+    default: {
+      ...originalModule.default,
+      defaultNetworkId: 'celo-alfajores',
+    },
+  }
+})
 
 const mockCeloAddress = '0x471ece3750da237f93b8e339c536989b8978a438'
 const mockUbeAddress = '0x00be915b9dcf56a3cbe739d9b9c202ca692409ec'
+const mockCeloTokenId = `celo-alfajores:${mockCeloAddress}`
+const mockUbeTokenId = `celo-alfajores:${mockUbeAddress}`
 
 const getPositionWithClaimableBalance = (balance?: string): Position => ({
   type: 'contract-position',
@@ -89,23 +103,29 @@ const defaultState = {
   },
   tokens: {
     tokenBalances: {
-      [mockCeloAddress]: {
+      [mockCeloTokenId]: {
         address: mockCeloAddress,
+        tokenId: mockCeloTokenId,
+        networkId: NetworkId['celo-alfajores'],
         symbol: 'CELO',
         priceUsd: '0.6959536890241361', // matches data in mockPositions
         balance: '10',
         priceFetchedAt: Date.now(),
         isCoreToken: true,
       },
-      [mockUbeAddress]: {
+      [mockUbeTokenId]: {
         address: mockUbeAddress,
+        tokenId: mockUbeTokenId,
+        networkId: NetworkId['celo-alfajores'],
         symbol: 'UBE',
         priceUsd: '0.00904673476946796903', // matches data in mockPositions
         balance: '10',
         priceFetchedAt: Date.now(),
       },
-      [mockCusdAddress]: {
+      [mockCusdTokenId]: {
         address: mockCusdAddress,
+        tokenId: mockCusdTokenId,
+        networkId: NetworkId['celo-alfajores'],
         symbol: 'cUSD',
         priceUsd: '1',
         balance: '10',

--- a/src/fees/hooks.test.tsx
+++ b/src/fees/hooks.test.tsx
@@ -10,10 +10,26 @@ import { RecursivePartial, createMockStore, getElementText } from 'test/utils'
 import {
   emptyFees,
   mockCeloAddress,
+  mockCeloTokenId,
   mockCeurAddress,
+  mockCeurTokenId,
   mockCusdAddress,
+  mockCusdTokenId,
   mockFeeInfo,
 } from 'test/values'
+import { NetworkId } from 'src/transactions/types'
+
+jest.mock('src/web3/networkConfig', () => {
+  const originalModule = jest.requireActual('src/web3/networkConfig')
+  return {
+    ...originalModule,
+    __esModule: true,
+    default: {
+      ...originalModule.default,
+      defaultNetworkId: 'celo-alfajores',
+    },
+  }
+})
 
 interface ComponentProps {
   feeType: FeeType.SEND
@@ -52,24 +68,30 @@ describe('useMaxSendAmount', () => {
     const store = createMockStore({
       tokens: {
         tokenBalances: {
-          [mockCusdAddress]: {
+          [mockCusdTokenId]: {
             address: mockCusdAddress,
+            tokenId: mockCusdTokenId,
+            networkId: NetworkId['celo-alfajores'],
             symbol: 'cUSD',
             balance: '200',
             priceUsd: '1',
             isCoreToken: true,
             priceFetchedAt: Date.now(),
           },
-          [mockCeurAddress]: {
+          [mockCeurTokenId]: {
             address: mockCeurAddress,
+            tokenId: mockCeurTokenId,
+            networkId: NetworkId['celo-alfajores'],
             symbol: 'cEUR',
             balance: '100',
             priceUsd: '1.2',
             isCoreToken: true,
             priceFetchedAt: Date.now(),
           },
-          [mockCeloAddress]: {
+          [mockCeloTokenId]: {
             address: mockCeloAddress,
+            tokenId: mockCeloTokenId,
+            networkId: NetworkId['celo-alfajores'],
             symbol: 'CELO',
             balance: '200',
             priceUsd: '5',

--- a/src/fees/saga.test.ts
+++ b/src/fees/saga.test.ts
@@ -13,27 +13,43 @@ import { buildSendTx } from 'src/send/saga'
 import { getContractKit, getContractKitAsync } from 'src/web3/contracts'
 import { estimateGas } from 'src/web3/utils'
 import { createMockStore } from 'test/utils'
-import { mockCeurAddress, mockCusdAddress } from 'test/values'
+import { mockCeurAddress, mockCeurTokenId, mockCusdAddress, mockCusdTokenId } from 'test/values'
+import { NetworkId } from 'src/transactions/types'
 
 const GAS_AMOUNT = 500000
 
 jest.mock('@celo/connect')
+jest.mock('src/web3/networkConfig', () => {
+  const originalModule = jest.requireActual('src/web3/networkConfig')
+  return {
+    ...originalModule,
+    __esModule: true,
+    default: {
+      ...originalModule.default,
+      defaultNetworkId: 'celo-alfajores',
+    },
+  }
+})
 
 const mockTxo = jest.fn()
 
 const store = createMockStore({
   tokens: {
     tokenBalances: {
-      [mockCusdAddress]: {
+      [mockCusdTokenId]: {
         address: mockCusdAddress,
+        tokenId: mockCusdTokenId,
+        networkId: NetworkId['celo-alfajores'],
         symbol: 'cUSD',
         priceUsd: '1',
         balance: '100',
         isCoreToken: true,
         priceFetchedAt: Date.now(),
       },
-      [mockCeurAddress]: {
+      [mockCeurTokenId]: {
         address: mockCeurAddress,
+        tokenId: mockCeurTokenId,
+        networkId: NetworkId['celo-alfajores'],
         symbol: 'cEUR',
         priceUsd: '1.2',
         balance: '0',

--- a/src/fiatExchanges/FiatExchangeAmount.test.tsx
+++ b/src/fiatExchanges/FiatExchangeAmount.test.tsx
@@ -14,8 +14,17 @@ import { StatsigFeatureGates } from 'src/statsig/types'
 import { Network } from 'src/transactions/types'
 import { CiCoCurrency } from 'src/utils/currencies'
 import { createMockStore, getElementText, getMockStackScreenProps } from 'test/utils'
-import { mockCeloAddress, mockCeurAddress, mockCusdAddress, mockMaxSendAmount } from 'test/values'
+import {
+  mockCeloAddress,
+  mockCeloTokenId,
+  mockCeurAddress,
+  mockCeurTokenId,
+  mockCusdAddress,
+  mockCusdTokenId,
+  mockMaxSendAmount,
+} from 'test/values'
 import { CICOFlow } from './utils'
+import { NetworkId } from 'src/transactions/types'
 
 const mockUseMaxSendAmount = jest.fn(() => mockMaxSendAmount)
 jest.mock('src/fees/hooks', () => ({
@@ -24,6 +33,21 @@ jest.mock('src/fees/hooks', () => ({
 jest.mock('src/statsig', () => ({
   getFeatureGate: jest.fn(),
 }))
+jest.mock('src/web3/networkConfig', () => {
+  const originalModule = jest.requireActual('src/web3/networkConfig')
+  return {
+    __esModule: true,
+    ...originalModule,
+    default: {
+      ...originalModule.default,
+      networkToNetworkId: {
+        celo: 'celo-alfajores',
+        ethereum: 'ethereuim-sepolia',
+      },
+      defaultNetworkId: 'celo-alfajores',
+    },
+  }
+})
 
 const usdToUsdRate = '1'
 const usdToEurRate = '0.862'
@@ -31,24 +55,30 @@ const usdToPhpRate = '50'
 
 const mockTokens = {
   tokenBalances: {
-    [mockCusdAddress]: {
+    [mockCusdTokenId]: {
       address: mockCusdAddress,
+      tokenId: mockCusdTokenId,
+      networkId: NetworkId['celo-alfajores'],
       symbol: 'cUSD',
       balance: '200',
       priceUsd: '1',
       isCoreToken: true,
       priceFetchedAt: Date.now(),
     },
-    [mockCeurAddress]: {
+    [mockCeurTokenId]: {
       address: mockCeurAddress,
+      tokenId: mockCeurTokenId,
+      networkId: NetworkId['celo-alfajores'],
       symbol: 'cEUR',
       balance: '100',
       priceUsd: '1.2',
       isCoreToken: true,
       priceFetchedAt: Date.now(),
     },
-    [mockCeloAddress]: {
+    [mockCeloTokenId]: {
       address: mockCeloAddress,
+      tokenId: mockCeloTokenId,
+      networkId: NetworkId['celo-alfajores'],
       symbol: 'CELO',
       balance: '200',
       priceUsd: '5',

--- a/src/fiatExchanges/PaymentMethodSection.test.tsx
+++ b/src/fiatExchanges/PaymentMethodSection.test.tsx
@@ -14,11 +14,13 @@ import { CiCoCurrency } from 'src/utils/currencies'
 import { createMockStore } from 'test/utils'
 import {
   mockCusdAddress,
+  mockCusdTokenId,
   mockFiatConnectQuotes,
   mockFiatConnectQuotesWithUnknownFees,
   mockProviders,
   mockProviderSelectionAnalyticsData,
 } from 'test/values'
+import { NetworkId } from 'src/transactions/types'
 
 const mockStore = createMockStore({
   localCurrency: {
@@ -26,8 +28,10 @@ const mockStore = createMockStore({
   },
   tokens: {
     tokenBalances: {
-      [mockCusdAddress]: {
+      [mockCusdTokenId]: {
         address: mockCusdAddress,
+        tokenId: mockCusdTokenId,
+        networkId: NetworkId['celo-alfajores'],
         symbol: 'cUSD',
         priceUsd: '1',
         balance: '10',
@@ -36,6 +40,18 @@ const mockStore = createMockStore({
       },
     },
   },
+})
+
+jest.mock('src/web3/networkConfig', () => {
+  const originalModule = jest.requireActual('src/web3/networkConfig')
+  return {
+    ...originalModule,
+    __esModule: true,
+    default: {
+      ...originalModule.default,
+      defaultNetworkId: 'celo-alfajores',
+    },
+  }
 })
 
 jest.mock('src/statsig', () => ({

--- a/src/fiatconnect/ReviewScreen.test.tsx
+++ b/src/fiatconnect/ReviewScreen.test.tsx
@@ -19,12 +19,27 @@ import { Currency } from 'src/utils/currencies'
 import { createMockStore, getMockStackScreenProps, sleep } from 'test/utils'
 import {
   mockCeloAddress,
+  mockCeloTokenId,
   mockCeurAddress,
+  mockCeurTokenId,
   mockCusdAddress,
+  mockCusdTokenId,
   mockFeeInfo,
   mockFiatConnectQuotes,
 } from 'test/values'
+import { NetworkId } from 'src/transactions/types'
 
+jest.mock('src/web3/networkConfig', () => {
+  const originalModule = jest.requireActual('src/web3/networkConfig')
+  return {
+    ...originalModule,
+    __esModule: true,
+    default: {
+      ...originalModule.default,
+      defaultNetworkId: 'celo-alfajores',
+    },
+  }
+})
 jest.mock('src/localCurrency/selectors', () => {
   const originalModule = jest.requireActual('src/localCurrency/selectors')
 
@@ -107,24 +122,30 @@ function getStore({ feeEstimate = defaultFeeEstimate }: { feeEstimate?: FeeEstim
     },
     tokens: {
       tokenBalances: {
-        [mockCusdAddress]: {
+        [mockCusdTokenId]: {
           address: mockCusdAddress,
+          tokenId: mockCusdTokenId,
+          networkId: NetworkId['celo-alfajores'],
           symbol: 'cUSD',
           balance: '200',
           priceUsd: '1',
           isCoreToken: true,
           priceFetchedAt: Date.now(),
         },
-        [mockCeurAddress]: {
+        [mockCeurTokenId]: {
           address: mockCeurAddress,
+          tokenId: mockCeurTokenId,
+          networkId: NetworkId['celo-alfajores'],
           symbol: 'cEUR',
           balance: '100',
           priceUsd: '1.2',
           isCoreToken: true,
           priceFetchedAt: Date.now(),
         },
-        [mockCeloAddress]: {
+        [mockCeloTokenId]: {
           address: mockCeloAddress,
+          tokenId: mockCeloTokenId,
+          networkId: NetworkId['celo-alfajores'],
           symbol: 'CELO',
           balance: '200',
           priceUsd: '5',

--- a/src/home/NotificationBox.test.tsx
+++ b/src/home/NotificationBox.test.tsx
@@ -9,14 +9,32 @@ import { Screens } from 'src/navigator/Screens'
 import { createMockStore, getElementText } from 'test/utils'
 import {
   mockCusdAddress,
+  mockCusdTokenId,
   mockE164Number,
   mockE164NumberPepper,
   mockPaymentRequests,
   mockTokenBalances,
 } from 'test/values'
+import { NetworkId } from 'src/transactions/types'
 
 const TWO_DAYS_MS = 2 * 24 * 60 * 1000
 const BACKUP_TIME = new Date().getTime() - TWO_DAYS_MS
+
+jest.mock('src/web3/networkConfig', () => {
+  const originalModule = jest.requireActual('src/web3/networkConfig')
+  return {
+    __esModule: true,
+    ...originalModule,
+    default: {
+      ...originalModule.default,
+      networkToNetworkId: {
+        celo: 'celo-alfajores',
+        ethereum: 'ethereuim-sepolia',
+      },
+      defaultNetworkId: 'celo-alfajores',
+    },
+  }
+})
 
 const testNotification = {
   ctaUri: 'https://celo.org',
@@ -97,8 +115,10 @@ const superchargeWithoutRewardsSetUp = {
 }
 
 const mockcUsdBalance = {
-  [mockCusdAddress]: {
+  [mockCusdTokenId]: {
     address: mockCusdAddress,
+    tokenId: mockCusdTokenId,
+    networkId: NetworkId['celo-alfajores'],
     isCoreToken: true,
     balance: '100',
     symbol: 'cUSD',
@@ -108,8 +128,10 @@ const mockcUsdBalance = {
 }
 
 const mockcUsdWithoutEnoughBalance = {
-  [mockCusdAddress]: {
+  [mockCusdTokenId]: {
     address: mockCusdAddress,
+    tokenId: mockCusdTokenId,
+    networkId: NetworkId['celo-alfajores'],
     isCoreToken: true,
     balance: '5',
     symbol: 'cUSD',

--- a/src/home/NotificationCenter.test.tsx
+++ b/src/home/NotificationCenter.test.tsx
@@ -16,12 +16,25 @@ import { multiplyByWei } from 'src/utils/formatting'
 import { createMockStore, getElementText, getMockStackScreenProps } from 'test/utils'
 import {
   mockCusdAddress,
+  mockCusdTokenId,
   mockE164Number,
   mockE164NumberPepper,
   mockEscrowedPayment,
   mockPaymentRequests,
 } from 'test/values'
+import { NetworkId } from 'src/transactions/types'
 
+jest.mock('src/web3/networkConfig', () => {
+  const originalModule = jest.requireActual('src/web3/networkConfig')
+  return {
+    ...originalModule,
+    __esModule: true,
+    default: {
+      ...originalModule.default,
+      defaultNetworkId: 'celo-alfajores',
+    },
+  }
+})
 jest.mock('src/analytics/ValoraAnalytics')
 jest.mock('src/navigator/NavigationService', () => ({
   ensurePincode: jest.fn(async () => true),
@@ -101,8 +114,10 @@ const superchargeWithoutRewardsSetUp = {
 }
 
 const mockcUsdBalance = {
-  [mockCusdAddress]: {
+  [mockCusdTokenId]: {
     address: mockCusdAddress,
+    tokenId: mockCusdTokenId,
+    networkId: NetworkId['celo-alfajores'],
     isCoreToken: true,
     balance: '100',
     symbol: 'cUSD',
@@ -112,8 +127,10 @@ const mockcUsdBalance = {
 }
 
 const mockcUsdWithoutEnoughBalance = {
-  [mockCusdAddress]: {
+  [mockCusdTokenId]: {
     address: mockCusdAddress,
+    tokenId: mockCusdTokenId,
+    networkId: NetworkId['celo-alfajores'],
     isCoreToken: true,
     balance: '5',
     symbol: 'cUSD',

--- a/src/home/WalletHome.test.tsx
+++ b/src/home/WalletHome.test.tsx
@@ -11,13 +11,36 @@ import { Actions as IdentityActions } from 'src/identity/actions'
 import { RootState } from 'src/redux/reducers'
 import { getExperimentParams, getFeatureGate } from 'src/statsig'
 import { RecursivePartial, createMockStore } from 'test/utils'
-import { mockCeloAddress, mockCeurAddress, mockCusdAddress, mockProviders } from 'test/values'
+import {
+  mockCeloAddress,
+  mockCeloTokenId,
+  mockCeurAddress,
+  mockCeurTokenId,
+  mockCusdAddress,
+  mockCusdTokenId,
+  mockProviders,
+} from 'test/values'
+import { NetworkId } from 'src/transactions/types'
+
+jest.mock('src/web3/networkConfig', () => {
+  const originalModule = jest.requireActual('src/web3/networkConfig')
+  return {
+    ...originalModule,
+    __esModule: true,
+    default: {
+      ...originalModule.default,
+      defaultNetworkId: 'celo-alfajores',
+    },
+  }
+})
 
 const mockBalances = {
   tokens: {
     tokenBalances: {
-      [mockCusdAddress]: {
+      [mockCusdTokenId]: {
         address: mockCusdAddress,
+        tokenId: mockCusdTokenId,
+        networkId: NetworkId['celo-alfajores'],
         symbol: 'cUSD',
         decimals: 18,
         balance: '1',
@@ -25,8 +48,10 @@ const mockBalances = {
         priceUsd: '1',
         priceFetchedAt: Date.now(),
       },
-      [mockCeurAddress]: {
+      [mockCeurTokenId]: {
         address: mockCeurAddress,
+        tokenId: mockCeurTokenId,
+        networkId: NetworkId['celo-alfajores'],
         symbol: 'cEUR',
         decimals: 18,
         balance: '0',
@@ -41,22 +66,28 @@ const mockBalances = {
 const zeroBalances = {
   tokens: {
     tokenBalances: {
-      [mockCusdAddress]: {
+      [mockCusdTokenId]: {
         address: mockCusdAddress,
+        tokenId: mockCusdTokenId,
+        networkId: NetworkId['celo-alfajores'],
         symbol: 'cUSD',
         decimals: 18,
         balance: '0',
         isCoreToken: true,
       },
-      [mockCeurAddress]: {
+      [mockCeurTokenId]: {
         address: mockCeurAddress,
+        tokenId: mockCeurTokenId,
+        networkId: NetworkId['celo-alfajores'],
         symbol: 'cEUR',
         decimals: 18,
         balance: '0',
         isCoreToken: true,
       },
-      [mockCeloAddress]: {
+      [mockCeloTokenId]: {
         address: mockCeloAddress,
+        tokenId: mockCeloTokenId,
+        networkId: NetworkId['celo-alfajores'],
         symbol: 'CELO',
         decimals: 18,
         balance: '0',

--- a/src/merchantPayment/MerchantPaymentScreen.test.tsx
+++ b/src/merchantPayment/MerchantPaymentScreen.test.tsx
@@ -5,7 +5,26 @@ import { Provider } from 'react-redux'
 import MerchantPaymentScreen from 'src/merchantPayment/MerchantPaymentScreen'
 import { Screens } from 'src/navigator/Screens'
 import { createMockStore, getMockStackScreenProps } from 'test/utils'
-import { makeExchangeRates, mockCeloAddress, mockCusdAddress } from 'test/values'
+import {
+  makeExchangeRates,
+  mockCeloAddress,
+  mockCeloTokenId,
+  mockCusdAddress,
+  mockCusdTokenId,
+} from 'test/values'
+import { NetworkId } from 'src/transactions/types'
+
+jest.mock('src/web3/networkConfig', () => {
+  const originalModule = jest.requireActual('src/web3/networkConfig')
+  return {
+    ...originalModule,
+    __esModule: true,
+    default: {
+      ...originalModule.default,
+      defaultNetworkId: 'celo-alfajores',
+    },
+  }
+})
 
 const mockScreenProps = getMockStackScreenProps(Screens.MerchantPayment, {
   apiBase: 'https://example.com',
@@ -18,15 +37,19 @@ describe('MerchantPaymentScreen', () => {
     const store = createMockStore({
       tokens: {
         tokenBalances: {
-          [mockCeloAddress]: {
+          [mockCeloTokenId]: {
             address: mockCeloAddress,
+            tokenId: mockCeloTokenId,
+            networkId: NetworkId['celo-alfajores'],
             symbol: 'CELO',
             priceUsd: '.6',
             balance: '2',
             priceFetchedAt: Date.now(),
           },
-          [mockCusdAddress]: {
+          [mockCusdTokenId]: {
             address: mockCusdAddress,
+            tokenId: mockCusdTokenId,
+            networkId: NetworkId['celo-alfajores'],
             symbol: 'cUSD',
             priceUsd: '1',
             balance: '10',

--- a/src/send/SendAmount/SendAmount.test.tsx
+++ b/src/send/SendAmount/SendAmount.test.tsx
@@ -18,12 +18,28 @@ import {
   mockAccount2Invite,
   mockAccountInvite,
   mockCeurAddress,
+  mockCeurTokenId,
   mockCusdAddress,
+  mockCusdTokenId,
   mockE164NumberInvite,
   mockTestTokenAddress,
+  mockTestTokenTokenId,
   mockTransactionData,
   mockTransactionDataLegacy,
 } from 'test/values'
+import { NetworkId } from 'src/transactions/types'
+
+jest.mock('src/web3/networkConfig', () => {
+  const originalModule = jest.requireActual('src/web3/networkConfig')
+  return {
+    ...originalModule,
+    __esModule: true,
+    default: {
+      ...originalModule.default,
+      defaultNetworkId: 'celo-alfajores',
+    },
+  }
+})
 
 const AMOUNT_ZERO = '0.00'
 const AMOUNT_VALID = '4.93'
@@ -33,24 +49,30 @@ const BALANCE_VALID = '23.85'
 const storeData = {
   tokens: {
     tokenBalances: {
-      [mockCusdAddress]: {
+      [mockCusdTokenId]: {
         address: mockCusdAddress,
+        tokenId: mockCusdTokenId,
+        networkId: NetworkId['celo-alfajores'],
         symbol: 'cUSD',
         priceUsd: '1',
         balance: BALANCE_VALID,
         isCoreToken: true,
         priceFetchedAt: Date.now(),
       },
-      [mockCeurAddress]: {
+      [mockCeurTokenId]: {
         address: mockCeurAddress,
+        tokenId: mockCeurTokenId,
+        networkId: NetworkId['celo-alfajores'],
         symbol: 'cEUR',
         priceUsd: '1.2',
         balance: '10',
         isCoreToken: true,
         priceFetchedAt: Date.now(),
       },
-      [mockTestTokenAddress]: {
+      [mockTestTokenTokenId]: {
         address: mockTestTokenAddress,
+        tokenId: mockTestTokenTokenId,
+        networkId: NetworkId['celo-alfajores'],
         symbol: 'TT',
         balance: '50',
       },
@@ -218,8 +240,10 @@ describe('SendAmount', () => {
         },
         tokens: {
           tokenBalances: {
-            [mockCusdAddress]: {
+            [mockCusdTokenId]: {
               address: mockCusdAddress,
+              tokenId: mockCusdTokenId,
+              networkId: NetworkId['celo-alfajores'],
               symbol: 'cUSD',
               priceUsd: '1',
               balance: '22.85789012',

--- a/src/send/SendAmount/SendAmountHeader.test.tsx
+++ b/src/send/SendAmount/SendAmountHeader.test.tsx
@@ -3,8 +3,27 @@ import * as React from 'react'
 import { Provider } from 'react-redux'
 import SendAmountHeader from 'src/send/SendAmount/SendAmountHeader'
 import { createMockStore } from 'test/utils'
-import { mockCeloAddress, mockCeurAddress, mockCusdAddress } from 'test/values'
+import {
+  mockCeloAddress,
+  mockCeloTokenId,
+  mockCeurAddress,
+  mockCeurTokenId,
+  mockCusdAddress,
+  mockCusdTokenId,
+} from 'test/values'
+import { NetworkId } from 'src/transactions/types'
 
+jest.mock('src/web3/networkConfig', () => {
+  const originalModule = jest.requireActual('src/web3/networkConfig')
+  return {
+    ...originalModule,
+    __esModule: true,
+    default: {
+      ...originalModule.default,
+      defaultNetworkId: 'celo-alfajores',
+    },
+  }
+})
 const mockOnChangeToken = jest.fn()
 
 function renderComponent({
@@ -21,20 +40,26 @@ function renderComponent({
       store={createMockStore({
         tokens: {
           tokenBalances: {
-            [mockCusdAddress]: {
+            [mockCusdTokenId]: {
               address: mockCusdAddress,
+              tokenId: mockCusdTokenId,
+              networkId: NetworkId['celo-alfajores'],
               symbol: 'cUSD',
               priceUsd: '1',
               balance: cUsdBalance ?? '10',
             },
-            [mockCeurAddress]: {
+            [mockCeurTokenId]: {
               address: mockCeurAddress,
+              tokenId: mockCeurTokenId,
+              networkId: NetworkId['celo-alfajores'],
               symbol: 'cEUR',
               priceUsd: '1.2',
               balance: '20',
             },
-            [mockCeloAddress]: {
+            [mockCeloTokenId]: {
               address: mockCeloAddress,
+              tokenId: mockCeloTokenId,
+              networkId: NetworkId['celo-alfajores'],
               symbol: 'CELO',
               priceUsd: '5',
               balance: '0',

--- a/src/send/SendConfirmation.test.tsx
+++ b/src/send/SendConfirmation.test.tsx
@@ -27,15 +27,20 @@ import {
   mockAccount2Invite,
   mockAccountInvite,
   mockCeloAddress,
+  mockCeloTokenId,
   mockCeurAddress,
+  mockCeurTokenId,
   mockCusdAddress,
+  mockCusdTokenId,
   mockE164Number,
   mockFeeInfo,
   mockGasPrice,
   mockTestTokenAddress,
+  mockTestTokenTokenId,
   mockTokenInviteTransactionData,
   mockTokenTransactionData,
 } from 'test/values'
+import { NetworkId } from 'src/transactions/types'
 
 const mockDekFeeGas = new BigNumber(100000)
 
@@ -45,6 +50,18 @@ const mockGetGasPrice = getGasPrice as jest.Mock
 jest.mock('src/web3/dataEncryptionKey', () => ({
   getRegisterDekTxGas: () => mockDekFeeGas,
 }))
+
+jest.mock('src/web3/networkConfig', () => {
+  const originalModule = jest.requireActual('src/web3/networkConfig')
+  return {
+    ...originalModule,
+    __esModule: true,
+    default: {
+      ...originalModule.default,
+      defaultNetworkId: 'celo-alfajores',
+    },
+  }
+})
 
 const mockScreenProps = getMockStackScreenProps(Screens.SendConfirmation, {
   transactionData: {
@@ -90,32 +107,40 @@ describe('SendConfirmation', () => {
     const store = createMockStore({
       tokens: {
         tokenBalances: {
-          [mockCusdAddress]: {
+          [mockCusdTokenId]: {
             address: mockCusdAddress,
+            tokenId: mockCusdTokenId,
+            networkId: NetworkId['celo-alfajores'],
             symbol: 'cUSD',
             balance: '200',
             priceUsd: '1',
             isCoreToken: true,
             priceFetchedAt: Date.now(),
           },
-          [mockCeurAddress]: {
+          [mockCeurTokenId]: {
             address: mockCeurAddress,
+            tokenId: mockCeurTokenId,
+            networkId: NetworkId['celo-alfajores'],
             symbol: 'cEUR',
             balance: '100',
             priceUsd: '1.2',
             isCoreToken: true,
             priceFetchedAt: Date.now(),
           },
-          [mockCeloAddress]: {
+          [mockCeloTokenId]: {
             address: mockCeloAddress,
+            tokenId: mockCeloTokenId,
+            networkId: NetworkId['celo-alfajores'],
             symbol: 'CELO',
             balance: '20',
             priceUsd: '5',
             isCoreToken: true,
             priceFetchedAt: Date.now(),
           },
-          [mockTestTokenAddress]: {
+          [mockTestTokenTokenId]: {
             address: mockTestTokenAddress,
+            tokenId: mockTestTokenTokenId,
+            networkId: NetworkId['celo-alfajores'],
             symbol: 'TT',
             balance: '10',
             priceUsd: '0.1234',
@@ -171,16 +196,20 @@ describe('SendConfirmation', () => {
     const { getByText, getByTestId } = renderScreen({
       tokens: {
         tokenBalances: {
-          [mockCusdAddress]: {
+          [mockCusdTokenId]: {
             address: mockCusdAddress,
+            tokenId: mockCusdTokenId,
+            networkId: NetworkId['celo-alfajores'],
             symbol: 'cUSD',
             balance: '2',
             priceUsd: '1',
             isCoreToken: true,
             priceFetchedAt: Date.now(),
           },
-          [mockCeurAddress]: {
+          [mockCeurTokenId]: {
             address: mockCeurAddress,
+            tokenId: mockCeurTokenId,
+            networkId: NetworkId['celo-alfajores'],
             symbol: 'cEUR',
             balance: '100',
             priceUsd: '1.2',
@@ -372,6 +401,7 @@ describe('SendConfirmation', () => {
     fireEvent.press(getByTestId('ConfirmButton'))
 
     const { inputAmount, tokenAddress, recipient } = mockTokenTransactionData
+
     expect(store.getActions()).toEqual(
       expect.arrayContaining([
         sendPayment(

--- a/src/swap/SwapReviewScreen.test.tsx
+++ b/src/swap/SwapReviewScreen.test.tsx
@@ -15,10 +15,15 @@ import { createMockStore } from 'test/utils'
 import {
   mockAccount,
   mockCeloAddress,
+  mockCeloTokenId,
   mockCeurAddress,
+  mockCeurTokenId,
   mockCusdAddress,
+  mockCusdTokenId,
   mockWBTCAddress,
+  mockWBTCTokenId,
 } from 'test/values'
+import { NetworkId } from 'src/transactions/types'
 
 const mockFetch = fetch as FetchMock
 const mockFeeCurrency = jest.fn()
@@ -54,38 +59,46 @@ const store = {
   },
   tokens: {
     tokenBalances: {
-      [mockCeloAddress]: {
+      [mockCeloTokenId]: {
         balance: '5',
         priceUsd: '3.1',
         symbol: 'CELO',
         address: mockCeloAddress,
+        tokenId: mockCeloTokenId,
+        networkId: NetworkId['celo-alfajores'],
         priceFetchedAt: Date.now(),
         isCoreToken: true,
         decimals: 18,
       },
-      [mockCusdAddress]: {
+      [mockCusdTokenId]: {
         balance: '10',
         priceUsd: '1',
         symbol: 'cUSD',
         address: mockCusdAddress,
+        tokenId: mockCusdTokenId,
+        networkId: NetworkId['celo-alfajores'],
         isCoreToken: true,
         priceFetchedAt: Date.now(),
         decimals: 18,
       },
-      [mockCeurAddress]: {
+      [mockCeurTokenId]: {
         balance: '20',
         priceUsd: '1.2',
         symbol: 'cEUR',
         address: mockCeurAddress,
+        tokenId: mockCeurTokenId,
+        networkId: NetworkId['celo-alfajores'],
         isCoreToken: true,
         priceFetchedAt: Date.now(),
         decimals: 18,
       },
-      [mockWBTCAddress]: {
+      [mockWBTCTokenId]: {
         balance: '0',
         priceUsd: '20000',
         symbol: 'WBTC',
         address: mockWBTCAddress,
+        tokenId: mockWBTCTokenId,
+        networkId: NetworkId['celo-alfajores'],
         isCoreToken: false,
         priceFetchedAt: Date.now(),
         decimals: 8,

--- a/src/swap/SwapScreen.test.tsx
+++ b/src/swap/SwapScreen.test.tsx
@@ -18,11 +18,17 @@ import { createMockStore } from 'test/utils'
 import {
   mockAccount,
   mockCeloAddress,
+  mockCeloTokenId,
   mockCeurAddress,
+  mockCeurTokenId,
   mockCusdAddress,
+  mockCusdTokenId,
   mockPoofAddress,
+  mockPoofTokenId,
   mockTestTokenAddress,
+  mockTestTokenTokenId,
 } from 'test/values'
+import { NetworkId } from 'src/transactions/types'
 
 const mockFetch = fetch as FetchMock
 const mockExperimentParams = jest.fn()
@@ -33,6 +39,18 @@ const mockGetNumberFormatSettings = jest.fn()
 jest.mock('react-native-localize', () => ({
   getNumberFormatSettings: () => mockGetNumberFormatSettings(),
 }))
+
+jest.mock('src/web3/networkConfig', () => {
+  const originalModule = jest.requireActual('src/web3/networkConfig')
+  return {
+    ...originalModule,
+    __esModule: true,
+    default: {
+      ...originalModule.default,
+      defaultNetworkId: 'celo-alfajores',
+    },
+  }
+})
 
 jest.mock('src/statsig', () => {
   return {
@@ -47,8 +65,10 @@ const renderScreen = ({ celoBalance = '10', cUSDBalance = '20.456', showDrawerTo
   const store = createMockStore({
     tokens: {
       tokenBalances: {
-        [mockCeurAddress]: {
+        [mockCeurTokenId]: {
           address: mockCeurAddress,
+          tokenId: mockCeurTokenId,
+          networkId: NetworkId['celo-alfajores'],
           symbol: 'cEUR',
           priceFetchedAt: now,
           historicalPricesUsd: {
@@ -66,11 +86,13 @@ const renderScreen = ({ celoBalance = '10', cUSDBalance = '20.456', showDrawerTo
           name: 'Celo Euro',
           balance: '0',
         },
-        [mockCusdAddress]: {
+        [mockCusdTokenId]: {
           priceUsd: '1',
           isCoreToken: true,
           isSwappable: true,
           address: mockCusdAddress,
+          tokenId: mockCusdTokenId,
+          networkId: NetworkId['celo-alfajores'],
           priceFetchedAt: now,
           symbol: 'cUSD',
           imageUrl:
@@ -85,8 +107,10 @@ const renderScreen = ({ celoBalance = '10', cUSDBalance = '20.456', showDrawerTo
           },
           name: 'Celo Dollar',
         },
-        [mockCeloAddress]: {
+        [mockCeloTokenId]: {
           address: mockCeloAddress,
+          tokenId: mockCeloTokenId,
+          networkId: NetworkId['celo-alfajores'],
           symbol: 'CELO',
           priceFetchedAt: now,
           historicalPricesUsd: {
@@ -104,9 +128,11 @@ const renderScreen = ({ celoBalance = '10', cUSDBalance = '20.456', showDrawerTo
           name: 'Celo native asset',
           balance: celoBalance,
         },
-        [mockTestTokenAddress]: {
+        [mockTestTokenTokenId]: {
           // no priceUsd
           address: mockTestTokenAddress,
+          tokenId: mockTestTokenTokenId,
+          networkId: NetworkId['celo-alfajores'],
           symbol: 'TT',
           decimals: 18,
           imageUrl:
@@ -116,9 +142,11 @@ const renderScreen = ({ celoBalance = '10', cUSDBalance = '20.456', showDrawerTo
           name: 'Test Token',
           balance: '100',
         },
-        [mockPoofAddress]: {
+        [mockPoofTokenId]: {
           // no priceUsd
           address: mockPoofAddress,
+          tokenId: mockPoofTokenId,
+          networkId: NetworkId['celo-alfajores'],
           symbol: 'POOF',
           decimals: 18,
           imageUrl: `https://raw.githubusercontent.com/valora-inc/address-metadata/main/assets/tokens/POOF.png`,

--- a/src/tokens/saga.test.ts
+++ b/src/tokens/saga.test.ts
@@ -35,6 +35,7 @@ import Logger from 'src/utils/Logger'
 import { apolloClient } from 'src/apollo'
 import { getFeatureGate } from 'src/statsig'
 import { ApolloQueryResult } from 'apollo-client'
+import { NetworkId } from 'src/transactions/types'
 
 jest.mock('src/statsig')
 jest.mock('src/apollo', () => {
@@ -217,6 +218,7 @@ describe(tokenAmountInSmallestUnit, () => {
               [mockTokenId]: {
                 address: mockAddress,
                 tokenId: mockTokenId,
+                networkId: NetworkId['celo-alfajores'],
                 decimals: 5,
               },
             },

--- a/src/tokens/selectors.test.ts
+++ b/src/tokens/selectors.test.ts
@@ -14,6 +14,18 @@ import { ONE_DAY_IN_MILLIS } from 'src/utils/time'
 
 const mockDate = 1588200517518
 
+jest.mock('src/web3/networkConfig', () => {
+  const originalModule = jest.requireActual('src/web3/networkConfig')
+  return {
+    ...originalModule,
+    __esModule: true,
+    default: {
+      ...originalModule.default,
+      defaultNetworkId: 'celo-alfajores',
+    },
+  }
+})
+
 jest.mock('react-native-device-info', () => ({
   getVersion: () => '1.10.0',
 }))

--- a/src/tokens/selectors.test.ts
+++ b/src/tokens/selectors.test.ts
@@ -95,6 +95,14 @@ const state: any = {
         priceUsd: '500',
         priceFetchedAt: mockDate - 2 * ONE_DAY_IN_MILLIS,
       },
+      ['ethereum-sepolia:0x7']: {
+        tokenId: 'ethereum-sepolia:0x7',
+        networkId: NetworkId['ethereum-sepolia'],
+        address: '0x7',
+        balance: '50',
+        priceUsd: '500',
+        priceFetchedAt: mockDate - 2 * ONE_DAY_IN_MILLIS,
+      },
     },
   },
   localCurrency: {

--- a/src/tokens/selectors.ts
+++ b/src/tokens/selectors.ts
@@ -12,6 +12,7 @@ import { TokenBalance, TokenBalanceWithAddress, TokenBalancesWithAddress } from 
 import { Currency } from 'src/utils/currencies'
 import { isVersionBelowMinimum } from 'src/utils/versionCheck'
 import { sortByUsdBalance, sortFirstStableThenCeloThenOthersByUsdBalance } from './utils'
+import networkConfig from 'src/web3/networkConfig'
 
 type TokenBalanceWithPriceUsd = TokenBalanceWithAddress & {
   priceUsd: BigNumber
@@ -30,7 +31,12 @@ export const tokensByAddressSelector = createSelector(
   (storedBalances) => {
     const tokenBalances: TokenBalancesWithAddress = {}
     for (const storedState of Object.values(storedBalances)) {
-      if (!storedState || storedState.balance === null || !storedState.address) {
+      if (
+        !storedState ||
+        storedState.balance === null ||
+        !storedState.address ||
+        storedState.networkId !== networkConfig.defaultNetworkId
+      ) {
         continue
       }
       const priceUsd = new BigNumber(storedState.priceUsd)

--- a/src/transactions/feed/TransferFeedItem.test.tsx
+++ b/src/transactions/feed/TransferFeedItem.test.tsx
@@ -25,6 +25,7 @@ import {
   mockFiatConnectQuotes,
   mockName,
   mockTestTokenAddress,
+  mockTestTokenTokenId,
 } from 'test/values'
 
 const MOCK_TX_HASH = '0x006b866d20452a24d1d90c7514422188cc7c5d873e2f1ed661ec3f810ad5331c'
@@ -469,8 +470,10 @@ describe('TransferFeedItem', () => {
       storeOverrides: {
         tokens: {
           tokenBalances: {
-            [mockTestTokenAddress]: {
+            [mockTestTokenTokenId]: {
               address: mockTestTokenAddress,
+              tokenId: mockTestTokenTokenId,
+              networkId: NetworkId['celo-alfajores'],
               symbol: 'TT',
               balance: '50',
             },

--- a/src/transactions/send.test.ts
+++ b/src/transactions/send.test.ts
@@ -8,33 +8,59 @@ import {
   shouldTxFailureRetry,
 } from 'src/transactions/send'
 import { createMockStore } from 'test/utils'
-import { mockCeloAddress, mockCeurAddress, mockCusdAddress } from 'test/values'
+import {
+  mockCeloAddress,
+  mockCeloTokenId,
+  mockCeurAddress,
+  mockCeurTokenId,
+  mockCusdAddress,
+  mockCusdTokenId,
+} from 'test/values'
+import { NetworkId } from 'src/transactions/types'
+
+jest.mock('src/web3/networkConfig', () => {
+  const originalModule = jest.requireActual('src/web3/networkConfig')
+  return {
+    ...originalModule,
+    __esModule: true,
+    default: {
+      ...originalModule.default,
+      defaultNetworkId: 'celo-alfajores',
+    },
+  }
+})
 
 const state = (override?: { celoBalance: string }) =>
   createMockStore({
     tokens: {
       tokenBalances: {
-        [mockCusdAddress]: {
+        [mockCusdTokenId]: {
           balance: '0',
           priceUsd: '1',
           symbol: 'cUSD',
           address: mockCusdAddress,
+          tokenId: mockCusdTokenId,
+          networkId: NetworkId['celo-alfajores'],
           isCoreToken: true,
           priceFetchedAt: Date.now(),
         },
-        [mockCeurAddress]: {
+        [mockCeurTokenId]: {
           balance: '1',
           priceUsd: '1.2',
           symbol: 'cEUR',
           address: mockCeurAddress,
+          tokenId: mockCeurTokenId,
+          networkId: NetworkId['celo-alfajores'],
           isCoreToken: true,
           priceFetchedAt: Date.now(),
         },
-        [mockCeloAddress]: {
+        [mockCeloTokenId]: {
           balance: override?.celoBalance ?? '0',
           priceUsd: '3.5',
           symbol: 'CELO',
           address: mockCeloAddress,
+          tokenId: mockCeloTokenId,
+          networkId: NetworkId['celo-alfajores'],
           isCoreToken: true,
           priceFetchedAt: Date.now(),
         },

--- a/src/walletConnect/request.test.ts
+++ b/src/walletConnect/request.test.ts
@@ -5,7 +5,28 @@ import { handleRequest } from 'src/walletConnect/request'
 import { getWallet } from 'src/web3/contracts'
 import { unlockAccount } from 'src/web3/saga'
 import { createMockStore } from 'test/utils'
-import { mockCeloAddress, mockCeurAddress, mockCusdAddress, mockWallet } from 'test/values'
+import {
+  mockCeloAddress,
+  mockCeloTokenId,
+  mockCeurAddress,
+  mockCeurTokenId,
+  mockCusdAddress,
+  mockCusdTokenId,
+  mockWallet,
+} from 'test/values'
+import { NetworkId } from 'src/transactions/types'
+
+jest.mock('src/web3/networkConfig', () => {
+  const originalModule = jest.requireActual('src/web3/networkConfig')
+  return {
+    ...originalModule,
+    __esModule: true,
+    default: {
+      ...originalModule.default,
+      defaultNetworkId: 'celo-alfajores',
+    },
+  }
+})
 
 const signTransactionRequest = {
   method: SupportedActions.eth_signTransaction,
@@ -28,27 +49,33 @@ const state = createMockStore({
   web3: { account: '0xWALLET', mtwAddress: undefined },
   tokens: {
     tokenBalances: {
-      [mockCusdAddress]: {
+      [mockCusdTokenId]: {
         balance: '00',
         priceUsd: '1',
         symbol: 'cUSD',
         address: mockCusdAddress,
+        tokenId: mockCusdTokenId,
+        networkId: NetworkId['celo-alfajores'],
         isCoreToken: true,
         priceFetchedAt: Date.now(),
       },
-      [mockCeurAddress]: {
+      [mockCeurTokenId]: {
         balance: '0',
         priceUsd: '1.2',
         symbol: 'cEUR',
         address: mockCeurAddress,
+        tokenId: mockCeurTokenId,
+        networkId: NetworkId['celo-alfajores'],
         isCoreToken: true,
         priceFetchedAt: Date.now(),
       },
-      [mockCeloAddress]: {
+      [mockCeloTokenId]: {
         balance: '5',
         priceUsd: '3.5',
         symbol: 'CELO',
         address: mockCeloAddress,
+        tokenId: mockCeloTokenId,
+        networkId: NetworkId['celo-alfajores'],
         isCoreToken: true,
         priceFetchedAt: Date.now(),
       },
@@ -145,27 +172,33 @@ describe(handleRequest, () => {
           web3: { account: '0xWALLET', mtwAddress: undefined },
           tokens: {
             tokenBalances: {
-              [mockCusdAddress]: {
+              [mockCusdTokenId]: {
                 balance: '10',
                 priceUsd: '1',
                 symbol: 'cUSD',
                 address: mockCusdAddress,
+                tokenId: mockCusdTokenId,
+                networkId: NetworkId['celo-alfajores'],
                 isCoreToken: true,
                 priceFetchedAt: Date.now(),
               },
-              [mockCeurAddress]: {
+              [mockCeurTokenId]: {
                 balance: '0',
                 priceUsd: '1.2',
                 symbol: 'cEUR',
                 address: mockCeurAddress,
+                tokenId: mockCeurTokenId,
+                networkId: NetworkId['celo-alfajores'],
                 isCoreToken: true,
                 priceFetchedAt: Date.now(),
               },
-              [mockCeloAddress]: {
+              [mockCeloTokenId]: {
                 balance: '0',
                 priceUsd: '3.5',
                 symbol: 'CELO',
                 address: mockCeloAddress,
+                tokenId: mockCeloTokenId,
+                networkId: NetworkId['celo-alfajores'],
                 isCoreToken: true,
                 priceFetchedAt: Date.now(),
               },
@@ -247,27 +280,33 @@ describe(handleRequest, () => {
           web3: { account: '0xWALLET', mtwAddress: undefined },
           tokens: {
             tokenBalances: {
-              [mockCusdAddress]: {
+              [mockCusdTokenId]: {
                 balance: '0',
                 priceUsd: '1',
                 symbol: 'cUSD',
                 address: mockCusdAddress,
+                tokenId: mockCusdTokenId,
+                networkId: NetworkId['celo-alfajores'],
                 isCoreToken: true,
                 priceFetchedAt: Date.now(),
               },
-              [mockCeurAddress]: {
+              [mockCeurTokenId]: {
                 balance: '10',
                 priceUsd: '1.2',
                 symbol: 'cEUR',
                 address: mockCeurAddress,
+                tokenId: mockCeurTokenId,
+                networkId: NetworkId['celo-alfajores'],
                 isCoreToken: true,
                 priceFetchedAt: Date.now(),
               },
-              [mockCeloAddress]: {
+              [mockCeloTokenId]: {
                 balance: '0',
                 priceUsd: '3.5',
                 symbol: 'CELO',
                 address: mockCeloAddress,
+                tokenId: mockCeloTokenId,
+                networkId: NetworkId['celo-alfajores'],
                 isCoreToken: true,
                 priceFetchedAt: Date.now(),
               },


### PR DESCRIPTION
### Description

Fixes an issue where non-Celo tokens can possibly be returned by legacy selectors, leaking multi-chain features in unintended places. [Slack thread with context.](https://valora-app.slack.com/archives/C02KBT0DAHJ/p1695763773794809)

### Test plan

Unit tested

### Related issues

N/A

### Backwards compatibility

Yes.
