### PR TITLE
fix(send): Assorted Send recipient bugfixes

### DIFF
--- a/src/recipients/recipient.test.ts
+++ b/src/recipients/recipient.test.ts
@@ -82,6 +82,9 @@ describe('getRecipientVerificationStatus', () => {
       expect(getRecipientVerificationStatus(recipient, {}, { [recipient.address]: false })).toEqual(
         RecipientVerificationStatus.UNVERIFIED
       )
+      expect(
+        getRecipientVerificationStatus(recipient, {}, { [recipient.address]: undefined })
+      ).toEqual(RecipientVerificationStatus.UNKNOWN)
       expect(getRecipientVerificationStatus(recipient, {}, {})).toEqual(
         RecipientVerificationStatus.UNKNOWN
       )

--- a/src/recipients/recipient.test.ts
+++ b/src/recipients/recipient.test.ts
@@ -1,6 +1,18 @@
 import { MinimalContact } from 'react-native-contacts'
-import { contactsToRecipients, sortRecipients } from 'src/recipients/recipient'
-import { mockRecipient, mockRecipient2, mockRecipient3 } from 'test/values'
+import { RecipientVerificationStatus } from 'src/identity/types'
+import {
+  contactsToRecipients,
+  getRecipientVerificationStatus,
+  sortRecipients,
+} from 'src/recipients/recipient'
+import {
+  mockAccount,
+  mockAddressRecipient,
+  mockInvitableRecipient,
+  mockRecipient,
+  mockRecipient2,
+  mockRecipient3,
+} from 'test/values'
 
 describe('contactsToRecipients', () => {
   it('returns a recipient per phone number', () => {
@@ -55,5 +67,44 @@ describe('Recipient sorting', () => {
       mockRecipient2,
       mockRecipient,
     ])
+  })
+})
+
+describe('getRecipientVerificationStatus', () => {
+  describe.each([
+    { recipient: mockAddressRecipient, type: 'without phone number' },
+    { recipient: mockRecipient, type: 'with phone number' },
+  ])('address recipient $type', ({ recipient }) => {
+    it('returns appropriate status', () => {
+      expect(getRecipientVerificationStatus(recipient, {}, { [recipient.address]: true })).toEqual(
+        RecipientVerificationStatus.VERIFIED
+      )
+      expect(getRecipientVerificationStatus(recipient, {}, { [recipient.address]: false })).toEqual(
+        RecipientVerificationStatus.UNVERIFIED
+      )
+      expect(getRecipientVerificationStatus(recipient, {}, {})).toEqual(
+        RecipientVerificationStatus.UNKNOWN
+      )
+    })
+  })
+
+  it('returns appropriate status for phone recipient', () => {
+    expect(
+      getRecipientVerificationStatus(
+        mockInvitableRecipient,
+        { [mockInvitableRecipient.e164PhoneNumber]: [mockAccount] },
+        {}
+      )
+    ).toEqual(RecipientVerificationStatus.VERIFIED)
+    expect(
+      getRecipientVerificationStatus(
+        mockInvitableRecipient,
+        { [mockInvitableRecipient.e164PhoneNumber]: null },
+        {}
+      )
+    ).toEqual(RecipientVerificationStatus.UNVERIFIED)
+    expect(getRecipientVerificationStatus(mockInvitableRecipient, {}, {})).toEqual(
+      RecipientVerificationStatus.UNKNOWN
+    )
   })
 })

--- a/src/recipients/recipient.ts
+++ b/src/recipients/recipient.ts
@@ -6,8 +6,8 @@ import { formatShortenedAddress } from 'src/components/ShortenedAddress'
 import {
   AddressToDisplayNameType,
   AddressToE164NumberType,
-  E164NumberToAddressType,
   AddressToVerificationStatus,
+  E164NumberToAddressType,
 } from 'src/identity/reducer'
 import { RecipientVerificationStatus } from 'src/identity/types'
 import Logger from 'src/utils/Logger'
@@ -178,20 +178,7 @@ export function getRecipientVerificationStatus(
   e164NumberToAddress: E164NumberToAddressType,
   addressToVerificationStatus: AddressToVerificationStatus
 ): RecipientVerificationStatus {
-  if (!recipientHasNumber(recipient)) {
-    if (recipientHasAddress(recipient) && recipient.address in addressToVerificationStatus) {
-      switch (addressToVerificationStatus[recipient.address]) {
-        case true:
-          return RecipientVerificationStatus.VERIFIED
-        case false:
-          return RecipientVerificationStatus.UNVERIFIED
-        case undefined:
-          return RecipientVerificationStatus.UNKNOWN
-      }
-    } else {
-      return RecipientVerificationStatus.UNKNOWN
-    }
-  } else {
+  if (recipient.recipientType === RecipientType.PhoneNumber && recipientHasNumber(recipient)) {
     const addresses = e164NumberToAddress[recipient.e164PhoneNumber]
     if (addresses === undefined) {
       return RecipientVerificationStatus.UNKNOWN
@@ -202,6 +189,18 @@ export function getRecipientVerificationStatus(
     }
 
     return RecipientVerificationStatus.VERIFIED
+  }
+  if (recipientHasAddress(recipient) && recipient.address in addressToVerificationStatus) {
+    switch (addressToVerificationStatus[recipient.address]) {
+      case true:
+        return RecipientVerificationStatus.VERIFIED
+      case false:
+        return RecipientVerificationStatus.UNVERIFIED
+      case undefined:
+        return RecipientVerificationStatus.UNKNOWN
+    }
+  } else {
+    return RecipientVerificationStatus.UNKNOWN
   }
 }
 

--- a/src/recipients/recipient.ts
+++ b/src/recipients/recipient.ts
@@ -178,6 +178,7 @@ export function getRecipientVerificationStatus(
   e164NumberToAddress: E164NumberToAddressType,
   addressToVerificationStatus: AddressToVerificationStatus
 ): RecipientVerificationStatus {
+  // phone recipients should always have a number, the extra check is to ensure typing
   if (recipient.recipientType === RecipientType.PhoneNumber && recipientHasNumber(recipient)) {
     const addresses = e164NumberToAddress[recipient.e164PhoneNumber]
     if (addresses === undefined) {

--- a/src/send/SendSelectRecipient.tsx
+++ b/src/send/SendSelectRecipient.tsx
@@ -153,7 +153,7 @@ function SendOrInviteButton({
     !!recipient && recipientVerificationStatus === RecipientVerificationStatus.UNKNOWN
   const shouldInviteRecipient =
     !sendOrInviteButtonDisabled &&
-    !!recipient?.e164PhoneNumber &&
+    recipient?.recipientType === RecipientType.PhoneNumber &&
     recipientVerificationStatus === RecipientVerificationStatus.UNVERIFIED
   return (
     <Button

--- a/src/send/hooks.ts
+++ b/src/send/hooks.ts
@@ -17,6 +17,7 @@ import { defaultCountryCodeSelector } from 'src/account/selectors'
 import { useTranslation } from 'react-i18next'
 import { NameResolution, ResolutionKind } from '@valora/resolve-kit'
 import { resolveId } from 'src/recipients/RecipientPicker'
+import { phoneNumberVerifiedSelector } from 'src/app/selectors'
 
 const TYPING_DEBOUNCE_MILLSECONDS = 300
 const SEARCH_THROTTLE_TIME = 100
@@ -114,10 +115,11 @@ export function useResolvedRecipients(searchQuery: string): Recipient[] {
  * Returns recent and contact recipients from Redux.
  */
 export function useSendRecipients() {
+  const phoneNumberVerified = useSelector(phoneNumberVerifiedSelector)
   const contactsCache = useSelector(phoneRecipientCacheSelector)
   const contactRecipients = useMemo(
-    () => sortRecipients(Object.values(contactsCache)),
-    [contactsCache]
+    () => sortRecipients(phoneNumberVerified ? Object.values(contactsCache) : []),
+    [contactsCache, phoneNumberVerified]
   )
   const recentRecipients = useSelector((state) => state.send.recentRecipients)
   return {

--- a/src/send/useFetchRecipientVerificationStatus.ts
+++ b/src/send/useFetchRecipientVerificationStatus.ts
@@ -6,7 +6,7 @@ import {
   addressToVerificationStatusSelector,
 } from 'src/identity/selectors'
 import { RecipientVerificationStatus } from 'src/identity/types'
-import { getRecipientVerificationStatus, Recipient } from 'src/recipients/recipient'
+import { getRecipientVerificationStatus, Recipient, RecipientType } from 'src/recipients/recipient'
 import useSelector from 'src/redux/useSelector'
 import { getFeatureGate } from 'src/statsig'
 import { StatsigFeatureGates } from 'src/statsig/types'
@@ -36,7 +36,10 @@ const useFetchRecipientVerificationStatus = () => {
     setRecipient(selectedRecipient)
     setRecipientVerificationStatus(RecipientVerificationStatus.UNKNOWN)
 
-    if (selectedRecipient?.e164PhoneNumber) {
+    if (
+      selectedRecipient.recipientType === RecipientType.PhoneNumber &&
+      selectedRecipient.e164PhoneNumber
+    ) {
       dispatch(fetchAddressesAndValidate(selectedRecipient.e164PhoneNumber))
     } else if (selectedRecipient?.address) {
       if (

--- a/src/send/useFetchRecipientVerificationStatus.ts
+++ b/src/send/useFetchRecipientVerificationStatus.ts
@@ -36,6 +36,7 @@ const useFetchRecipientVerificationStatus = () => {
     setRecipient(selectedRecipient)
     setRecipientVerificationStatus(RecipientVerificationStatus.UNKNOWN)
 
+    // phone recipients should always have a number, the extra check is to ensure typing
     if (
       selectedRecipient.recipientType === RecipientType.PhoneNumber &&
       selectedRecipient.e164PhoneNumber


### PR DESCRIPTION
### Description

This PR adjusts the behavior of recipients on the Send flow in order to fix a handful of bugs. Really, it's trading in very undesirable behavior for somewhat less undesirable behavior.

Functionally, this fixes the following issues:

* Fixes an issue where you revoke your phone number and can no longer send to addresses associated with phone numbers that were previously cached on your device. Searching for such an address now will allow you to send to that address.
* Fixes V icon behavior with recipients from above.
* If your phone number becomes unlinked, we do _not_ show contact recipients anywhere. Since contact recipients are always considered `RecipientType.PhoneNumber`, we would always attempt to perform a CPV lookup, which we _cannot do_ since the user's wallet is unlinked. If you happened to send to a contact before revoking your phone number such that that contact has become a recent recipient, you can still send to that recent recipient via the fix from the first bullet. 

Some potential issues/buggy behavior that still exist after these changes:

 - You have a PN cached that maps to some address A
   - Address A is revoked from PN mapping OR your revoke your phone number
 - You search address A
 - RecipientType.Address recipient appears, as a phone number line item
 - Pressing on the recipient will kick off an address verification lookup
   - This will either fail because address A has been revoked OR fail because /you/ revoked your phone number
 - Valora V will be removed from phone number item if present
 - "unknown address" warning will appear at bottom

also:

- Send to a phone number, so it becomes a recent recipient and stores PN -> address A in cache
- That phone number is revoked
- Searching for a prefix of address A will show the recent (PN) recipient from above
  - Pressing this will show an "invite" button, despite there being an address associated with that recent recipient
  - (Searching for the full address A will yield a resolved address recipient, which we /can/ send to - same case as bug above)
- However, pressing the recent recipient from the initial `SendSelectRecipient` screen will take you straight to `SendEnterAmount` since we skip the extra button press for the list of recent recipients


### Test plan

Unit tests, manually

Searching for addresses connected to phone number, first address is still connected, second is no longer connected

| Before | After |
|--------|--------|
| <video src="https://github.com/valora-inc/wallet/assets/5062591/8ca4b979-c130-439f-a5b0-4d2ad9e9c62e" /> | <video src="https://github.com/valora-inc/wallet/assets/5062591/6fe671ea-eb7e-4800-bf3a-7690b1949eb7" /> | 

Searching for contact with phone unverified, but contacts previously shared


| Before | After |
|--------|--------|
| <video src="https://github.com/valora-inc/wallet/assets/5062591/1fd610bb-1191-4783-9a3f-4ce612a6d39c" /> | <video src="https://github.com/valora-inc/wallet/assets/5062591/b8f4d3c7-a3c3-465d-87f0-eb91a18b5207" /> | 

### Related issues

- Part of ACT-971

### Backwards compatibility

Yes
