### PR TITLE
chore: refactor getting fee currencies from selector instead of hook

### DIFF
--- a/src/fees/hooks.test.tsx
+++ b/src/fees/hooks.test.tsx
@@ -2,10 +2,9 @@ import { render } from '@testing-library/react-native'
 import React from 'react'
 import { Text, View } from 'react-native'
 import { Provider } from 'react-redux'
-import { useFeeCurrencies, useMaxSendAmountByAddress } from 'src/fees/hooks'
+import { useMaxSendAmountByAddress } from 'src/fees/hooks'
 import { FeeType, estimateFee } from 'src/fees/reducer'
 import { RootState } from 'src/redux/reducers'
-import { TokenBalance } from 'src/tokens/slice'
 import { NetworkId } from 'src/transactions/types'
 import { ONE_HOUR_IN_MILLIS } from 'src/utils/time'
 import { RecursivePartial, createMockStore, getElementText } from 'test/utils'
@@ -17,7 +16,6 @@ import {
   mockCeurTokenId,
   mockCusdAddress,
   mockCusdTokenId,
-  mockEthTokenId,
   mockFeeInfo,
 } from 'test/values'
 
@@ -212,90 +210,5 @@ describe('useMaxSendAmountByAddress', () => {
     )
     expect(store.dispatch).not.toHaveBeenCalled()
     expect(getElementText(getByTestId('maxSendAmount'))).toBe('199.996')
-  })
-})
-
-describe(useFeeCurrencies, () => {
-  beforeEach(() => {
-    jest.clearAllMocks()
-  })
-
-  function renderHook(storeOverrides: RecursivePartial<RootState> = {}) {
-    const store = createMockStore({
-      tokens: {
-        tokenBalances: {
-          [mockCusdTokenId]: {
-            address: mockCusdAddress,
-            tokenId: mockCusdTokenId,
-            networkId: NetworkId['celo-alfajores'],
-            symbol: 'cUSD',
-            balance: '200',
-            priceUsd: '1',
-            isFeeCurrency: true,
-            priceFetchedAt: Date.now(),
-          },
-          [mockCeurTokenId]: {
-            address: mockCeurAddress,
-            tokenId: mockCeurTokenId,
-            networkId: NetworkId['celo-alfajores'],
-            symbol: 'cEUR',
-            balance: '0',
-            priceUsd: '1.2',
-            isFeeCurrency: true,
-            priceFetchedAt: Date.now(),
-          },
-          [mockCeloTokenId]: {
-            address: mockCeloAddress,
-            tokenId: mockCeloTokenId,
-            networkId: NetworkId['celo-alfajores'],
-            symbol: 'CELO',
-            balance: '200',
-            priceUsd: '5',
-            isFeeCurrency: true,
-            priceFetchedAt: Date.now(),
-          },
-          [mockEthTokenId]: {
-            tokenId: mockEthTokenId,
-            networkId: NetworkId['ethereum-sepolia'],
-            symbol: 'ETH',
-            balance: '200',
-            priceUsd: '10',
-            isFeeCurrency: true,
-            priceFetchedAt: Date.now(),
-          },
-        },
-      },
-      ...storeOverrides,
-    })
-    store.dispatch = jest.fn()
-
-    const result = jest.fn()
-
-    function TestComponent() {
-      const feeCurrencies = useFeeCurrencies(NetworkId['celo-alfajores'])
-      result(feeCurrencies)
-      return null
-    }
-
-    const tree = render(
-      <Provider store={store}>
-        <TestComponent />
-      </Provider>
-    )
-
-    return {
-      store,
-      result,
-      ...tree,
-    }
-  }
-
-  it('returns feeCurrencies sorted by native currency first, then by USD balance, and balance otherwise', () => {
-    const { result } = renderHook()
-    expect(result.mock.calls[0][0].map((curr: TokenBalance) => curr.tokenId)).toEqual([
-      mockCeloTokenId,
-      mockCusdTokenId,
-      mockCeurTokenId,
-    ])
   })
 })

--- a/src/fees/hooks.ts
+++ b/src/fees/hooks.ts
@@ -1,5 +1,5 @@
 import BigNumber from 'bignumber.js'
-import { useEffect, useMemo } from 'react'
+import { useEffect } from 'react'
 import { useDispatch } from 'react-redux'
 import { FeeType, estimateFee } from 'src/fees/reducer'
 import { fetchFeeCurrency } from 'src/fees/saga'
@@ -10,9 +10,8 @@ import {
   celoAddressSelector,
   tokensByCurrencySelector,
   tokensByUsdBalanceSelector,
-  tokensListSelector,
 } from 'src/tokens/selectors'
-import { Fee, NetworkId, FeeType as TransactionFeeType } from 'src/transactions/types'
+import { Fee, FeeType as TransactionFeeType } from 'src/transactions/types'
 import { Currency } from 'src/utils/currencies'
 import { ONE_HOUR_IN_MILLIS } from 'src/utils/time'
 
@@ -111,41 +110,4 @@ export function useMaxSendAmountByAddress(
 ) {
   const tokenInfo = useTokenInfoByAddress(tokenAddress)
   return useMaxSendAmount(tokenInfo?.tokenId, feeType, shouldRefresh)
-}
-
-/**
- * Returns the list of currencies that can be used to pay fees
- * Sorted by native currency first, then by USD balance, and balance otherwise
- */
-export function useFeeCurrencies(networkId: NetworkId) {
-  const networkTokens = useSelector((state) => tokensListSelector(state, [networkId]))
-
-  const result = useMemo(
-    () =>
-      networkTokens
-        .filter((token) => token.isFeeCurrency || token.isNative)
-        .sort((a, b) => {
-          if (a.isNative && !b.isNative) {
-            return -1
-          }
-          if (b.isNative && !a.isNative) {
-            return 1
-          }
-          if (a.priceUsd && b.priceUsd) {
-            const aBalanceUsd = a.balance.multipliedBy(a.priceUsd)
-            const bBalanceUsd = b.balance.multipliedBy(b.priceUsd)
-            return bBalanceUsd.comparedTo(aBalanceUsd)
-          }
-          if (a.priceUsd) {
-            return -1
-          }
-          if (b.priceUsd) {
-            return 1
-          }
-          return b.balance.comparedTo(a.balance)
-        }),
-    [networkTokens]
-  )
-
-  return result
 }

--- a/src/send/SendEnterAmount.test.tsx
+++ b/src/send/SendEnterAmount.test.tsx
@@ -6,7 +6,6 @@ import { Provider } from 'react-redux'
 import { SendEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import { SendOrigin } from 'src/analytics/types'
-import { useFeeCurrencies } from 'src/fees/hooks'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import { RecipientType } from 'src/recipients/recipient'
@@ -40,6 +39,11 @@ const mockStore = {
   tokens: {
     tokenBalances: {
       ...mockTokenBalances,
+      [mockCeloTokenId]: {
+        ...mockTokenBalances[mockCeloTokenId],
+        priceUsd: '0.5',
+        balance: '0.5',
+      }, // fee currency, matches mockC
       [mockEthTokenId]: {
         tokenId: mockEthTokenId,
         balance: '0',
@@ -103,7 +107,6 @@ describe('SendEnterAmount', () => {
     jest
       .mocked(getNumberFormatSettings)
       .mockReturnValue({ decimalSeparator: '.', groupingSeparator: ',' })
-    jest.mocked(useFeeCurrencies).mockReturnValue(mockFeeCurrencies)
     jest.mocked(usePrepareSendTransactions).mockReturnValue(mockUsePrepareSendTransactionsOutput)
     BigNumber.config({
       FORMAT: {

--- a/src/send/SendEnterAmount.test.tsx
+++ b/src/send/SendEnterAmount.test.tsx
@@ -43,7 +43,7 @@ const mockStore = {
         ...mockTokenBalances[mockCeloTokenId],
         priceUsd: '0.5',
         balance: '0.5',
-      }, // fee currency, matches mockC
+      }, // fee currency, matches mockCeloTokenBalance
       [mockEthTokenId]: {
         tokenId: mockEthTokenId,
         balance: '0',

--- a/src/send/SendEnterAmount.tsx
+++ b/src/send/SendEnterAmount.tsx
@@ -26,7 +26,6 @@ import TokenDisplay from 'src/components/TokenDisplay'
 import Touchable from 'src/components/Touchable'
 import CustomHeader from 'src/components/header/CustomHeader'
 import { MAX_ENCRYPTED_COMMENT_LENGTH_APPROX } from 'src/config'
-import { useFeeCurrencies } from 'src/fees/hooks'
 import DownArrowIcon from 'src/icons/DownArrowIcon'
 import { getLocalCurrencyCode, usdToLocalCurrencyRateSelector } from 'src/localCurrency/selectors'
 import { navigate } from 'src/navigator/NavigationService'
@@ -40,7 +39,10 @@ import Colors from 'src/styles/colors'
 import { typeScale } from 'src/styles/fonts'
 import { Spacing } from 'src/styles/styles'
 import { useTokenToLocalAmount } from 'src/tokens/hooks'
-import { tokensWithNonZeroBalanceAndShowZeroBalanceSelector } from 'src/tokens/selectors'
+import {
+  feeCurrenciesSelector,
+  tokensWithNonZeroBalanceAndShowZeroBalanceSelector,
+} from 'src/tokens/selectors'
 import { TokenBalance } from 'src/tokens/slice'
 import { getSupportedNetworkIdsForSend } from 'src/tokens/utils'
 import Logger from 'src/utils/Logger'
@@ -204,7 +206,8 @@ function SendEnterAmount({ route }: Props) {
   const { feeAmount, feeCurrency } = getFeeCurrencyAndAmount(prepareTransactionsResult)
 
   const walletAddress = useSelector(walletAddressSelector)
-  const feeCurrencies = useFeeCurrencies(token.networkId)
+  const feeCurrencies = useSelector((state) => feeCurrenciesSelector(state, token.networkId))
+
   useEffect(() => {
     if (!walletAddress) {
       Logger.error(TAG, 'Wallet address not set. Cannot refresh prepared transactions.')

--- a/src/swap/useSwapQuote.ts
+++ b/src/swap/useSwapQuote.ts
@@ -1,11 +1,11 @@
 import BigNumber from 'bignumber.js'
 import { useState } from 'react'
 import { useAsyncCallback } from 'react-async-hook'
-import { useSelector } from 'react-redux'
 import erc20 from 'src/abis/IERC20'
-import { useFeeCurrencies } from 'src/fees/hooks'
+import useSelector from 'src/redux/useSelector'
 import { guaranteedSwapPriceEnabledSelector } from 'src/swap/selectors'
 import { FetchQuoteResponse, Field, ParsedSwapAmount, SwapTransaction } from 'src/swap/types'
+import { feeCurrenciesSelector } from 'src/tokens/selectors'
 import { TokenBalance } from 'src/tokens/slice'
 import { NetworkId } from 'src/transactions/types'
 import Logger from 'src/utils/Logger'
@@ -115,8 +115,8 @@ export async function prepareSwapTransactions(
 function useSwapQuote(networkId: NetworkId, slippagePercentage: string) {
   const walletAddress = useSelector(walletAddressSelector)
   const useGuaranteedPrice = useSelector(guaranteedSwapPriceEnabledSelector)
+  const feeCurrencies = useSelector((state) => feeCurrenciesSelector(state, networkId))
   const [exchangeRate, setExchangeRate] = useState<QuoteResult | null>(null)
-  const feeCurrencies = useFeeCurrencies(networkId)
 
   const refreshQuote = useAsyncCallback(
     async (

--- a/src/tokens/selectors.ts
+++ b/src/tokens/selectors.ts
@@ -422,7 +422,6 @@ const feeCurrenciesByNetworkIdSelector = createSelector(
   (state: RootState) => tokensByIdSelector(state, Object.values(NetworkId)),
   (tokens) => {
     const feeCurrenciesByNetworkId: { [key in NetworkId]?: TokenBalance[] } = {}
-
     // collect fee currencies
     Object.values(tokens).forEach((token) => {
       if (token?.isNative || token?.isFeeCurrency) {
@@ -435,28 +434,26 @@ const feeCurrenciesByNetworkIdSelector = createSelector(
 
     // sort the fee currencies by native currency first, then by USD balance, and balance otherwise
     Object.entries(feeCurrenciesByNetworkId).forEach(([networkId, tokens]) => {
-      feeCurrenciesByNetworkId[networkId as NetworkId] = tokens
-        .filter((token) => token.isFeeCurrency || token.isNative)
-        .sort((a, b) => {
-          if (a.isNative && !b.isNative) {
-            return -1
-          }
-          if (b.isNative && !a.isNative) {
-            return 1
-          }
-          if (a.priceUsd && b.priceUsd) {
-            const aBalanceUsd = a.balance.multipliedBy(a.priceUsd)
-            const bBalanceUsd = b.balance.multipliedBy(b.priceUsd)
-            return bBalanceUsd.comparedTo(aBalanceUsd)
-          }
-          if (a.priceUsd) {
-            return -1
-          }
-          if (b.priceUsd) {
-            return 1
-          }
-          return b.balance.comparedTo(a.balance)
-        })
+      feeCurrenciesByNetworkId[networkId as NetworkId] = tokens.sort((a, b) => {
+        if (a.isNative && !b.isNative) {
+          return -1
+        }
+        if (b.isNative && !a.isNative) {
+          return 1
+        }
+        if (a.priceUsd && b.priceUsd) {
+          const aBalanceUsd = a.balance.multipliedBy(a.priceUsd)
+          const bBalanceUsd = b.balance.multipliedBy(b.priceUsd)
+          return bBalanceUsd.comparedTo(aBalanceUsd)
+        }
+        if (a.priceUsd) {
+          return -1
+        }
+        if (b.priceUsd) {
+          return 1
+        }
+        return b.balance.comparedTo(a.balance)
+      })
     })
 
     return feeCurrenciesByNetworkId

--- a/src/tokens/selectors.ts
+++ b/src/tokens/selectors.ts
@@ -418,5 +418,61 @@ export const tokensWithNonZeroBalanceAndShowZeroBalanceSelector = createSelector
       })
 )
 
+const feeCurrenciesByNetworkIdSelector = createSelector(
+  (state: RootState) => tokensByIdSelector(state, Object.values(NetworkId)),
+  (tokens) => {
+    const feeCurrenciesByNetworkId: { [key in NetworkId]?: TokenBalance[] } = {}
+
+    // collect fee currencies
+    Object.values(tokens).forEach((token) => {
+      if (token?.isNative || token?.isFeeCurrency) {
+        feeCurrenciesByNetworkId[token.networkId] = [
+          ...(feeCurrenciesByNetworkId[token.networkId] ?? []),
+          token,
+        ]
+      }
+    })
+
+    // sort the fee currencies by native currency first, then by USD balance, and balance otherwise
+    Object.entries(feeCurrenciesByNetworkId).forEach(([networkId, tokens]) => {
+      feeCurrenciesByNetworkId[networkId as NetworkId] = tokens
+        .filter((token) => token.isFeeCurrency || token.isNative)
+        .sort((a, b) => {
+          if (a.isNative && !b.isNative) {
+            return -1
+          }
+          if (b.isNative && !a.isNative) {
+            return 1
+          }
+          if (a.priceUsd && b.priceUsd) {
+            const aBalanceUsd = a.balance.multipliedBy(a.priceUsd)
+            const bBalanceUsd = b.balance.multipliedBy(b.priceUsd)
+            return bBalanceUsd.comparedTo(aBalanceUsd)
+          }
+          if (a.priceUsd) {
+            return -1
+          }
+          if (b.priceUsd) {
+            return 1
+          }
+          return b.balance.comparedTo(a.balance)
+        })
+    })
+
+    return feeCurrenciesByNetworkId
+  }
+)
+
+// for testing
+export const _feeCurrenciesByNetworkIdSelector = feeCurrenciesByNetworkIdSelector
+
+export const feeCurrenciesSelector = createSelector(
+  feeCurrenciesByNetworkIdSelector,
+  (_state: RootState, networkId: NetworkId) => networkId,
+  (feeCurrencies, networkId) => {
+    return feeCurrencies[networkId] ?? []
+  }
+)
+
 export const visualizeNFTsEnabledInHomeAssetsPageSelector = (state: RootState) =>
   state.app.visualizeNFTsEnabledInHomeAssetsPage


### PR DESCRIPTION
### Description

Pulling this part out of #4585. Currently we have a hook for getting the fee currencies given a network, but for the wallet connect work, we will need to prepare the transactions / get the fee currency from sagas so we need a selector instead. I don't think we need both a selector and a hook, so in this PR I've replaced the existing hook with a selector.

I got a bit of analysis paralysis doing this work so I think there might be a way simpler solution that I've overlooked. I wanted to keep the interface the same - consumers should be able to fetch a list of fee currencies for one networkId, however selectors have only 1 memoized value. The simplest option I could think of was to have 1 (unexported) selector calculate fee currencies for all networks upfront, and then have a selector that returns the fee currencies that consumers actually need. Open to alternative ideas...

### Test plan

Unit tests

### Related issues

- Related to RET-905

### Backwards compatibility

Y
