### PR TITLE
chore: Change key label for TokenBalanceWithAddress

### DIFF
--- a/src/tokens/slice.ts
+++ b/src/tokens/slice.ts
@@ -99,7 +99,7 @@ export interface TokenBalances {
  * @deprecated use `TokenBalances` for new code
  */
 export interface TokenBalancesWithAddress {
-  [tokenId: string]: TokenBalanceWithAddress | undefined
+  [tokenAddress: string]: TokenBalanceWithAddress | undefined
 }
 
 export interface State {


### PR DESCRIPTION
### Description

TokenBalanceWithAddress type had the key labelled as tokenId but actually used tokenAddress to key, changed the label.

### Test plan

ci

### Related issues

https://linear.app/valora/issue/ACT-944/create-new-send-confirmation-screen

### Backwards compatibility

na
