### PR TITLE
chore: add dev mainnet scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "build:metro": "yarn run react-native bundle --entry-file index.js --bundle-output bundle.js; rm bundle.js",
     "dev:android": "./scripts/run_app.sh -p android",
     "dev:ios": "./scripts/run_app.sh -p ios",
+    "dev:ios:mainnet": "yarn dev:ios -e mainnetdev",
+    "dev:android:mainnet": "yarn dev:android -e mainnetdev",
     "dev:show-menu": "adb devices | grep '\t' | awk '{print $1}' | sed 's/\\s//g' | xargs -I {} adb -s {} shell input keyevent 82",
     "dev:clear-data": "adb shell pm clear org.celo.mobile.dev",
     "dev:clean-android": "cd android && ./gradlew clean",


### PR DESCRIPTION
### Description

Enhance the visibility of the ability to run the dev mode against the mainnet by placing it to the dev scripts.

It is indispensable to debug/manually test features available only on the mainnet, e.g. swaps.

Shoutout to @MuckT for providing this env option.

### Test plan

Tested manually on iOS and Android emulators

### Backwards compatibility

Y