### PR TITLE
feat: enable display of eth on providers cash in

### DIFF
--- a/src/fiatExchanges/amount.test.tsx
+++ b/src/fiatExchanges/amount.test.tsx
@@ -2,13 +2,13 @@ import { render } from '@testing-library/react-native'
 import React from 'react'
 import { Provider } from 'react-redux'
 import CurrencyDisplay from 'src/components/CurrencyDisplay'
-import LegacyTokenDisplay from 'src/components/LegacyTokenDisplay'
+import TokenDisplay from 'src/components/TokenDisplay'
 import { CryptoAmount, FiatAmount } from 'src/fiatExchanges/amount'
 import { CiCoCurrency } from 'src/utils/currencies'
 import { createMockStore } from 'test/utils'
-import { mockCusdAddress } from 'test/values'
+import { mockCusdTokenId } from 'test/values'
 
-jest.mock('src/components/LegacyTokenDisplay')
+jest.mock('src/components/TokenDisplay')
 jest.mock('src/components/CurrencyDisplay')
 
 describe('CryptoAmount', () => {
@@ -18,12 +18,12 @@ describe('CryptoAmount', () => {
         <CryptoAmount amount={10} currency={CiCoCurrency.cUSD} testID="cryptoAmt" />
       </Provider>
     )
-    expect(LegacyTokenDisplay).toHaveBeenCalledWith(
+    expect(TokenDisplay).toHaveBeenCalledWith(
       {
         amount: 10,
         showLocalAmount: false,
         testID: 'cryptoAmt',
-        tokenAddress: mockCusdAddress,
+        tokenId: mockCusdTokenId,
       },
       {}
     )

--- a/src/fiatExchanges/amount.tsx
+++ b/src/fiatExchanges/amount.tsx
@@ -1,9 +1,10 @@
 import BigNumber from 'bignumber.js'
 import React from 'react'
 import CurrencyDisplay, { FormatType } from 'src/components/CurrencyDisplay'
-import LegacyTokenDisplay from 'src/components/LegacyTokenDisplay'
-import { useTokenInfoWithAddressBySymbol } from 'src/tokens/hooks'
+import TokenDisplay from 'src/components/TokenDisplay'
+import { useTokenInfo } from 'src/tokens/hooks'
 import { CiCoCurrency } from 'src/utils/currencies'
+import networkConfig from 'src/web3/networkConfig'
 
 export function CryptoAmount({
   amount,
@@ -14,15 +15,9 @@ export function CryptoAmount({
   currency: CiCoCurrency
   testID?: string
 }) {
-  const { address } = useTokenInfoWithAddressBySymbol(currency) ?? {}
-  return (
-    <LegacyTokenDisplay
-      amount={amount}
-      tokenAddress={address}
-      showLocalAmount={false}
-      testID={testID}
-    />
-  )
+  const { tokenId } = useTokenInfo(networkConfig.currencyToTokenId[currency]) ?? {}
+
+  return <TokenDisplay amount={amount} tokenId={tokenId} showLocalAmount={false} testID={testID} />
 }
 
 export function FiatAmount({

--- a/src/fiatExchanges/amount.tsx
+++ b/src/fiatExchanges/amount.tsx
@@ -16,7 +16,6 @@ export function CryptoAmount({
   testID?: string
 }) {
   const { tokenId } = useTokenInfo(networkConfig.currencyToTokenId[currency]) ?? {}
-
   return <TokenDisplay amount={amount} tokenId={tokenId} showLocalAmount={false} testID={testID} />
 }
 


### PR DESCRIPTION
### Description

Enables the display of eth providers by moving from `address` to `tokenId`.


### Test plan

Tested locally by deploying a modified fetch providers cloud function on Alfajores.

| On this Branch | On #4450 |
| ----- | ----- |
| ![](https://github.com/valora-inc/wallet/assets/26950305/df0bfa44-5993-4a89-a097-744e6c06c86d "On Branch") | ![](https://github.com/valora-inc/wallet/assets/26950305/2693fcb0-d49c-44cc-a1b5-6457a82121d8 "On #4450") |

### Related issues

- ACT-965

### Backwards compatibility

Yes