### PR TITLE
fix(viem): Fix Viem gas estimation bug

### DIFF
--- a/src/viem/prepareTransactions.ts
+++ b/src/viem/prepareTransactions.ts
@@ -17,6 +17,7 @@ import {
   TransactionRequestBase,
   TransactionRequestEIP1559,
   encodeFunctionData,
+  InvalidInputRpcError,
 } from 'viem'
 import { estimateGas } from 'viem/actions'
 
@@ -121,7 +122,9 @@ export async function tryEstimateTransaction({
       e instanceof EstimateGasExecutionError &&
       (e.cause instanceof InsufficientFundsError ||
         (e.cause instanceof ExecutionRevertedError && // viem does not reliably label node errors as InsufficientFundsError when the user has enough to pay for the transfer, but not for the transfer + gas
-          /transfer value exceeded balance of sender/.test(e.cause.details)))
+          /transfer value exceeded balance of sender/.test(e.cause.details)) ||
+        (e.cause instanceof InvalidInputRpcError &&
+          /gas required exceeds allowance/.test(e.cause.details)))
     ) {
       // too much gas was needed
       Logger.warn(TAG, `Couldn't estimate gas with feeCurrency ${feeCurrencySymbol}`, e)


### PR DESCRIPTION
### Description

Previously, in cases where we were attempting to estimate gas for a TX where `gas + amount > balance`, we would _throw_ rather than returning a null estimation. This had the downstream effect of causing the gas estimation on the SendEnterAmount screen to spin forever, _without_ a warning to the user telling them to enter a lower amount. This change catches that case, and sets the gas estimate to null, causing the appropriate warning to appear to the user.

### Test plan

Manual and unit tested. See video below:

https://github.com/valora-inc/wallet/assets/569401/e012637f-45fd-4ad6-87a8-03cf8319d0b5


### Related issues

N/A

### Backwards compatibility

Yes