### PR TITLE
fix: swaps using CELO sometimes not working

### DIFF
--- a/src/swap/SwapReviewScreen.tsx
+++ b/src/swap/SwapReviewScreen.tsx
@@ -13,9 +13,10 @@ import { maxSwapSlippagePercentageSelector } from 'src/app/selectors'
 import BackButton from 'src/components/BackButton'
 import Button, { BtnSizes } from 'src/components/Button'
 import Dialog from 'src/components/Dialog'
-import CustomHeader from 'src/components/header/CustomHeader'
 import LegacyTokenDisplay from 'src/components/LegacyTokenDisplay'
+import { formatValueToDisplay } from 'src/components/TokenDisplay'
 import Touchable from 'src/components/Touchable'
+import CustomHeader from 'src/components/header/CustomHeader'
 import { useFeeCurrency } from 'src/fees/hooks'
 import InfoIcon from 'src/icons/InfoIcon'
 import { noHeader } from 'src/navigator/Headers'
@@ -28,11 +29,10 @@ import { swapUserInputSelector } from 'src/swap/selectors'
 import { swapStart } from 'src/swap/slice'
 import { FetchQuoteResponse, Field } from 'src/swap/types'
 import { celoAddressSelector, tokensByAddressSelector } from 'src/tokens/selectors'
-import { divideByWei } from 'src/utils/formatting'
 import Logger from 'src/utils/Logger'
+import { divideByWei } from 'src/utils/formatting'
 import networkConfig from 'src/web3/networkConfig'
 import { walletAddressSelector } from 'src/web3/selectors'
-import { formatValueToDisplay } from 'src/components/TokenDisplay'
 
 const TAG = 'SWAP_REVIEW_SCREEN'
 const initialUserInput = {
@@ -43,14 +43,6 @@ const initialUserInput = {
     [Field.TO]: null,
   },
   updatedField: Field.TO,
-}
-
-// Workaround for buying Celo - Mainnet only
-const toCeloWorkaround = (tokenAddress: string) => {
-  // Check if the token is CELO
-  return tokenAddress.toLowerCase() === '0x471ece3750da237f93b8e339c536989b8978a438'
-    ? '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE'
-    : tokenAddress
 }
 
 export function SwapReviewScreen() {
@@ -129,7 +121,7 @@ export function SwapReviewScreen() {
     async () => {
       if (!shouldFetch) return
       const params = {
-        buyToken: toCeloWorkaround(toToken),
+        buyToken: toToken,
         sellToken: fromToken,
         [swapAmountParam]: swapAmountInWei.toString().split('.')[0],
         // Enable when supported by 0xAPI & valora-rest-api

--- a/src/swap/saga.test.ts
+++ b/src/swap/saga.test.ts
@@ -70,8 +70,8 @@ const mockSwap: PayloadAction<SwapInfo> = {
     },
     userInput: {
       updatedField: Field.TO,
-      fromToken: mockCeloAddress,
-      toToken: mockCeurAddress,
+      fromToken: mockCeurAddress,
+      toToken: mockCeloAddress,
       swapAmount: {
         [Field.FROM]: '100',
         [Field.TO]: '200',

--- a/src/swap/saga.ts
+++ b/src/swap/saga.ts
@@ -82,7 +82,8 @@ function* handleSendSwapTransaction(
   )
 
   const receipt = yield* call(sendTransaction, txo, walletAddress, transactionContext)
-  return receipt
+
+  yield* put(addHashToStandbyTransaction(transactionContext.id, receipt.transactionHash))
 }
 
 function calculateEstimatedUsdValue({
@@ -225,7 +226,7 @@ export function* swapSubmitSaga(action: PayloadAction<SwapInfo>) {
 
     const beforeSwapExecutionTimestamp = Date.now()
     quoteToTransactionElapsedTimeInMs = beforeSwapExecutionTimestamp - quoteReceivedAt
-    const receipt = yield* call(
+    yield* call(
       handleSendSwapTransaction,
       { ...action.payload.unvalidatedSwapTransaction },
       swapExecuteContext,
@@ -235,7 +236,6 @@ export function* swapSubmitSaga(action: PayloadAction<SwapInfo>) {
 
     const timeMetrics = getTimeMetrics()
 
-    yield* put(addHashToStandbyTransaction(swapExecuteContext.id, receipt.transactionHash))
     yield* put(swapSuccess())
     vibrateSuccess()
     ValoraAnalytics.track(SwapEvents.swap_execute_success, {

--- a/src/swap/saga.ts
+++ b/src/swap/saga.ts
@@ -208,13 +208,16 @@ export function* swapSubmitSaga(action: PayloadAction<SwapInfo>) {
       TAG,
       `Approving ${amountToApprove} of ${sellTokenAddress} for address: ${allowanceTarget}`
     )
-    yield* call(
-      sendApproveTx,
-      sellTokenAddress,
-      amountToApprove,
-      allowanceTarget,
-      swapApproveContext
-    )
+
+    if (fromToken.address) {
+      yield* call(
+        sendApproveTx,
+        fromToken.address,
+        amountToApprove,
+        allowanceTarget,
+        swapApproveContext
+      )
+    }
 
     // Execute transaction
     yield* put(swapExecute())

--- a/src/swap/saga.ts
+++ b/src/swap/saga.ts
@@ -20,10 +20,10 @@ import {
 } from 'src/swap/slice'
 import { Field, SwapInfo, SwapTransaction } from 'src/swap/types'
 import { getERC20TokenContract } from 'src/tokens/saga'
-import { swappableTokensSelector } from 'src/tokens/selectors'
+import { tokensByIdSelector } from 'src/tokens/selectors'
 import { TokenBalance } from 'src/tokens/slice'
 import { getTokenId } from 'src/tokens/utils'
-import { addStandbyTransaction } from 'src/transactions/actions'
+import { addHashToStandbyTransaction, addStandbyTransaction } from 'src/transactions/actions'
 import { sendTransaction } from 'src/transactions/send'
 import {
   TokenTransactionTypeV2,
@@ -42,13 +42,17 @@ import { call, put, select, takeLatest } from 'typed-redux-saga'
 
 const TAG = 'swap/saga'
 
+const nativeTokenAddressForSwapProviders = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee'
+
 function getPercentageDifference(price1: number, price2: number) {
   return (Math.abs(price1 - price2) / ((price1 + price2) / 2)) * 100
 }
 
 function* handleSendSwapTransaction(
   rawTx: SwapTransaction,
-  transactionContext: TransactionContext
+  transactionContext: TransactionContext,
+  fromToken: TokenBalance,
+  toToken: TokenBalance
 ) {
   const kit: ContractKit = yield* call(getContractKit)
   const walletAddress: string = yield* call(getConnectedUnlockedAccount)
@@ -57,6 +61,25 @@ function* handleSendSwapTransaction(
   applyChainIdWorkaround(rawTx, yield* call([kit.connection, 'chainId']))
   const tx: CeloTx = yield* call(normalizer.populate.bind(normalizer), rawTx)
   const txo = buildTxo(kit, tx)
+
+  yield* put(
+    addStandbyTransaction({
+      context: transactionContext,
+      __typename: 'TokenExchangeV3',
+      networkId: networkConfig.defaultNetworkId,
+      type: TokenTransactionTypeV2.SwapTransaction,
+      inAmount: {
+        value: valueToBigNumber(rawTx.sellAmount)
+          .multipliedBy(rawTx.guaranteedPrice)
+          .shiftedBy(-toToken.decimals),
+        tokenId: toToken.tokenId,
+      },
+      outAmount: {
+        value: valueToBigNumber(rawTx.sellAmount).shiftedBy(-fromToken.decimals),
+        tokenId: fromToken.tokenId,
+      },
+    })
+  )
 
   const receipt = yield* call(sendTransaction, txo, walletAddress, transactionContext)
   return receipt
@@ -90,9 +113,23 @@ export function* swapSubmitSaga(action: PayloadAction<SwapInfo>) {
   const amount = action.payload.unvalidatedSwapTransaction[amountType]
   const { quoteReceivedAt } = action.payload
 
-  const tokenBalances: TokenBalance[] = yield* select(swappableTokensSelector)
-  const fromToken = tokenBalances.find((token) => token.address === sellTokenAddress)
-  const toToken = tokenBalances.find((token) => token.address === buyTokenAddress)
+  const tokens = yield* select((state) =>
+    tokensByIdSelector(state, [networkConfig.defaultNetworkId])
+  )
+  const fromToken =
+    tokens[
+      getTokenId(
+        networkConfig.defaultNetworkId,
+        sellTokenAddress === nativeTokenAddressForSwapProviders ? undefined : sellTokenAddress
+      )
+    ]
+  const toToken =
+    tokens[
+      getTokenId(
+        networkConfig.defaultNetworkId,
+        buyTokenAddress === nativeTokenAddressForSwapProviders ? undefined : buyTokenAddress
+      )
+    ]
 
   if (!fromToken || !toToken) {
     Logger.error(
@@ -188,31 +225,14 @@ export function* swapSubmitSaga(action: PayloadAction<SwapInfo>) {
     const receipt = yield* call(
       handleSendSwapTransaction,
       { ...action.payload.unvalidatedSwapTransaction },
-      swapExecuteContext
+      swapExecuteContext,
+      fromToken,
+      toToken
     )
 
     const timeMetrics = getTimeMetrics()
 
-    yield* put(
-      addStandbyTransaction({
-        context: swapExecuteContext,
-        __typename: 'TokenExchangeV3',
-        networkId: networkConfig.defaultNetworkId,
-        type: TokenTransactionTypeV2.SwapTransaction,
-        inAmount: {
-          value: valueToBigNumber(sellAmount)
-            .multipliedBy(guaranteedPrice)
-            .shiftedBy(-toToken.decimals),
-          tokenId: getTokenId(networkConfig.defaultNetworkId, buyTokenAddress),
-        },
-        outAmount: {
-          value: valueToBigNumber(sellAmount).shiftedBy(-fromToken.decimals),
-          tokenId: getTokenId(networkConfig.defaultNetworkId, sellTokenAddress),
-        },
-        transactionHash: receipt.transactionHash,
-      })
-    )
-
+    yield* put(addHashToStandbyTransaction(swapExecuteContext.id, receipt.transactionHash))
     yield* put(swapSuccess())
     vibrateSuccess()
     ValoraAnalytics.track(SwapEvents.swap_execute_success, {

--- a/src/swap/saga.ts
+++ b/src/swap/saga.ts
@@ -42,8 +42,6 @@ import { call, put, select, takeLatest } from 'typed-redux-saga'
 
 const TAG = 'swap/saga'
 
-const nativeTokenAddressForSwapProviders = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee'
-
 function getPercentageDifference(price1: number, price2: number) {
   return (Math.abs(price1 - price2) / ((price1 + price2) / 2)) * 100
 }
@@ -118,19 +116,9 @@ export function* swapSubmitSaga(action: PayloadAction<SwapInfo>) {
     tokensByIdSelector(state, [networkConfig.defaultNetworkId])
   )
   const fromToken =
-    tokens[
-      getTokenId(
-        networkConfig.defaultNetworkId,
-        sellTokenAddress === nativeTokenAddressForSwapProviders ? undefined : sellTokenAddress
-      )
-    ]
+    tokens[getTokenId(networkConfig.defaultNetworkId, action.payload.userInput.fromToken)]
   const toToken =
-    tokens[
-      getTokenId(
-        networkConfig.defaultNetworkId,
-        buyTokenAddress === nativeTokenAddressForSwapProviders ? undefined : buyTokenAddress
-      )
-    ]
+    tokens[getTokenId(networkConfig.defaultNetworkId, action.payload.userInput.toToken)]
 
   if (!fromToken || !toToken) {
     Logger.error(

--- a/src/transactions/reducer.ts
+++ b/src/transactions/reducer.ts
@@ -108,7 +108,7 @@ export const reducer = (
         standbyTransactions: mapForContextId(state.standbyTransactions, action.idx, (tx) => {
           return {
             ...tx,
-            hash: action.hash,
+            transactionHash: action.hash,
           }
         }),
       }


### PR DESCRIPTION
### Description

When the swap quote comes from 0x, the buy token is "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee". We need to turn this into something we recognise to get the related token info.

This PR does a few things:
1. given the sell and buy tokens from the swap quote, get the token id's and use those to get the token info
2. map "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee" to the native token. it'd be nice to avoid this in the wallet but we'll need similar logic for ETH.
3. use the sell and buy tokens directly in the swap saga (instead of the buy and sell token addresses from the swap quotes)
4. create the standby swap transaction before submitting the swap, and manually add the tx hash.
5. fix typo for variable name in reducer

### Test plan

(This quote wasn't from 0x, I tried many times but couldn't get one from 0x. So this shows the regression scenario)
https://github.com/valora-inc/wallet/assets/20150449/7d619789-3305-4757-9612-b1fd92051ce4

### Related issues

- Fixes RET-894

### Backwards compatibility

Y
