### PR TITLE
feat(send): show valora icon for phone number recipients

### DIFF
--- a/src/recipients/RecipientItemV2.test.tsx
+++ b/src/recipients/RecipientItemV2.test.tsx
@@ -1,60 +1,100 @@
 import { fireEvent, render } from '@testing-library/react-native'
 import * as React from 'react'
 import 'react-native'
+import { Provider } from 'react-redux'
 import RecipientItem from 'src/recipients/RecipientItemV2'
-import { mockRecipient } from 'test/values'
+import { createMockStore } from 'test/utils'
+import { mockInvitableRecipient } from 'test/values'
 
 describe('RecipientItemV2', () => {
-  it('renders correctly with no icon or loading state', () => {
+  it('renders correctly with no valora icon if phone number recipient is not a known valora user (number never looked up)', () => {
     const { queryByTestId, getByText } = render(
-      <RecipientItem recipient={mockRecipient} onSelectRecipient={jest.fn()} loading={false} />
+      <Provider
+        store={createMockStore({
+          identity: {
+            e164NumberToAddress: {},
+          },
+        })}
+      >
+        <RecipientItem
+          recipient={mockInvitableRecipient}
+          onSelectRecipient={jest.fn()}
+          loading={false}
+        />
+      </Provider>
     )
-    expect(getByText(mockRecipient.name)).toBeTruthy()
-    expect(getByText(mockRecipient.displayNumber)).toBeTruthy()
+    expect(getByText(mockInvitableRecipient.name)).toBeTruthy()
+    expect(getByText(mockInvitableRecipient.displayNumber)).toBeTruthy()
     expect(queryByTestId('RecipientItem/ValoraIcon')).toBeFalsy()
     expect(queryByTestId('RecipientItem/ActivityIndicator')).toBeFalsy()
   })
 
-  it('renders correctly with icon and no loading state', () => {
-    const { queryByTestId, getByText, getByTestId } = render(
-      <RecipientItem
-        recipient={mockRecipient}
-        onSelectRecipient={jest.fn()}
-        loading={false}
-        showValoraIcon={true}
-      />
+  it('renders correctly with no valora icon if phone number recipient is not a known valora user (number looked up before)', () => {
+    const { queryByTestId, getByText } = render(
+      <Provider
+        store={createMockStore({
+          identity: {
+            e164NumberToAddress: { [mockInvitableRecipient.e164PhoneNumber]: null },
+          },
+        })}
+      >
+        <RecipientItem
+          recipient={mockInvitableRecipient}
+          onSelectRecipient={jest.fn()}
+          loading={false}
+        />
+      </Provider>
     )
-    expect(getByText(mockRecipient.name)).toBeTruthy()
-    expect(getByText(mockRecipient.displayNumber)).toBeTruthy()
+    expect(getByText(mockInvitableRecipient.name)).toBeTruthy()
+    expect(getByText(mockInvitableRecipient.displayNumber)).toBeTruthy()
+    expect(queryByTestId('RecipientItem/ValoraIcon')).toBeFalsy()
+    expect(queryByTestId('RecipientItem/ActivityIndicator')).toBeFalsy()
+  })
+
+  it('renders correctly with valora icon if phone number recipient is a valora user', () => {
+    const { queryByTestId, getByText, getByTestId } = render(
+      // default store includes a cached mapping
+      <Provider store={createMockStore()}>
+        <RecipientItem
+          recipient={mockInvitableRecipient}
+          onSelectRecipient={jest.fn()}
+          loading={false}
+        />
+      </Provider>
+    )
+    expect(getByText(mockInvitableRecipient.name)).toBeTruthy()
+    expect(getByText(mockInvitableRecipient.displayNumber)).toBeTruthy()
     expect(getByTestId('RecipientItem/ValoraIcon')).toBeTruthy()
     expect(queryByTestId('RecipientItem/ActivityIndicator')).toBeFalsy()
   })
 
-  it('renders correctly with no icon and loading state', () => {
-    const { queryByTestId, getByText, getByTestId } = render(
-      <RecipientItem
-        recipient={mockRecipient}
-        onSelectRecipient={jest.fn()}
-        loading={true}
-        showValoraIcon={false}
-      />
+  it('renders correctly if loading is set to true', () => {
+    const { getByText, getByTestId } = render(
+      <Provider store={createMockStore()}>
+        <RecipientItem
+          recipient={mockInvitableRecipient}
+          onSelectRecipient={jest.fn()}
+          loading={true}
+        />
+      </Provider>
     )
-    expect(getByText(mockRecipient.name)).toBeTruthy()
-    expect(getByText(mockRecipient.displayNumber)).toBeTruthy()
+    expect(getByText(mockInvitableRecipient.name)).toBeTruthy()
+    expect(getByText(mockInvitableRecipient.displayNumber)).toBeTruthy()
     expect(getByTestId('RecipientItem/ActivityIndicator')).toBeTruthy()
-    expect(queryByTestId('RecipientItem/ValoraIcon')).toBeFalsy()
   })
 
   it('tapping item invokes onSelectRecipient', () => {
     const mockSelectRecipient = jest.fn()
     const { getByTestId } = render(
-      <RecipientItem
-        recipient={mockRecipient}
-        onSelectRecipient={mockSelectRecipient}
-        loading={false}
-      />
+      <Provider store={createMockStore()}>
+        <RecipientItem
+          recipient={mockInvitableRecipient}
+          onSelectRecipient={mockSelectRecipient}
+          loading={false}
+        />
+      </Provider>
     )
     fireEvent.press(getByTestId('RecipientItem'))
-    expect(mockSelectRecipient).toHaveBeenLastCalledWith(mockRecipient)
+    expect(mockSelectRecipient).toHaveBeenLastCalledWith(mockInvitableRecipient)
   })
 })

--- a/src/recipients/RecipientItemV2.tsx
+++ b/src/recipients/RecipientItemV2.tsx
@@ -1,11 +1,18 @@
-import React, { memo } from 'react'
+import React, { memo, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ActivityIndicator, StyleSheet, Text, View } from 'react-native'
 import ContactCircle from 'src/components/ContactCircle'
 import Touchable from 'src/components/Touchable'
 import Logo, { LogoTypes } from 'src/icons/Logo'
 import QuestionIcon from 'src/icons/QuestionIcon'
-import { Recipient, getDisplayDetail, getDisplayName } from 'src/recipients/recipient'
+import { e164NumberToAddressSelector } from 'src/identity/selectors'
+import {
+  Recipient,
+  RecipientType,
+  getDisplayDetail,
+  getDisplayName,
+} from 'src/recipients/recipient'
+import useSelector from 'src/redux/useSelector'
 import colors, { Colors } from 'src/styles/colors'
 import { typeScale } from 'src/styles/fonts'
 import { Spacing } from 'src/styles/styles'
@@ -14,18 +21,25 @@ interface Props {
   recipient: Recipient
   onSelectRecipient(recipient: Recipient): void
   loading: boolean
-  showValoraIcon?: boolean
   selected?: boolean
 }
 
 const ICON_SIZE = 10
 
-function RecipientItem({ recipient, onSelectRecipient, loading, showValoraIcon, selected }: Props) {
+function RecipientItem({ recipient, onSelectRecipient, loading, selected }: Props) {
   const { t } = useTranslation()
 
   const onPress = () => {
     onSelectRecipient(recipient)
   }
+
+  const e164NumberToAddress = useSelector(e164NumberToAddressSelector)
+
+  const showValoraIcon = useMemo(() => {
+    if (recipient.recipientType === RecipientType.PhoneNumber) {
+      return recipient.e164PhoneNumber && !!e164NumberToAddress[recipient.e164PhoneNumber]
+    }
+  }, [e164NumberToAddress, recipient])
 
   return (
     <Touchable onPress={onPress} testID="RecipientItem">

--- a/src/recipients/RecipientItemV2.tsx
+++ b/src/recipients/RecipientItemV2.tsx
@@ -35,6 +35,8 @@ function RecipientItem({ recipient, onSelectRecipient, loading, selected }: Prop
 
   const e164NumberToAddress = useSelector(e164NumberToAddressSelector)
 
+  // TODO(ACT-980): avoid icon flash when a known valora contact is clicked
+  // TODO(ACT-950): show icon for address recipients
   const showValoraIcon = useMemo(() => {
     if (recipient.recipientType === RecipientType.PhoneNumber) {
       return recipient.e164PhoneNumber && !!e164NumberToAddress[recipient.e164PhoneNumber]

--- a/src/recipients/RecipientPickerV2.test.tsx
+++ b/src/recipients/RecipientPickerV2.test.tsx
@@ -1,20 +1,25 @@
 import { render } from '@testing-library/react-native'
 import * as React from 'react'
+import { Provider } from 'react-redux'
 import { ReactTestInstance } from 'react-test-renderer'
 import RecipientPicker from 'src/recipients/RecipientPickerV2'
+import { createMockStore } from 'test/utils'
 import { mockRecipient, mockRecipient2, mockRecipient3 } from 'test/values'
 
 const mockRecipients = [mockRecipient, mockRecipient2, mockRecipient3]
+const store = createMockStore()
 
 describe('RecipientPickerV2', () => {
   it('renders all recipients', () => {
     const { getAllByTestId } = render(
-      <RecipientPicker
-        recipients={mockRecipients}
-        onSelectRecipient={jest.fn()}
-        selectedRecipient={null}
-        isSelectedRecipientLoading={false}
-      />
+      <Provider store={store}>
+        <RecipientPicker
+          recipients={mockRecipients}
+          onSelectRecipient={jest.fn()}
+          selectedRecipient={null}
+          isSelectedRecipientLoading={false}
+        />
+      </Provider>
     )
 
     expect(getAllByTestId('RecipientItem')).toHaveLength(3)
@@ -22,13 +27,15 @@ describe('RecipientPickerV2', () => {
 
   it('renders all recipients with title', () => {
     const { getAllByTestId, getByText } = render(
-      <RecipientPicker
-        title="mockRecipientTitle"
-        recipients={mockRecipients}
-        onSelectRecipient={jest.fn()}
-        selectedRecipient={null}
-        isSelectedRecipientLoading={false}
-      />
+      <Provider store={store}>
+        <RecipientPicker
+          title="mockRecipientTitle"
+          recipients={mockRecipients}
+          onSelectRecipient={jest.fn()}
+          selectedRecipient={null}
+          isSelectedRecipientLoading={false}
+        />
+      </Provider>
     )
 
     expect(getByText('mockRecipientTitle')).toBeTruthy()
@@ -37,12 +44,14 @@ describe('RecipientPickerV2', () => {
 
   it('renders all recipients with one recipient selected', () => {
     const { getAllByTestId, queryByTestId } = render(
-      <RecipientPicker
-        recipients={mockRecipients}
-        onSelectRecipient={jest.fn()}
-        selectedRecipient={mockRecipient2}
-        isSelectedRecipientLoading={false}
-      />
+      <Provider store={store}>
+        <RecipientPicker
+          recipients={mockRecipients}
+          onSelectRecipient={jest.fn()}
+          selectedRecipient={mockRecipient2}
+          isSelectedRecipientLoading={false}
+        />
+      </Provider>
     )
 
     expect(getAllByTestId('RecipientItem')).toHaveLength(3)
@@ -60,12 +69,14 @@ describe('RecipientPickerV2', () => {
 
   it('renders all recipients with one recipient selected and loading', () => {
     const { getAllByTestId, getByTestId } = render(
-      <RecipientPicker
-        recipients={mockRecipients}
-        onSelectRecipient={jest.fn()}
-        selectedRecipient={mockRecipient}
-        isSelectedRecipientLoading={true}
-      />
+      <Provider store={store}>
+        <RecipientPicker
+          recipients={mockRecipients}
+          onSelectRecipient={jest.fn()}
+          selectedRecipient={mockRecipient}
+          isSelectedRecipientLoading={true}
+        />
+      </Provider>
     )
 
     expect(getAllByTestId('RecipientItem')).toHaveLength(3)


### PR DESCRIPTION
### Description

Show valora icon for phone number contacts if we can map it to an address. Showing the Send / Invite button and showing icon for address contacts will be in a follow up PR

### Test plan

Unit tests, manual

Video recording: https://drive.google.com/file/d/1DaMreLTRTGjxRtWUnzaLBdwuzRNPg79j/view?usp=sharing

Includes clicking 3 types of contacts in order:

1. Contact which has never been lookup before and mapped to an address
2. Contact with no phone number mapping 
3. Contact which already has a mapping - momentarily removes the icon and then brings it back up once the lookup is complete

### Related issues

- Part of ACT-952

### Backwards compatibility

N/A
