### PR TITLE
fix: prevent pending transaction from being stuck

### DIFF
--- a/src/send/saga.ts
+++ b/src/send/saga.ts
@@ -250,8 +250,6 @@ function* sendPayment(
     Logger.error(`${TAG}/sendPayment`, 'Could not make token transfer', error.message)
     ValoraAnalytics.track(SendEvents.send_tx_error, { error: error.message })
     yield* put(showErrorOrFallback(error, ErrorMessages.TRANSACTION_FAILED))
-    // TODO: Uncomment this when the transaction feed supports multiple tokens.
-    // yield put(removeStandbyTransaction(context.id))
   }
 }
 

--- a/src/transactions/reducer.ts
+++ b/src/transactions/reducer.ts
@@ -85,12 +85,6 @@ export const reducer = (
       }
     case Actions.TRANSACTION_CONFIRMED: {
       const { status, transactionHash, block } = action.receipt
-      if (!status) {
-        return {
-          ...state,
-        }
-      }
-
       return {
         ...state,
         standbyTransactions: state.standbyTransactions.map(
@@ -98,7 +92,7 @@ export const reducer = (
             if (standbyTransaction.context.id === action.txId) {
               return {
                 ...standbyTransaction,
-                status: TransactionStatus.Complete,
+                status: status ? TransactionStatus.Complete : TransactionStatus.Failed,
                 transactionHash,
                 block,
                 timestamp: Date.now(),

--- a/src/transactions/reducer.ts
+++ b/src/transactions/reducer.ts
@@ -55,9 +55,13 @@ export const reducer = (
 ): State => {
   switch (action.type) {
     case REHYDRATE: {
+      const rehydratePayload: State = getRehydratePayload(action, 'transactions')
       return {
         ...state,
-        ...getRehydratePayload(action, 'transactions'),
+        ...rehydratePayload,
+        standbyTransactions: rehydratePayload.standbyTransactions.filter(
+          (standbyTransaction) => !!standbyTransaction.transactionHash
+        ),
       }
     }
     case Actions.ADD_STANDBY_TRANSACTION:

--- a/src/transactions/reducer.ts
+++ b/src/transactions/reducer.ts
@@ -59,6 +59,8 @@ export const reducer = (
       return {
         ...state,
         ...rehydratePayload,
+        // without the transaction hash, we cannot fetch the status of the
+        // transaction from previous app sessions so we should clear them
         standbyTransactions: rehydratePayload.standbyTransactions.filter(
           (standbyTransaction) => !!standbyTransaction.transactionHash
         ),

--- a/src/transactions/types.ts
+++ b/src/transactions/types.ts
@@ -30,7 +30,7 @@ export type CompletedStandbyTransaction = (
   | Omit<TokenExchange, 'status'>
   | Omit<TokenTransfer, 'status'>
 ) & {
-  status: TransactionStatus.Complete
+  status: TransactionStatus.Complete | TransactionStatus.Failed
   context: TransactionContext
 }
 


### PR DESCRIPTION
### Description

In addition to #4405, I think there are still some scenarios where a user could have a stuck pending transaction.
1. in the contractKit flows, if the transaction receipt has false status (transaction failed) then no state transaction happens (the tx remains in pending state)
2. if for whatever reason a transaction hash is not added to a standby transaction, we cannot really do anything with them in in subsequent app sessions as we lose the execution context. i think even if we fetched all pending tx's for a wallet, it'd be difficult to match the pending tx to the standby tx. so we should just remove them in the next app session.

### Test plan

<!-- Demonstrate the change is solid, or why it doesn't need testing.
Example: add any manual testing steps or scenarios (if not obvious), screenshots / videos if the pull request changes the user interface.
-->

### Related issues

- Fixes #[issue number here]

### Backwards compatibility

<!-- Brief explanation of why these changes are/are not backwards compatible. -->
