### PR TITLE
fix: look up the recipient DEK, not your own DEK

### DIFF
--- a/src/web3/dataEncryptionKey.test.ts
+++ b/src/web3/dataEncryptionKey.test.ts
@@ -42,7 +42,7 @@ describe('doFetchDataEncryptionKey', () => {
 
     expect(mockFetch).toHaveBeenCalledTimes(1)
     expect(mockFetch).toHaveBeenCalledWith(
-      `${networkConfig.getPublicDEKUrl}?address=0xbcd&clientPlatform=android&clientVersion=0.0.1`,
+      `${networkConfig.getPublicDEKUrl}?address=0xabc&clientPlatform=android&clientVersion=0.0.1`,
       {
         method: 'GET',
         headers: {


### PR DESCRIPTION
### Description

previously, anyone who sent with a comment after verifying their own phone number with CPV would erroneously encrypt the comment with their own DEK, rather than that of the recipient. The comment appeared as "Comment Unavailable" for the recipient, who failed to decode it.

### Test plan

- fixed unit test that will now provide regression coverage
- manually tested. sent a transaction from a wallet with a verified phone number and confirmed it can be decoded now by another wallet (and that it is still encoded on chain). tx is here https://celoscan.io/tx/0xe766b83c0798880aa233b74da1a0c1a3c9c7296f97119d869d6ee15bba29635d . 

### Related issues

na

### Backwards compatibility

na