### PR TITLE
chore: add OS version to support requests

### DIFF
--- a/__mocks__/react-native-device-info.ts
+++ b/__mocks__/react-native-device-info.ts
@@ -3,6 +3,7 @@ import mockRNDeviceInfo from 'react-native-device-info/jest/react-native-device-
 mockRNDeviceInfo.getBundleId.mockImplementation(() => 'org.celo.mobile.debug')
 mockRNDeviceInfo.getVersion.mockImplementation(() => '0.0.1')
 mockRNDeviceInfo.getBuildNumber.mockImplementation(() => '1')
+mockRNDeviceInfo.getSystemVersion.mockImplementation(() => '7.1')
 mockRNDeviceInfo.getUniqueId.mockImplementation(() => Promise.resolve('abc-def-123'))
 mockRNDeviceInfo.getUniqueIdSync.mockImplementation(() => 'abc-def-123')
 mockRNDeviceInfo.getDeviceId.mockImplementation(() => 'someDeviceId')

--- a/src/account/SupportContact.test.tsx
+++ b/src/account/SupportContact.test.tsx
@@ -80,7 +80,7 @@ describe('Contact', () => {
       expect(Mailer.mail).toBeCalledWith(
         expect.objectContaining({
           isHTML: true,
-          body: 'Test Message<br/><br/><b>{"version":"0.0.1","buildNumber":"1","apiLevel":-1,"os":"android","country":"US","region":null,"deviceId":"someDeviceId","deviceBrand":"someBrand","deviceModel":"someModel","address":"0x0000000000000000000000000000000000007e57","sessionId":"","numberVerifiedCentralized":false,"hooksPreviewEnabled":false,"network":"alfajores"}</b><br/><br/><b>Support logs are attached...</b>',
+          body: 'Test Message<br/><br/><b>{"version":"0.0.1","systemVersion":"7.1","buildNumber":"1","apiLevel":-1,"os":"android","country":"US","region":null,"deviceId":"someDeviceId","deviceBrand":"someBrand","deviceModel":"someModel","address":"0x0000000000000000000000000000000000007e57","sessionId":"","numberVerifiedCentralized":false,"hooksPreviewEnabled":false,"network":"alfajores"}</b><br/><br/><b>Support logs are attached...</b>',
           recipients: [CELO_SUPPORT_EMAIL_ADDRESS],
           subject: i18n.t('supportEmailSubject', { appName: APP_NAME, user: '+1415555XXXX' }),
           attachments: logAttachments,
@@ -139,6 +139,7 @@ describe('Contact', () => {
           os: 'android',
           region: null,
           sessionId: '',
+          systemVersion: '7.1',
           version: '0.0.1',
         },
         logFiles: logAttachments,

--- a/src/account/SupportContact.tsx
+++ b/src/account/SupportContact.tsx
@@ -91,6 +91,7 @@ function SupportContact({ route }: Props) {
     setInProgress(true)
     const deviceInfo = {
       version: DeviceInfo.getVersion(),
+      systemVersion: DeviceInfo.getSystemVersion(),
       buildNumber: DeviceInfo.getBuildNumber(),
       apiLevel: DeviceInfo.getApiLevelSync(),
       os: Platform.OS,

--- a/src/account/zendesk.ts
+++ b/src/account/zendesk.ts
@@ -6,6 +6,7 @@ const ZENDESK_PROJECT_NAME = 'valoraapp'
 
 export interface DeviceInfo {
   version: string
+  systemVersion: string
   buildNumber: string
   apiLevel: number
   os: 'ios' | 'android' | 'windows' | 'macos' | 'web'
@@ -79,6 +80,10 @@ export function _generateCustomFields(deviceInfo: DeviceInfo) {
     {
       id: 5381862498317,
       value: deviceInfo.apiLevel.toString(),
+    },
+    {
+      id: 20129806706445,
+      value: deviceInfo.systemVersion,
     },
     {
       id: 15494972694029,


### PR DESCRIPTION
### Description

This PR adds the [system version](https://github.com/react-native-device-info/react-native-device-info#getsystemversion) to the support contact requests email body + zendesk field. The new zendesk field id was created by Lisa.

### Test plan

Updated unit tests, e2e testing with Lisa

### Related issues

- Fixes RET-883

### Backwards compatibility

Y