### PR TITLE
chore(analytics): add networkId to send_tx_complete

### DIFF
--- a/src/analytics/Properties.tsx
+++ b/src/analytics/Properties.tsx
@@ -599,6 +599,7 @@ interface SendEventsProperties {
     usdAmount: string | undefined
     tokenAddress: string | undefined
     tokenId: string
+    networkId: string
   }
   [SendEvents.send_tx_error]: {
     error: string

--- a/src/send/saga.test.ts
+++ b/src/send/saga.test.ts
@@ -50,6 +50,7 @@ import {
   mockRecipientInfo,
   mockTransactionData,
 } from 'test/values'
+import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 
 jest.mock('@celo/connect')
 jest.mock('src/statsig')
@@ -365,6 +366,16 @@ describe(sendPaymentSaga, () => {
 
     expect(mockContract.methods.transferWithComment).not.toHaveBeenCalled()
     expect(mockContract.methods.transfer).not.toHaveBeenCalled()
+    expect(ValoraAnalytics.track).toHaveBeenCalledWith('send_tx_complete', {
+      txId: mockContext.id,
+      recipientAddress: mockQRCodeRecipient.address,
+      amount: '10',
+      usdAmount: '10',
+      tokenAddress: '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1'.toLowerCase(),
+      tokenId: mockCusdTokenId,
+      web3Library: 'viem',
+      networkId: 'celo-alfajores',
+    })
   })
 
   it('fails if user cancels PIN input', async () => {

--- a/src/send/saga.ts
+++ b/src/send/saga.ts
@@ -261,6 +261,7 @@ function* sendPayment(
       tokenAddress: tokenInfo.address ?? undefined,
       tokenId: tokenInfo.tokenId,
       web3Library,
+      networkId: tokenInfo.networkId,
     })
   } catch (err) {
     const error = ensureError(err)


### PR DESCRIPTION
### Description

add network id to send_tx_complete

### Test plan

added check to jest test

### Related issues

cc https://linear.app/valora/issue/ACT-992/ability-to-group-analytics-events-by-network-id

### Backwards compatibility

na
