### PR TITLE
feat: show bridge info in swap token bottom sheet

### DIFF
--- a/src/swap/SwapScreen.test.tsx
+++ b/src/swap/SwapScreen.test.tsx
@@ -225,13 +225,19 @@ const defaultQuoteResponse = JSON.stringify(defaultQuote)
 
 const selectToken = (
   swapAmountContainer: ReactTestInstance,
-  tokenName: string,
+  tokenSymbol: string,
   tokenBottomSheet: ReactTestInstance
 ) => {
+  const tokenSymbolNameMap: Record<string, string> = {
+    cUSD: 'Celo Dollar',
+    cEUR: 'Celo Euro',
+    CELO: 'Celo native asset',
+    POOF: 'Poof',
+  }
   fireEvent.press(within(swapAmountContainer).getByTestId('SwapAmountInput/TokenSelect'))
-  fireEvent.press(within(tokenBottomSheet).getByTestId(`${tokenName}Touchable`))
+  fireEvent.press(within(tokenBottomSheet).getByText(tokenSymbolNameMap[tokenSymbol]))
 
-  expect(within(swapAmountContainer).getByText(tokenName)).toBeTruthy()
+  expect(within(swapAmountContainer).getByText(tokenSymbol)).toBeTruthy()
 }
 
 describe('SwapScreen', () => {
@@ -777,24 +783,19 @@ describe('SwapScreen', () => {
       swappingNonNativeTokensEnabled: true,
     })
 
-    const {
-      swapToContainer,
-      getByPlaceholderText,
-      getByTestId,
-      queryByTestId,
-      swapFromContainer,
-      tokenBottomSheet,
-    } = renderScreen({})
+    const { swapToContainer, getByPlaceholderText, swapFromContainer, tokenBottomSheet } =
+      renderScreen({})
 
     selectToken(swapFromContainer, 'CELO', tokenBottomSheet)
     fireEvent.press(within(swapToContainer).getByTestId('SwapAmountInput/TokenSelect'))
 
     expect(getByPlaceholderText('tokenBottomSheet.searchAssets')).toBeTruthy()
-    expect(getByTestId('cUSDTouchable')).toBeTruthy()
-    expect(getByTestId('cEURTouchable')).toBeTruthy()
-    expect(getByTestId('CELOTouchable')).toBeTruthy()
-    expect(queryByTestId('POOFTouchable')).toBeTruthy()
-    expect(queryByTestId('TTTouchable')).toBeFalsy()
+
+    expect(within(tokenBottomSheet).getByText('Celo Dollar')).toBeTruthy()
+    expect(within(tokenBottomSheet).getByText('Celo Euro')).toBeTruthy()
+    expect(within(tokenBottomSheet).getByText('Celo native asset')).toBeTruthy()
+    expect(within(tokenBottomSheet).getByText('Poof')).toBeTruthy()
+    expect(within(tokenBottomSheet).queryByText('Test Token')).toBeFalsy()
   })
 
   it('should disable buy amount input when swap buy amount experiment is set is false', () => {

--- a/src/swap/SwapScreen.tsx
+++ b/src/swap/SwapScreen.tsx
@@ -17,7 +17,10 @@ import BottomSheet, { BottomSheetRefType } from 'src/components/BottomSheet'
 import Button, { BtnSizes, BtnTypes } from 'src/components/Button'
 import KeyboardAwareScrollView from 'src/components/KeyboardAwareScrollView'
 import KeyboardSpacer from 'src/components/KeyboardSpacer'
-import TokenBottomSheet, { TokenPickerOrigin } from 'src/components/TokenBottomSheet'
+import TokenBottomSheet, {
+  TokenBalanceItemOption,
+  TokenPickerOrigin,
+} from 'src/components/TokenBottomSheet'
 import Warning from 'src/components/Warning'
 import CustomHeader from 'src/components/header/CustomHeader'
 import { SWAP_LEARN_MORE } from 'src/config'
@@ -508,6 +511,7 @@ export function SwapScreen({ route }: Props) {
             ? t('swapScreen.swapFromTokenSelection')
             : t('swapScreen.swapToTokenSelection')
         }
+        TokenOptionComponent={TokenBalanceItemOption}
       />
       {exchangeRate?.preparedTransactions && (
         <PreparedTransactionsReviewBottomSheet


### PR DESCRIPTION
### Description

As the title. As we think about marketing expanded swap assets, it'll be important to be able to distinguish the bridge of any wrapped tokens.

### Test plan

![Simulator Screenshot - iPhone 14 Pro - 2023-11-09 at 10 46 21](https://github.com/valora-inc/wallet/assets/20150449/722d7f0d-4d39-4c23-868f-bc352bbdf7ad)


### Related issues

Related to  RET-865

### Backwards compatibility

Y
