### PR TITLE
refactor: make tokensByAddressSelector more DRY

### DIFF
--- a/src/localCurrency/hooks.test.tsx
+++ b/src/localCurrency/hooks.test.tsx
@@ -21,6 +21,7 @@ function createStore(usdToLocalRate: string | null = '2') {
       tokenBalances: {
         'celo-alfajores:0xcUSD': {
           networkId: NetworkId['celo-alfajores'],
+          tokenId: 'celo-alfajores:0xcUSD',
           address: '0xcUSD',
           symbol: 'cUSD',
           balance: '0',
@@ -29,6 +30,7 @@ function createStore(usdToLocalRate: string | null = '2') {
         },
         'celo-alfajores:native': {
           networkId: NetworkId['celo-alfajores'],
+          tokenId: 'celo-alfajores:native',
           address: '0xCELO',
           symbol: 'CELO',
           balance: '0',
@@ -37,6 +39,7 @@ function createStore(usdToLocalRate: string | null = '2') {
         },
         'celo-alfajores:0xT1': {
           networkId: NetworkId['celo-alfajores'],
+          tokenId: 'celo-alfajores:0xT1',
           address: '0xT1',
           symbol: 'T1',
           balance: '0',
@@ -45,6 +48,7 @@ function createStore(usdToLocalRate: string | null = '2') {
         },
         'celo-alfajores:0xT2': {
           networkId: NetworkId['celo-alfajores'],
+          tokenId: 'celo-alfajores:0xT2',
           address: '0xT2',
           symbol: 'T2',
           priceUsd: '5',


### PR DESCRIPTION
### Description

a toy example of where we can use strategy 3 for [this doc](https://www.figma.com/file/iiPCJG2cA18ysZrLAZI80d/Multichain-refactor-strategies?type=whiteboard&node-id=4-181&t=E6ENxluAmHAfiloW-0) (vertical refactor with DRY helper) and cut down on duplicated code as we do multichain refactors

obviously nothing earth-shattering here, but I'd like us to keep a lookout for opportunities to do more of this to avoid adding duplication and complexity as we add multichain features

### Test plan

existing coverage makes sure the bridge names are in the token name and ethereum is filtered out, so I think we're good

### Related issues

na

### Backwards compatibility

yes
