### PR TITLE
feat(multichain): add beta status property to statsig user

### DIFF
--- a/src/app/selectors.ts
+++ b/src/app/selectors.ts
@@ -119,3 +119,5 @@ export const showNotificationSpotlightSelector = (state: RootState) =>
   state.app.showNotificationSpotlight
 
 export const hideHomeBalancesSelector = (state: RootState) => state.app.hideHomeBalances
+
+export const multichainBetaStatusSelector = (state: RootState) => state.app.multichainBetaStatus

--- a/src/statsig/index.test.ts
+++ b/src/statsig/index.test.ts
@@ -1,4 +1,5 @@
 import { LaunchArguments } from 'react-native-launch-arguments'
+import { MultichainBetaStatus } from 'src/app/actions'
 import { store } from 'src/redux/store'
 import { DynamicConfigs, ExperimentConfigs, FeatureGates } from 'src/statsig/constants'
 import {
@@ -199,6 +200,7 @@ describe('Statsig helpers', () => {
         userID: MOCK_ACCOUNT.toLowerCase(),
         custom: {
           startOnboardingTime: MOCK_START_ONBOARDING_TIME,
+          multichainBetaStatus: MultichainBetaStatus.NotSeen,
           loadTime: 1234,
         },
       })
@@ -211,6 +213,7 @@ describe('Statsig helpers', () => {
         userID: MOCK_ACCOUNT.toLowerCase(),
         custom: {
           startOnboardingTime: MOCK_START_ONBOARDING_TIME,
+          multichainBetaStatus: MultichainBetaStatus.NotSeen,
           loadTime: 1234,
         },
       })
@@ -219,6 +222,7 @@ describe('Statsig helpers', () => {
       const statsigUser = {
         custom: {
           startOnboardingTime: 1680563880,
+          multichainBetaStatus: MultichainBetaStatus.OptedIn,
           otherCustomProperty: 'foo',
           loadTime: 12345,
         },
@@ -235,6 +239,7 @@ describe('Statsig helpers', () => {
         userID: 'some address',
         custom: {
           startOnboardingTime: 1680563880,
+          multichainBetaStatus: MultichainBetaStatus.OptedIn,
           otherCustomProperty: 'foo',
           loadTime: 12345,
         },
@@ -256,6 +261,7 @@ describe('Statsig helpers', () => {
         userID: MOCK_ACCOUNT.toLowerCase(),
         custom: {
           startOnboardingTime: MOCK_START_ONBOARDING_TIME,
+          multichainBetaStatus: MultichainBetaStatus.NotSeen,
           ...statsigUser.custom,
           loadTime: 1234,
         },

--- a/src/statsig/index.ts
+++ b/src/statsig/index.ts
@@ -1,6 +1,7 @@
 import * as _ from 'lodash'
 import { LaunchArguments } from 'react-native-launch-arguments'
 import { startOnboardingTimeSelector } from 'src/account/selectors'
+import { multichainBetaStatusSelector } from 'src/app/selectors'
 import { FeatureGates } from 'src/statsig/constants'
 import {
   StatsigDynamicConfigs,
@@ -103,6 +104,7 @@ export function getDefaultStatsigUser(): StatsigUser {
     userID: walletAddressSelector(state) ?? undefined,
     custom: {
       startOnboardingTime: startOnboardingTimeSelector(state),
+      multichainBetaStatus: multichainBetaStatusSelector(state),
       loadTime: Date.now(),
     },
   }


### PR DESCRIPTION
### Description

Add `multichainBetaStatus` prop to statsig user whenever the user opts in / out of multichain beta. This prop is used in this [dynamic config](https://console.statsig.com/4plizaPmWwPL21ASV4QAO0/dynamic_configs/multi_chain_features) to select network ids based on this custom prop. Included a loading state when statsig updateUser is invoked, which makes a network request to fetch all gate / config evaluations for the updated user. 

### Test plan

Unit tests, manually

| Opt In | Opt out |
|--------|--------|
| <video src="https://github.com/valora-inc/wallet/assets/5062591/db096a15-f640-4cd2-9e1a-9d874da69c6b"/> | <video src="https://github.com/valora-inc/wallet/assets/5062591/ec47afea-b8da-4fdb-b3d8-61e6dcc0f7c8" /> | 


### Related issues

- Fixes ACT-982

### Backwards compatibility

yes
