### PR TITLE
fix: use token ids not addresses accessing test fixture data

### DIFF
--- a/src/exchange/CeloGoldHistoryChart.test.tsx
+++ b/src/exchange/CeloGoldHistoryChart.test.tsx
@@ -4,7 +4,7 @@ import 'react-native'
 import { Provider } from 'react-redux'
 import CeloGoldHistoryChart from 'src/exchange/CeloGoldHistoryChart'
 import { createMockStore, getMockI18nProps } from 'test/utils'
-import { exchangePriceHistory, mockCeloAddress, mockTokenBalances } from 'test/values'
+import { exchangePriceHistory, mockCeloTokenId, mockTokenBalances } from 'test/values'
 
 const SAMPLE_BALANCE = '55.00001'
 
@@ -14,8 +14,8 @@ it('renders without history', () => {
       store={createMockStore({
         tokens: {
           tokenBalances: {
-            [mockCeloAddress]: {
-              ...mockTokenBalances[mockCeloAddress],
+            [mockCeloTokenId]: {
+              ...mockTokenBalances[mockCeloTokenId],
               balance: SAMPLE_BALANCE,
             },
           },
@@ -53,8 +53,8 @@ it('renders while update is in progress', () => {
         },
         tokens: {
           tokenBalances: {
-            [mockCeloAddress]: {
-              ...mockTokenBalances[mockCeloAddress],
+            [mockCeloTokenId]: {
+              ...mockTokenBalances[mockCeloTokenId],
               balance: SAMPLE_BALANCE,
             },
           },
@@ -76,8 +76,8 @@ it('renders properly', () => {
         },
         tokens: {
           tokenBalances: {
-            [mockCeloAddress]: {
-              ...mockTokenBalances[mockCeloAddress],
+            [mockCeloTokenId]: {
+              ...mockTokenBalances[mockCeloTokenId],
               balance: SAMPLE_BALANCE,
             },
           },

--- a/src/exchange/ExchangeHomeScreen.test.tsx
+++ b/src/exchange/ExchangeHomeScreen.test.tsx
@@ -5,24 +5,20 @@ import ExchangeHomeScreen from 'src/exchange/ExchangeHomeScreen'
 import { createMockStore } from 'test/utils'
 import {
   exchangePriceHistory,
-  mockCeloAddress,
-  mockCusdAddress,
+  mockCeloTokenId,
+  mockCusdTokenId,
   mockTokenBalances,
 } from 'test/values'
 
 const store = createMockStore({
   tokens: {
     tokenBalances: {
-      [mockCusdAddress]: {
-        ...mockTokenBalances[mockCusdAddress],
+      [mockCusdTokenId]: {
+        ...mockTokenBalances[mockCusdTokenId],
         balance: '10',
       },
-      [mockCeloAddress]: {
-        ...mockTokenBalances[mockCeloAddress],
-        balance: '2',
-      },
-      [mockCeloAddress]: {
-        ...mockTokenBalances[mockCeloAddress],
+      [mockCeloTokenId]: {
+        ...mockTokenBalances[mockCeloTokenId],
         balance: '2',
       },
     },

--- a/test/values.ts
+++ b/test/values.ts
@@ -568,8 +568,8 @@ export const mockTokenBalancesWithHistoricalPrices = {
       },
     },
   },
-  '0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F': {
-    ...mockTokenBalances['0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F'],
+  [mockCeurTokenId]: {
+    ...mockTokenBalances[mockCeurTokenId],
     historicalPricesUsd: {
       lastDay: {
         price: '1.14',
@@ -577,8 +577,8 @@ export const mockTokenBalancesWithHistoricalPrices = {
       },
     },
   },
-  '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1': {
-    ...mockTokenBalances['0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1'],
+  [mockCusdTokenId]: {
+    ...mockTokenBalances[mockCusdTokenId],
     historicalPricesUsd: {
       lastDay: {
         price: '0.99',


### PR DESCRIPTION
### Description

A few tests imported mockTokenBalances, an object that was refactored on 9/26 to use token IDs as keys instead of addresses, but then assumed that the keys were still addresses.

Evidently, these tests did not actually need overrides passed into createMockStore for the tests to pass. However, I kept the overrides in place (just fixed them) because it reduces the number of dependencies on the exact values in our shared fixture data, which can help for creating new tests down the road. (I don't feel too strongly about this though, and could probably be talked into deleting the overrides instead.)

### Test plan

ci

### Related issues

na

### Backwards compatibility

yes
