### PR TITLE
fix: ensure swap review screen displays gas fee in correct units

### DIFF
--- a/src/swap/SwapReviewScreen.tsx
+++ b/src/swap/SwapReviewScreen.tsx
@@ -112,9 +112,9 @@ export function SwapReviewScreen({ route }: Props) {
       return new BigNumber(0)
     }
 
-    return getMaxGasFee(quote.preparedTransactions.transactions)
-      .shiftedBy(-feeCurrencyToken.decimals)
-      .times(feeCurrencyToken.priceUsd)
+    return getMaxGasFee(quote.preparedTransactions.transactions).shiftedBy(
+      -feeCurrencyToken.decimals
+    )
   }
 
   const estimatedFeeAmount = quote ? getEstimatedMaxFee() : estimateFeeAmount()


### PR DESCRIPTION
### Description

This PR fixes mismatching units for gas fee on the swap review screen. The unit should be in token units rather than fiat.

### Test plan

n/a

### Related issues

n/a

### Backwards compatibility

Y
