### PR TITLE
ci: unblock dependabot PRs failing because of missing secrets

### DIFF
--- a/.github/workflows/e2e-ios.yml
+++ b/.github/workflows/e2e-ios.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: ios-e2e-group
     steps:
       - uses: google-github-actions/auth@v1
+        if: ${{ env.SECRETS_AVAILABLE }}
         with:
           project_id: celo-mobile-mainnet
           credentials_json: ${{ secrets.MAINNET_SERVICE_ACCOUNT_KEY }}


### PR DESCRIPTION
See example PR [failing](https://github.com/valora-inc/wallet/actions/runs/6402571572/job/17384661694?pr=4255).
