### PR TITLE
feat: add slippage tolerance info bottom sheet to swap screen

### DIFF
--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -1700,6 +1700,7 @@
       "swapFeeWaived": "Free",
       "slippagePercentage": "Slippage Tolerance",
       "networkFeeInfo": "You are swapping on the {{networkName}} Network.\n\nThis estimated network fee is required to conduct a transaction on the {{networkName}} Network. This fee secures your transaction and goes towards keeping the network operational.",
+      "slippageToleranceInfo": "Slippage tolerance\n\nYour swap will execute within the slippage tolerance percentage. If the price changes more than the slippage tolerance, {{appName}} protects you by preventing the trade from executing.",
       "networkFeeInfoDismissButton": "Got it",
       "exchangeRate": "Exchange Rate",
       "estimatedValue": "Estimated Value"

--- a/src/analytics/Events.tsx
+++ b/src/analytics/Events.tsx
@@ -597,6 +597,7 @@ export enum SwapEvents {
   swap_price_impact_warning_displayed = 'swap_price_impact_warning_displayed',
   swap_again = 'swap_again',
   swap_try_again = 'swap_try_again',
+  swap_show_info = 'swap_show_info',
 }
 
 export enum CeloNewsEvents {

--- a/src/analytics/Properties.tsx
+++ b/src/analytics/Properties.tsx
@@ -1312,6 +1312,10 @@ export type SwapTxsReceiptProperties = Partial<ApproveTxReceiptProperties> &
     feeCurrencySymbol: string | undefined // Fee currency symbol used
   }>
 
+export enum SwapShowInfoType {
+  NETWORK_FEE,
+  SLIPPAGE,
+}
 interface SwapEventsProperties {
   [SwapEvents.swap_screen_open]: undefined
   [SwapEvents.swap_screen_select_token]: {
@@ -1374,6 +1378,9 @@ interface SwapEventsProperties {
   }
   [SwapEvents.swap_again]: undefined
   [SwapEvents.swap_try_again]: undefined
+  [SwapEvents.swap_show_info]: {
+    type: SwapShowInfoType
+  }
 }
 
 interface CeloNewsEventsProperties {

--- a/src/analytics/docs.ts
+++ b/src/analytics/docs.ts
@@ -523,6 +523,7 @@ export const eventDocs: Record<AnalyticsEventType, string> = {
   [SwapEvents.swap_price_impact_warning_displayed]: `When the price impact warning is displayed`,
   [SwapEvents.swap_again]: `When a user taps "Swap again" button after a successful swap`,
   [SwapEvents.swap_try_again]: `When a user taps "Try again" button after an unsuccessful swap`,
+  [SwapEvents.swap_show_info]: `When a user taps an info icon to show more information on the swap screen`,
   [CeloNewsEvents.celo_news_screen_open]: `When the screen is mounted`,
   [CeloNewsEvents.celo_news_article_tap]: `When a user taps on a news article`,
   [CeloNewsEvents.celo_news_bottom_read_more_tap]: `When a user taps on the read more button at the bottom of the screen`,

--- a/src/swap/SwapScreen.tsx
+++ b/src/swap/SwapScreen.tsx
@@ -95,6 +95,7 @@ export function SwapScreen({ route }: Props) {
   const tokenBottomSheetRef = useRef<BottomSheetRefType>(null)
   const preparedTransactionsReviewBottomSheetRef = useRef<BottomSheetRefType>(null)
   const networkFeeInfoBottomSheetRef = useRef<BottomSheetRefType>(null)
+  const slippageInfoBottomSheetRef = useRef<BottomSheetRefType>(null)
 
   const { decimalSeparator } = getNumberFormatSettings()
 
@@ -564,6 +565,7 @@ export function SwapScreen({ route }: Props) {
           <SwapTransactionDetails
             networkFee={networkFee}
             networkFeeInfoBottomSheetRef={networkFeeInfoBottomSheetRef}
+            slippageInfoBottomSheetRef={slippageInfoBottomSheetRef}
             feeTokenId={feeTokenId}
             slippagePercentage={parsedSlippagePercentage}
             fromToken={fromToken}
@@ -655,6 +657,21 @@ export function SwapScreen({ route }: Props) {
           style={styles.bottomSheetButton}
           onPress={() => {
             networkFeeInfoBottomSheetRef.current?.close()
+          }}
+          text={t('swapScreen.transactionDetails.networkFeeInfoDismissButton')}
+        />
+      </BottomSheet>
+      <BottomSheet
+        forwardedRef={slippageInfoBottomSheetRef}
+        description={t('swapScreen.transactionDetails.slippageToleranceInfo')}
+        testId="NetworkFeeInfoBottomSheet"
+      >
+        <Button
+          type={BtnTypes.SECONDARY}
+          size={BtnSizes.FULL}
+          style={styles.bottomSheetButton}
+          onPress={() => {
+            slippageInfoBottomSheetRef.current?.close()
           }}
           text={t('swapScreen.transactionDetails.networkFeeInfoDismissButton')}
         />

--- a/src/swap/SwapTransactionDetails.test.tsx
+++ b/src/swap/SwapTransactionDetails.test.tsx
@@ -18,6 +18,7 @@ describe('SwapTransactionDetails', () => {
         <SwapTransactionDetails
           networkFee={new BigNumber(0.0001)}
           networkFeeInfoBottomSheetRef={{ current: null }}
+          slippageInfoBottomSheetRef={{ current: null }}
           feeTokenId={'someId'}
           slippagePercentage={'0.5'}
           fetchingSwapQuote={false}
@@ -46,6 +47,7 @@ describe('SwapTransactionDetails', () => {
         <SwapTransactionDetails
           networkFee={new BigNumber(0.0001)}
           networkFeeInfoBottomSheetRef={{ current: null }}
+          slippageInfoBottomSheetRef={{ current: null }}
           feeTokenId={'someId'}
           slippagePercentage={'0.5'}
           fetchingSwapQuote={false}
@@ -64,6 +66,7 @@ describe('SwapTransactionDetails', () => {
         <SwapTransactionDetails
           networkFee={new BigNumber(0.0001)}
           networkFeeInfoBottomSheetRef={{ current: null }}
+          slippageInfoBottomSheetRef={{ current: null }}
           feeTokenId={mockCeloTokenId}
           slippagePercentage={'0.5'}
           fromToken={mockCeloTokenBalance}
@@ -80,5 +83,26 @@ describe('SwapTransactionDetails', () => {
     )
     expect(getByTestId('SwapTransactionDetails/NetworkFee/MoreInfo/Icon')).toBeTruthy()
     expect(getByTestId('SwapTransactionDetails/NetworkFee/MoreInfo')).not.toBeDisabled()
+  })
+
+  it('should render correctly with slippage info', () => {
+    const { getByText, getByTestId } = render(
+      <Provider store={createMockStore()}>
+        <SwapTransactionDetails
+          networkFee={new BigNumber(0.0001)}
+          networkFeeInfoBottomSheetRef={{ current: null }}
+          slippageInfoBottomSheetRef={{ current: null }}
+          feeTokenId={mockCeloTokenId}
+          slippagePercentage={'0.5'}
+          fromToken={mockCeloTokenBalance}
+          fetchingSwapQuote={false}
+        />
+      </Provider>
+    )
+
+    expect(getByText('swapScreen.transactionDetails.slippagePercentage')).toBeTruthy()
+    expect(getByTestId('SwapTransactionDetails/Slippage')).toHaveTextContent('0.5%')
+    expect(getByTestId('SwapTransactionDetails/Slippage/MoreInfo/Icon')).toBeTruthy()
+    expect(getByTestId('SwapTransactionDetails/Slippage/MoreInfo')).not.toBeDisabled()
   })
 })

--- a/src/swap/SwapTransactionDetails.tsx
+++ b/src/swap/SwapTransactionDetails.tsx
@@ -2,6 +2,9 @@ import BigNumber from 'bignumber.js'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 import { StyleSheet, Text, View } from 'react-native'
+import { SwapEvents } from 'src/analytics/Events'
+import { SwapShowInfoType } from 'src/analytics/Properties'
+import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import { BottomSheetRefType } from 'src/components/BottomSheet'
 import TokenDisplay from 'src/components/TokenDisplay'
 import Touchable from 'src/components/Touchable'
@@ -15,6 +18,7 @@ import { TokenBalance } from 'src/tokens/slice'
 interface Props {
   networkFee?: BigNumber
   networkFeeInfoBottomSheetRef: React.RefObject<BottomSheetRefType>
+  slippageInfoBottomSheetRef: React.RefObject<BottomSheetRefType>
   slippagePercentage: string
   feeTokenId: string
   fromToken?: TokenBalance
@@ -24,9 +28,29 @@ interface Props {
   fetchingSwapQuote: boolean
 }
 
+function LabelWithInfo({
+  label,
+  onPress,
+  testID,
+}: {
+  label: string
+  onPress: () => void
+  testID: string
+}) {
+  return (
+    <Touchable style={styles.touchableRow} onPress={onPress} testID={testID}>
+      <>
+        <Text style={styles.label}>{label}</Text>
+        <InfoIcon size={14} color={colors.gray4} testID={`${testID}/Icon`} />
+      </>
+    </Touchable>
+  )
+}
+
 export function SwapTransactionDetails({
   networkFee,
   networkFeeInfoBottomSheetRef,
+  slippageInfoBottomSheetRef,
   feeTokenId,
   slippagePercentage,
   fromToken,
@@ -63,26 +87,18 @@ export function SwapTransactionDetails({
       <View style={styles.row} testID="SwapTransactionDetails/NetworkFee">
         {fromToken?.networkId ? (
           <>
-            <Touchable
-              style={styles.touchableRow}
+            <LabelWithInfo
               onPress={() => {
+                ValoraAnalytics.track(SwapEvents.swap_show_info, {
+                  type: SwapShowInfoType.NETWORK_FEE,
+                })
                 networkFeeInfoBottomSheetRef.current?.snapToIndex(0)
               }}
+              label={t('swapScreen.transactionDetails.networkFee', {
+                networkName: NETWORK_NAMES[fromToken.networkId],
+              })}
               testID="SwapTransactionDetails/NetworkFee/MoreInfo"
-            >
-              <>
-                <Text style={styles.label}>
-                  {t('swapScreen.transactionDetails.networkFee', {
-                    networkName: NETWORK_NAMES[fromToken.networkId],
-                  })}
-                </Text>
-                <InfoIcon
-                  size={14}
-                  color={colors.gray4}
-                  testID="SwapTransactionDetails/NetworkFee/MoreInfo/Icon"
-                />
-              </>
-            </Touchable>
+            />
             {!fetchingSwapQuote && networkFee ? (
               <View style={styles.networkFeeContainer}>
                 <TokenDisplay
@@ -123,7 +139,16 @@ export function SwapTransactionDetails({
         </Text>
       </View>
       <View style={styles.row} testID="SwapTransactionDetails/Slippage">
-        <Text style={styles.label}>{t('swapScreen.transactionDetails.slippagePercentage')}</Text>
+        <LabelWithInfo
+          onPress={() => {
+            ValoraAnalytics.track(SwapEvents.swap_show_info, {
+              type: SwapShowInfoType.SLIPPAGE,
+            })
+            slippageInfoBottomSheetRef.current?.snapToIndex(0)
+          }}
+          label={t('swapScreen.transactionDetails.slippagePercentage')}
+          testID="SwapTransactionDetails/Slippage/MoreInfo"
+        />
         <Text style={styles.value}>{`${slippagePercentage}%`}</Text>
       </View>
     </View>


### PR DESCRIPTION
### Description

This PR:
- add an info bottom sheet for slippage tolerance
- add analytics for the info bottom sheets

This was in the [design](https://www.figma.com/file/YxVf7jqvALnHfzr1Vgz5uV/Swap-2.0?node-id=752%3A20371&mode=dev) but I missed it because I was working from an outdated design.

### Test plan

![Simulator Screenshot - iPhone 14 Pro - 2023-12-06 at 10 39 34](https://github.com/valora-inc/wallet/assets/20150449/f48d64fe-3792-4f35-9a8c-e0c8a7678c0a)


### Related issues

- Fixes RET-865

### Backwards compatibility

Y
