### PR TITLE
chore: reduce the number of colors in the palette

### DIFF
--- a/src/components/BottomSheet.tsx
+++ b/src/components/BottomSheet.tsx
@@ -105,7 +105,7 @@ const BottomSheet = ({
 
 const styles = StyleSheet.create({
   handle: {
-    backgroundColor: Colors.gray6,
+    backgroundColor: Colors.gray2,
     width: 40,
   },
   headerContentSpacing: {

--- a/src/home/ActionsCarousel.tsx
+++ b/src/home/ActionsCarousel.tsx
@@ -16,10 +16,10 @@ import QuickActionsWithdraw from 'src/icons/quick-actions/Withdraw'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import { isAppSwapsEnabledSelector } from 'src/navigator/selectors'
-import Colors from 'src/styles/colors'
-import fontStyles from 'src/styles/fonts'
 import { getFeatureGate } from 'src/statsig'
 import { StatsigFeatureGates } from 'src/statsig/types'
+import Colors from 'src/styles/colors'
+import fontStyles from 'src/styles/fonts'
 
 function ActionsCarousel() {
   const { t } = useTranslation()
@@ -120,7 +120,7 @@ const styles = StyleSheet.create({
     width: 84,
     marginHorizontal: 6,
     padding: 0,
-    backgroundColor: '#E8FCEF',
+    backgroundColor: Colors.greenBackground,
     borderRadius: 10,
   },
   touchable: {

--- a/src/home/DappsCarousel.tsx
+++ b/src/home/DappsCarousel.tsx
@@ -220,7 +220,7 @@ const styles = StyleSheet.create({
     marginBottom: Spacing.Smallest8,
   },
   viewAllIcon: {
-    backgroundColor: Colors.greenLight,
+    backgroundColor: Colors.greenBackground,
     alignItems: 'center',
     justifyContent: 'center',
   },

--- a/src/send/SendAmount/TokenPickerSelector.tsx
+++ b/src/send/SendAmount/TokenPickerSelector.tsx
@@ -44,7 +44,7 @@ const styles = StyleSheet.create({
     marginRight: 16,
     paddingRight: 8,
     borderRadius: 14,
-    backgroundColor: colors.lightGreen,
+    backgroundColor: colors.greenBackground,
   },
   token: {
     paddingVertical: 8,

--- a/src/styles/colors.tsx
+++ b/src/styles/colors.tsx
@@ -1,13 +1,13 @@
 // Designer Created Figma Colors
 export enum Colors {
   // to be updated
-  greenFaint = '#97DFC1', // green disabled
+  greenFaint = '#97DFC1', // green
   goldBrand = '#FBCC5C',
-  beige = '#F1F0EB',
-  onboardingBrownLight = '#A49B80',
-  onboardingBackground = '#F9F6F0',
-  onboardingGreen = '#178154',
-  greenBackground = '#DEF8EA',
+  beige = '#F1F0EB', // this is more of a gray
+  onboardingBrownLight = '#A49B80', // very dark beige
+  onboardingBackground = '#F9F6F0', // light beigey grey, very similar to beige but slightly lighter
+  onboardingGreen = '#178154', // dark green
+  greenBackground = '#E8FCEF', // light green
 
   // finalised colors
   error = '#EA6042',

--- a/src/styles/colors.tsx
+++ b/src/styles/colors.tsx
@@ -9,7 +9,6 @@ export enum Colors {
   onboardingBackground = '#F9F6F0',
   onboardingGreen = '#178154',
   greenBackground = '#DEF8EA',
-  lightGreen = '#E6F7EC',
 
   // finalised colors
   error = '#EA6042',

--- a/src/styles/colors.tsx
+++ b/src/styles/colors.tsx
@@ -1,7 +1,6 @@
 // Designer Created Figma Colors
 export enum Colors {
   // to be updated
-  greenLight = '#D0F4E1',
   greenFaint = '#97DFC1', // green disabled
   goldBrand = '#FBCC5C',
   beige = '#F1F0EB',

--- a/src/styles/colors.tsx
+++ b/src/styles/colors.tsx
@@ -5,7 +5,6 @@ export enum Colors {
   greenFaint = '#97DFC1', // green disabled
   goldBrand = '#FBCC5C',
   beige = '#F1F0EB',
-  gray6 = '#DFDBCE',
   onboardingBrownLight = '#A49B80',
   onboardingBackground = '#F9F6F0',
   onboardingGreen = '#178154',

--- a/src/verify/ResendButtonWithDelay.tsx
+++ b/src/verify/ResendButtonWithDelay.tsx
@@ -41,7 +41,7 @@ function ResendButtonWithDelay({ onPress }: Props) {
       testID="PhoneVerificationResendSmsBtn"
       disabled={disabled}
       style={{
-        color: disabled ? colors.gray6 : colors.onboardingBrownLight,
+        color: disabled ? colors.gray2 : colors.onboardingBrownLight,
         fontVariant: ['tabular-nums'],
       }}
       onPress={handleOnPress}


### PR DESCRIPTION
### Description

Taking some shortcuts to reduce the number of similar colors we have.
- gray6 -> gray2 (there is hardly any noticeable difference between these 2 hex values, and affects only the bottom sheet handle bar + the disabled "resend sms" text on the phone verification screen)
- lightGreen -> greenBackground (affects only the token select pill in the send amount screen)
- greenLight -> greenBackground (affects only the dapps carousel "view all" circle background)
- change the hex value of greenBackground to use what the home actions carousel uses since this is the most recent shade of light green.

### Test plan

Example of the greenBackground on a pill in the send amount screen. It should be safe to use because it is already being used as a background shade in the home screen.
![Simulator Screenshot - iPhone 14 Pro - 2023-11-23 at 12 11 30](https://github.com/valora-inc/wallet/assets/20150449/6f8b0e44-c032-4256-86f9-441cd03ea0aa)


### Related issues

Relates to RET-913

### Backwards compatibility

Y
