### PR TITLE
fix(standby-txs): Setting the failed transactions status correctly.

### DIFF
--- a/src/transactions/reducer.ts
+++ b/src/transactions/reducer.ts
@@ -108,7 +108,7 @@ export const reducer = (
             if (standbyTransaction.context.id === action.txId) {
               return {
                 ...standbyTransaction,
-                status: status ? TransactionStatus.Complete : TransactionStatus.Failed,
+                status: status,
                 transactionHash,
                 block,
                 timestamp: Date.now(),


### PR DESCRIPTION
### Description

In my last [PR](https://github.com/valora-inc/wallet/pull/4580), I introduced a bug.
After the refactor the `status` that the reducer receives is already a `TransactionStatus`. So it was always setting the transactions as `Complete`

### Test plan

Locally in a emulator