### PR TITLE
chore(renovate): allow updating node

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -32,6 +32,11 @@
       prPriority: 2,
     },
     {
+      // Allow renovate to update node
+      matchDepTypes: ['engines'],
+      enabled: true,
+    },
+    {
       // Group devDependencies updates
       matchDepTypes: ['devDependencies'],
       groupName: 'devDependencies',

--- a/renovate.json5
+++ b/renovate.json5
@@ -35,6 +35,8 @@
       // Allow renovate to update node
       matchDepTypes: ['engines'],
       enabled: true,
+      // a bit higher priority for node updates
+      prPriority: 3,
     },
     {
       // Group devDependencies updates


### PR DESCRIPTION
### Description

This tweaks our revonate config to allow updating node automatically.
This should keep us on the current LTS version for now (node 20.x, and not 21.x). But I'll make sure it's the case.

Note: it's disabled in our [shared config](https://github.com/valora-inc/renovate-config/blob/27a6002970c6bfe4a04be4837a9f16b75f089d9e/base.json5#L52-L56) as it could cause issues in other projects which may not support newly released node versions soon after they are released (for instance GCP not supporting the latest node patch update directly). And the node version being used in production is set in the workflow. But maybe we could improve that too.
