### PR TITLE
fix: incorrect color for token sent in homefeed

### DIFF
--- a/src/transactions/feed/TransferFeedItem.tsx
+++ b/src/transactions/feed/TransferFeedItem.tsx
@@ -111,7 +111,7 @@ const styles = StyleSheet.create({
   },
   amount: {
     ...typeScale.labelMedium,
-    color: colors.primary,
+    color: colors.black,
     flexWrap: 'wrap',
     textAlign: 'right',
   },


### PR DESCRIPTION
### Description

This happened because of a careless copy+paste when I aligned the styles for the swap and transfer feed items. The token amount was displayed as green for a "payment sent" homefeed item, when it should have been black.

### Test plan

![Simulator Screenshot - iPhone 14 Pro - 2023-12-06 at 18 37 27](https://github.com/valora-inc/wallet/assets/20150449/363c1717-8f04-42be-a6b6-f8221e390a79)


### Related issues

n/a

### Backwards compatibility

Y
