### PR TITLE
fix(swaps): ensure clear button works on swap input

### DIFF
--- a/src/swap/SwapScreen.tsx
+++ b/src/swap/SwapScreen.tsx
@@ -529,7 +529,10 @@ export function SwapScreen({ route }: Props) {
         left={<BackButton />}
         title={t('swapScreen.title')}
       />
-      <ScrollView contentContainerStyle={styles.contentContainer}>
+      <ScrollView
+        contentContainerStyle={styles.contentContainer}
+        keyboardShouldPersistTaps="handled"
+      >
         <View style={styles.swapAmountsContainer}>
           <SwapAmountInput
             label={t('swapScreen.swapFrom')}


### PR DESCRIPTION
### Description

Context https://valora-app.slack.com/archives/C04B61SJ6DS/p1700841917661059

A change was made to require users to dismiss the keyboard before proceeding with the swap, to ensure all warnings are visible. As a side effect, dismissing the keyboard => the textinput is not focused => cannot clear the input using the clear button. This PR adds the prop to allow actions to be handled on tap.

### Test plan

https://github.com/valora-inc/wallet/assets/20150449/8fd10e6f-0a46-49e8-8dd2-020b76a5cc32


### Related issues

n/a

### Backwards compatibility

Y
