### PR TITLE
feat(send): use verification status for showing unknown address info

### DIFF
--- a/src/send/SendSelectRecipient.tsx
+++ b/src/send/SendSelectRecipient.tsx
@@ -202,13 +202,12 @@ function SendSelectRecipient({ route }: Props) {
   const { recipientVerificationStatus, recipient, setSelectedRecipient, unsetSelectedRecipient } =
     useFetchRecipientVerificationStatus()
 
-  // TODO(satish/joe): update condition to not show this if the address
-  // recipient is not a known valora address
   const showUnknownAddressInfo =
     showSendOrInviteButton &&
     showSearchResults &&
-    mergedRecipients.length === 1 &&
-    mergedRecipients[0].recipientType === RecipientType.Address
+    recipient &&
+    recipient.recipientType !== RecipientType.PhoneNumber &&
+    recipientVerificationStatus === RecipientVerificationStatus.UNVERIFIED
 
   const setSelectedRecipientWrapper = (selectedRecipient: Recipient) => {
     setSelectedRecipient(selectedRecipient)


### PR DESCRIPTION
### Description

Builds on #4586, uses the verification status to show the unknown address info notification.

### Test plan


https://github.com/valora-inc/wallet/assets/5062591/cc15480d-2411-4d88-a656-51dee5e051d9



### Related issues

- Fixes ACT-979

### Backwards compatibility

Yes
