### PR TITLE
fix(prepare-transactions): add `throwOnSpendTokenAmountExceedsBalance` option

### DIFF
--- a/src/swap/useSwapQuote.ts
+++ b/src/swap/useSwapQuote.ts
@@ -103,6 +103,8 @@ export async function prepareSwapTransactions(
     spendTokenAmount: new BigNumber(amountToApprove.toString()),
     decreasedAmountGasFeeMultiplier: DECREASED_SWAP_AMOUNT_GAS_FEE_MULTIPLIER,
     baseTransactions,
+    // We still want to prepare the transactions even if the user doesn't have enough balance
+    throwOnSpendTokenAmountExceedsBalance: false,
   })
 }
 

--- a/src/viem/prepareTransactions.test.ts
+++ b/src/viem/prepareTransactions.test.ts
@@ -119,7 +119,7 @@ describe('prepareTransactions module', () => {
     it('does not throw if trying to sendAmount > sendToken balance when throwOnSpendTokenAmountExceedsBalance is false', async () => {
       mocked(estimateFeesPerGas).mockResolvedValue({
         maxFeePerGas: BigInt(100),
-        maxPriorityFeePerGas: undefined,
+        maxPriorityFeePerGas: BigInt(2),
       })
       mockPublicClient.estimateGas.mockResolvedValue(BigInt(1_000))
 

--- a/src/viem/prepareTransactions.ts
+++ b/src/viem/prepareTransactions.ts
@@ -172,13 +172,14 @@ export async function tryEstimateTransactions(
  * Adds "maxFeePerGas" and "maxPriorityFeePerGas" fields to base transactions. Adds "gas" field to base
  *  transactions if they do not already include them.
  *
- * NOTE: throws if spendTokenAmount exceeds the user's balance of that token.
+ * NOTE: throws if spendTokenAmount exceeds the user's balance of that token, unless throwOnSpendTokenAmountExceedsBalance is false
  *
  * @param feeCurrencies
  * @param spendToken
  * @param spendTokenAmount
  * @param decreasedAmountGasFeeMultiplier
  * @param baseTransactions
+ * @param throwOnSpendTokenAmountExceedsBalance
  */
 export async function prepareTransactions({
   feeCurrencies,
@@ -186,14 +187,19 @@ export async function prepareTransactions({
   spendTokenAmount,
   decreasedAmountGasFeeMultiplier,
   baseTransactions,
+  throwOnSpendTokenAmountExceedsBalance = true,
 }: {
   feeCurrencies: TokenBalance[]
   spendToken: TokenBalanceWithAddress
   spendTokenAmount: BigNumber
   decreasedAmountGasFeeMultiplier: number
   baseTransactions: (TransactionRequestCIP42 & { gas?: bigint })[]
+  throwOnSpendTokenAmountExceedsBalance?: boolean
 }): Promise<PreparedTransactionsResult> {
-  if (spendTokenAmount.isGreaterThan(spendToken.balance.shiftedBy(spendToken.decimals))) {
+  if (
+    throwOnSpendTokenAmountExceedsBalance &&
+    spendTokenAmount.isGreaterThan(spendToken.balance.shiftedBy(spendToken.decimals))
+  ) {
     throw new Error(
       `Cannot prepareTransactions for amount greater than balance. Amount: ${spendTokenAmount}, Balance: ${spendToken.balance}, Decimals: ${spendToken.decimals}`
     )


### PR DESCRIPTION
### Description

I realized a bit too late that the changes in https://github.com/valora-inc/wallet/pull/4432 broke the swap flow where we want to prepare transactions when the spend amount is greater than the balance.
This is because we want users to be able to try any amount to see the quote (and associated fee).

### Test plan

- Updated tests

### Related issues

- N/A

### Backwards compatibility

Yes