### PR TITLE
feat: add supported networks to navigation drawer

### DIFF
--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -265,6 +265,9 @@
   "confirmTransaction": "Confirm transaction",
   "allow": "Allow",
   "address": "Wallet Address",
+  "supportedNetwork": "Supported Network: {{network}}",
+  "supportedNetworks": "Supported Networks: {{networks}}",
+  "and": "and",
   "phoneNumber": "Phone Number",
   "transaction": {
     "operation": "Operation",

--- a/src/components/AccountNumber.tsx
+++ b/src/components/AccountNumber.tsx
@@ -70,7 +70,7 @@ const styles = StyleSheet.create({
   text: {
     ...fontStyles.small,
     color: colors.gray4,
-    marginVertical: 8,
+    marginBottom: 8,
   },
   link: {
     ...fontStyles.label,

--- a/src/components/__snapshots__/AccountNumber.test.tsx.snap
+++ b/src/components/__snapshots__/AccountNumber.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`AccountNumber renders correctly when touch disabled 1`] = `
       "fontFamily": "Inter-Regular",
       "fontSize": 14,
       "lineHeight": 18,
-      "marginVertical": 8,
+      "marginBottom": 8,
     }
   }
   testID="AccountNumber"
@@ -62,7 +62,7 @@ exports[`AccountNumber renders correctly when touch enabled 1`] = `
         "fontFamily": "Inter-Regular",
         "fontSize": 14,
         "lineHeight": 18,
-        "marginVertical": 8,
+        "marginBottom": 8,
       }
     }
     testID="AccountNumber"

--- a/src/navigator/DrawerNavigator.test.tsx
+++ b/src/navigator/DrawerNavigator.test.tsx
@@ -3,7 +3,8 @@ import * as React from 'react'
 import 'react-native'
 import { Provider } from 'react-redux'
 import DrawerNavigator from 'src/navigator/DrawerNavigator'
-import { getExperimentParams, getFeatureGate } from 'src/statsig'
+import { getDynamicConfigParams, getExperimentParams, getFeatureGate } from 'src/statsig'
+import { NetworkId } from 'src/transactions/types'
 import MockedNavigator from 'test/MockedNavigator'
 import { createMockStore } from 'test/utils'
 
@@ -193,6 +194,45 @@ describe('DrawerNavigator', () => {
       )
 
       expect(queryByText('+1 302-306-1234')).toBeFalsy()
+    })
+  })
+
+  describe('network display', () => {
+    const testCases = [
+      {
+        testName: 'one network',
+        showBalances: [NetworkId['celo-alfajores']],
+        expectedText: 'supportedNetwork, {"network":"Celo Alfajores"}',
+      },
+      {
+        testName: 'two networks',
+        showBalances: [NetworkId['celo-alfajores'], NetworkId['ethereum-sepolia']],
+        expectedText: 'supportedNetworks, {"networks":"Celo Alfajores and Ethereum Sepolia"}',
+      },
+      {
+        testName: 'three networks',
+        showBalances: [
+          NetworkId['celo-mainnet'],
+          NetworkId['ethereum-sepolia'],
+          NetworkId['celo-alfajores'],
+        ],
+        expectedText: 'supportedNetworks, {"networks":"Celo, Ethereum Sepolia and Celo Alfajores"}',
+      },
+    ]
+
+    it.each(testCases)('shows $testName correctly', ({ showBalances, expectedText }) => {
+      jest.mocked(getDynamicConfigParams).mockReturnValue({
+        showBalances,
+      })
+
+      const store = createMockStore({})
+      const { getByText } = render(
+        <Provider store={store}>
+          <MockedNavigator component={DrawerNavigator}></MockedNavigator>
+        </Provider>
+      )
+
+      expect(getByText(expectedText)).toBeTruthy()
     })
   })
 })

--- a/src/navigator/DrawerNavigator.tsx
+++ b/src/navigator/DrawerNavigator.tsx
@@ -195,9 +195,7 @@ function CustomDrawerContent(props: DrawerContentComponentProps) {
         <Text style={styles.supportedNetworks}>
           {networks.length > 1
             ? t('supportedNetworks', {
-                networks: [networkNames.slice(0, -1).join(', '), networkNames.at(-1)].join(
-                  ` ${t('and')} `
-                ),
+                networks: `${networkNames.slice(0, -1).join(', ')} ${t('and')} ${networkNames.at(-1)}`,
               })
             : t('supportedNetwork', {
                 network: networkNames[0],

--- a/src/navigator/DrawerNavigator.tsx
+++ b/src/navigator/DrawerNavigator.tsx
@@ -63,9 +63,11 @@ import { getExperimentParams, getFeatureGate } from 'src/statsig'
 import { ExperimentConfigs } from 'src/statsig/constants'
 import { StatsigExperiments, StatsigFeatureGates } from 'src/statsig/types'
 import colors from 'src/styles/colors'
-import fontStyles from 'src/styles/fonts'
+import fontStyles, { typeScale } from 'src/styles/fonts'
 import { Spacing } from 'src/styles/styles'
+import { getSupportedNetworkIdsForTokenBalances } from 'src/tokens/utils'
 import Logger from 'src/utils/Logger'
+import { networkIdToNetworkDisplayName } from 'src/web3/networkConfig'
 import { currentAccountSelector } from 'src/web3/selectors'
 
 const TAG = 'NavigationService'
@@ -163,6 +165,8 @@ function CustomDrawerContent(props: DrawerContentComponentProps) {
   const account = useSelector(currentAccountSelector)
   const appVersion = deviceInfoModule.getVersion()
   const phoneNumberVerified = useSelector(phoneNumberVerifiedSelector)
+  const networks = getSupportedNetworkIdsForTokenBalances()
+  const networkNames = networks.map((network) => networkIdToNetworkDisplayName[network])
 
   return (
     <DrawerContentScrollView {...props}>
@@ -188,6 +192,17 @@ function CustomDrawerContent(props: DrawerContentComponentProps) {
       <View style={styles.drawerBottom}>
         <Text style={fontStyles.label}>{t('address')}</Text>
         <AccountNumber address={account || ''} location={Screens.DrawerNavigator} />
+        <Text style={styles.supportedNetworks}>
+          {networks.length > 1
+            ? t('supportedNetworks', {
+                networks: [networkNames.slice(0, -1).join(', '), networkNames.at(-1)].join(
+                  ` ${t('and')} `
+                ),
+              })
+            : t('supportedNetwork', {
+                network: networkNames[0],
+              })}
+        </Text>
         <Text style={styles.smallLabel}>{t('version', { appVersion })}</Text>
       </View>
     </DrawerContentScrollView>
@@ -370,6 +385,10 @@ const styles = StyleSheet.create({
     ...fontStyles.small,
     color: colors.gray4,
     marginTop: 32,
+  },
+  supportedNetworks: {
+    ...typeScale.bodyXSmall,
+    color: colors.gray3,
   },
   itemStyle: {
     marginLeft: -20,

--- a/src/navigator/DrawerNavigator.tsx
+++ b/src/navigator/DrawerNavigator.tsx
@@ -59,6 +59,7 @@ import { Screens } from 'src/navigator/Screens'
 import { StackParamList } from 'src/navigator/types'
 import NftGallery from 'src/nfts/NftGallery'
 import { default as useSelector } from 'src/redux/useSelector'
+import { NETWORK_NAMES } from 'src/shared/conts'
 import { getExperimentParams, getFeatureGate } from 'src/statsig'
 import { ExperimentConfigs } from 'src/statsig/constants'
 import { StatsigExperiments, StatsigFeatureGates } from 'src/statsig/types'
@@ -67,7 +68,6 @@ import fontStyles, { typeScale } from 'src/styles/fonts'
 import { Spacing } from 'src/styles/styles'
 import { getSupportedNetworkIdsForTokenBalances } from 'src/tokens/utils'
 import Logger from 'src/utils/Logger'
-import { networkIdToNetworkDisplayName } from 'src/web3/networkConfig'
 import { currentAccountSelector } from 'src/web3/selectors'
 
 const TAG = 'NavigationService'
@@ -166,7 +166,7 @@ function CustomDrawerContent(props: DrawerContentComponentProps) {
   const appVersion = deviceInfoModule.getVersion()
   const phoneNumberVerified = useSelector(phoneNumberVerifiedSelector)
   const networks = getSupportedNetworkIdsForTokenBalances()
-  const networkNames = networks.map((network) => networkIdToNetworkDisplayName[network])
+  const networkNames = networks.map((network) => NETWORK_NAMES[network])
 
   return (
     <DrawerContentScrollView {...props}>

--- a/src/navigator/DrawerNavigator.tsx
+++ b/src/navigator/DrawerNavigator.tsx
@@ -380,11 +380,12 @@ const styles = StyleSheet.create({
   drawerBottom: {
     marginVertical: 32,
     marginHorizontal: 16,
+    gap: Spacing.Smallest8,
   },
   smallLabel: {
     ...fontStyles.small,
     color: colors.gray4,
-    marginTop: 32,
+    marginTop: 24,
   },
   supportedNetworks: {
     ...typeScale.bodyXSmall,

--- a/src/navigator/DrawerNavigator.tsx
+++ b/src/navigator/DrawerNavigator.tsx
@@ -195,7 +195,9 @@ function CustomDrawerContent(props: DrawerContentComponentProps) {
         <Text style={styles.supportedNetworks}>
           {networks.length > 1
             ? t('supportedNetworks', {
-                networks: `${networkNames.slice(0, -1).join(', ')} ${t('and')} ${networkNames.at(-1)}`,
+                networks: `${networkNames.slice(0, -1).join(', ')} ${t('and')} ${networkNames.at(
+                  -1
+                )}`,
               })
             : t('supportedNetwork', {
                 network: networkNames[0],

--- a/src/web3/networkConfig.ts
+++ b/src/web3/networkConfig.ts
@@ -384,13 +384,6 @@ export const networkIdToNetwork: NetworkIdToNetwork = {
   [NetworkId['ethereum-sepolia']]: Network.Ethereum,
 }
 
-export const networkIdToNetworkDisplayName: Record<NetworkId, string> = {
-  [NetworkId['celo-mainnet']]: 'Celo',
-  [NetworkId['celo-alfajores']]: 'Celo Alfajores',
-  [NetworkId['ethereum-mainnet']]: 'Ethereum',
-  [NetworkId['ethereum-sepolia']]: 'Ethereum Sepolia',
-}
-
 export const networkIdToWalletConnectChainId: Record<NetworkId, string> = {
   [NetworkId['celo-alfajores']]: 'eip155:44787',
   [NetworkId['celo-mainnet']]: 'eip155:42220',

--- a/src/web3/networkConfig.ts
+++ b/src/web3/networkConfig.ts
@@ -384,6 +384,13 @@ export const networkIdToNetwork: NetworkIdToNetwork = {
   [NetworkId['ethereum-sepolia']]: Network.Ethereum,
 }
 
+export const networkIdToNetworkDisplayName: Record<NetworkId, string> = {
+  [NetworkId['celo-mainnet']]: 'Celo',
+  [NetworkId['celo-alfajores']]: 'Celo Alfajores',
+  [NetworkId['ethereum-mainnet']]: 'Ethereum',
+  [NetworkId['ethereum-sepolia']]: 'Ethereum Sepolia',
+}
+
 export const networkIdToWalletConnectChainId: Record<NetworkId, string> = {
   [NetworkId['celo-alfajores']]: 'eip155:44787',
   [NetworkId['celo-mainnet']]: 'eip155:42220',


### PR DESCRIPTION
### Description

Adds the supported networks in the drawer navigator also some minor spacing adjustments to match the mocks.

| iOS One Network | iOS Two Networks | iOS Three Networks | iOS Three Networks Large Font |
| ----- | ----- | ----- | ----- |
| ![](https://github.com/valora-inc/wallet/assets/26950305/4030a3ed-243d-461b-aa17-739d025eb268 "iOS One Network") | ![](https://github.com/valora-inc/wallet/assets/26950305/fc3abdfa-13b7-4cdd-aaeb-7237832fe1ac "iOS Two Networks") | ![](https://github.com/valora-inc/wallet/assets/26950305/db3c0141-98e6-434d-aa54-c0f6ceb64830 "iOS Three Networks") | ![](https://github.com/valora-inc/wallet/assets/26950305/90b99277-f264-457c-bd38-161bcdcdc363 "iOS Three Networks Large Font") |

### Test plan

- Tested locally on iOS
- Unit tests added

### Related issues

- Fixes ACT-1001

### Backwards compatibility

Yes