### PR TITLE
feat(send): set last used token id

### DIFF
--- a/src/fiatExchanges/saga.test.ts
+++ b/src/fiatExchanges/saga.test.ts
@@ -27,10 +27,10 @@ import Logger from 'src/utils/Logger'
 import { Currency } from 'src/utils/currencies'
 import {
   mockAccount,
-  mockCusdAddress,
-  mockCusdTokenId,
   mockCeurAddress,
   mockCeurTokenId,
+  mockCusdAddress,
+  mockCusdTokenId,
 } from 'test/values'
 
 const now = Date.now()
@@ -105,7 +105,7 @@ describe(watchBidaliPaymentRequests, () => {
             }
           )
         )
-        .dispatch(sendPaymentSuccess(amount))
+        .dispatch(sendPaymentSuccess({ amount, tokenId: expectedTokenId }))
         .run()
 
       expect(navigate).toHaveBeenCalledWith(Screens.SendConfirmationModal, {

--- a/src/send/actions.ts
+++ b/src/send/actions.ts
@@ -49,6 +49,7 @@ export interface SendPaymentAction {
 export interface SendPaymentSuccessAction {
   type: Actions.SEND_PAYMENT_SUCCESS
   amount: BigNumber
+  tokenId: string
 }
 
 export interface SendPaymentFailureAction {
@@ -113,9 +114,16 @@ export const sendPayment = (
   feeInfo,
 })
 
-export const sendPaymentSuccess = (amount: BigNumber): SendPaymentSuccessAction => ({
+export const sendPaymentSuccess = ({
+  amount,
+  tokenId,
+}: {
+  amount: BigNumber
+  tokenId: string
+}): SendPaymentSuccessAction => ({
   type: Actions.SEND_PAYMENT_SUCCESS,
   amount,
+  tokenId,
 })
 
 export const sendPaymentFailure = (): SendPaymentFailureAction => ({

--- a/src/send/reducers.ts
+++ b/src/send/reducers.ts
@@ -65,8 +65,7 @@ export const sendReducer = (
         ...state,
         isSending: false,
         recentPayments: [...paymentsLast24Hours, latestPayment],
-        // TODO(satish): set lastUsedToken once this is available in the send flow (after
-        // #4306 is merged)
+        lastUsedTokenId: action.tokenId,
       }
     case Actions.SEND_PAYMENT_FAILURE:
       return {

--- a/src/send/saga.ts
+++ b/src/send/saga.ts
@@ -27,9 +27,9 @@ import { StatsigFeatureGates } from 'src/statsig/types'
 import {
   getERC20TokenContract,
   getStableTokenContract,
+  getTokenInfo,
   getTokenInfoByAddress,
   tokenAmountInSmallestUnit,
-  getTokenInfo,
 } from 'src/tokens/saga'
 import { TokenBalance } from 'src/tokens/slice'
 import { getTokenId } from 'src/tokens/utils'
@@ -298,7 +298,7 @@ export function* sendPaymentSaga({
       navigateHome()
     }
 
-    yield* put(sendPaymentSuccess(amount))
+    yield* put(sendPaymentSuccess({ amount, tokenId }))
     SentryTransactionHub.finishTransaction(SentryTransaction.send_payment)
   } catch (e) {
     yield* put(showErrorOrFallback(e, ErrorMessages.SEND_PAYMENT_FAILED))


### PR DESCRIPTION
### Description

Addressing a todo from #4370 to complete the last used token id feature

### Test plan

Manually by doing a send and checking that the token defaults to the last sent token on the new send amount screen and also checked the redux state on flipper

### Related issues

- na

### Backwards compatibility

Yes
