### PR TITLE
fix(logs): logs sometimes cannot be attached

### DIFF
--- a/src/account/zendesk.test.ts
+++ b/src/account/zendesk.test.ts
@@ -4,9 +4,33 @@ import { ZENDESK_API_KEY } from 'src/config'
 
 const mockFetch = fetch as FetchMock
 
-jest.mock('src/utils/readFile', () => ({
-  readFileChunked: jest.fn((filepath) => Promise.resolve(`${filepath} contents`)),
-}))
+async function areBlobsEqual(blob1: Blob, blob2: Blob) {
+  return !Buffer.from(await blob1.arrayBuffer()).compare(Buffer.from(await blob2.arrayBuffer()))
+}
+
+expect.extend({
+  async toEqualBlob(received, expected) {
+    const pass = await areBlobsEqual(received, expected)
+    const message = () =>
+      this.utils.printDiffOrStringify(expected, received, 'Expected', 'Received', true)
+    return {
+      message,
+      pass,
+    }
+  },
+})
+
+interface CustomMatchers<R = unknown> {
+  toEqualBlob(blob: Blob): R
+}
+
+declare global {
+  namespace jest {
+    interface Matchers<R> extends CustomMatchers<R> {}
+    interface InverseAsymmetricMatchers extends CustomMatchers {}
+  }
+}
+
 describe('Zendesk', () => {
   beforeEach(() => {
     mockFetch.resetMocks()
@@ -37,15 +61,25 @@ describe('Zendesk', () => {
       userName: 'foo',
       subject: 'subject of ticket',
     }
-    mockFetch.mockResponseOnce(JSON.stringify({ upload: { token: 'uploadToken' } }), {
-      status: 201,
-    })
-    mockFetch.mockResponseOnce(JSON.stringify({ upload: { token: 'uploadToken2' } }), {
-      status: 201,
+    mockFetch.mockResponse(async (req) => {
+      switch (req.url) {
+        case 'file://path1/':
+          return 'path1 contents'
+        case 'file://path2/':
+          return 'path2 contents'
+        case 'https://valoraapp.zendesk.com/api/v2/uploads.json?filename=name1&binary=false':
+          return { status: 201, body: JSON.stringify({ upload: { token: 'uploadToken' } }) }
+        case 'https://valoraapp.zendesk.com/api/v2/uploads.json?filename=name2&binary=false':
+          return { status: 201, body: JSON.stringify({ upload: { token: 'uploadToken2' } }) }
+        case 'https://valoraapp.zendesk.com/api/v2/requests':
+          return JSON.stringify({ request: { id: 1234 } })
+        default:
+          throw new Error(`unexpected url: ${req.url}`)
+      }
     })
 
     await sendSupportRequest(args)
-    expect(mockFetch.mock.calls.length).toEqual(3)
+    expect(mockFetch.mock.calls.length).toEqual(5)
     expect(mockFetch).toHaveBeenCalledWith(
       'https://valoraapp.zendesk.com/api/v2/uploads.json?filename=name1&binary=false',
       {
@@ -56,9 +90,15 @@ describe('Zendesk', () => {
             `${args.userEmail}/token:${ZENDESK_API_KEY}`
           ).toString('base64')}`,
         },
-        body: 'path1 contents',
+        body: expect.anything(),
       }
     )
+
+    const callName1 = mockFetch.mock.calls.find(
+      (call) =>
+        call[0] === 'https://valoraapp.zendesk.com/api/v2/uploads.json?filename=name1&binary=false'
+    )
+    expect(callName1?.[1]?.body).toEqualBlob(new Blob(['path1 contents']))
 
     expect(mockFetch).toHaveBeenCalledWith(
       'https://valoraapp.zendesk.com/api/v2/uploads.json?filename=name2&binary=false',
@@ -70,9 +110,15 @@ describe('Zendesk', () => {
             `${args.userEmail}/token:${ZENDESK_API_KEY}`
           ).toString('base64')}`,
         },
-        body: 'path2 contents',
+        body: expect.anything(),
       }
     )
+
+    const callName2 = mockFetch.mock.calls.find(
+      (call) =>
+        call[0] === 'https://valoraapp.zendesk.com/api/v2/uploads.json?filename=name2&binary=false'
+    )
+    expect(callName2?.[1]?.body).toEqualBlob(new Blob(['path2 contents']))
 
     expect(mockFetch).toHaveBeenCalledWith('https://valoraapp.zendesk.com/api/v2/requests', {
       method: 'POST',

--- a/src/account/zendesk.test.ts
+++ b/src/account/zendesk.test.ts
@@ -20,14 +20,12 @@ expect.extend({
   },
 })
 
-interface CustomMatchers<R = unknown> {
-  toEqualBlob(blob: Blob): R
-}
-
 declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace jest {
-    interface Matchers<R> extends CustomMatchers<R> {}
-    interface InverseAsymmetricMatchers extends CustomMatchers {}
+    interface Matchers<R> {
+      toEqualBlob(blob: Blob): R
+    }
   }
 }
 

--- a/src/account/zendesk.test.ts
+++ b/src/account/zendesk.test.ts
@@ -10,12 +10,10 @@ async function areBlobsEqual(blob1: Blob, blob2: Blob) {
 
 expect.extend({
   async toEqualBlob(received, expected) {
-    const pass = await areBlobsEqual(received, expected)
-    const message = () =>
-      this.utils.printDiffOrStringify(expected, received, 'Expected', 'Received', true)
     return {
-      message,
-      pass,
+      message: () =>
+        this.utils.printDiffOrStringify(expected, received, 'Expected', 'Received', true),
+      pass: await areBlobsEqual(received, expected),
     }
   },
 })

--- a/src/account/zendesk.ts
+++ b/src/account/zendesk.ts
@@ -1,6 +1,5 @@
 import { ZENDESK_API_KEY } from 'src/config'
 import Logger from 'src/utils/Logger'
-import { readFileChunked } from 'src/utils/readFile'
 
 const ZENDESK_PROJECT_NAME = 'valoraapp'
 
@@ -152,7 +151,9 @@ async function _uploadFile(
   { path, name }: { path: string; type: string; name: string },
   userEmail: string
 ) {
-  const blob = await readFileChunked(path)
+  // This reads the file into a blob, the actual data is kept on the native side
+  // and is not copied into JS memory, which is good for large files.
+  const blob = await fetch(`file://${path}`).then((r) => r.blob())
   const uploadFileResponse = await fetch(
     `https://${ZENDESK_PROJECT_NAME}.zendesk.com/api/v2/uploads.json?filename=${name}&binary=false`,
     {


### PR DESCRIPTION
### Description

This should fix logs failing to be attached when sent to Zendesk.

Instead of using `react-native-fs` to read the logs in chunk, we now create a `Blob` which is kept on the native side,
then it's uploaded. 
The advantage is the data doesn't need to be copied in JS memory and we should avoid the utf8 read error.
So more performant and will work better with large files.

Note: I noticed my log files are rather large (30-40MB!), we should address this too. Either by compressing or reducing the unnecessary noise they contain.

### Test plan

- Updated unit tests
- Manually tested

### Related issues

- Fixes RET-948

### Backwards compatibility

Yes
