### PR TITLE
chore(deps): add WalletConnect to renovate ignore list

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -66,4 +66,14 @@
       groupName: 'prettier',
     },
   ],
+
+  // A list of dependencies to be ignored by Renovate - "exact match" only
+  ignoreDeps: [
+    '@walletconnect/react-native-compat',
+    '@walletconnect/utils',
+    '@walletconnect/web3wallet',
+    '@walletconnect/legacy-types',
+    '@walletconnect/sign-client',
+    '@walletconnect/types',
+  ],
 }


### PR DESCRIPTION
### Description

Adds WalletConnect dependencies to [renovate's ignoreDeps list](https://docs.renovatebot.com/configuration-options/#ignoredeps).

### Test plan

N/A

### Related issues

N/A

### Backwards compatibility

Yes