### PR TITLE
fix: show completed standby transactions in the homefeed

### DIFF
--- a/src/redux/migrations.ts
+++ b/src/redux/migrations.ts
@@ -1380,4 +1380,17 @@ export const migrations = {
       }),
     },
   }),
+  162: (state: any) => ({
+    ...state,
+    transactions: {
+      ...state.transactions,
+      standbyTransactions: state.transactions.standbyTransactions.filter((tx: any) => {
+        // this migration requires extra data on completed standby transactions
+        // that we cannot recover, so we remove these from the store. this is
+        // low risk since completed tx's will be returned by blockchain-api
+        // eventually.
+        return tx.status !== 'Complete'
+      }),
+    },
+  }),
 }

--- a/src/redux/store.test.ts
+++ b/src/redux/store.test.ts
@@ -98,7 +98,7 @@ describe('store state', () => {
       {
         "_persist": {
           "rehydrated": true,
-          "version": 161,
+          "version": 162,
         },
         "account": {
           "acceptedTerms": false,

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -23,7 +23,7 @@ const persistConfig: PersistConfig<RootState> = {
   key: 'root',
   // default is -1, increment as we make migrations
   // See https://github.com/valora-inc/wallet/tree/main/WALLET.md#redux-state-migration
-  version: 161,
+  version: 162,
   keyPrefix: `reduxStore-`, // the redux-persist default is `persist:` which doesn't work with some file systems.
   storage: FSStorage(),
   blacklist: ['networkInfo', 'alert', 'imports', 'keylessBackup'],

--- a/src/transactions/actions.ts
+++ b/src/transactions/actions.ts
@@ -1,14 +1,16 @@
-import { CeloTxReceipt } from '@celo/connect'
 import { NumberToRecipient } from 'src/recipients/recipient'
 import { InviteTransactions } from 'src/transactions/reducer'
-import { StandbySwap, StandbyTransfer, TokenTransaction } from 'src/transactions/types'
+import {
+  PendingStandbySwap,
+  PendingStandbyTransfer,
+  TokenTransaction,
+} from 'src/transactions/types'
 
 export enum Actions {
   ADD_STANDBY_TRANSACTION = 'TRANSACTIONS/ADD_STANDBY_TRANSACTION',
   REMOVE_STANDBY_TRANSACTION = 'TRANSACTIONS/REMOVE_STANDBY_TRANSACTION',
   ADD_HASH_TO_STANDBY_TRANSACTIONS = 'TRANSACTIONS/ADD_HASH_TO_STANDBY_TRANSACTIONS',
   TRANSACTION_CONFIRMED = 'TRANSACTIONS/TRANSACTION_CONFIRMED',
-  TRANSACTION_CONFIRMED_VIEM = 'TRANSACTIONS/TRANSACTION_CONFIRMED_VIEM',
   TRANSACTION_FAILED = 'TRANSACTIONS/TRANSACTION_FAILED',
   REFRESH_RECENT_TX_RECIPIENTS = 'TRANSACTIONS/REFRESH_RECENT_TX_RECIPIENTS',
   UPDATE_RECENT_TX_RECIPIENT_CACHE = 'TRANSACTIONS/UPDATE_RECENT_TX_RECIPIENT_CACHE',
@@ -17,8 +19,8 @@ export enum Actions {
 }
 
 type BaseStandbyTransaction =
-  | Omit<StandbyTransfer, 'timestamp' | 'status'>
-  | Omit<StandbySwap, 'timestamp' | 'status'>
+  | Omit<PendingStandbyTransfer, 'timestamp' | 'status'>
+  | Omit<PendingStandbySwap, 'timestamp' | 'status'>
 
 export interface AddStandbyTransactionAction {
   type: Actions.ADD_STANDBY_TRANSACTION
@@ -36,15 +38,17 @@ export interface AddHashToStandbyTransactionAction {
   hash: string
 }
 
+// this type would ideally be TransactionReceipt from viem however the numbers
+// are of type bigint which is not serializable and causes problems at runtime
+type BaseTransactionReceipt = {
+  status: boolean
+  block: string
+  transactionHash: string
+}
 export interface TransactionConfirmedAction {
   type: Actions.TRANSACTION_CONFIRMED
   txId: string
-  receipt: CeloTxReceipt
-}
-
-export interface TransactionConfirmedViemAction {
-  type: Actions.TRANSACTION_CONFIRMED_VIEM
-  txId: string
+  receipt: BaseTransactionReceipt
 }
 
 export interface TransactionFailedAction {
@@ -74,7 +78,6 @@ export type ActionTypes =
   | UpdatedRecentTxRecipientsCacheAction
   | UpdateTransactionsAction
   | TransactionConfirmedAction
-  | TransactionConfirmedViemAction
   | UpdateInviteTransactionsAction
 
 export const addStandbyTransaction = (
@@ -98,16 +101,11 @@ export const updateRecentTxRecipientsCache = (
 
 export const transactionConfirmed = (
   txId: string,
-  receipt: CeloTxReceipt
+  receipt: BaseTransactionReceipt
 ): TransactionConfirmedAction => ({
   type: Actions.TRANSACTION_CONFIRMED,
   txId,
   receipt,
-})
-
-export const transactionConfirmedViem = (txId: string): TransactionConfirmedViemAction => ({
-  type: Actions.TRANSACTION_CONFIRMED_VIEM,
-  txId,
 })
 
 export const transactionFailed = (txId: string): TransactionFailedAction => ({

--- a/src/transactions/feed/TransactionFeed.tsx
+++ b/src/transactions/feed/TransactionFeed.tsx
@@ -20,20 +20,17 @@ export type FeedTokenProperties = {
 export type FeedTokenTransaction = TokenTransaction & FeedTokenProperties
 
 function TransactionFeed() {
-  const { loading, error, transactions, fetchingMoreTransactions, fetchMoreTransactions } =
-    useFetchTransactions()
+  const { loading, error, fetchingMoreTransactions, fetchMoreTransactions } = useFetchTransactions()
 
-  const cachedTransactions = useSelector(transactionsSelector)
+  const transactions = useSelector(transactionsSelector)
   const allPendingTransactions = useSelector(pendingStandbyTransactionsSelector)
   const allowedNetworks = getAllowedNetworkIds()
 
   const confirmedFeedTransactions = useMemo(() => {
-    const confirmedTokenTransactions: TokenTransaction[] =
-      transactions.length > 0 ? transactions : cachedTransactions
-    return confirmedTokenTransactions.filter((tx) => {
+    return transactions.filter((tx) => {
       return allowedNetworks.includes(tx.networkId)
     })
-  }, [transactions, cachedTransactions, allowedNetworks])
+  }, [transactions, allowedNetworks])
 
   const pendingTransactions = useMemo(() => {
     return allPendingTransactions.filter((tx) => {

--- a/src/transactions/feed/queryHelper.ts
+++ b/src/transactions/feed/queryHelper.ts
@@ -25,7 +25,6 @@ const MIN_NUM_TRANSACTIONS = 10
 export interface QueryHookResult {
   loading: boolean
   error: Error | undefined
-  transactions: TokenTransaction[]
   fetchingMoreTransactions: boolean
   fetchMoreTransactions: () => void
 }
@@ -238,7 +237,6 @@ export function useFetchTransactions(): QueryHookResult {
   return {
     loading,
     error,
-    transactions: fetchedResult.transactions,
     fetchingMoreTransactions,
     fetchMoreTransactions: () => {
       if (!fetchedResult.pageInfo) {

--- a/src/transactions/reducer.ts
+++ b/src/transactions/reducer.ts
@@ -4,7 +4,12 @@ import { NumberToRecipient } from 'src/recipients/recipient'
 import { getRehydratePayload, REHYDRATE, RehydrateAction } from 'src/redux/persist-helper'
 import { RootState } from 'src/redux/reducers'
 import { Actions, ActionTypes } from 'src/transactions/actions'
-import { StandbyTransaction, TokenTransaction, TransactionStatus } from 'src/transactions/types'
+import {
+  CompletedStandbyTransaction,
+  StandbyTransaction,
+  TokenTransaction,
+  TransactionStatus,
+} from 'src/transactions/types'
 import { deduplicateTransactions } from 'src/transactions/utils'
 
 export interface InviteTransactions {
@@ -75,9 +80,8 @@ export const reducer = (
           (tx: StandbyTransaction) => tx.context.id !== action.idx
         ),
       }
-    case Actions.TRANSACTION_CONFIRMED:
-      const status = action.receipt.status
-
+    case Actions.TRANSACTION_CONFIRMED: {
+      const { status, transactionHash, block } = action.receipt
       if (!status) {
         return {
           ...state,
@@ -86,32 +90,34 @@ export const reducer = (
 
       return {
         ...state,
-        standbyTransactions: mapForContextId(state.standbyTransactions, action.txId, (tx) => {
-          return {
-            ...tx,
-            status: TransactionStatus.Complete,
+        standbyTransactions: state.standbyTransactions.map(
+          (standbyTransaction): StandbyTransaction => {
+            if (standbyTransaction.context.id === action.txId) {
+              return {
+                ...standbyTransaction,
+                status: TransactionStatus.Complete,
+                transactionHash,
+                block,
+                timestamp: Date.now(),
+                fees: [],
+              }
+            }
+            return standbyTransaction
           }
-        }),
+        ),
       }
-    case Actions.TRANSACTION_CONFIRMED_VIEM:
-      return {
-        ...state,
-        standbyTransactions: mapForContextId(state.standbyTransactions, action.txId, (tx) => {
-          return {
-            ...tx,
-            status: TransactionStatus.Complete,
-          }
-        }),
-      }
+    }
     case Actions.ADD_HASH_TO_STANDBY_TRANSACTIONS:
       return {
         ...state,
-        standbyTransactions: mapForContextId(state.standbyTransactions, action.idx, (tx) => {
-          return {
-            ...tx,
-            transactionHash: action.hash,
+        standbyTransactions: state.standbyTransactions.map(
+          (standbyTransaction): StandbyTransaction => {
+            if (standbyTransaction.context.id === action.idx) {
+              return { ...standbyTransaction, transactionHash: action.hash }
+            }
+            return standbyTransaction
           }
-        }),
+        ),
       }
     case Actions.UPDATE_RECENT_TX_RECIPIENT_CACHE:
       return {
@@ -141,21 +147,11 @@ export const reducer = (
   }
 }
 
-function mapForContextId(
-  txs: { context: { id: string } }[],
-  contextId: string,
-  mapping: (tx: any) => any
-) {
-  return txs.map((tx) => {
-    if (tx.context.id !== contextId) {
-      return tx
-    }
-    return mapping(tx)
-  })
-}
+export const standbyTransactionsSelector = (state: RootState) =>
+  state.transactions.standbyTransactions
 
 export const pendingStandbyTransactionsSelector = createSelector(
-  [(state: RootState) => state.transactions.standbyTransactions],
+  [standbyTransactionsSelector],
   (transactions) => {
     return transactions
       .filter((transaction) => transaction.status === TransactionStatus.Pending)
@@ -174,7 +170,18 @@ export const knownFeedTransactionsSelector = (state: RootState) =>
 export const recentTxRecipientsCacheSelector = (state: RootState) =>
   state.transactions.recentTxRecipientsCache
 
-export const transactionsSelector = (state: RootState) => state.transactions.transactions
+export const transactionsSelector = createSelector(
+  [standbyTransactionsSelector, (state: RootState) => state.transactions.transactions],
+  (standbyTransactions, transactions) => {
+    return [
+      ...standbyTransactions.filter(
+        (transaction: StandbyTransaction): transaction is CompletedStandbyTransaction =>
+          transaction.status === TransactionStatus.Complete
+      ),
+      ...transactions,
+    ].sort((a, b) => b.timestamp - a.timestamp)
+  }
+)
 
 export const inviteTransactionsSelector = (state: RootState) =>
   state.transactions.inviteTransactions

--- a/src/transactions/saga.ts
+++ b/src/transactions/saga.ts
@@ -25,7 +25,7 @@ import {
   KnownFeedTransactionsType,
   inviteTransactionsSelector,
   knownFeedTransactionsSelector,
-  pendingStandbyTransactionsSelector,
+  standbyTransactionsSelector,
 } from 'src/transactions/reducer'
 import { sendTransactionPromises, wrapSendTransactionWithRetry } from 'src/transactions/send'
 import {
@@ -44,7 +44,7 @@ const RECENT_TX_RECIPIENT_CACHE_LIMIT = 10
 
 // Remove standby txs from redux state when the real ones show up in the feed
 function* cleanupStandbyTransactions({ transactions }: UpdateTransactionsAction) {
-  const standbyTxs: StandbyTransaction[] = yield* select(pendingStandbyTransactionsSelector)
+  const standbyTxs: StandbyTransaction[] = yield* select(standbyTransactionsSelector)
   const newFeedTxHashes = new Set(transactions.map((tx) => tx?.transactionHash))
   for (const standbyTx of standbyTxs) {
     if (standbyTx.transactionHash && newFeedTxHashes.has(standbyTx.transactionHash)) {
@@ -145,7 +145,13 @@ export function* sendAndMonitorTransaction<T>(
       sendTxMethod,
       context
     )) as unknown as CeloTxReceipt
-    yield* put(transactionConfirmed(context.id, txReceipt))
+    yield* put(
+      transactionConfirmed(context.id, {
+        transactionHash: txReceipt.transactionHash,
+        block: txReceipt.blockNumber.toString(),
+        status: txReceipt.status,
+      })
+    )
 
     yield* put(fetchTokenBalances({ showLoading: true }))
     return { receipt: txReceipt }

--- a/src/transactions/types.ts
+++ b/src/transactions/types.ts
@@ -14,19 +14,30 @@ export enum NetworkId {
   'ethereum-sepolia' = 'ethereum-sepolia',
 }
 
-export type StandbySwap = {
-  type: TokenTransactionTypeV2.SwapTransaction | TokenTransactionTypeV2.Exchange
+export type PendingStandbySwap = {
   transactionHash?: string
   context: TransactionContext
-} & Omit<TokenExchange, 'block' | 'fees' | 'transactionHash'>
+  status: TransactionStatus.Pending
+} & Omit<TokenExchange, 'block' | 'fees' | 'transactionHash' | 'status'>
 
-export type StandbyTransfer = {
-  type: TokenTransactionTypeV2.Sent | TokenTransactionTypeV2.Received
+export type PendingStandbyTransfer = {
   transactionHash?: string
   context: TransactionContext
-} & Omit<TokenTransfer, 'block' | 'fees' | 'transactionHash'>
+  status: TransactionStatus.Pending
+} & Omit<TokenTransfer, 'block' | 'fees' | 'transactionHash' | 'status'>
 
-export type StandbyTransaction = StandbySwap | StandbyTransfer
+export type CompletedStandbyTransaction = (
+  | Omit<TokenExchange, 'status'>
+  | Omit<TokenTransfer, 'status'>
+) & {
+  status: TransactionStatus.Complete
+  context: TransactionContext
+}
+
+export type StandbyTransaction =
+  | PendingStandbySwap
+  | PendingStandbyTransfer
+  | CompletedStandbyTransaction
 
 // Context used for logging the transaction execution flow.
 export interface TransactionContext {

--- a/src/viem/saga.test.ts
+++ b/src/viem/saga.test.ts
@@ -14,7 +14,7 @@ import {
   Actions,
   addHashToStandbyTransaction,
   removeStandbyTransaction,
-  transactionConfirmedViem,
+  transactionConfirmed,
   transactionFailed,
 } from 'src/transactions/actions'
 import { chooseTxFeeDetails } from 'src/transactions/send'
@@ -288,7 +288,7 @@ describe('getSendTxFeeDetails', () => {
 
 describe('sendAndMonitorTransaction', () => {
   const mockTxHash = '0x12345678901234'
-  const mockTxReceipt = { status: 'success' }
+  const mockTxReceipt = { status: 'success', transactionHash: mockTxHash, blockNumber: 123 }
   const mockArgs = {
     context: { id: 'txId' },
     wallet: mockViemWallet,
@@ -305,7 +305,13 @@ describe('sendAndMonitorTransaction', () => {
         [matchers.call.fn(publicClient.celo.waitForTransactionReceipt), mockTxReceipt],
       ])
       .put(addHashToStandbyTransaction('txId', mockTxHash))
-      .put(transactionConfirmedViem('txId'))
+      .put(
+        transactionConfirmed('txId', {
+          transactionHash: mockTxHash,
+          block: '123',
+          status: true,
+        })
+      )
       .put(fetchTokenBalances({ showLoading: true }))
       .call([mockViemWallet, 'writeContract'], mockArgs.request)
       .call([publicClient.celo, 'waitForTransactionReceipt'], { hash: mockTxHash })

--- a/src/viem/saga.ts
+++ b/src/viem/saga.ts
@@ -15,7 +15,7 @@ import {
   addHashToStandbyTransaction,
   addStandbyTransaction,
   removeStandbyTransaction,
-  transactionConfirmedViem,
+  transactionConfirmed,
   transactionFailed,
 } from 'src/transactions/actions'
 import { chooseTxFeeDetails, wrapSendTransactionWithRetry } from 'src/transactions/send'
@@ -303,7 +303,13 @@ export function* sendAndMonitorTransaction({
       throw new Error('transaction reverted')
     }
     ValoraAnalytics.track(TransactionEvents.transaction_confirmed, commonTxAnalyticsProps)
-    yield* put(transactionConfirmedViem(context.id))
+    yield* put(
+      transactionConfirmed(context.id, {
+        transactionHash: receipt.transactionHash,
+        block: receipt.blockNumber.toString(),
+        status: true,
+      })
+    )
     yield* put(fetchTokenBalances({ showLoading: true }))
     return receipt
   } catch (err) {

--- a/test/RootStateSchema.json
+++ b/test/RootStateSchema.json
@@ -2100,6 +2100,103 @@
             ],
             "type": "object"
         },
+        "PendingStandbySwap": {
+            "additionalProperties": false,
+            "properties": {
+                "__typename": {
+                    "const": "TokenExchangeV3",
+                    "type": "string"
+                },
+                "context": {
+                    "$ref": "#/definitions/TransactionContext"
+                },
+                "inAmount": {
+                    "$ref": "#/definitions/TokenAmount"
+                },
+                "metadata": {
+                    "$ref": "#/definitions/TokenExchangeMetadata"
+                },
+                "networkId": {
+                    "$ref": "#/definitions/NetworkId"
+                },
+                "outAmount": {
+                    "$ref": "#/definitions/TokenAmount"
+                },
+                "status": {
+                    "const": "Pending",
+                    "type": "string"
+                },
+                "timestamp": {
+                    "type": "number"
+                },
+                "transactionHash": {
+                    "type": "string"
+                },
+                "type": {
+                    "$ref": "#/definitions/TokenTransactionTypeV2"
+                }
+            },
+            "required": [
+                "__typename",
+                "context",
+                "inAmount",
+                "networkId",
+                "outAmount",
+                "status",
+                "timestamp",
+                "type"
+            ],
+            "type": "object"
+        },
+        "PendingStandbyTransfer": {
+            "additionalProperties": false,
+            "properties": {
+                "__typename": {
+                    "const": "TokenTransferV3",
+                    "type": "string"
+                },
+                "address": {
+                    "type": "string"
+                },
+                "amount": {
+                    "$ref": "#/definitions/TokenAmount"
+                },
+                "context": {
+                    "$ref": "#/definitions/TransactionContext"
+                },
+                "metadata": {
+                    "$ref": "#/definitions/TokenTransferMetadata"
+                },
+                "networkId": {
+                    "$ref": "#/definitions/NetworkId"
+                },
+                "status": {
+                    "const": "Pending",
+                    "type": "string"
+                },
+                "timestamp": {
+                    "type": "number"
+                },
+                "transactionHash": {
+                    "type": "string"
+                },
+                "type": {
+                    "$ref": "#/definitions/TokenTransactionTypeV2"
+                }
+            },
+            "required": [
+                "__typename",
+                "address",
+                "amount",
+                "context",
+                "metadata",
+                "networkId",
+                "status",
+                "timestamp",
+                "type"
+            ],
+            "type": "object"
+        },
         "PersistState": {
             "additionalProperties": false,
             "properties": {
@@ -2640,110 +2737,136 @@
             ],
             "type": "object"
         },
-        "StandbySwap": {
-            "additionalProperties": false,
-            "properties": {
-                "__typename": {
-                    "const": "TokenExchangeV3",
-                    "type": "string"
-                },
-                "context": {
-                    "$ref": "#/definitions/TransactionContext"
-                },
-                "inAmount": {
-                    "$ref": "#/definitions/TokenAmount"
-                },
-                "metadata": {
-                    "$ref": "#/definitions/TokenExchangeMetadata"
-                },
-                "networkId": {
-                    "$ref": "#/definitions/NetworkId"
-                },
-                "outAmount": {
-                    "$ref": "#/definitions/TokenAmount"
-                },
-                "status": {
-                    "$ref": "#/definitions/TransactionStatus"
-                },
-                "timestamp": {
-                    "type": "number"
-                },
-                "transactionHash": {
-                    "type": "string"
-                },
-                "type": {
-                    "$ref": "#/definitions/TokenTransactionTypeV2"
-                }
-            },
-            "required": [
-                "__typename",
-                "context",
-                "inAmount",
-                "networkId",
-                "outAmount",
-                "status",
-                "timestamp",
-                "type"
-            ],
-            "type": "object"
-        },
         "StandbyTransaction": {
             "anyOf": [
                 {
-                    "$ref": "#/definitions/StandbySwap"
+                    "$ref": "#/definitions/PendingStandbySwap"
                 },
                 {
-                    "$ref": "#/definitions/StandbyTransfer"
+                    "$ref": "#/definitions/PendingStandbyTransfer"
+                },
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "__typename": {
+                            "const": "TokenExchangeV3",
+                            "type": "string"
+                        },
+                        "block": {
+                            "type": "string"
+                        },
+                        "context": {
+                            "$ref": "#/definitions/TransactionContext"
+                        },
+                        "fees": {
+                            "items": {
+                                "$ref": "#/definitions/Fee"
+                            },
+                            "type": "array"
+                        },
+                        "inAmount": {
+                            "$ref": "#/definitions/TokenAmount"
+                        },
+                        "metadata": {
+                            "$ref": "#/definitions/TokenExchangeMetadata"
+                        },
+                        "networkId": {
+                            "$ref": "#/definitions/NetworkId"
+                        },
+                        "outAmount": {
+                            "$ref": "#/definitions/TokenAmount"
+                        },
+                        "status": {
+                            "const": "Complete",
+                            "type": "string"
+                        },
+                        "timestamp": {
+                            "type": "number"
+                        },
+                        "transactionHash": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "$ref": "#/definitions/TokenTransactionTypeV2"
+                        }
+                    },
+                    "required": [
+                        "__typename",
+                        "block",
+                        "context",
+                        "fees",
+                        "inAmount",
+                        "networkId",
+                        "outAmount",
+                        "status",
+                        "timestamp",
+                        "transactionHash",
+                        "type"
+                    ],
+                    "type": "object"
+                },
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "__typename": {
+                            "const": "TokenTransferV3",
+                            "type": "string"
+                        },
+                        "address": {
+                            "type": "string"
+                        },
+                        "amount": {
+                            "$ref": "#/definitions/TokenAmount"
+                        },
+                        "block": {
+                            "type": "string"
+                        },
+                        "context": {
+                            "$ref": "#/definitions/TransactionContext"
+                        },
+                        "fees": {
+                            "items": {
+                                "$ref": "#/definitions/Fee"
+                            },
+                            "type": "array"
+                        },
+                        "metadata": {
+                            "$ref": "#/definitions/TokenTransferMetadata"
+                        },
+                        "networkId": {
+                            "$ref": "#/definitions/NetworkId"
+                        },
+                        "status": {
+                            "const": "Complete",
+                            "type": "string"
+                        },
+                        "timestamp": {
+                            "type": "number"
+                        },
+                        "transactionHash": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "$ref": "#/definitions/TokenTransactionTypeV2"
+                        }
+                    },
+                    "required": [
+                        "__typename",
+                        "address",
+                        "amount",
+                        "block",
+                        "context",
+                        "fees",
+                        "metadata",
+                        "networkId",
+                        "status",
+                        "timestamp",
+                        "transactionHash",
+                        "type"
+                    ],
+                    "type": "object"
                 }
             ]
-        },
-        "StandbyTransfer": {
-            "additionalProperties": false,
-            "properties": {
-                "__typename": {
-                    "const": "TokenTransferV3",
-                    "type": "string"
-                },
-                "address": {
-                    "type": "string"
-                },
-                "amount": {
-                    "$ref": "#/definitions/TokenAmount"
-                },
-                "context": {
-                    "$ref": "#/definitions/TransactionContext"
-                },
-                "metadata": {
-                    "$ref": "#/definitions/TokenTransferMetadata"
-                },
-                "networkId": {
-                    "$ref": "#/definitions/NetworkId"
-                },
-                "status": {
-                    "$ref": "#/definitions/TransactionStatus"
-                },
-                "timestamp": {
-                    "type": "number"
-                },
-                "transactionHash": {
-                    "type": "string"
-                },
-                "type": {
-                    "$ref": "#/definitions/TokenTransactionTypeV2"
-                }
-            },
-            "required": [
-                "__typename",
-                "address",
-                "amount",
-                "context",
-                "metadata",
-                "networkId",
-                "status",
-                "timestamp",
-                "type"
-            ],
-            "type": "object"
         },
         "State": {
             "additionalProperties": false,

--- a/test/schemas.ts
+++ b/test/schemas.ts
@@ -2729,6 +2729,20 @@ export const v161Schema = {
   },
 }
 
+export const v162Schema = {
+  ...v161Schema,
+  _persist: {
+    ...v161Schema._persist,
+    version: 162,
+  },
+  transactions: {
+    ...v161Schema.transactions,
+    standbyTransactions: v161Schema.transactions.standbyTransactions.filter((tx: any) => {
+      return tx.status !== 'Complete'
+    }),
+  },
+}
+
 export function getLatestSchema(): Partial<RootState> {
-  return v161Schema as Partial<RootState>
+  return v162Schema as Partial<RootState>
 }


### PR DESCRIPTION
### Description

There are a few things going on in this PR to achieve the end result:
1. update the TransactionFeed component to show transactions using redux instead of this hook OR redux logic. i'm not sure why it was like this, but the useFetchTransactions hook already saves transactions to redux so i can't see why we can't just rely on this single source of truth.
2. the transactions selector should select from the `transactions` store (where new tx's from blockchain-api are stored) and combine that with completed tx's in the standby tx store. sort by time.
3. update the `StandbyTransaction` type to make step 2 easier: when a tx is confirmed, use the tx receipt to make the standby tx data as similar as possible to what comes back from blockchain-api from the reducer. i didn't bother trying to construct the fees object because i can't see the fee currency from the receipt. this means that between the tx confirmed and blockchain-api catching up, no fees can be shown in the tx details screen.
4. i removed the TRANSACTION_CONFIRMED_VIEM action because it seems to do the same thing as TRANSACTION_CONFIRMED. rather than rewriting the same reducer twice, i just combined the actions.
5. ensure that the `UPDATE_TRANSACTIONS` reducer stores the new transactions without overwriting the old transactions.

### Test plan

<!-- Demonstrate the change is solid, or why it doesn't need testing.
Example: add any manual testing steps or scenarios (if not obvious), screenshots / videos if the pull request changes the user interface.
-->

### Related issues

- Fixes RET-894

### Backwards compatibility

Y
