### PR TITLE
chore: remove code paths related to NEW_TRANSACTIONS_IN_FEED action

### DIFF
--- a/src/fiatExchanges/actions.ts
+++ b/src/fiatExchanges/actions.ts
@@ -1,8 +1,7 @@
-import { ProviderFeedInfo, ProviderLogos } from 'src/fiatExchanges/reducer'
+import { ProviderLogos } from 'src/fiatExchanges/reducer'
 
 export enum Actions {
   BIDALI_PAYMENT_REQUESTED = 'FIAT_EXCHANGES/BIDALI_PAYMENT_REQUESTED',
-  ASSIGN_PROVIDER_TO_TX_HASH = 'FIAT_EXCHANGES/ASSIGN_PROVIDER_TO_TX_HASH',
   SET_PROVIDER_LOGOS = 'SET_PROVIDER_LOGOS',
 }
 
@@ -36,21 +35,6 @@ export const bidaliPaymentRequested = (
   onCancelled,
 })
 
-export interface AssignProviderToTxHashAction {
-  type: Actions.ASSIGN_PROVIDER_TO_TX_HASH
-  txHash: string
-  displayInfo: ProviderFeedInfo
-}
-
-export const assignProviderToTxHash = (
-  txHash: string,
-  displayInfo: ProviderFeedInfo
-): AssignProviderToTxHashAction => ({
-  type: Actions.ASSIGN_PROVIDER_TO_TX_HASH,
-  txHash,
-  displayInfo,
-})
-
 export interface SetProviderLogos {
   type: Actions.SET_PROVIDER_LOGOS
   providerLogos: ProviderLogos
@@ -61,7 +45,4 @@ export const setProviderLogos = (providerLogos: ProviderLogos): SetProviderLogos
   providerLogos,
 })
 
-export type ActionTypes =
-  | BidaliPaymentRequestedAction
-  | AssignProviderToTxHashAction
-  | SetProviderLogos
+export type ActionTypes = BidaliPaymentRequestedAction | SetProviderLogos

--- a/src/fiatExchanges/reducer.ts
+++ b/src/fiatExchanges/reducer.ts
@@ -7,10 +7,6 @@ export interface ProviderLogos {
   [providerName: string]: string
 }
 
-export interface TxHashToProvider {
-  [txHash: string]: string | undefined
-}
-
 export interface ProviderFeedInfo {
   name: string
   icon: string

--- a/src/fiatExchanges/reducer.ts
+++ b/src/fiatExchanges/reducer.ts
@@ -39,16 +39,6 @@ export const reducer = (state: State = initialState, action: ActionTypes | Rehyd
         ...state,
         providerLogos: action.providerLogos,
       }
-    case Actions.ASSIGN_PROVIDER_TO_TX_HASH:
-      const { txHash, displayInfo } = action
-
-      return {
-        ...state,
-        txHashToProvider: {
-          ...state.txHashToProvider,
-          [txHash]: displayInfo,
-        },
-      }
     default:
       return state
   }

--- a/src/home/saga.ts
+++ b/src/home/saga.ts
@@ -8,7 +8,6 @@ import { executeShortcutSuccess } from 'src/positions/slice'
 import { withTimeout } from 'src/redux/sagas-helpers'
 import { shouldUpdateBalance } from 'src/redux/selectors'
 import { fetchTokenBalances } from 'src/tokens/slice'
-import { Actions as TransactionActions } from 'src/transactions/actions'
 import Logger from 'src/utils/Logger'
 import { safely } from 'src/utils/safely'
 import { getConnectedAccount } from 'src/web3/saga'
@@ -74,10 +73,6 @@ export function* watchRefreshBalances() {
   yield* takeLeading(
     [Actions.REFRESH_BALANCES, executeShortcutSuccess.type],
     safely(withLoading(withTimeout(REFRESH_TIMEOUT, refreshBalances)))
-  )
-  yield* takeLeading(
-    TransactionActions.NEW_TRANSACTIONS_IN_FEED,
-    safely(withTimeout(REFRESH_TIMEOUT, refreshBalances))
   )
 }
 

--- a/src/identity/actions.ts
+++ b/src/identity/actions.ts
@@ -5,7 +5,6 @@ import {
   AddressToE164NumberType,
   AddressValidationType,
   E164NumberToAddressType,
-  E164NumberToSaltType,
   WalletToAccountAddressType,
 } from 'src/identity/reducer'
 import { ImportContactsStatus } from 'src/identity/types'
@@ -15,7 +14,6 @@ export enum Actions {
   SET_SEEN_VERIFICATION_NUX = 'IDENTITY/SET_SEEN_VERIFICATION_NUX',
   UPDATE_E164_PHONE_NUMBER_ADDRESSES = 'IDENTITY/UPDATE_E164_PHONE_NUMBER_ADDRESSES',
   UPDATE_WALLET_TO_ACCOUNT_ADDRESS = 'UPDATE_WALLET_TO_ACCOUNT_ADDRESS',
-  UPDATE_E164_PHONE_NUMBER_SALT = 'IDENTITY/UPDATE_E164_PHONE_NUMBER_SALT',
   UPDATE_KNOWN_ADDRESSES = 'IDENTITY/UPDATE_KNOWN_ADDRESSES',
   FETCH_ADDRESSES_AND_VALIDATION_STATUS = 'IDENTITY/FETCH_ADDRESSES_AND_VALIDATION_STATUS',
   END_FETCHING_ADDRESSES = 'IDENTITY/END_FETCHING_ADDRESSES',
@@ -46,11 +44,6 @@ export interface UpdateE164PhoneNumberAddressesAction {
 export interface UpdateWalletToAccountAddressAction {
   type: Actions.UPDATE_WALLET_TO_ACCOUNT_ADDRESS
   walletToAccountAddress: WalletToAccountAddressType
-}
-
-export interface UpdateE164PhoneNumberSaltAction {
-  type: Actions.UPDATE_E164_PHONE_NUMBER_SALT
-  e164NumberToSalt: E164NumberToSaltType
 }
 
 export interface UpdateKnownAddressesAction {
@@ -134,7 +127,6 @@ export type ActionTypes =
   | SetHasSeenVerificationNux
   | UpdateE164PhoneNumberAddressesAction
   | UpdateWalletToAccountAddressAction
-  | UpdateE164PhoneNumberSaltAction
   | UpdateKnownAddressesAction
   | ImportContactsAction
   | UpdateImportContactProgress
@@ -198,13 +190,6 @@ export const updateWalletToAccountAddress = (
     walletToAccountAddress: newWalletToAccountAddresses,
   }
 }
-
-export const updateE164PhoneNumberSalts = (
-  e164NumberToSalt: E164NumberToSaltType
-): UpdateE164PhoneNumberSaltAction => ({
-  type: Actions.UPDATE_E164_PHONE_NUMBER_SALT,
-  e164NumberToSalt,
-})
 
 export const updateKnownAddresses = (
   addresses: AddressToDisplayNameType

--- a/src/identity/contactMapping.ts
+++ b/src/identity/contactMapping.ts
@@ -1,8 +1,4 @@
-import { Address } from '@celo/base'
-import { AttestationStat, AttestationsWrapper } from '@celo/contractkit/lib/wrappers/Attestations'
-import { isValidAddress } from '@celo/utils/lib/address'
-import { isAccountConsideredVerified } from '@celo/utils/lib/attestations'
-import BigNumber from 'bignumber.js'
+import { AttestationsWrapper } from '@celo/contractkit/lib/wrappers/Attestations'
 import { Platform } from 'react-native'
 import DeviceInfo from 'react-native-device-info'
 import { setUserContactDetails } from 'src/account/actions'
@@ -257,48 +253,6 @@ export function* lookupAccountAddressesForIdentifier(id: string, lostAccounts: s
   )
   return accounts.filter((address: string) => !lostAccounts.includes(address.toLowerCase()))
 }
-
-// Deconstruct the lookup result and return
-// any addresess that are considered verified
-export function* filterNonVerifiedAddresses(accountAddresses: Address[], phoneHash: string) {
-  if (!accountAddresses) {
-    return []
-  }
-
-  const contractKit = yield* call(getContractKit)
-  const attestationsWrapper: AttestationsWrapper = yield* call([
-    contractKit.contracts,
-    contractKit.contracts.getAttestations,
-  ])
-
-  const verifiedAccountAddresses: Address[] = []
-  for (const address of accountAddresses) {
-    if (!isValidNon0Address(address)) {
-      continue
-    }
-    // Get stats for the address
-    const stats: AttestationStat = yield* call(
-      [attestationsWrapper, attestationsWrapper.getAttestationStat],
-      phoneHash,
-      address
-    )
-    // Check if result for given hash is considered 'verified'
-    const { isVerified } = isAccountConsideredVerified(stats)
-    if (!isVerified) {
-      Logger.debug(
-        TAG + 'getAddressesFromLookupResult',
-        `Address ${address} has attestation stats but is not considered verified. Skipping it.`
-      )
-      continue
-    }
-    verifiedAccountAddresses.push(address.toLowerCase())
-  }
-
-  return verifiedAccountAddresses
-}
-
-const isValidNon0Address = (address: string) =>
-  typeof address === 'string' && isValidAddress(address) && !new BigNumber(address).isZero()
 
 // Only use with multiple addresses if user has
 // gone through SecureSend

--- a/src/identity/reducer.ts
+++ b/src/identity/reducer.ts
@@ -143,11 +143,6 @@ export const reducer = (
           ...action.walletToAccountAddress,
         },
       }
-    case Actions.UPDATE_E164_PHONE_NUMBER_SALT:
-      return {
-        ...state,
-        e164NumberToSalt: { ...state.e164NumberToSalt, ...action.e164NumberToSalt },
-      }
     case Actions.UPDATE_KNOWN_ADDRESSES:
       return {
         ...state,

--- a/src/identity/saga.ts
+++ b/src/identity/saga.ts
@@ -7,19 +7,17 @@ import {
   ValidateRecipientAddressAction,
   validateRecipientAddressSuccess,
 } from 'src/identity/actions'
-import { checkTxsForIdentityMetadata } from 'src/identity/commentEncryption'
 import { doImportContactsWrapper, fetchAddressesAndValidateSaga } from 'src/identity/contactMapping'
 import { AddressValidationType } from 'src/identity/reducer'
 import { validateAndReturnMatch } from 'src/identity/secureSend'
 import { e164NumberToAddressSelector } from 'src/identity/selectors'
 import { recipientHasNumber } from 'src/recipients/recipient'
-import { Actions as TransactionActions } from 'src/transactions/actions'
 import Logger from 'src/utils/Logger'
 import { ensureError } from 'src/utils/ensureError'
 import { safely } from 'src/utils/safely'
 import { fetchDataEncryptionKeyWrapper } from 'src/web3/dataEncryptionKey'
 import { currentAccountSelector } from 'src/web3/selectors'
-import { cancelled, put, select, spawn, takeEvery, takeLatest, takeLeading } from 'typed-redux-saga'
+import { cancelled, put, select, spawn, takeLatest, takeLeading } from 'typed-redux-saga'
 
 const TAG = 'identity/saga'
 
@@ -99,10 +97,6 @@ export function* watchValidateRecipientAddress() {
   yield* takeLatest(Actions.VALIDATE_RECIPIENT_ADDRESS, safely(validateRecipientAddressSaga))
 }
 
-function* watchNewFeedTransactions() {
-  yield* takeEvery(TransactionActions.NEW_TRANSACTIONS_IN_FEED, safely(checkTxsForIdentityMetadata))
-}
-
 function* watchFetchDataEncryptionKey() {
   yield* takeLeading(Actions.FETCH_DATA_ENCRYPTION_KEY, safely(fetchDataEncryptionKeyWrapper))
 }
@@ -112,7 +106,6 @@ export function* identitySaga() {
   try {
     yield* spawn(watchContactMapping)
     yield* spawn(watchValidateRecipientAddress)
-    yield* spawn(watchNewFeedTransactions)
     yield* spawn(watchFetchDataEncryptionKey)
   } catch (error) {
     Logger.error(TAG, 'Error initializing identity sagas', error)

--- a/src/redux/sagas.ts
+++ b/src/redux/sagas.ts
@@ -57,7 +57,6 @@ const loggerBlocklist = [
   ImportActions.IMPORT_BACKUP_PHRASE,
   setPhoneRecipientCache.toString(),
   updateValoraRecipientCache.toString(),
-  TransactionActions.NEW_TRANSACTIONS_IN_FEED,
   TransactionActions.UPDATE_RECENT_TX_RECIPIENT_CACHE,
   TransactionActions.UPDATE_TRANSACTIONS,
   Web3Actions.SET_DATA_ENCRYPTION_KEY,

--- a/src/transactions/actions.ts
+++ b/src/transactions/actions.ts
@@ -1,6 +1,5 @@
 import { CeloTxReceipt } from '@celo/connect'
 import { SendOrigin } from 'src/analytics/types'
-import { TransactionFeedFragment } from 'src/apollo/types'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import { NumberToRecipient } from 'src/recipients/recipient'
@@ -15,7 +14,6 @@ export enum Actions {
   TRANSACTION_CONFIRMED = 'TRANSACTIONS/TRANSACTION_CONFIRMED',
   TRANSACTION_CONFIRMED_VIEM = 'TRANSACTIONS/TRANSACTION_CONFIRMED_VIEM',
   TRANSACTION_FAILED = 'TRANSACTIONS/TRANSACTION_FAILED',
-  NEW_TRANSACTIONS_IN_FEED = 'TRANSACTIONS/NEW_TRANSACTIONS_IN_FEED',
   REFRESH_RECENT_TX_RECIPIENTS = 'TRANSACTIONS/REFRESH_RECENT_TX_RECIPIENTS',
   UPDATE_RECENT_TX_RECIPIENT_CACHE = 'TRANSACTIONS/UPDATE_RECENT_TX_RECIPIENT_CACHE',
   UPDATE_TRANSACTIONS = 'TRANSACTIONS/UPDATE_TRANSACTIONS',
@@ -54,11 +52,6 @@ export interface TransactionFailedAction {
   txId: string
 }
 
-export interface NewTransactionsInFeedAction {
-  type: Actions.NEW_TRANSACTIONS_IN_FEED
-  transactions: TransactionFeedFragment[]
-}
-
 export interface UpdatedRecentTxRecipientsCacheAction {
   type: Actions.UPDATE_RECENT_TX_RECIPIENT_CACHE
   recentTxRecipientsCache: NumberToRecipient
@@ -78,7 +71,6 @@ export type ActionTypes =
   | AddStandbyTransactionAction
   | RemoveStandbyTransactionAction
   | AddHashToStandbyTransactionAction
-  | NewTransactionsInFeedAction
   | UpdatedRecentTxRecipientsCacheAction
   | UpdateTransactionsAction
   | TransactionConfirmedAction
@@ -130,13 +122,6 @@ export const addHashToStandbyTransaction = (
   type: Actions.ADD_HASH_TO_STANDBY_TRANSACTIONS,
   idx,
   hash,
-})
-
-export const newTransactionsInFeed = (
-  transactions: TransactionFeedFragment[]
-): NewTransactionsInFeedAction => ({
-  type: Actions.NEW_TRANSACTIONS_IN_FEED,
-  transactions,
 })
 
 export const updateTransactions = (transactions: TokenTransaction[]): UpdateTransactionsAction => ({

--- a/src/transactions/reducer.ts
+++ b/src/transactions/reducer.ts
@@ -104,15 +104,6 @@ export const reducer = (
           }
         }),
       }
-    case Actions.NEW_TRANSACTIONS_IN_FEED:
-      const newKnownFeedTransactions = { ...state.knownFeedTransactions }
-      action.transactions.forEach((tx) => {
-        newKnownFeedTransactions[tx.hash] = tx.address
-      })
-      return {
-        ...state,
-        knownFeedTransactions: newKnownFeedTransactions,
-      }
     case Actions.UPDATE_RECENT_TX_RECIPIENT_CACHE:
       return {
         ...state,

--- a/src/transactions/saga.ts
+++ b/src/transactions/saga.ts
@@ -214,7 +214,6 @@ function* refreshRecentTxRecipients() {
 function* watchNewFeedTransactions() {
   yield* takeEvery(Actions.UPDATE_TRANSACTIONS, safely(cleanupStandbyTransactions))
   yield* takeEvery(Actions.UPDATE_TRANSACTIONS, safely(getInviteTransactionsDetails))
-  yield* takeLatest(Actions.NEW_TRANSACTIONS_IN_FEED, safely(refreshRecentTxRecipients))
 }
 
 function* watchAddressToE164PhoneNumberUpdate() {


### PR DESCRIPTION
### Description

As the title - I noticed now that the `NEW_TRANSACTIONS_IN_FEED` action is no longer dispatched from anywhere, but we have a bunch of sagas and state changes that are triggered from it. 

This PR removes the `NEW_TRANSACTIONS_IN_FEED` action and:
- tagTxsWithProviderInfo saga
- checkTxsForIdentityMetadata saga

### Test plan

CI

### Related issues

N/A

### Backwards compatibility

Y
