### PR TITLE
chore(eth): display external exchanges for ethereum

### DIFF
--- a/src/fiatExchanges/FiatExchangeCurrencyBottomSheet.test.tsx
+++ b/src/fiatExchanges/FiatExchangeCurrencyBottomSheet.test.tsx
@@ -29,7 +29,7 @@ const MOCK_STORE_DATA = {
         networkId: NetworkId['celo-alfajores'],
         name: 'cUSD',
         address: mockCusdAddress,
-        balance: '0',
+        balance: '50',
         priceUsd: '1',
         symbol: 'cUSD',
         priceFetchedAt: mockDate,
@@ -71,7 +71,7 @@ const MOCK_STORE_DATA = {
         networkId: NetworkId['celo-alfajores'],
         name: 'cREAL',
         address: mockCrealAddress,
-        balance: '0',
+        balance: '10',
         priceUsd: '0.75',
         symbol: 'cREAL',
         isSupercharged: true,
@@ -260,5 +260,29 @@ describe(FiatExchangeCurrencyBottomSheet, () => {
     expect(queryByTestId('CELOSymbol')).toBeFalsy()
     expect(queryByTestId('cREALSymbol')).toBeFalsy()
     expect(queryByTestId('ETHSymbol')).toBeFalsy()
+  })
+  it('shows the correct order when cicoOrder missing/same value', () => {
+    jest.mocked(getDynamicConfigParams).mockReturnValue({
+      showCico: ['celo-alfajores', 'ethereum-sepolia'],
+      cicoOrder: {
+        [mockCusdTokenId]: 1,
+        [mockCrealTokenId]: 1,
+      },
+    })
+    const { getAllByTestId } = render(
+      <Provider store={mockStore}>
+        <MockedNavigator
+          component={FiatExchangeCurrencyBottomSheet}
+          params={{
+            flow: FiatExchangeFlow.CashIn,
+          }}
+        />
+      </Provider>
+    )
+    expect(getAllByTestId('TokenBalanceItem')[0]).toHaveTextContent('cUSD')
+    expect(getAllByTestId('TokenBalanceItem')[1]).toHaveTextContent('cREAL')
+    expect(getAllByTestId('TokenBalanceItem')[2]).toHaveTextContent('cEUR')
+    expect(getAllByTestId('TokenBalanceItem')[3]).toHaveTextContent('CELO')
+    expect(getAllByTestId('TokenBalanceItem')[4]).toHaveTextContent('ETH')
   })
 })

--- a/src/fiatExchanges/FiatExchangeCurrencyBottomSheet.test.tsx
+++ b/src/fiatExchanges/FiatExchangeCurrencyBottomSheet.test.tsx
@@ -43,7 +43,7 @@ const MOCK_STORE_DATA = {
         networkId: NetworkId['celo-alfajores'],
         name: 'cEUR',
         address: mockCeurAddress,
-        balance: '50',
+        balance: '0',
         priceUsd: '0.5',
         symbol: 'cEUR',
         isSupercharged: true,
@@ -57,7 +57,7 @@ const MOCK_STORE_DATA = {
         networkId: NetworkId['celo-alfajores'],
         name: 'Celo',
         address: mockCeloAddress,
-        balance: '100',
+        balance: '0',
         priceUsd: '0.2',
         symbol: 'CELO',
         isSupercharged: true,
@@ -71,7 +71,7 @@ const MOCK_STORE_DATA = {
         networkId: NetworkId['celo-alfajores'],
         name: 'cREAL',
         address: mockCrealAddress,
-        balance: '20',
+        balance: '0',
         priceUsd: '0.75',
         symbol: 'cREAL',
         isSupercharged: true,
@@ -83,7 +83,7 @@ const MOCK_STORE_DATA = {
         tokenId: mockEthTokenId,
         networkId: NetworkId['ethereum-sepolia'],
         name: 'Ether',
-        balance: '1',
+        balance: '0',
         priceUsd: '0.1000',
         symbol: 'ETH',
         isSupercharged: true,
@@ -119,10 +119,19 @@ describe(FiatExchangeCurrencyBottomSheet, () => {
   const mockStore = createMockStore(MOCK_STORE_DATA)
   beforeEach(() => {
     jest.clearAllMocks()
+    jest.mocked(getDynamicConfigParams).mockReturnValue({
+      showCico: ['celo-alfajores'],
+      cicoOrder: {
+        [mockEthTokenId]: 1,
+        [mockCeloTokenId]: 2,
+        [mockCusdTokenId]: 3,
+        [mockCeurTokenId]: 4,
+        [mockCrealTokenId]: 5,
+      },
+    })
   })
   it('shows the correct tokens for cash in (multichain disabled, no ETH)', () => {
-    jest.mocked(getDynamicConfigParams).mockReturnValue({ showCico: ['celo-alfajores'] })
-    const { queryByTestId } = render(
+    const { queryByTestId, getAllByTestId } = render(
       <Provider store={mockStore}>
         <MockedNavigator
           component={FiatExchangeCurrencyBottomSheet}
@@ -132,17 +141,24 @@ describe(FiatExchangeCurrencyBottomSheet, () => {
         />
       </Provider>
     )
-    expect(queryByTestId('cUSDSymbol')).toBeTruthy()
-    expect(queryByTestId('cEURSymbol')).toBeTruthy()
-    expect(queryByTestId('cREALSymbol')).toBeTruthy()
-    expect(queryByTestId('CELOSymbol')).toBeTruthy()
+    expect(getAllByTestId('TokenBalanceItem')[0]).toHaveTextContent('CELO')
+    expect(getAllByTestId('TokenBalanceItem')[1]).toHaveTextContent('cUSD')
+    expect(getAllByTestId('TokenBalanceItem')[2]).toHaveTextContent('cEUR')
+    expect(getAllByTestId('TokenBalanceItem')[3]).toHaveTextContent('cREAL')
     expect(queryByTestId('ETHSymbol')).toBeFalsy()
   })
   it('shows the correct tokens for cash in (multichain)', () => {
-    jest
-      .mocked(getDynamicConfigParams)
-      .mockReturnValue({ showCico: ['celo-alfajores', 'ethereum-sepolia'] })
-    const { queryByTestId } = render(
+    jest.mocked(getDynamicConfigParams).mockReturnValue({
+      showCico: ['celo-alfajores', 'ethereum-sepolia'],
+      cicoOrder: {
+        [mockEthTokenId]: 1,
+        [mockCeloTokenId]: 2,
+        [mockCusdTokenId]: 3,
+        [mockCeurTokenId]: 4,
+        [mockCrealTokenId]: 5,
+      },
+    })
+    const { getAllByTestId } = render(
       <Provider store={mockStore}>
         <MockedNavigator
           component={FiatExchangeCurrencyBottomSheet}
@@ -152,15 +168,14 @@ describe(FiatExchangeCurrencyBottomSheet, () => {
         />
       </Provider>
     )
-    expect(queryByTestId('cUSDSymbol')).toBeTruthy()
-    expect(queryByTestId('cEURSymbol')).toBeTruthy()
-    expect(queryByTestId('cREALSymbol')).toBeTruthy()
-    expect(queryByTestId('CELOSymbol')).toBeTruthy()
-    expect(queryByTestId('ETHSymbol')).toBeTruthy()
+    expect(getAllByTestId('TokenBalanceItem')[0]).toHaveTextContent('ETH')
+    expect(getAllByTestId('TokenBalanceItem')[1]).toHaveTextContent('CELO')
+    expect(getAllByTestId('TokenBalanceItem')[2]).toHaveTextContent('cUSD')
+    expect(getAllByTestId('TokenBalanceItem')[3]).toHaveTextContent('cEUR')
+    expect(getAllByTestId('TokenBalanceItem')[4]).toHaveTextContent('cREAL')
   })
   it('shows the correct tokens for cash out', () => {
-    jest.mocked(getDynamicConfigParams).mockReturnValue({ showCico: ['celo-alfajores'] })
-    const { queryByTestId } = render(
+    const { queryByTestId, getAllByTestId } = render(
       <Provider store={mockStore}>
         <MockedNavigator
           component={FiatExchangeCurrencyBottomSheet}
@@ -170,16 +185,23 @@ describe(FiatExchangeCurrencyBottomSheet, () => {
         />
       </Provider>
     )
-    expect(queryByTestId('cUSDSymbol')).toBeTruthy()
-    expect(queryByTestId('cEURSymbol')).toBeTruthy()
+    expect(getAllByTestId('TokenBalanceItem')[0]).toHaveTextContent('CELO')
+    expect(getAllByTestId('TokenBalanceItem')[1]).toHaveTextContent('cUSD')
+    expect(getAllByTestId('TokenBalanceItem')[2]).toHaveTextContent('cEUR')
     expect(queryByTestId('cREALSymbol')).toBeFalsy()
-    expect(queryByTestId('CELOSymbol')).toBeTruthy()
   })
   it('shows the correct tokens for cash out (multichain)', () => {
-    jest
-      .mocked(getDynamicConfigParams)
-      .mockReturnValue({ showCico: ['celo-alfajores', 'ethereum-sepolia'] })
-    const { queryByTestId } = render(
+    jest.mocked(getDynamicConfigParams).mockReturnValue({
+      showCico: ['celo-alfajores', 'ethereum-sepolia'],
+      cicoOrder: {
+        [mockEthTokenId]: 1,
+        [mockCeloTokenId]: 2,
+        [mockCusdTokenId]: 3,
+        [mockCeurTokenId]: 4,
+        [mockCrealTokenId]: 5,
+      },
+    })
+    const { queryByTestId, getAllByTestId } = render(
       <Provider store={mockStore}>
         <MockedNavigator
           component={FiatExchangeCurrencyBottomSheet}
@@ -189,15 +211,14 @@ describe(FiatExchangeCurrencyBottomSheet, () => {
         />
       </Provider>
     )
-    expect(queryByTestId('cUSDSymbol')).toBeTruthy()
-    expect(queryByTestId('cEURSymbol')).toBeTruthy()
+    expect(getAllByTestId('TokenBalanceItem')[0]).toHaveTextContent('CELO')
+    expect(getAllByTestId('TokenBalanceItem')[1]).toHaveTextContent('cUSD')
+    expect(getAllByTestId('TokenBalanceItem')[2]).toHaveTextContent('cEUR')
     expect(queryByTestId('cREALSymbol')).toBeFalsy()
-    expect(queryByTestId('CELOSymbol')).toBeTruthy()
     expect(queryByTestId('ETHSymbol')).toBeFalsy()
   })
   it('shows the correct tokens for cash spend', () => {
-    jest.mocked(getDynamicConfigParams).mockReturnValue({ showCico: ['celo-alfajores'] })
-    const { queryByTestId } = render(
+    const { queryByTestId, getAllByTestId } = render(
       <Provider store={mockStore}>
         <MockedNavigator
           component={FiatExchangeCurrencyBottomSheet}
@@ -207,16 +228,23 @@ describe(FiatExchangeCurrencyBottomSheet, () => {
         />
       </Provider>
     )
-    expect(queryByTestId('cUSDSymbol')).toBeTruthy()
-    expect(queryByTestId('cEURSymbol')).toBeTruthy()
-    expect(queryByTestId('cREALSymbol')).toBeFalsy()
+    expect(getAllByTestId('TokenBalanceItem')[0]).toHaveTextContent('cUSD')
+    expect(getAllByTestId('TokenBalanceItem')[1]).toHaveTextContent('cEUR')
     expect(queryByTestId('CELOSymbol')).toBeFalsy()
+    expect(queryByTestId('cREALSymbol')).toBeFalsy()
   })
   it('shows the correct tokens for cash spend (multichain)', () => {
-    jest
-      .mocked(getDynamicConfigParams)
-      .mockReturnValue({ showCico: ['celo-alfajores', 'ethereum-sepolia'] })
-    const { queryByTestId } = render(
+    jest.mocked(getDynamicConfigParams).mockReturnValue({
+      showCico: ['celo-alfajores', 'ethereum-sepolia'],
+      cicoOrder: {
+        [mockEthTokenId]: 1,
+        [mockCeloTokenId]: 2,
+        [mockCusdTokenId]: 3,
+        [mockCeurTokenId]: 4,
+        [mockCrealTokenId]: 5,
+      },
+    })
+    const { queryByTestId, getAllByTestId } = render(
       <Provider store={mockStore}>
         <MockedNavigator
           component={FiatExchangeCurrencyBottomSheet}
@@ -226,10 +254,10 @@ describe(FiatExchangeCurrencyBottomSheet, () => {
         />
       </Provider>
     )
-    expect(queryByTestId('cUSDSymbol')).toBeTruthy()
-    expect(queryByTestId('cEURSymbol')).toBeTruthy()
-    expect(queryByTestId('cREALSymbol')).toBeFalsy()
+    expect(getAllByTestId('TokenBalanceItem')[0]).toHaveTextContent('cUSD')
+    expect(getAllByTestId('TokenBalanceItem')[1]).toHaveTextContent('cEUR')
     expect(queryByTestId('CELOSymbol')).toBeFalsy()
+    expect(queryByTestId('cREALSymbol')).toBeFalsy()
     expect(queryByTestId('ETHSymbol')).toBeFalsy()
   })
 })

--- a/src/fiatExchanges/FiatExchangeCurrencyBottomSheet.tsx
+++ b/src/fiatExchanges/FiatExchangeCurrencyBottomSheet.tsx
@@ -14,7 +14,7 @@ import { Spacing } from 'src/styles/styles'
 import { TokenBalanceItem } from 'src/tokens/TokenBalanceItem'
 import { useCashInTokens, useCashOutTokens, useSpendTokens } from 'src/tokens/hooks'
 import { TokenBalance } from 'src/tokens/slice'
-import { sortFirstStableThenCeloThenOthersByUsdBalance } from 'src/tokens/utils'
+import { sortCicoTokens } from 'src/tokens/utils'
 import { resolveCICOCurrency, resolveCurrency } from 'src/utils/currencies'
 import { CICOFlow, FiatExchangeFlow } from './utils'
 
@@ -34,10 +34,7 @@ function FiatExchangeCurrencyBottomSheet({ route }: Props) {
       ? cashOutTokens
       : spendTokens
 
-  const tokenList = useMemo(
-    () => unsortedTokenList.sort(sortFirstStableThenCeloThenOthersByUsdBalance),
-    [unsortedTokenList]
-  )
+  const tokenList = useMemo(() => unsortedTokenList.sort(sortCicoTokens), [unsortedTokenList])
 
   // Fetch FiatConnect providers silently in the background early in the CICO funnel
   useEffect(() => {

--- a/src/fiatExchanges/FiatExchangeCurrencyBottomSheet.tsx
+++ b/src/fiatExchanges/FiatExchangeCurrencyBottomSheet.tsx
@@ -1,5 +1,5 @@
 import { BottomSheetScreenProps } from '@th3rdwave/react-navigation-bottom-sheet'
-import React, { useEffect } from 'react'
+import React, { useEffect, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { StyleSheet, Text } from 'react-native'
 import { useDispatch } from 'react-redux'
@@ -34,7 +34,10 @@ function FiatExchangeCurrencyBottomSheet({ route }: Props) {
       ? cashOutTokens
       : spendTokens
 
-  const tokenList = unsortedTokenList.sort(sortFirstStableThenCeloThenOthersByUsdBalance)
+  const tokenList = useMemo(
+    () => unsortedTokenList.sort(sortFirstStableThenCeloThenOthersByUsdBalance),
+    [unsortedTokenList]
+  )
 
   // Fetch FiatConnect providers silently in the background early in the CICO funnel
   useEffect(() => {

--- a/src/fiatExchanges/FiatExchangeCurrencyBottomSheet.tsx
+++ b/src/fiatExchanges/FiatExchangeCurrencyBottomSheet.tsx
@@ -14,6 +14,7 @@ import { Spacing } from 'src/styles/styles'
 import { TokenBalanceItem } from 'src/tokens/TokenBalanceItem'
 import { useCashInTokens, useCashOutTokens, useSpendTokens } from 'src/tokens/hooks'
 import { TokenBalance } from 'src/tokens/slice'
+import { sortFirstStableThenCeloThenOthersByUsdBalance } from 'src/tokens/utils'
 import { resolveCICOCurrency, resolveCurrency } from 'src/utils/currencies'
 import { CICOFlow, FiatExchangeFlow } from './utils'
 
@@ -26,12 +27,14 @@ function FiatExchangeCurrencyBottomSheet({ route }: Props) {
   const cashInTokens = useCashInTokens()
   const cashOutTokens = useCashOutTokens(true)
   const spendTokens = useSpendTokens()
-  const tokenList =
+  const unsortedTokenList =
     flow === FiatExchangeFlow.CashIn
       ? cashInTokens
       : flow === FiatExchangeFlow.CashOut
       ? cashOutTokens
       : spendTokens
+
+  const tokenList = unsortedTokenList.sort(sortFirstStableThenCeloThenOthersByUsdBalance)
 
   // Fetch FiatConnect providers silently in the background early in the CICO funnel
   useEffect(() => {

--- a/src/fiatExchanges/SelectProvider.tsx
+++ b/src/fiatExchanges/SelectProvider.tsx
@@ -132,7 +132,7 @@ export default function SelectProviderScreen({ route, navigation }: Props) {
     try {
       const availableExchanges = await fetchExchanges(
         userLocation.countryCodeAlpha2,
-        tokenInfo.symbol
+        tokenInfo.tokenId
       )
 
       return availableExchanges

--- a/src/fiatExchanges/utils.tsx
+++ b/src/fiatExchanges/utils.tsx
@@ -284,15 +284,14 @@ export const filterLegacyMobileMoneyProviders = (
 
 export async function fetchExchanges(
   countryCodeAlpha2: string | null,
-  currency: string
+  tokenId: string
 ): Promise<ExternalExchangeProvider[] | undefined> {
   // If user location data is not available, default fetching exchanges serving the US
   if (!countryCodeAlpha2) countryCodeAlpha2 = 'us'
   // Standardize cGLD to CELO
-
   try {
     const resp = await fetchWithTimeout(
-      `${networkConfig.fetchExchangesUrl}?country=${countryCodeAlpha2}&currency=${currency}`,
+      `${networkConfig.fetchExchangesUrl}?country=${countryCodeAlpha2}&tokenId=${tokenId}`,
       undefined,
       getDynamicConfigParams(DynamicConfigs[StatsigDynamicConfigs.WALLET_NETWORK_TIMEOUT_SECONDS])
         .cico * 1000

--- a/src/statsig/constants.ts
+++ b/src/statsig/constants.ts
@@ -115,4 +115,10 @@ export const DynamicConfigs = {
       maxSlippagePercentage: '0.3',
     },
   },
+  [StatsigDynamicConfigs.CICO_TOKEN_INFO]: {
+    configName: StatsigDynamicConfigs.CICO_TOKEN_INFO,
+    defaultValues: {
+      cicoOrder: {} as { [key: string]: number },
+    },
+  },
 }

--- a/src/statsig/types.ts
+++ b/src/statsig/types.ts
@@ -18,6 +18,7 @@ export enum StatsigDynamicConfigs {
   MULTI_CHAIN_FEATURES = 'multi_chain_features',
   DAPP_WEBVIEW_CONFIG = 'dapp_webview_config',
   SWAP_CONFIG = 'swap_config',
+  CICO_TOKEN_INFO = 'cico_token_info',
 }
 
 export enum StatsigFeatureGates {

--- a/src/tokens/utils.ts
+++ b/src/tokens/utils.ts
@@ -87,6 +87,22 @@ export function sortFirstStableThenCeloThenOthersByUsdBalance(
   return usdBalance(token2).comparedTo(usdBalance(token1))
 }
 
+export function sortCicoTokens(token1: TokenBalance, token2: TokenBalance): number {
+  const cicoTokenInfo = getDynamicConfigParams(
+    DynamicConfigs[StatsigDynamicConfigs.CICO_TOKEN_INFO]
+  )
+  if (!cicoTokenInfo.cicoOrder[token1.tokenId] && !cicoTokenInfo.cicoOrder[token2.tokenId]) {
+    return sortFirstStableThenCeloThenOthersByUsdBalance(token1, token2)
+  }
+  if (!cicoTokenInfo.cicoOrder[token1.tokenId]) {
+    return 1
+  }
+  if (!cicoTokenInfo.cicoOrder[token2.tokenId]) {
+    return -1
+  }
+  return cicoTokenInfo.cicoOrder[token1.tokenId] < cicoTokenInfo.cicoOrder[token2.tokenId] ? -1 : 1
+}
+
 export function usdBalance(token: TokenBalance): BigNumber {
   return token.balance.times(token.priceUsd ?? 0)
 }

--- a/src/tokens/utils.ts
+++ b/src/tokens/utils.ts
@@ -91,7 +91,10 @@ export function sortCicoTokens(token1: TokenBalance, token2: TokenBalance): numb
   const cicoTokenInfo = getDynamicConfigParams(
     DynamicConfigs[StatsigDynamicConfigs.CICO_TOKEN_INFO]
   )
-  if (!cicoTokenInfo.cicoOrder[token1.tokenId] && !cicoTokenInfo.cicoOrder[token2.tokenId]) {
+  if (
+    (!cicoTokenInfo.cicoOrder[token1.tokenId] && !cicoTokenInfo.cicoOrder[token2.tokenId]) ||
+    cicoTokenInfo.cicoOrder[token1.tokenId] < cicoTokenInfo.cicoOrder[token2.tokenId]
+  ) {
     return sortFirstStableThenCeloThenOthersByUsdBalance(token1, token2)
   }
   if (!cicoTokenInfo.cicoOrder[token1.tokenId]) {

--- a/src/tokens/utils.ts
+++ b/src/tokens/utils.ts
@@ -93,7 +93,7 @@ export function sortCicoTokens(token1: TokenBalance, token2: TokenBalance): numb
   )
   if (
     (!cicoTokenInfo.cicoOrder[token1.tokenId] && !cicoTokenInfo.cicoOrder[token2.tokenId]) ||
-    cicoTokenInfo.cicoOrder[token1.tokenId] < cicoTokenInfo.cicoOrder[token2.tokenId]
+    cicoTokenInfo.cicoOrder[token1.tokenId] === cicoTokenInfo.cicoOrder[token2.tokenId]
   ) {
     return sortFirstStableThenCeloThenOthersByUsdBalance(token1, token2)
   }

--- a/src/tokens/utils.ts
+++ b/src/tokens/utils.ts
@@ -87,6 +87,14 @@ export function sortFirstStableThenCeloThenOthersByUsdBalance(
   return usdBalance(token2).comparedTo(usdBalance(token1))
 }
 
+/**
+ *
+ * Sorts by:
+ * 1. cicoOrder value, smallest first
+ *  1.1. If both tokens have cicoOrder value, sort by sortFirstStableThenCeloThenOthersByUsdBalance
+ * 2. If only one token has cicoOrder value, it goes first
+ * 3. If neither token has cicoOrder value, sort by sortFirstStableThenCeloThenOthersByUsdBalance
+ */
 export function sortCicoTokens(token1: TokenBalance, token2: TokenBalance): number {
   const cicoTokenInfo = getDynamicConfigParams(
     DynamicConfigs[StatsigDynamicConfigs.CICO_TOKEN_INFO]


### PR DESCRIPTION
### Description

Exchanges show up on the CICO flow for ETH

### Test plan

Before change for ETH:

https://github.com/valora-inc/wallet/assets/140328381/24be889e-075c-46b5-85a8-c81755b18d15



After change for ETH:

https://github.com/valora-inc/wallet/assets/140328381/6c4af83b-6bb4-47c0-aa59-303d377e74ef



After change for CELO (no change, exchanges still show up but now got with token ID):

https://github.com/valora-inc/wallet/assets/140328381/ae1dc3bf-d39c-4bb3-82a8-e76dd442f3a0




### Related issues

- [ACT-895](https://linear.app/valora/issue/ACT-895/display-external-exchanges-for-ethereum-wallet)

### Backwards compatibility

Yes
