### PR TITLE
feat(swap): update max fee currency warning

### DIFF
--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -1676,7 +1676,9 @@
     },
     "maxSwapAmountWarning": {
       "title": "Swapping the MAX amount",
-      "body": "Make sure you have {{tokenSymbol}} in your wallet to cover gas fees for future transactions",
+      "titleV1_74": "Swapping the MAX amount",
+      "body": "Make sure you have CELO in your wallet to cover gas fees for future transactions",
+      "bodyV1_74": "Make sure you have {{tokenSymbol}} in your wallet to cover gas fees for future transactions",
       "learnMore": "Learn more"
     },
     "priceImpactWarning": {

--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -1676,7 +1676,7 @@
     },
     "maxSwapAmountWarning": {
       "title": "Swapping the MAX amount",
-      "body": "Make sure you have CELO in your wallet to cover gas fees for future transactions",
+      "body": "Make sure you have {{tokenSymbol}} in your wallet to cover gas fees for future transactions",
       "learnMore": "Learn more"
     },
     "priceImpactWarning": {

--- a/src/swap/SwapScreen.test.tsx
+++ b/src/swap/SwapScreen.test.tsx
@@ -697,14 +697,16 @@ describe('SwapScreen', () => {
     expect(getByText('swapScreen.confirmSwap')).not.toBeDisabled()
   })
 
-  it('should show and hide the max warning', async () => {
+  it('should show and hide the max warning for fee currencies', async () => {
     mockFetch.mockResponse(defaultQuoteResponse)
     const { swapFromContainer, getByText, getByTestId, queryByTestId, tokenBottomSheet } =
       renderScreen({ celoBalance: '0', cUSDBalance: '10' }) // so that cUSD is the only feeCurrency with a balance
 
-    selectToken(swapFromContainer, 'CELO', tokenBottomSheet)
+    selectToken(swapFromContainer, 'cUSD', tokenBottomSheet)
     fireEvent.press(getByTestId('SwapAmountInput/MaxButton'))
-    await waitFor(() => expect(getByTestId('MaxSwapAmountWarning')).toBeTruthy())
+    await waitFor(() =>
+      expect(getByText('swapScreen.maxSwapAmountWarning.body, {"tokenSymbol":"cUSD"}')).toBeTruthy()
+    )
 
     fireEvent.press(getByText('swapScreen.maxSwapAmountWarning.learnMore'))
     expect(navigate).toHaveBeenCalledWith(Screens.WebViewScreen, {
@@ -715,7 +717,7 @@ describe('SwapScreen', () => {
     await waitFor(() => expect(queryByTestId('MaxSwapAmountWarning')).toBeFalsy())
   })
 
-  it("shouldn't show the max warning when there's balance for more than 1 feeCurrency", async () => {
+  it("shouldn't show the max warning when there's balance for more than 1 fee currency", async () => {
     mockFetch.mockResponse(defaultQuoteResponse)
     const { swapFromContainer, getByTestId, queryByTestId, tokenBottomSheet } = renderScreen({
       celoBalance: '10',

--- a/src/swap/SwapScreen.test.tsx
+++ b/src/swap/SwapScreen.test.tsx
@@ -705,7 +705,9 @@ describe('SwapScreen', () => {
     selectToken(swapFromContainer, 'cUSD', tokenBottomSheet)
     fireEvent.press(getByTestId('SwapAmountInput/MaxButton'))
     await waitFor(() =>
-      expect(getByText('swapScreen.maxSwapAmountWarning.body, {"tokenSymbol":"cUSD"}')).toBeTruthy()
+      expect(
+        getByText('swapScreen.maxSwapAmountWarning.bodyV1_74, {"tokenSymbol":"cUSD"}')
+      ).toBeTruthy()
     )
 
     fireEvent.press(getByText('swapScreen.maxSwapAmountWarning.learnMore'))

--- a/src/swap/SwapScreen.test.tsx
+++ b/src/swap/SwapScreen.test.tsx
@@ -699,12 +699,12 @@ describe('SwapScreen', () => {
 
   it('should show and hide the max warning', async () => {
     mockFetch.mockResponse(defaultQuoteResponse)
-    const { swapFromContainer, getByText, getByTestId, queryByText, tokenBottomSheet } =
-      renderScreen({})
+    const { swapFromContainer, getByText, getByTestId, queryByTestId, tokenBottomSheet } =
+      renderScreen({ celoBalance: '0', cUSDBalance: '10' }) // so that cUSD is the only feeCurrency with a balance
 
     selectToken(swapFromContainer, 'CELO', tokenBottomSheet)
     fireEvent.press(getByTestId('SwapAmountInput/MaxButton'))
-    await waitFor(() => expect(getByText('swapScreen.maxSwapAmountWarning.body')).toBeTruthy())
+    await waitFor(() => expect(getByTestId('MaxSwapAmountWarning')).toBeTruthy())
 
     fireEvent.press(getByText('swapScreen.maxSwapAmountWarning.learnMore'))
     expect(navigate).toHaveBeenCalledWith(Screens.WebViewScreen, {
@@ -712,7 +712,19 @@ describe('SwapScreen', () => {
     })
 
     fireEvent.changeText(within(swapFromContainer).getByTestId('SwapAmountInput/Input'), '1.234')
-    await waitFor(() => expect(queryByText('swapScreen.maxSwapAmountWarning.body')).toBeFalsy())
+    await waitFor(() => expect(queryByTestId('MaxSwapAmountWarning')).toBeFalsy())
+  })
+
+  it("shouldn't show the max warning when there's balance for more than 1 feeCurrency", async () => {
+    mockFetch.mockResponse(defaultQuoteResponse)
+    const { swapFromContainer, getByTestId, queryByTestId, tokenBottomSheet } = renderScreen({
+      celoBalance: '10',
+      cUSDBalance: '20',
+    })
+
+    selectToken(swapFromContainer, 'CELO', tokenBottomSheet)
+    fireEvent.press(getByTestId('SwapAmountInput/MaxButton'))
+    await waitFor(() => expect(queryByTestId('MaxSwapAmountWarning')).toBeFalsy())
   })
 
   it('should fetch the quote if the amount is cleared and re-entered', async () => {
@@ -1096,7 +1108,7 @@ describe('SwapScreen', () => {
       swapToContainer,
       swapFromContainer,
       tokenBottomSheet,
-    } = renderScreen({})
+    } = renderScreen({ cUSDBalance: '0' })
 
     // First get a quote for a network
     selectToken(swapFromContainer, 'CELO', tokenBottomSheet)

--- a/src/swap/SwapScreen.tsx
+++ b/src/swap/SwapScreen.tsx
@@ -643,8 +643,10 @@ export function SwapScreen({ route }: Props) {
           {showMaxSwapAmountWarning && (
             <InLineNotification
               severity={Severity.Warning}
-              title={t('swapScreen.maxSwapAmountWarning.title', { tokenSymbol: fromToken?.symbol })}
-              description={t('swapScreen.maxSwapAmountWarning.body', {
+              title={t('swapScreen.maxSwapAmountWarning.titleV1_74', {
+                tokenSymbol: fromToken?.symbol,
+              })}
+              description={t('swapScreen.maxSwapAmountWarning.bodyV1_74', {
                 tokenSymbol: fromToken?.symbol,
               })}
               ctaLabel={t('swapScreen.maxSwapAmountWarning.learnMore')}

--- a/src/swap/SwapScreen.tsx
+++ b/src/swap/SwapScreen.tsx
@@ -46,7 +46,7 @@ import { swapStart, swapStartPrepared } from 'src/swap/slice'
 import { Field, SwapAmount } from 'src/swap/types'
 import useSwapQuote, { QuoteResult } from 'src/swap/useSwapQuote'
 import { useSwappableTokens, useTokenInfo } from 'src/tokens/hooks'
-import { tokensByIdSelector } from 'src/tokens/selectors'
+import { feeCurrenciesSelector, tokensByIdSelector } from 'src/tokens/selectors'
 import { TokenBalance } from 'src/tokens/slice'
 import { getSupportedNetworkIdsForSwap, getTokenId } from 'src/tokens/utils'
 import { NetworkId } from 'src/transactions/types'
@@ -88,6 +88,18 @@ function getNetworkFee(quote: QuoteResult | null, networkId?: NetworkId) {
     networkFee: feeAmount,
     feeTokenId: feeCurrency?.tokenId ?? getTokenId(networkId ?? networkConfig.defaultNetworkId), // native token
   }
+}
+
+function useFeeCurrenciesWithBalances(networkId: NetworkId) {
+  const feeCurrencies = useSelector((state) => feeCurrenciesSelector(state, networkId))
+
+  const feeCurrenciesWithBalances = useMemo(() => {
+    return feeCurrencies.filter((feeCurrency) => {
+      return feeCurrency.balance.isGreaterThan(0)
+    })
+  }, [feeCurrencies])
+
+  return feeCurrenciesWithBalances
 }
 
 export function SwapScreen({ route }: Props) {
@@ -147,6 +159,10 @@ export function SwapScreen({ route }: Props) {
   // TODO: Check the user has enough balance in native tokens to pay for the gas fee
 
   const fromTokenBalance = useTokenInfo(fromToken?.tokenId)?.balance ?? new BigNumber(0)
+
+  const feeCurrenciesWithBalances = useFeeCurrenciesWithBalances(
+    fromToken?.networkId || networkConfig.defaultNetworkId
+  )
 
   const { exchangeRate, refreshQuote, fetchSwapQuoteError, fetchingSwapQuote, clearQuote } =
     useSwapQuote(fromToken?.networkId || networkConfig.defaultNetworkId, slippagePercentage)
@@ -217,12 +233,6 @@ export function SwapScreen({ route }: Props) {
       clearTimeout(debouncedRefreshQuote)
     }
   }, [fromToken, toToken, parsedSwapAmount, updatedField, exchangeRate])
-
-  useEffect(() => {
-    if (shouldShowMaxSwapAmountWarning && fromToken?.symbol !== 'CELO') {
-      setShouldShowMaxSwapAmountWarning(false)
-    }
-  }, [fromToken, shouldShowMaxSwapAmountWarning])
 
   useEffect(
     () => {
@@ -300,7 +310,7 @@ export function SwapScreen({ route }: Props) {
 
     if (parsedSwapAmount[Field.FROM].gt(fromTokenBalance)) {
       setFromSwapAmountError(true)
-      showMaxCeloSwapWarning()
+      hideOrShowMaxFeeCurrencySwapWarning(fromToken)
       dispatch(showError(t('swapScreen.insufficientFunds', { token: fromToken.symbol })))
       return
     }
@@ -481,6 +491,7 @@ export function SwapScreen({ route }: Props) {
     setFromToken(newFromToken)
     setToToken(newToToken)
     setSwitchedToNetworkId(newSwitchedToNetworkId)
+    hideOrShowMaxFeeCurrencySwapWarning(shouldShowMaxSwapAmountWarning ? newFromToken : undefined)
 
     if (newSwitchedToNetworkId) {
       clearQuote()
@@ -525,7 +536,7 @@ export function SwapScreen({ route }: Props) {
         decimalSeparator,
       }),
     }))
-    showMaxCeloSwapWarning()
+    hideOrShowMaxFeeCurrencySwapWarning(fromToken)
     if (!fromToken) {
       // Should never happen
       return
@@ -537,10 +548,11 @@ export function SwapScreen({ route }: Props) {
     })
   }
 
-  const showMaxCeloSwapWarning = () => {
-    if (fromToken?.symbol === 'CELO') {
-      setShouldShowMaxSwapAmountWarning(true)
-    }
+  const hideOrShowMaxFeeCurrencySwapWarning = (fromToken: TokenBalance | undefined) => {
+    setShouldShowMaxSwapAmountWarning(
+      feeCurrenciesWithBalances.length === 1 &&
+        fromToken?.tokenId === feeCurrenciesWithBalances[0].tokenId
+    )
   }
 
   const onPressLearnMore = () => {
@@ -640,8 +652,10 @@ export function SwapScreen({ route }: Props) {
           {showMaxSwapAmountWarning && (
             <InLineNotification
               severity={Severity.Warning}
-              title={t('swapScreen.maxSwapAmountWarning.title')}
-              description={t('swapScreen.maxSwapAmountWarning.body')}
+              title={t('swapScreen.maxSwapAmountWarning.title', { tokenSymbol: fromToken?.symbol })}
+              description={t('swapScreen.maxSwapAmountWarning.body', {
+                tokenSymbol: fromToken?.symbol,
+              })}
               ctaLabel={t('swapScreen.maxSwapAmountWarning.learnMore')}
               style={styles.warning}
               onPressCta={onPressLearnMoreFees}

--- a/src/tokens/selectors.ts
+++ b/src/tokens/selectors.ts
@@ -35,6 +35,10 @@ export type CurrencyTokens = {
   [currency in Currency]: TokenBalanceWithAddress | undefined
 }
 
+// This is somewhat arbitrary, but appears to reliably prevent recalculation
+// for selectors using networkId as a parameter
+const DEFAULT_MEMOIZE_MAX_SIZE = 10
+
 function isNetworkIdList(networkIds: any): networkIds is NetworkId[] {
   return (
     networkIds.constructor === Array &&
@@ -79,7 +83,7 @@ export const tokensByIdSelector = createSelector(
         }
         return previousValue === currentValue
       },
-      maxSize: 10, // This is somewhat arbitrary, but appears to reliably prevent recalculation
+      maxSize: DEFAULT_MEMOIZE_MAX_SIZE,
     },
   }
 )
@@ -468,6 +472,19 @@ export const feeCurrenciesSelector = createSelector(
   (_state: RootState, networkId: NetworkId) => networkId,
   (feeCurrencies, networkId) => {
     return feeCurrencies[networkId] ?? []
+  }
+)
+
+// Note this takes a networkId as parameter
+export const feeCurrenciesWithPositiveBalancesSelector = createSelector(
+  feeCurrenciesSelector,
+  (feeCurrencies) => {
+    return feeCurrencies.filter((token) => token.balance.gt(0))
+  },
+  {
+    memoizeOptions: {
+      maxSize: DEFAULT_MEMOIZE_MAX_SIZE,
+    },
   }
 )
 


### PR DESCRIPTION
### Description

This shows the MAX amount warning for ETH too.

Also it tweaks the logic on Celo, so it only displays the warning if there's only 1 fee currency with a balance.
For instance if the user only has cUSD and tries to swap the MAX amount of cUSD, the warning is also shown.

### Test plan

- Updated tests
- Manual tests:

|  **before**  | **after**   |
|---|---|
| ![image](https://github.com/valora-inc/wallet/assets/57791/05eabaa4-551d-4f45-9ece-384ca8c0f369)   |  ![image](https://github.com/valora-inc/wallet/assets/57791/ff25f66b-ca98-4e5a-bc77-f9fe6d763fee) |

Warning when only cUSD is left to pay for gas and MAX amount is chosen:

<img src="https://github.com/valora-inc/wallet/assets/57791/c958c58d-cf2b-4b05-8cc0-9dd3a281746a" width="50%" />

### Related issues

- Fixes RET-946

### Backwards compatibility

Yes
