### PR TITLE
fix: back button hit area too small

### DIFF
--- a/src/components/BackButton.tsx
+++ b/src/components/BackButton.tsx
@@ -3,6 +3,7 @@ import { StyleSheet, View } from 'react-native'
 import BackChevron, { Props as BackChevronProps } from 'src/icons/BackChevron'
 import { navigateBack } from 'src/navigator/NavigationService'
 import { TopBarIconButton, TopBarIconButtonProps } from 'src/navigator/TopBarButton'
+import { Spacing } from 'src/styles/styles'
 
 type Props = Omit<TopBarIconButtonProps, 'icon'> & BackChevronProps
 
@@ -30,9 +31,9 @@ const styles = StyleSheet.create({
   button: {
     // Quick hack to workaround hitSlop set for the internal Touchable component not working
     // I tried removing the parent view, but it didn't help either
-    paddingHorizontal: 16,
-    paddingVertical: 12, // vertical padding slightly smaller so the ripple effect isn't cut off
-    left: -16,
+    paddingHorizontal: Spacing.Regular16,
+    paddingVertical: Spacing.Small12, // vertical padding slightly smaller so the ripple effect isn't cut off
+    left: -Spacing.Regular16,
   },
 })
 

--- a/src/components/BackButton.tsx
+++ b/src/components/BackButton.tsx
@@ -11,6 +11,7 @@ function BackButton(props: Props) {
     <View style={[styles.container, props.style]}>
       <TopBarIconButton
         {...props}
+        style={styles.button}
         icon={<BackChevron color={props.color} height={props.height} />}
       />
     </View>
@@ -25,6 +26,13 @@ const styles = StyleSheet.create({
   container: {
     justifyContent: 'center',
     alignItems: 'center',
+  },
+  button: {
+    // Quick hack to workaround hitSlop set for the internal Touchable component not working
+    // I tried removing the parent view, but it didn't help either
+    paddingHorizontal: 16,
+    paddingVertical: 12, // vertical padding slightly smaller so the ripple effect isn't cut off
+    left: -16,
   },
 })
 

--- a/src/send/__snapshots__/SendConfirmation.test.tsx.snap
+++ b/src/send/__snapshots__/SendConfirmation.test.tsx.snap
@@ -96,6 +96,13 @@ exports[`SendConfirmation renders correctly 1`] = `
           onResponderTerminate={[Function]}
           onResponderTerminationRequest={[Function]}
           onStartShouldSetResponder={[Function]}
+          style={
+            {
+              "left": -16,
+              "paddingHorizontal": 16,
+              "paddingVertical": 12,
+            }
+          }
         >
           <svg
             fill="none"


### PR DESCRIPTION
### Description

Increased back button hit area, which was too small and almost impossible to hit.

I'm not too happy about the manual padding added, I would have preferred the [hitSlop](https://github.com/valora-inc/wallet/blob/ede52965f035ce263c38e83839be64c7412cb3bb/src/navigator/TopBarButton.tsx#L47) to work, but somehow it doesn't.
We can investigate this more later. But for now this should be good enough.

### Test plan

**before/after**

Showing with the ripple effect:
<img src="https://github.com/valora-inc/wallet/assets/57791/f3dd90dc-c717-420e-b7e1-bccb1e78ee6b" width="50%" /><img src="https://github.com/valora-inc/wallet/assets/57791/56b7f956-61aa-410e-9982-1dc6407edca2" width="50%" /> 

Note: it would be nice for the ripple effect to not be cut off on the left, but this would mean moving the button more toward the right, and then not be aligned anymore with the content. We can discuss that with design later on.

### Related issues

- See Slack [thread](https://valora-app.slack.com/archives/C025V1D6F3J/p1696953791346979?thread_ts=1696932462.287309&cid=C025V1D6F3J)

### Backwards compatibility

Yes
