### PR TITLE
fix: add confirmed state for swap standby transaction

### DIFF
--- a/src/swap/saga.test.ts
+++ b/src/swap/saga.test.ts
@@ -41,7 +41,7 @@ const contractKit = {
 }
 
 jest.mock('src/transactions/send', () => ({
-  sendTransaction: jest.fn(() => ({ transactionHash: '0x123' })),
+  sendTransaction: jest.fn(() => ({ transactionHash: '0x123', blockNumber: '1234', status: true })),
 }))
 
 const mockSwapTransaction: SwapTransaction = {
@@ -160,6 +160,16 @@ describe(swapSubmitSaga, () => {
               value: BigNumber('0.01'),
               tokenId: mockCeurTokenId,
             },
+          },
+        },
+      })
+      .put.like({
+        action: {
+          type: Actions.TRANSACTION_CONFIRMED,
+          receipt: {
+            transactionHash: '0x123',
+            block: '1234',
+            status: true,
           },
         },
       })

--- a/src/swap/saga.ts
+++ b/src/swap/saga.ts
@@ -23,7 +23,11 @@ import { getERC20TokenContract } from 'src/tokens/saga'
 import { tokensByIdSelector } from 'src/tokens/selectors'
 import { TokenBalance } from 'src/tokens/slice'
 import { getTokenId } from 'src/tokens/utils'
-import { addHashToStandbyTransaction, addStandbyTransaction } from 'src/transactions/actions'
+import {
+  addHashToStandbyTransaction,
+  addStandbyTransaction,
+  transactionConfirmed,
+} from 'src/transactions/actions'
 import { sendTransaction } from 'src/transactions/send'
 import {
   TokenTransactionTypeV2,
@@ -83,6 +87,13 @@ function* handleSendSwapTransaction(
   const receipt = yield* call(sendTransaction, txo, walletAddress, transactionContext)
 
   yield* put(addHashToStandbyTransaction(transactionContext.id, receipt.transactionHash))
+  yield* put(
+    transactionConfirmed(transactionContext.id, {
+      transactionHash: receipt.transactionHash,
+      block: receipt.blockNumber.toString(),
+      status: receipt.status,
+    })
+  )
 }
 
 function calculateEstimatedUsdValue({


### PR DESCRIPTION
### Description

As the title.

It's not nice that we're dispatching 2 consecutive actions here, but this will change in the future.

### Test plan

Swap transactions should be already confirmed before the next blockchain-api poll.

https://github.com/valora-inc/wallet/assets/20150449/6ab8e4b5-dba8-444b-ae25-68189cda0c42

### Related issues

- Fixes RET-894

### Backwards compatibility

Y
