### PR TITLE
feat(send): show contacts on new recipient screen

### DIFF
--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -1877,6 +1877,7 @@
   "sendSelectRecipient": {
     "searchText": "Search by name, phone, wallet...",
     "title": "Select a recipient",
+    "contactsTitle": "Select a contact",
     "recents": "Recents",
     "qr": {
       "title": "Scan or Show QR Code",

--- a/src/analytics/Events.tsx
+++ b/src/analytics/Events.tsx
@@ -311,7 +311,7 @@ export enum SendEvents {
 
   // events specific to send select recipient screen
   send_select_recipient_scan_qr = 'send_select_recipient_scan_qr',
-  send_select_recipient_invite = 'send_select_recipient_invite',
+  send_select_recipient_contacts = 'send_select_recipient_contacts',
 }
 
 export enum QrScreenEvents {

--- a/src/analytics/Properties.tsx
+++ b/src/analytics/Properties.tsx
@@ -628,7 +628,7 @@ interface SendEventsProperties {
   [SendEvents.check_account_alert_back]: undefined
   [SendEvents.check_account_alerts_continue]: undefined
   [SendEvents.send_select_recipient_scan_qr]: undefined
-  [SendEvents.send_select_recipient_invite]: undefined
+  [SendEvents.send_select_recipient_contacts]: undefined
 }
 
 interface RequestEventsProperties {

--- a/src/analytics/docs.ts
+++ b/src/analytics/docs.ts
@@ -292,7 +292,7 @@ export const eventDocs: Record<AnalyticsEventType, string> = {
 
   // Events for the send select recipient screen
   [SendEvents.send_select_recipient_scan_qr]: `When the QR code button is pressed`,
-  [SendEvents.send_select_recipient_invite]: `When the import contacts button is pressed`,
+  [SendEvents.send_select_recipient_contacts]: `When the import contacts button is pressed`,
 
   // Events for the QR screen redesign
   [QrScreenEvents.qr_screen_bottom_sheet_open]: ``,

--- a/src/recipients/RecipientPickerV2.test.tsx
+++ b/src/recipients/RecipientPickerV2.test.tsx
@@ -1,0 +1,86 @@
+import { render } from '@testing-library/react-native'
+import * as React from 'react'
+import { ReactTestInstance } from 'react-test-renderer'
+import RecipientPicker from 'src/recipients/RecipientPickerV2'
+import { mockRecipient, mockRecipient2, mockRecipient3 } from 'test/values'
+
+const mockRecipients = [mockRecipient, mockRecipient2, mockRecipient3]
+
+describe('RecipientPickerV2', () => {
+  it('renders all recipients', () => {
+    const { getAllByTestId } = render(
+      <RecipientPicker
+        recipients={mockRecipients}
+        onSelectRecipient={jest.fn()}
+        selectedRecipient={null}
+        isSelectedRecipientLoading={false}
+      />
+    )
+
+    expect(getAllByTestId('RecipientItem')).toHaveLength(3)
+  })
+
+  it('renders all recipients with title', () => {
+    const { getAllByTestId, getByText } = render(
+      <RecipientPicker
+        title="mockRecipientTitle"
+        recipients={mockRecipients}
+        onSelectRecipient={jest.fn()}
+        selectedRecipient={null}
+        isSelectedRecipientLoading={false}
+      />
+    )
+
+    expect(getByText('mockRecipientTitle')).toBeTruthy()
+    expect(getAllByTestId('RecipientItem')).toHaveLength(3)
+  })
+
+  it('renders all recipients with one recipient selected', () => {
+    const { getAllByTestId, queryByTestId } = render(
+      <RecipientPicker
+        recipients={mockRecipients}
+        onSelectRecipient={jest.fn()}
+        selectedRecipient={mockRecipient2}
+        isSelectedRecipientLoading={false}
+      />
+    )
+
+    expect(getAllByTestId('RecipientItem')).toHaveLength(3)
+    expect(queryByTestId('RecipientItem/ActivityIndicator')).toBeFalsy()
+    expect(
+      (getAllByTestId('RecipientItem')[0].children[0] as ReactTestInstance).props.style[1]
+    ).toBeFalsy()
+    expect(
+      (getAllByTestId('RecipientItem')[1].children[0] as ReactTestInstance).props.style[1]
+    ).toHaveProperty('backgroundColor')
+    expect(
+      (getAllByTestId('RecipientItem')[2].children[0] as ReactTestInstance).props.style[1]
+    ).toBeFalsy()
+  })
+
+  it('renders all recipients with one recipient selected and loading', () => {
+    const { getAllByTestId, getByTestId } = render(
+      <RecipientPicker
+        recipients={mockRecipients}
+        onSelectRecipient={jest.fn()}
+        selectedRecipient={mockRecipient}
+        isSelectedRecipientLoading={true}
+      />
+    )
+
+    expect(getAllByTestId('RecipientItem')).toHaveLength(3)
+    expect(getAllByTestId('RecipientItem/ActivityIndicator')).toHaveLength(1)
+    expect(
+      (getAllByTestId('RecipientItem')[0].children[0] as ReactTestInstance).props.style[1]
+    ).toHaveProperty('backgroundColor')
+    expect(getAllByTestId('RecipientItem')[0]).toContainElement(
+      getByTestId('RecipientItem/ActivityIndicator')
+    )
+    expect(
+      (getAllByTestId('RecipientItem')[1].children[0] as ReactTestInstance).props.style[1]
+    ).toBeFalsy()
+    expect(
+      (getAllByTestId('RecipientItem')[2].children[0] as ReactTestInstance).props.style[1]
+    ).toBeFalsy()
+  })
+})

--- a/src/recipients/RecipientPickerV2.tsx
+++ b/src/recipients/RecipientPickerV2.tsx
@@ -1,0 +1,56 @@
+import React from 'react'
+import { FlatList, StyleSheet, Text, View } from 'react-native'
+import RecipientItem from 'src/recipients/RecipientItemV2'
+import { Recipient } from 'src/recipients/recipient'
+import Colors from 'src/styles/colors'
+import { typeScale } from 'src/styles/fonts'
+import { Spacing } from 'src/styles/styles'
+
+interface Props {
+  testID?: string
+  recipients: Recipient[]
+  title?: string | null
+  onSelectRecipient(recipient: Recipient): void
+  selectedRecipient: Recipient | null
+  isSelectedRecipientLoading: boolean
+}
+
+function RecipientPicker({
+  testID,
+  recipients,
+  title,
+  onSelectRecipient,
+  selectedRecipient,
+  isSelectedRecipientLoading,
+}: Props) {
+  return (
+    <View style={styles.body} testID={testID}>
+      {title && <Text style={styles.title}>{title}</Text>}
+      <FlatList
+        data={recipients}
+        renderItem={({ item }) => (
+          <RecipientItem
+            recipient={item}
+            onSelectRecipient={onSelectRecipient}
+            selected={selectedRecipient === item}
+            loading={selectedRecipient === item && isSelectedRecipientLoading}
+          />
+        )}
+      />
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  body: {
+    flex: 1,
+  },
+  title: {
+    ...typeScale.labelSmall,
+    marginBottom: Spacing.Regular16,
+    marginHorizontal: Spacing.Thick24,
+    color: Colors.gray3,
+  },
+})
+
+export default RecipientPicker

--- a/src/send/SendSelectRecipient.test.tsx
+++ b/src/send/SendSelectRecipient.test.tsx
@@ -1,39 +1,62 @@
 import { act, fireEvent, render } from '@testing-library/react-native'
 import * as React from 'react'
 import { Provider } from 'react-redux'
+import { SendEvents } from 'src/analytics/Events'
+import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import SendSelectRecipient from 'src/send/SendSelectRecipient'
+import { requestContactsPermission } from 'src/utils/permissions'
 import { createMockStore } from 'test/utils'
-import { mockRecipient, mockRecipient2 } from 'test/values'
-import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
-import { SendEvents } from 'src/analytics/Events'
+import { mockPhoneRecipientCache, mockRecipient, mockRecipient2 } from 'test/values'
+
+jest.mock('src/utils/permissions')
 
 const defaultStore = {
   send: {
-    inviteRewardsVersion: 'disabled',
     recentRecipients: [mockRecipient, mockRecipient2],
-    showSendToAddressWarning: true,
+  },
+  recipients: {
+    phoneRecipientCache: mockPhoneRecipientCache,
   },
 }
 
 describe('SendSelectRecipient', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    jest.mocked(requestContactsPermission).mockResolvedValue(false)
   })
 
-  it('emits event when invite button is pressed', async () => {
+  it('shows contacts when send to contacts button is pressed and contact permission is granted', async () => {
+    jest.mocked(requestContactsPermission).mockResolvedValue(true)
     const store = createMockStore(defaultStore)
 
-    const { getByTestId } = render(
+    const { getByTestId, queryByTestId } = render(
       <Provider store={store}>
         <SendSelectRecipient />
       </Provider>
     )
     await act(() => {
-      fireEvent.press(getByTestId('SelectRecipient/Invite'))
+      fireEvent.press(getByTestId('SelectRecipient/Contacts'))
     })
-    expect(ValoraAnalytics.track).toHaveBeenCalledWith(SendEvents.send_select_recipient_invite)
+    expect(ValoraAnalytics.track).toHaveBeenCalledWith(SendEvents.send_select_recipient_contacts)
+    expect(getByTestId('SelectRecipient/ContactRecipientPicker')).toBeTruthy()
+    expect(queryByTestId('SelectRecipient/RecentRecipientPicker')).toBeFalsy()
+  })
+  it('stays on current screen when send to contacts button is pressed and contact permission is denied', async () => {
+    const store = createMockStore(defaultStore)
+
+    const { getByTestId, queryByTestId } = render(
+      <Provider store={store}>
+        <SendSelectRecipient />
+      </Provider>
+    )
+    await act(() => {
+      fireEvent.press(getByTestId('SelectRecipient/Contacts'))
+    })
+    expect(ValoraAnalytics.track).toHaveBeenCalledWith(SendEvents.send_select_recipient_contacts)
+    expect(getByTestId('SelectRecipient/RecentRecipientPicker')).toBeTruthy()
+    expect(queryByTestId('SelectRecipient/ContactRecipientPicker')).toBeFalsy()
   })
   it('navigates to QR screen when QR button is pressed', async () => {
     const store = createMockStore(defaultStore)
@@ -67,6 +90,6 @@ describe('SendSelectRecipient', () => {
         <SendSelectRecipient />
       </Provider>
     )
-    expect(getByTestId('SelectRecipient/RecipientPicker')).toBeTruthy()
+    expect(getByTestId('SelectRecipient/RecentRecipientPicker')).toBeTruthy()
   })
 })


### PR DESCRIPTION
### Description

On clicking the "Send crypto to your friends", open the contacts page if permissions are granted. Also made a V2 RecipientPicker which uses the V2 recipient item.

Showing valora icon, showing permissions modal and navigation on selecting recipients will be in follow up PRs

### Test plan

Unit tests, manual

https://github.com/valora-inc/wallet/assets/5062591/23fa3d60-355f-4acf-b5e1-2e487f0c0265

Note that the Get started box pins to the bottom, this is the behavior on main and will be fixed in a separate PR


### Related issues

- Part of ACT-952

### Backwards compatibility

N/A
