### PR TITLE
fix(token-details): update withdraw to navigate to WithdrawSpend screen

### DIFF
--- a/src/tokens/TokenDetails.tsx
+++ b/src/tokens/TokenDetails.tsx
@@ -150,20 +150,6 @@ function PriceInfo({ token }: { token: TokenBalance }) {
   )
 }
 
-export const onPressCicoAction = (token: TokenBalance, flow: CICOFlow) => {
-  const tokenSymbol = token.symbol
-  // this should always be true given that we only show Add / Withdraw if a
-  // token is CiCoCurrency, but adding it here to ensure type safety
-  if (isCicoToken(tokenSymbol)) {
-    navigate(Screens.FiatExchangeAmount, {
-      currency: tokenSymbol,
-      tokenId: token.tokenId,
-      flow,
-      network: Network.Celo, // TODO (ACT-954): use networkId from token
-    })
-  }
-}
-
 export const useActions = (token: TokenBalance) => {
   const { t } = useTranslation()
   const sendableTokens = useTokensForSend()
@@ -203,7 +189,17 @@ export const useActions = (token: TokenBalance) => {
       details: t('tokenDetails.actionDescriptions.add'),
       iconComponent: QuickActionsAdd,
       onPress: () => {
-        onPressCicoAction(token, CICOFlow.CashIn)
+        const tokenSymbol = token.symbol
+        // this should always be true given that we only show Add / Withdraw if a
+        // token is CiCoCurrency, but adding it here to ensure type safety
+        if (isCicoToken(tokenSymbol)) {
+          navigate(Screens.FiatExchangeAmount, {
+            currency: tokenSymbol,
+            tokenId: token.tokenId,
+            flow: CICOFlow.CashIn,
+            network: Network.Celo, // TODO (ACT-954): use networkId from token
+          })
+        }
       },
       visible: !!cashInTokens.find((tokenInfo) => tokenInfo.tokenId === token.tokenId),
     },
@@ -213,7 +209,7 @@ export const useActions = (token: TokenBalance) => {
       details: t('tokenDetails.actionDescriptions.withdraw'),
       iconComponent: QuickActionsWithdraw,
       onPress: () => {
-        onPressCicoAction(token, CICOFlow.CashOut)
+        navigate(Screens.WithdrawSpend)
       },
       visible: showWithdraw,
     },

--- a/src/tokens/TokenDetailsMoreActions.tsx
+++ b/src/tokens/TokenDetailsMoreActions.tsx
@@ -43,6 +43,7 @@ export default function TokenDetailsMoreActions({
               })
               action.onPress()
             }}
+            testID={`TokenDetailsMoreActions/${action.name}`}
           >
             <>
               <action.iconComponent color={Colors.dark} />


### PR DESCRIPTION
### Description

Per feedback from Nitya, update withdraw to navigate to the WithdrawSpend screen to allow either using Spend or Withdraw.

### Test plan

Unit tests & manual


https://github.com/valora-inc/wallet/assets/5062591/03bb80b9-e9d8-4b08-8e34-cdc152ef3162



### Related issues

N/A

### Backwards compatibility

Yes