### PR TITLE
fix(swap): do not display fiat values that are 0 or NaN

### DIFF
--- a/src/swap/SwapAmountInput.tsx
+++ b/src/swap/SwapAmountInput.tsx
@@ -152,7 +152,14 @@ const SwapAmountInput = ({
         </Touchable>
       </View>
       <View testID="SwapAmountInput/FiatValue">
-        <Text style={[styles.fiatValue, { opacity: loading || !inputValue || !token ? 0 : 1 }]}>
+        <Text
+          style={[
+            styles.fiatValue,
+            {
+              opacity: loading || !parsedInputValue?.gt(0) || !token ? 0 : 1,
+            },
+          ]}
+        >
           <TokenDisplay
             amount={parsedInputValue ?? 0}
             showLocalAmount


### PR DESCRIPTION
### Description

When a user starts typing with a leading `,`, prevent showing NaN fiat value.

### Test plan

https://github.com/valora-inc/wallet/assets/20150449/6a3a0ee4-7ab1-40ff-bf6d-529dd05d317d


https://github.com/valora-inc/wallet/assets/20150449/90f83994-4ea3-4213-bb13-39319500bd05



### Related issues

Relates to RET-928

### Backwards compatibility

Y
