### PR TITLE
chore: rename "gas cost" -> "gas fee"

### DIFF
--- a/src/analytics/Properties.tsx
+++ b/src/analytics/Properties.tsx
@@ -1229,8 +1229,8 @@ export interface SwapTimeMetrics {
 
 export interface SwapTxsProperties {
   gas: number // Gas limit of the swap (approve + swap)
-  maxGasCost: number | undefined // Max gas cost for the swap (approve + swap) in feeCurrency (decimal value)
-  maxGasCostUsd: number | undefined // Max gas cost for the swap (approve + swap) in USD
+  maxGasFee: number | undefined // Max gas fee for the swap (approve + swap) in feeCurrency (decimal value)
+  maxGasFeeUsd: number | undefined // Max gas fee for the swap (approve + swap) in USD
   txCount: number // Number of transactions for the swap (1 or 2 depending on whether the approve tx is needed)
   feeCurrency: string | undefined // Fee currency used
   feeCurrencySymbol: string | undefined // Fee currency symbol used
@@ -1240,11 +1240,11 @@ export interface TxReceiptProperties {
   txCumulativeGasUsed: number // Gas used by the transaction and all preceding transactions in the block
   txEffectiveGasPrice: number // Pre-London, it is equal to the transaction's gasPrice. Post-London, it is equal to the actual gas price paid for inclusion.
   txGas: number // Gas limit of the transaction
-  txMaxGasCost: number | undefined // Max gas cost of the transaction in feeCurrency (decimal value)
-  txMaxGasCostUsd: number | undefined // Max gas cost of the in USD
+  txMaxGasFee: number | undefined // Max gas fee of the transaction in feeCurrency (decimal value)
+  txMaxGasFeeUsd: number | undefined // Max gas fee of the in USD
   txGasUsed: number // Gas used by the transaction
-  txGasCost: number // Actual gas cost of the transaction in feeCurrency (decimal value)
-  txGasCostUsd: number // Actual gas cost of the transaction in USD
+  txGasFee: number // Actual gas fee of the transaction in feeCurrency (decimal value)
+  txGasFeeUsd: number // Actual gas fee of the transaction in USD
   txHash: string // Hash of the transaction
   txFeeCurrency: string | undefined // Fee currency used
   txFeeCurrencySymbol: string | undefined // Fee currency symbol used
@@ -1266,11 +1266,11 @@ export type SwapTxsReceiptProperties = Partial<ApproveTxReceiptProperties> &
   Partial<SwapTxReceiptProperties> &
   Partial<{
     gas: number // Gas limit of the swap (approve + swap)
-    maxGasCost: number | undefined // Max gas cost for the swap (approve + swap) in feeCurrency (decimal value)
-    maxGasCostUsd: number | undefined // Max gas cost for the swap (approve + swap) in USD
+    maxGasFee: number | undefined // Max gas fee for the swap (approve + swap) in feeCurrency (decimal value)
+    maxGasFeeUsd: number | undefined // Max gas fee for the swap (approve + swap) in USD
     gasUsed: number // Gas used by the swap (approve + swap)
-    gasCost: number | undefined // Actual gas cost of the swap (approve + swap) in feeCurrency (decimal value)
-    gasCostUsd: number | undefined // Actual gas cost of the swap (approve + swap) in USD
+    gasFee: number | undefined // Actual gas fee of the swap (approve + swap) in feeCurrency (decimal value)
+    gasFeeUsd: number | undefined // Actual gas fee of the swap (approve + swap) in USD
     feeCurrency: string | undefined // Fee currency used
     feeCurrencySymbol: string | undefined // Fee currency symbol used
   }>

--- a/src/swap/SwapReviewScreen.tsx
+++ b/src/swap/SwapReviewScreen.tsx
@@ -35,7 +35,7 @@ import { FetchQuoteResponse, Field } from 'src/swap/types'
 import { celoAddressSelector, tokensByAddressSelector } from 'src/tokens/selectors'
 import Logger from 'src/utils/Logger'
 import { divideByWei } from 'src/utils/formatting'
-import { getMaxGasCost } from 'src/viem/prepareTransactions'
+import { getMaxGasFee } from 'src/viem/prepareTransactions'
 import networkConfig from 'src/web3/networkConfig'
 import { walletAddressSelector } from 'src/web3/selectors'
 import { getSwapTxsAnalyticsProperties } from './getSwapTxsAnalyticsProperties'
@@ -111,7 +111,7 @@ export function SwapReviewScreen({ route }: Props) {
       return new BigNumber(0)
     }
 
-    return getMaxGasCost(quote.preparedTransactions.transactions)
+    return getMaxGasFee(quote.preparedTransactions.transactions)
       .shiftedBy(-feeCurrencyToken.decimals)
       .times(feeCurrencyToken.priceUsd)
   }

--- a/src/swap/getSwapTxsAnalyticsProperties.tsx
+++ b/src/swap/getSwapTxsAnalyticsProperties.tsx
@@ -2,7 +2,7 @@ import { TransactionRequestCIP42 } from 'node_modules/viem/_types/chains/celo/ty
 import { SwapTxsProperties } from 'src/analytics/Properties'
 import { getFeeCurrency } from 'src/swap/getFeeCurrency'
 import { TokenBalancesWithAddress } from 'src/tokens/slice'
-import { getMaxGasCost } from 'src/viem/prepareTransactions'
+import { getMaxGasFee } from 'src/viem/prepareTransactions'
 
 export function getSwapTxsAnalyticsProperties(
   preparedTransactions: TransactionRequestCIP42[] | undefined,
@@ -17,18 +17,16 @@ export function getSwapTxsAnalyticsProperties(
   const feeCurrency = getFeeCurrency(preparedTransactions)
   const feeCurrencyAddress = feeCurrency || celoAddress
   const feeCurrencyToken = feeCurrencyAddress ? tokensByAddress[feeCurrencyAddress] : undefined
-  const maxGasCost = feeCurrencyToken
-    ? getMaxGasCost(preparedTransactions).shiftedBy(-feeCurrencyToken.decimals)
+  const maxGasFee = feeCurrencyToken
+    ? getMaxGasFee(preparedTransactions).shiftedBy(-feeCurrencyToken.decimals)
     : undefined
-  const maxGasCostUsd =
-    maxGasCost && feeCurrencyToken?.priceUsd
-      ? maxGasCost.times(feeCurrencyToken.priceUsd)
-      : undefined
+  const maxGasFeeUsd =
+    maxGasFee && feeCurrencyToken?.priceUsd ? maxGasFee.times(feeCurrencyToken.priceUsd) : undefined
 
   return {
     gas: Number(preparedTransactions.reduce((sum, tx) => sum + (tx.gas ?? BigInt(0)), BigInt(0))),
-    maxGasCost: maxGasCost?.toNumber(),
-    maxGasCostUsd: maxGasCostUsd?.toNumber(),
+    maxGasFee: maxGasFee?.toNumber(),
+    maxGasFeeUsd: maxGasFeeUsd?.toNumber(),
     feeCurrency,
     feeCurrencySymbol: feeCurrencyToken?.symbol,
     txCount: preparedTransactions.length,

--- a/src/swap/saga.test.ts
+++ b/src/swap/saga.test.ts
@@ -546,11 +546,11 @@ describe(swapSubmitPreparedSaga, () => {
       estimatedSellTokenUsdValue: 0.01,
       web3Library: 'viem',
       gas: 1384480,
-      maxGasCost: 0.01661376,
-      maxGasCostUsd: 0.00830688,
+      maxGasFee: 0.01661376,
+      maxGasFeeUsd: 0.00830688,
       gasUsed: 423252,
-      gasCost: 0.00211626,
-      gasCostUsd: 0.00105813,
+      gasFee: 0.00211626,
+      gasFeeUsd: 0.00105813,
       feeCurrency: undefined,
       feeCurrencySymbol: 'CELO',
       txCount: 2,
@@ -559,22 +559,22 @@ describe(swapSubmitPreparedSaga, () => {
       approveTxFeeCurrency: undefined,
       approveTxFeeCurrencySymbol: 'CELO',
       approveTxGas: 59_480,
-      approveTxMaxGasCost: 0.00071376,
-      approveTxMaxGasCostUsd: 0.00035688,
+      approveTxMaxGasFee: 0.00071376,
+      approveTxMaxGasFeeUsd: 0.00035688,
       approveTxGasUsed: 51_578,
-      approveTxGasCost: 0.00025789,
-      approveTxGasCostUsd: 0.000128945,
+      approveTxGasFee: 0.00025789,
+      approveTxGasFeeUsd: 0.000128945,
       approveTxHash: '0x1',
       swapTxCumulativeGasUsed: 3_899_547,
       swapTxEffectiveGasPrice: 5_000_000_000,
       swapTxFeeCurrency: undefined,
       swapTxFeeCurrencySymbol: 'CELO',
       swapTxGas: 1_325_000,
-      swapTxMaxGasCost: 0.0159,
-      swapTxMaxGasCostUsd: 0.00795,
+      swapTxMaxGasFee: 0.0159,
+      swapTxMaxGasFeeUsd: 0.00795,
       swapTxGasUsed: 371_674,
-      swapTxGasCost: 0.00185837,
-      swapTxGasCostUsd: 0.000929185,
+      swapTxGasFee: 0.00185837,
+      swapTxGasFeeUsd: 0.000929185,
       swapTxHash: '0x2',
     })
     const analyticsProps = (ValoraAnalytics.track as jest.Mock).mock.calls[0][1]
@@ -582,24 +582,24 @@ describe(swapSubmitPreparedSaga, () => {
       analyticsProps.approveTxGas + analyticsProps.swapTxGas,
       8
     )
-    expect(analyticsProps.maxGasCost).toBeCloseTo(
-      analyticsProps.approveTxMaxGasCost + analyticsProps.swapTxMaxGasCost,
+    expect(analyticsProps.maxGasFee).toBeCloseTo(
+      analyticsProps.approveTxMaxGasFee + analyticsProps.swapTxMaxGasFee,
       8
     )
-    expect(analyticsProps.maxGasCostUsd).toBeCloseTo(
-      analyticsProps.approveTxMaxGasCostUsd + analyticsProps.swapTxMaxGasCostUsd,
+    expect(analyticsProps.maxGasFeeUsd).toBeCloseTo(
+      analyticsProps.approveTxMaxGasFeeUsd + analyticsProps.swapTxMaxGasFeeUsd,
       8
     )
     expect(analyticsProps.gasUsed).toBeCloseTo(
       analyticsProps.approveTxGasUsed + analyticsProps.swapTxGasUsed,
       8
     )
-    expect(analyticsProps.gasCost).toBeCloseTo(
-      analyticsProps.approveTxGasCost + analyticsProps.swapTxGasCost,
+    expect(analyticsProps.gasFee).toBeCloseTo(
+      analyticsProps.approveTxGasFee + analyticsProps.swapTxGasFee,
       8
     )
-    expect(analyticsProps.gasCostUsd).toBeCloseTo(
-      analyticsProps.approveTxGasCostUsd + analyticsProps.swapTxGasCostUsd,
+    expect(analyticsProps.gasFeeUsd).toBeCloseTo(
+      analyticsProps.approveTxGasFeeUsd + analyticsProps.swapTxGasFeeUsd,
       8
     )
   })
@@ -695,11 +695,11 @@ describe(swapSubmitPreparedSaga, () => {
       estimatedSellTokenUsdValue: 0.01,
       web3Library: 'viem',
       gas: 1384480,
-      maxGasCost: 0.01661376,
-      maxGasCostUsd: 0.00830688,
+      maxGasFee: 0.01661376,
+      maxGasFeeUsd: 0.00830688,
       gasUsed: undefined,
-      gasCost: undefined,
-      gasCostUsd: undefined,
+      gasFee: undefined,
+      gasFeeUsd: undefined,
       feeCurrency: undefined,
       feeCurrencySymbol: 'CELO',
       txCount: 2,
@@ -709,22 +709,22 @@ describe(swapSubmitPreparedSaga, () => {
       approveTxFeeCurrency: undefined,
       approveTxFeeCurrencySymbol: 'CELO',
       approveTxGas: 59_480,
-      approveTxMaxGasCost: 0.00071376,
-      approveTxMaxGasCostUsd: 0.00035688,
+      approveTxMaxGasFee: 0.00071376,
+      approveTxMaxGasFeeUsd: 0.00035688,
       approveTxGasUsed: undefined,
-      approveTxGasCost: undefined,
-      approveTxGasCostUsd: undefined,
+      approveTxGasFee: undefined,
+      approveTxGasFeeUsd: undefined,
       approveTxHash: undefined,
       swapTxCumulativeGasUsed: undefined,
       swapTxEffectiveGasPrice: undefined,
       swapTxFeeCurrency: undefined,
       swapTxFeeCurrencySymbol: 'CELO',
       swapTxGas: 1_325_000,
-      swapTxMaxGasCost: 0.0159,
-      swapTxMaxGasCostUsd: 0.00795,
+      swapTxMaxGasFee: 0.0159,
+      swapTxMaxGasFeeUsd: 0.00795,
       swapTxGasUsed: undefined,
-      swapTxGasCost: undefined,
-      swapTxGasCostUsd: undefined,
+      swapTxGasFee: undefined,
+      swapTxGasFeeUsd: undefined,
       swapTxHash: undefined,
     })
     const analyticsProps = (ValoraAnalytics.track as jest.Mock).mock.calls[0][1]
@@ -732,12 +732,12 @@ describe(swapSubmitPreparedSaga, () => {
       analyticsProps.approveTxGas + analyticsProps.swapTxGas,
       8
     )
-    expect(analyticsProps.maxGasCost).toBeCloseTo(
-      analyticsProps.approveTxMaxGasCost + analyticsProps.swapTxMaxGasCost,
+    expect(analyticsProps.maxGasFee).toBeCloseTo(
+      analyticsProps.approveTxMaxGasFee + analyticsProps.swapTxMaxGasFee,
       8
     )
-    expect(analyticsProps.maxGasCostUsd).toBeCloseTo(
-      analyticsProps.approveTxMaxGasCostUsd + analyticsProps.swapTxMaxGasCostUsd,
+    expect(analyticsProps.maxGasFeeUsd).toBeCloseTo(
+      analyticsProps.approveTxMaxGasFeeUsd + analyticsProps.swapTxMaxGasFeeUsd,
       8
     )
   })

--- a/src/swap/saga.ts
+++ b/src/swap/saga.ts
@@ -51,7 +51,7 @@ import Logger from 'src/utils/Logger'
 import { ensureError } from 'src/utils/ensureError'
 import { safely } from 'src/utils/safely'
 import { publicClient } from 'src/viem'
-import { getMaxGasCost } from 'src/viem/prepareTransactions'
+import { getMaxGasFee } from 'src/viem/prepareTransactions'
 import { getContractKit, getViemWallet } from 'src/web3/contracts'
 import networkConfig from 'src/web3/networkConfig'
 import { getConnectedUnlockedAccount, unlockAccount } from 'src/web3/saga'
@@ -288,22 +288,22 @@ function getTxReceiptAnalyticsProperties(
   const feeCurrencyAddress = tx?.feeCurrency || celoAddress
   const feeCurrencyToken = feeCurrencyAddress ? tokensByAddress[feeCurrencyAddress] : undefined
 
-  const txMaxGasCost =
-    tx && feeCurrencyToken ? getMaxGasCost([tx]).shiftedBy(-feeCurrencyToken.decimals) : undefined
-  const txMaxGasCostUsd =
-    feeCurrencyToken && txMaxGasCost && feeCurrencyToken.priceUsd
-      ? txMaxGasCost.times(feeCurrencyToken.priceUsd)
+  const txMaxGasFee =
+    tx && feeCurrencyToken ? getMaxGasFee([tx]).shiftedBy(-feeCurrencyToken.decimals) : undefined
+  const txMaxGasFeeUsd =
+    feeCurrencyToken && txMaxGasFee && feeCurrencyToken.priceUsd
+      ? txMaxGasFee.times(feeCurrencyToken.priceUsd)
       : undefined
 
-  const txGasCost =
+  const txGasFee =
     txReceipt?.gasUsed && txReceipt?.effectiveGasPrice && feeCurrencyToken
       ? new BigNumber((txReceipt.gasUsed * txReceipt.effectiveGasPrice).toString()).shiftedBy(
           -feeCurrencyToken.decimals
         )
       : undefined
-  const txGasCostUsd =
-    feeCurrencyToken && txGasCost && feeCurrencyToken.priceUsd
-      ? txGasCost.times(feeCurrencyToken.priceUsd)
+  const txGasFeeUsd =
+    feeCurrencyToken && txGasFee && feeCurrencyToken.priceUsd
+      ? txGasFee.times(feeCurrencyToken.priceUsd)
       : undefined
 
   return {
@@ -314,11 +314,11 @@ function getTxReceiptAnalyticsProperties(
       ? Number(txReceipt.effectiveGasPrice)
       : undefined,
     txGas: tx?.gas ? Number(tx.gas) : undefined,
-    txMaxGasCost: txMaxGasCost?.toNumber(),
-    txMaxGasCostUsd: txMaxGasCostUsd?.toNumber(),
+    txMaxGasFee: txMaxGasFee?.toNumber(),
+    txMaxGasFeeUsd: txMaxGasFeeUsd?.toNumber(),
     txGasUsed: txReceipt?.gasUsed ? Number(txReceipt.gasUsed) : undefined,
-    txGasCost: txGasCost?.toNumber(),
-    txGasCostUsd: txGasCostUsd?.toNumber(),
+    txGasFee: txGasFee?.toNumber(),
+    txGasFeeUsd: txGasFeeUsd?.toNumber(),
     txHash,
     txFeeCurrency: tx?.feeCurrency,
     txFeeCurrencySymbol: feeCurrencyToken?.symbol,
@@ -352,9 +352,9 @@ function getSwapTxsReceiptAnalyticsProperties(
     ...getPrefixedTxAnalyticsProperties(approveTx || {}, 'approve'),
     ...getPrefixedTxAnalyticsProperties(swapTx, 'swap'),
     gasUsed: swapTx.txGasUsed ? txs.reduce((sum, tx) => sum + (tx.txGasUsed || 0), 0) : undefined,
-    gasCost: swapTx.txGasCost ? txs.reduce((sum, tx) => sum + (tx.txGasCost || 0), 0) : undefined,
-    gasCostUsd: swapTx.txGasCostUsd
-      ? txs.reduce((sum, tx) => sum + (tx.txGasCostUsd || 0), 0)
+    gasFee: swapTx.txGasFee ? txs.reduce((sum, tx) => sum + (tx.txGasFee || 0), 0) : undefined,
+    gasFeeUsd: swapTx.txGasFeeUsd
+      ? txs.reduce((sum, tx) => sum + (tx.txGasFeeUsd || 0), 0)
       : undefined,
   }
 }

--- a/src/swap/useSwapQuote.ts
+++ b/src/swap/useSwapQuote.ts
@@ -1,22 +1,22 @@
 import BigNumber from 'bignumber.js'
+import { TransactionRequestCIP42 } from 'node_modules/viem/_types/chains/celo/types'
 import { useRef, useState } from 'react'
 import { useAsyncCallback } from 'react-async-hook'
 import { useSelector } from 'react-redux'
+import erc20 from 'src/abis/IERC20'
 import { useFeeCurrencies } from 'src/fees/hooks'
 import { guaranteedSwapPriceEnabledSelector } from 'src/swap/selectors'
 import { FetchQuoteResponse, Field, ParsedSwapAmount, SwapTransaction } from 'src/swap/types'
 import { TokenBalance, TokenBalanceWithAddress } from 'src/tokens/slice'
 import Logger from 'src/utils/Logger'
+import { PreparedTransactionsResult, prepareTransactions } from 'src/viem/prepareTransactions'
 import networkConfig from 'src/web3/networkConfig'
 import { walletAddressSelector } from 'src/web3/selectors'
-import { PreparedTransactionsResult, prepareTransactions } from 'src/viem/prepareTransactions'
-import { TransactionRequestCIP42 } from 'node_modules/viem/_types/chains/celo/types'
-import { Address, encodeFunctionData, Hex, zeroAddress } from 'viem'
-import erc20 from 'src/abis/IERC20'
+import { Address, Hex, encodeFunctionData, zeroAddress } from 'viem'
 
 // Apply a multiplier for the decreased swap amount to account for the
-// varying gas costs of different swap providers (or even the same swap)
-const DECREASED_SWAP_AMOUNT_GAS_COST_MULTIPLIER = 1.2
+// varying gas fees of different swap providers (or even the same swap)
+const DECREASED_SWAP_AMOUNT_GAS_FEE_MULTIPLIER = 1.2
 
 export interface QuoteResult {
   toTokenAddress: string
@@ -101,7 +101,7 @@ export async function prepareSwapTransactions(
     feeCurrencies,
     spendToken: fromToken,
     spendTokenAmount: new BigNumber(amountToApprove.toString()),
-    decreasedAmountGasCostMultiplier: DECREASED_SWAP_AMOUNT_GAS_COST_MULTIPLIER,
+    decreasedAmountGasFeeMultiplier: DECREASED_SWAP_AMOUNT_GAS_FEE_MULTIPLIER,
     baseTransactions,
   })
 }

--- a/src/transactions/send.test.ts
+++ b/src/transactions/send.test.ts
@@ -7,6 +7,7 @@ import {
   isTxPossiblyPending,
   shouldTxFailureRetry,
 } from 'src/transactions/send'
+import { NetworkId } from 'src/transactions/types'
 import { createMockStore } from 'test/utils'
 import {
   mockCeloAddress,
@@ -16,7 +17,6 @@ import {
   mockCusdAddress,
   mockCusdTokenId,
 } from 'test/values'
-import { NetworkId } from 'src/transactions/types'
 
 jest.mock('src/web3/networkConfig', () => {
   const originalModule = jest.requireActual('src/web3/networkConfig')
@@ -232,7 +232,7 @@ describe('chooseTxFeeDetails', () => {
       .run()
   })
 
-  it('returns only estimated gas (with padding), not gasPrice if estimate is not enough for gas cost', async () => {
+  it('returns only estimated gas (with padding), not gasPrice if estimate is not enough for gas fee', async () => {
     await expectSaga(wrapperSaga, {
       tx: { from: '0xTEST', data: '0xABC' },
       feeCurrency: undefined,

--- a/src/viem/prepareTransactions.test.ts
+++ b/src/viem/prepareTransactions.test.ts
@@ -7,7 +7,7 @@ import { estimateFeesPerGas } from 'src/viem/estimateFeesPerGas'
 import { publicClient } from 'src/viem/index'
 import {
   getFeeCurrencyAddress,
-  getMaxGasCost,
+  getMaxGasFee,
   prepareERC20TransferTransaction,
   prepareTransactions,
   tryEstimateTransaction,
@@ -17,9 +17,9 @@ import {
   Address,
   BaseError,
   EstimateGasExecutionError,
-  encodeFunctionData,
   ExecutionRevertedError,
   InsufficientFundsError,
+  encodeFunctionData,
 } from 'viem'
 import mocked = jest.mocked
 
@@ -101,7 +101,7 @@ describe('prepareTransactions module', () => {
         feeCurrencies: mockFeeCurrencies,
         spendToken: mockSpendToken,
         spendTokenAmount: new BigNumber(100_000),
-        decreasedAmountGasCostMultiplier: 1,
+        decreasedAmountGasFeeMultiplier: 1,
         baseTransactions: [
           {
             from: '0xfrom' as Address,
@@ -127,7 +127,7 @@ describe('prepareTransactions module', () => {
         feeCurrencies: mockFeeCurrencies,
         spendToken: mockSpendToken,
         spendTokenAmount: new BigNumber(100_000),
-        decreasedAmountGasCostMultiplier: 1,
+        decreasedAmountGasFeeMultiplier: 1,
         baseTransactions: [
           {
             from: '0xfrom' as Address,
@@ -154,7 +154,7 @@ describe('prepareTransactions module', () => {
           feeCurrencies: mockFeeCurrencies,
           spendToken: mockSpendToken,
           spendTokenAmount: new BigNumber(100_000),
-          decreasedAmountGasCostMultiplier: 1,
+          decreasedAmountGasFeeMultiplier: 1,
           baseTransactions: [
             {
               from: '0xfrom' as Address,
@@ -176,7 +176,7 @@ describe('prepareTransactions module', () => {
         feeCurrencies: mockFeeCurrencies,
         spendToken: mockFeeCurrencies[1],
         spendTokenAmount: new BigNumber(100_000),
-        decreasedAmountGasCostMultiplier: 1.01,
+        decreasedAmountGasFeeMultiplier: 1.01,
         baseTransactions: [
           {
             from: '0xfrom' as Address,
@@ -189,9 +189,9 @@ describe('prepareTransactions module', () => {
       })
       expect(result).toStrictEqual({
         type: 'need-decrease-spend-amount-for-gas',
-        maxGasCost: new BigNumber('65.65'), // (15k + 50k non-native gas token buffer) * 1.01 multiplier / 1000 feeCurrency1 decimals
+        maxGasFee: new BigNumber('65.65'), // (15k + 50k non-native gas token buffer) * 1.01 multiplier / 1000 feeCurrency1 decimals
         feeCurrency: mockFeeCurrencies[1],
-        decreasedSpendAmount: new BigNumber(4.35), // 70.0 balance minus maxGasCost
+        decreasedSpendAmount: new BigNumber(4.35), // 70.0 balance minus maxGasFee
       })
     })
     it("returns a 'need-decrease-spend-amount-for-gas' result when spending the exact max amount of a feeCurrency, and no other feeCurrency has enough balance to pay for the fee", async () => {
@@ -204,7 +204,7 @@ describe('prepareTransactions module', () => {
         feeCurrencies: mockFeeCurrencies,
         spendToken: mockFeeCurrencies[1],
         spendTokenAmount: mockFeeCurrencies[1].balance.shiftedBy(mockFeeCurrencies[1].decimals),
-        decreasedAmountGasCostMultiplier: 1.01,
+        decreasedAmountGasFeeMultiplier: 1.01,
         baseTransactions: [
           {
             from: '0xfrom' as Address,
@@ -217,9 +217,9 @@ describe('prepareTransactions module', () => {
       })
       expect(result).toStrictEqual({
         type: 'need-decrease-spend-amount-for-gas',
-        maxGasCost: new BigNumber('65.65'), // (15k + 50k non-native gas token buffer) * 1.01 multiplier / 1000 feeCurrency1 decimals
+        maxGasFee: new BigNumber('65.65'), // (15k + 50k non-native gas token buffer) * 1.01 multiplier / 1000 feeCurrency1 decimals
         feeCurrency: mockFeeCurrencies[1],
-        decreasedSpendAmount: new BigNumber(4.35), // 70.0 balance minus maxGasCost
+        decreasedSpendAmount: new BigNumber(4.35), // 70.0 balance minus maxGasFee
       })
     })
     it("returns a 'need-decrease-spend-amount-for-gas' result when spending close to the max amount of a feeCurrency, and no other feeCurrency has enough balance to pay for the fee", async () => {
@@ -234,7 +234,7 @@ describe('prepareTransactions module', () => {
         spendTokenAmount: mockFeeCurrencies[1].balance
           .shiftedBy(mockFeeCurrencies[1].decimals)
           .minus(1), // 69.999k
-        decreasedAmountGasCostMultiplier: 1.01,
+        decreasedAmountGasFeeMultiplier: 1.01,
         baseTransactions: [
           {
             from: '0xfrom' as Address,
@@ -247,9 +247,9 @@ describe('prepareTransactions module', () => {
       })
       expect(result).toStrictEqual({
         type: 'need-decrease-spend-amount-for-gas',
-        maxGasCost: new BigNumber('65.65'), // (15k + 50k non-native gas token buffer) * 1.01 multiplier / 1000 feeCurrency1 decimals
+        maxGasFee: new BigNumber('65.65'), // (15k + 50k non-native gas token buffer) * 1.01 multiplier / 1000 feeCurrency1 decimals
         feeCurrency: mockFeeCurrencies[1],
-        decreasedSpendAmount: new BigNumber(4.35), // 70.0 balance minus maxGasCost
+        decreasedSpendAmount: new BigNumber(4.35), // 70.0 balance minus maxGasFee
       })
     })
     it("returns a 'possible' result when spending a feeCurrency, when there's enough balance to cover for the fee", async () => {
@@ -265,7 +265,7 @@ describe('prepareTransactions module', () => {
         feeCurrencies: mockFeeCurrencies,
         spendToken: mockFeeCurrencies[0],
         spendTokenAmount: new BigNumber(4_000),
-        decreasedAmountGasCostMultiplier: 1,
+        decreasedAmountGasFeeMultiplier: 1,
         baseTransactions: [
           {
             from: '0xfrom' as Address,
@@ -320,7 +320,7 @@ describe('prepareTransactions module', () => {
         feeCurrencies: mockFeeCurrencies,
         spendToken: mockFeeCurrencies[0],
         spendTokenAmount: mockFeeCurrencies[0].balance.shiftedBy(mockFeeCurrencies[0].decimals),
-        decreasedAmountGasCostMultiplier: 1,
+        decreasedAmountGasFeeMultiplier: 1,
         baseTransactions: [
           {
             from: '0xfrom' as Address,
@@ -376,7 +376,7 @@ describe('prepareTransactions module', () => {
         feeCurrencies: mockFeeCurrencies,
         spendToken: mockSpendToken,
         spendTokenAmount: mockSpendToken.balance.shiftedBy(mockSpendToken.decimals),
-        decreasedAmountGasCostMultiplier: 1,
+        decreasedAmountGasFeeMultiplier: 1,
         baseTransactions: [
           {
             from: '0xfrom' as Address,
@@ -518,10 +518,10 @@ describe('prepareTransactions module', () => {
       ])
     })
   })
-  describe('getMaxGasCost', () => {
+  describe('getMaxGasFee', () => {
     it('adds gas times maxFeePerGas', () => {
       expect(
-        getMaxGasCost([
+        getMaxGasFee([
           { gas: BigInt(2), maxFeePerGas: BigInt(3), from: '0x123' },
           { gas: BigInt(5), maxFeePerGas: BigInt(7), from: '0x123' },
         ])
@@ -529,13 +529,13 @@ describe('prepareTransactions module', () => {
     })
     it('throws if gas or maxFeePerGas are missing', () => {
       expect(() =>
-        getMaxGasCost([
+        getMaxGasFee([
           { gas: BigInt(2), maxFeePerGas: BigInt(3), from: '0x123' },
           { gas: BigInt(5), from: '0x123' },
         ])
       ).toThrowError('Missing gas or maxFeePerGas')
       expect(() =>
-        getMaxGasCost([
+        getMaxGasFee([
           { maxFeePerGas: BigInt(5), from: '0x123' },
           { gas: BigInt(2), maxFeePerGas: BigInt(3), from: '0x123' },
         ])
@@ -569,7 +569,7 @@ describe('prepareTransactions module', () => {
       feeCurrencies: mockFeeCurrencies,
       spendToken: mockSpendToken,
       spendTokenAmount: new BigNumber(100),
-      decreasedAmountGasCostMultiplier: 1,
+      decreasedAmountGasFeeMultiplier: 1,
       baseTransactions: [
         {
           from: '0x123',


### PR DESCRIPTION
I started using the "gas cost" terminology in https://github.com/valora-inc/wallet/pull/4368 which is also mentioned a few times in https://ethereum.org/en/developers/docs/gas
But I think we should use "gas fee" to be more clear maybe? Which is referred more commonly in that same doc.

https://github.com/valora-inc/wallet/pull/4402#discussion_r1376416923
