### PR TITLE
chore: remove `swapUserInput` from the `swap` slice

### DIFF
--- a/src/redux/migrations.test.ts
+++ b/src/redux/migrations.test.ts
@@ -34,6 +34,7 @@ import {
   v15Schema,
   v164Schema,
   v166Schema,
+  v167Schema,
   v16Schema,
   v17Schema,
   v18Schema,
@@ -1400,6 +1401,13 @@ describe('Redux persist migrations', () => {
     const migratedSchema = migrations[167](oldSchema)
     const expectedSchema: any = _.cloneDeep(oldSchema)
     expectedSchema.app.rampCashInButtonExpEnabled = false
+    expect(migratedSchema).toStrictEqual(expectedSchema)
+  })
+
+  it('works from 167 to 168', () => {
+    const oldSchema = v167Schema
+    const migratedSchema = migrations[168](oldSchema)
+    const expectedSchema: any = _.omit(oldSchema, 'swap.swapUserInput')
     expect(migratedSchema).toStrictEqual(expectedSchema)
   })
 })

--- a/src/redux/migrations.ts
+++ b/src/redux/migrations.ts
@@ -1424,4 +1424,8 @@ export const migrations = {
       rampCashInButtonExpEnabled: false,
     },
   }),
+  168: (state: any) => ({
+    ...state,
+    swap: _.omit(state.swap, 'swapUserInput'),
+  }),
 }

--- a/src/redux/store.test.ts
+++ b/src/redux/store.test.ts
@@ -98,7 +98,7 @@ describe('store state', () => {
       {
         "_persist": {
           "rehydrated": true,
-          "version": 167,
+          "version": 168,
         },
         "account": {
           "acceptedTerms": false,
@@ -333,7 +333,6 @@ describe('store state', () => {
           "priceImpactWarningThreshold": 0.04,
           "swapInfo": null,
           "swapState": "quote",
-          "swapUserInput": null,
         },
         "tokens": {
           "error": false,

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -23,7 +23,7 @@ const persistConfig: PersistConfig<RootState> = {
   key: 'root',
   // default is -1, increment as we make migrations
   // See https://github.com/valora-inc/wallet/tree/main/WALLET.md#redux-state-migration
-  version: 167,
+  version: 168,
   keyPrefix: `reduxStore-`, // the redux-persist default is `persist:` which doesn't work with some file systems.
   storage: FSStorage(),
   blacklist: ['networkInfo', 'alert', 'imports', 'keylessBackup'],

--- a/src/swap/SwapScreen.test.tsx
+++ b/src/swap/SwapScreen.test.tsx
@@ -14,7 +14,7 @@ import { Screens } from 'src/navigator/Screens'
 import { getFeatureGate } from 'src/statsig'
 import { StatsigFeatureGates } from 'src/statsig/types'
 import SwapScreen from 'src/swap/SwapScreen'
-import { setSwapUserInput, swapStart, swapStartPrepared } from 'src/swap/slice'
+import { swapStart, swapStartPrepared, swapUserInput } from 'src/swap/slice'
 import { Field } from 'src/swap/types'
 import { NetworkId } from 'src/transactions/types'
 import { SerializableTransactionRequest } from 'src/viem/preparedTransactionSerialization'
@@ -777,16 +777,6 @@ describe('SwapScreen', () => {
   })
 
   it('should be able to start a swap', async () => {
-    const userInput = {
-      toToken: mockCusdAddress,
-      fromToken: mockCeloAddress,
-      swapAmount: {
-        [Field.FROM]: '10',
-        [Field.TO]: '12.345678', // 10 * 1.2345678
-      },
-      updatedField: Field.FROM,
-    }
-
     const quoteReceivedTimestamp = 1000
     jest.spyOn(Date, 'now').mockReturnValue(quoteReceivedTimestamp) // quote received timestamp
 
@@ -807,10 +797,17 @@ describe('SwapScreen', () => {
 
     expect(store.getActions()).toEqual(
       expect.arrayContaining([
-        setSwapUserInput(userInput),
         swapStart({
           ...defaultQuote,
-          userInput,
+          userInput: {
+            toToken: mockCusdAddress,
+            fromToken: mockCeloAddress,
+            swapAmount: {
+              [Field.FROM]: '10',
+              [Field.TO]: '12.345678', // 10 * 1.2345678
+            },
+            updatedField: Field.FROM,
+          },
           quoteReceivedAt: quoteReceivedTimestamp,
         } as any),
       ])
@@ -850,7 +847,6 @@ describe('SwapScreen', () => {
 
     expect(store.getActions()).toEqual(
       expect.arrayContaining([
-        setSwapUserInput(userInput),
         swapStart({
           ...defaultQuote,
           userInput,
@@ -891,6 +887,12 @@ describe('SwapScreen', () => {
       provider: defaultQuote.details.swapProvider,
       web3Library: 'contract-kit',
     })
+  })
+
+  it('should set correct swap state on open', async () => {
+    const { store } = renderScreen({})
+
+    expect(store.getActions()).toEqual(expect.arrayContaining([swapUserInput()]))
   })
 
   it('should show swappable tokens and search box when the swapping non native tokens experiment is enabled', async () => {
@@ -1009,17 +1011,11 @@ describe('SwapScreen', () => {
     it("should warn when the balances for feeCurrencies are 0 and can't cover the fee", async () => {
       // Swap from POOF to CELO, when no feeCurrency has any balance
       mockFetch.mockResponse(defaultQuoteResponse)
-      const {
-        getByText,
-        getByTestId,
-        store,
-        swapFromContainer,
-        swapToContainer,
-        tokenBottomSheet,
-      } = renderScreen({
-        celoBalance: '0',
-        cUSDBalance: '0',
-      })
+      const { getByText, getByTestId, swapFromContainer, swapToContainer, tokenBottomSheet } =
+        renderScreen({
+          celoBalance: '0',
+          cUSDBalance: '0',
+        })
 
       selectToken(swapFromContainer, 'POOF', tokenBottomSheet)
       selectToken(swapToContainer, 'CELO', tokenBottomSheet)
@@ -1037,14 +1033,6 @@ describe('SwapScreen', () => {
           'swapScreen.notEnoughBalanceForGas.dismissButton, {"feeCurrencies":"CELO, cEUR, cUSD"}'
         )
       ).toBeTruthy()
-
-      expect(store.getActions()).toEqual(
-        expect.not.arrayContaining([
-          expect.objectContaining({
-            type: setSwapUserInput.type,
-          }),
-        ])
-      )
     })
 
     it('should warn when the balances for feeCurrencies are too low to cover the fee', async () => {
@@ -1078,14 +1066,6 @@ describe('SwapScreen', () => {
           'swapScreen.notEnoughBalanceForGas.dismissButton, {"feeCurrencies":"CELO, cUSD, cEUR"}'
         )
       ).toBeTruthy()
-
-      expect(store.getActions()).toEqual(
-        expect.not.arrayContaining([
-          expect.objectContaining({
-            type: setSwapUserInput.type,
-          }),
-        ])
-      )
     })
 
     it('should prompt the user to decrease the swap amount when swapping the max amount of a feeCurrency, and no other feeCurrency has enough balance to pay for the fee', async () => {
@@ -1123,14 +1103,6 @@ describe('SwapScreen', () => {
         'swapScreen.needDecreaseSwapAmountForGas.confirmDecreaseButton, {"tokenSymbol":"CELO"}'
       )
       expect(confirmDecrease).toBeTruthy()
-
-      expect(store.getActions()).toEqual(
-        expect.not.arrayContaining([
-          expect.objectContaining({
-            type: setSwapUserInput.type,
-          }),
-        ])
-      )
 
       // Mock next call with the decreased amount
       mockFetch.mockResponse(
@@ -1199,14 +1171,6 @@ describe('SwapScreen', () => {
         'swapScreen.needDecreaseSwapAmountForGas.confirmDecreaseButton, {"tokenSymbol":"CELO"}'
       )
       expect(confirmDecrease).toBeTruthy()
-
-      expect(store.getActions()).toEqual(
-        expect.not.arrayContaining([
-          expect.objectContaining({
-            type: setSwapUserInput.type,
-          }),
-        ])
-      )
 
       // Mock next call with the decreased amount
       mockFetch.mockResponse(
@@ -1304,16 +1268,6 @@ describe('SwapScreen', () => {
     })
 
     it('should be able to start a swap', async () => {
-      const userInput = {
-        toToken: mockCusdAddress,
-        fromToken: mockCeloAddress,
-        swapAmount: {
-          [Field.FROM]: '10',
-          [Field.TO]: '12.345678', // 10 * 1.2345678
-        },
-        updatedField: Field.FROM,
-      }
-
       const quoteReceivedTimestamp = 1000
       jest.spyOn(Date, 'now').mockReturnValue(quoteReceivedTimestamp) // quote received timestamp
 
@@ -1340,30 +1294,27 @@ describe('SwapScreen', () => {
 
       expect(store.getActions()).toEqual(
         expect.arrayContaining([
-          setSwapUserInput(userInput),
           swapStartPrepared({
             quote: {
               preparedTransactions,
               receivedAt: quoteReceivedTimestamp,
               rawSwapResponse: defaultQuote as any,
             },
-            userInput,
+            userInput: {
+              toToken: mockCusdAddress,
+              fromToken: mockCeloAddress,
+              swapAmount: {
+                [Field.FROM]: '10',
+                [Field.TO]: '12.345678', // 10 * 1.2345678
+              },
+              updatedField: Field.FROM,
+            },
           }),
         ])
       )
     })
 
     it('should be able to start a swap when the entered value uses comma as the decimal separator', async () => {
-      const userInput = {
-        toToken: mockCusdAddress,
-        fromToken: mockCeloAddress,
-        swapAmount: {
-          [Field.FROM]: '1.5',
-          [Field.TO]: '1.8518517', // 1.5 * 1.2345678
-        },
-        updatedField: Field.FROM,
-      }
-
       const quoteReceivedTimestamp = 1000
       jest.spyOn(Date, 'now').mockReturnValue(quoteReceivedTimestamp) // quote received timestamp
 
@@ -1385,14 +1336,21 @@ describe('SwapScreen', () => {
 
       expect(store.getActions()).toEqual(
         expect.arrayContaining([
-          setSwapUserInput(userInput),
           swapStartPrepared({
             quote: {
               preparedTransactions,
               receivedAt: quoteReceivedTimestamp,
               rawSwapResponse: defaultQuote as any,
             },
-            userInput,
+            userInput: {
+              toToken: mockCusdAddress,
+              fromToken: mockCeloAddress,
+              swapAmount: {
+                [Field.FROM]: '1.5',
+                [Field.TO]: '1.8518517', // 1.5 * 1.2345678
+              },
+              updatedField: Field.FROM,
+            },
           }),
         ])
       )

--- a/src/swap/SwapScreen.test.tsx
+++ b/src/swap/SwapScreen.test.tsx
@@ -1038,17 +1038,11 @@ describe('SwapScreen', () => {
     it('should warn when the balances for feeCurrencies are too low to cover the fee', async () => {
       // Swap from POOF to CELO, when no feeCurrency has any balance
       mockFetch.mockResponse(defaultQuoteResponse)
-      const {
-        getByText,
-        getByTestId,
-        store,
-        swapFromContainer,
-        swapToContainer,
-        tokenBottomSheet,
-      } = renderScreen({
-        celoBalance: '0.001',
-        cUSDBalance: '0.001',
-      })
+      const { getByText, getByTestId, swapFromContainer, swapToContainer, tokenBottomSheet } =
+        renderScreen({
+          celoBalance: '0.001',
+          cUSDBalance: '0.001',
+        })
 
       selectToken(swapFromContainer, 'POOF', tokenBottomSheet)
       selectToken(swapToContainer, 'CELO', tokenBottomSheet)
@@ -1075,7 +1069,6 @@ describe('SwapScreen', () => {
         getByText,
         getByTestId,
         queryByText,
-        store,
         swapToContainer,
         swapFromContainer,
         tokenBottomSheet,
@@ -1144,17 +1137,11 @@ describe('SwapScreen', () => {
           },
         })
       )
-      const {
-        getByText,
-        queryByText,
-        store,
-        swapToContainer,
-        swapFromContainer,
-        tokenBottomSheet,
-      } = renderScreen({
-        celoBalance: '1.234',
-        cUSDBalance: '0',
-      })
+      const { getByText, queryByText, swapToContainer, swapFromContainer, tokenBottomSheet } =
+        renderScreen({
+          celoBalance: '1.234',
+          cUSDBalance: '0',
+        })
 
       selectToken(swapFromContainer, 'CELO', tokenBottomSheet)
       selectToken(swapToContainer, 'cUSD', tokenBottomSheet)

--- a/src/swap/SwapScreen.test.tsx
+++ b/src/swap/SwapScreen.test.tsx
@@ -14,7 +14,7 @@ import { Screens } from 'src/navigator/Screens'
 import { getFeatureGate } from 'src/statsig'
 import { StatsigFeatureGates } from 'src/statsig/types'
 import SwapScreen from 'src/swap/SwapScreen'
-import { swapStart, swapStartPrepared, swapUserInput } from 'src/swap/slice'
+import { swapStart, swapStartPrepared } from 'src/swap/slice'
 import { Field } from 'src/swap/types'
 import { NetworkId } from 'src/transactions/types'
 import { SerializableTransactionRequest } from 'src/viem/preparedTransactionSerialization'
@@ -887,12 +887,6 @@ describe('SwapScreen', () => {
       provider: defaultQuote.details.swapProvider,
       web3Library: 'contract-kit',
     })
-  })
-
-  it('should set correct swap state on open', async () => {
-    const { store } = renderScreen({})
-
-    expect(store.getActions()).toEqual(expect.arrayContaining([swapUserInput()]))
   })
 
   it('should show swappable tokens and search box when the swapping non native tokens experiment is enabled', async () => {

--- a/src/swap/SwapScreen.tsx
+++ b/src/swap/SwapScreen.tsx
@@ -42,7 +42,7 @@ import SwapAmountInput from 'src/swap/SwapAmountInput'
 import SwapTransactionDetails from 'src/swap/SwapTransactionDetails'
 import { getSwapTxsAnalyticsProperties } from 'src/swap/getSwapTxsAnalyticsProperties'
 import { priceImpactWarningThresholdSelector, swapInfoSelector } from 'src/swap/selectors'
-import { setSwapUserInput, swapStart, swapStartPrepared } from 'src/swap/slice'
+import { swapStart, swapStartPrepared, swapUserInput } from 'src/swap/slice'
 import { Field, SwapAmount } from 'src/swap/types'
 import useSwapQuote, { QuoteResult } from 'src/swap/useSwapQuote'
 import { useTokenInfoByAddress } from 'src/tokens/hooks'
@@ -174,6 +174,7 @@ export function SwapScreen({ route }: Props) {
 
   useEffect(() => {
     ValoraAnalytics.track(SwapEvents.swap_screen_open)
+    dispatch(swapUserInput())
   }, [])
 
   useEffect(() => {
@@ -319,9 +320,6 @@ export function SwapScreen({ route }: Props) {
             ),
           })
 
-          // TODO: we want to remove the need to use redux, but for now keeping it
-          // to avoid too many changes
-          dispatch(setSwapUserInput(userInput))
           dispatch(
             swapStartPrepared({
               quote: {
@@ -364,7 +362,6 @@ export function SwapScreen({ route }: Props) {
       web3Library: 'contract-kit',
     })
 
-    dispatch(setSwapUserInput(userInput))
     dispatch(
       swapStart({
         ...exchangeRate.rawSwapResponse,

--- a/src/swap/SwapScreen.tsx
+++ b/src/swap/SwapScreen.tsx
@@ -42,7 +42,7 @@ import SwapAmountInput from 'src/swap/SwapAmountInput'
 import SwapTransactionDetails from 'src/swap/SwapTransactionDetails'
 import { getSwapTxsAnalyticsProperties } from 'src/swap/getSwapTxsAnalyticsProperties'
 import { priceImpactWarningThresholdSelector, swapInfoSelector } from 'src/swap/selectors'
-import { swapStart, swapStartPrepared, swapUserInput } from 'src/swap/slice'
+import { swapStart, swapStartPrepared } from 'src/swap/slice'
 import { Field, SwapAmount } from 'src/swap/types'
 import useSwapQuote, { QuoteResult } from 'src/swap/useSwapQuote'
 import { useTokenInfoByAddress } from 'src/tokens/hooks'
@@ -174,7 +174,6 @@ export function SwapScreen({ route }: Props) {
 
   useEffect(() => {
     ValoraAnalytics.track(SwapEvents.swap_screen_open)
-    dispatch(swapUserInput())
   }, [])
 
   useEffect(() => {

--- a/src/swap/selectors.ts
+++ b/src/swap/selectors.ts
@@ -4,8 +4,6 @@ export const swapStateSelector = (state: RootState) => state.swap.swapState
 
 export const swapInfoSelector = (state: RootState) => state.swap.swapInfo
 
-export const swapUserInputSelector = (state: RootState) => state.swap.swapUserInput
-
 export const guaranteedSwapPriceEnabledSelector = (state: RootState) =>
   state.swap.guaranteedSwapPriceEnabled
 

--- a/src/swap/slice.ts
+++ b/src/swap/slice.ts
@@ -33,10 +33,6 @@ export const slice = createSlice({
   name: 'swap',
   initialState,
   reducers: {
-    swapUserInput: (state) => {
-      state.swapState = SwapState.USER_INPUT
-      state.swapInfo = null
-    },
     // Legacy
     swapStart: (state, action: PayloadAction<SwapInfo>) => {
       state.swapState = SwapState.START
@@ -93,7 +89,6 @@ export const slice = createSlice({
 })
 
 export const {
-  swapUserInput,
   swapStart,
   swapStartPrepared,
   swapApprove,

--- a/src/swap/slice.ts
+++ b/src/swap/slice.ts
@@ -2,7 +2,7 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 import { REHYDRATE, RehydrateAction } from 'redux-persist'
 import { Actions as AppActions, UpdateConfigValuesAction } from 'src/app/actions'
 import { getRehydratePayload } from 'src/redux/persist-helper'
-import { SwapInfo, SwapInfoPrepared, SwapUserInput } from 'src/swap/types'
+import { SwapInfo, SwapInfoPrepared } from 'src/swap/types'
 
 export enum SwapState {
   USER_INPUT = 'user-input',
@@ -18,7 +18,6 @@ export enum SwapState {
 export interface State {
   swapState: SwapState
   swapInfo: SwapInfo | null
-  swapUserInput: SwapUserInput | null
   guaranteedSwapPriceEnabled: boolean
   priceImpactWarningThreshold: number
 }
@@ -26,7 +25,6 @@ export interface State {
 const initialState: State = {
   swapState: SwapState.QUOTE,
   swapInfo: null,
-  swapUserInput: null,
   guaranteedSwapPriceEnabled: false,
   priceImpactWarningThreshold: 0.04,
 }
@@ -35,9 +33,9 @@ export const slice = createSlice({
   name: 'swap',
   initialState,
   reducers: {
-    setSwapUserInput: (state, action: PayloadAction<SwapUserInput>) => {
+    swapUserInput: (state) => {
       state.swapState = SwapState.USER_INPUT
-      state.swapUserInput = action.payload
+      state.swapInfo = null
     },
     // Legacy
     swapStart: (state, action: PayloadAction<SwapInfo>) => {
@@ -90,13 +88,12 @@ export const slice = createSlice({
         ...getRehydratePayload(action, 'swap'),
         swapState: SwapState.QUOTE,
         swapInfo: null,
-        swapUserInput: null,
       }))
   },
 })
 
 export const {
-  setSwapUserInput,
+  swapUserInput,
   swapStart,
   swapStartPrepared,
   swapApprove,

--- a/test/RootStateSchema.json
+++ b/test/RootStateSchema.json
@@ -3841,24 +3841,13 @@
                 },
                 "swapState": {
                     "$ref": "#/definitions/SwapState"
-                },
-                "swapUserInput": {
-                    "anyOf": [
-                        {
-                            "$ref": "#/definitions/SwapUserInput"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
                 }
             },
             "required": [
                 "guaranteedSwapPriceEnabled",
                 "priceImpactWarningThreshold",
                 "swapInfo",
-                "swapState",
-                "swapUserInput"
+                "swapState"
             ],
             "type": "object"
         },

--- a/test/schemas.ts
+++ b/test/schemas.ts
@@ -2802,6 +2802,15 @@ export const v167Schema = {
   },
 }
 
+export const v168Schema = {
+  ...v167Schema,
+  _persist: {
+    ...v167Schema._persist,
+    version: 168,
+  },
+  swap: _.omit(v167Schema.swap, 'swapUserInput'),
+}
+
 export function getLatestSchema(): Partial<RootState> {
-  return v167Schema as Partial<RootState>
+  return v168Schema as Partial<RootState>
 }


### PR DESCRIPTION
### Description

Remove redundant property `swapUserInput` from the `swapSlice` as not used.

Note: this is a sub-PR to https://github.com/valora-inc/wallet/pull/4481

### Test plan

* Updated unit tests
* Migration tested manually

### Related issues

- Related to RET-909

### Backwards compatibility

Y
