### PR TITLE
fix: do not persist pending transactions across app sessions

### DIFF
--- a/src/transactions/reducer.ts
+++ b/src/transactions/reducer.ts
@@ -55,9 +55,18 @@ export const reducer = (
 ): State => {
   switch (action.type) {
     case REHYDRATE: {
+      const persistedState: State = getRehydratePayload(action, 'transactions')
       return {
         ...state,
-        ...getRehydratePayload(action, 'transactions'),
+        ...persistedState,
+        // TODO: remove this once we have a mechanism for watching and resolving
+        // pending transactions (then we should only remove transactions without
+        // tx hashes). for now, pending transactions can only be resolved within
+        // the same app session anyway. this will remove any stuck pending
+        // transactions for affected internal users.
+        standbyTransactions: persistedState.standbyTransactions.filter(
+          (tx) => tx.status !== TransactionStatus.Pending
+        ),
       }
     }
     case Actions.ADD_STANDBY_TRANSACTION:


### PR DESCRIPTION
### Description

As the title - we currently don't have a way to resolve these pending transactions across app sessions. 

### Test plan

n/a

### Related issues

- Fixes RET-894

### Backwards compatibility

Y
