### PR TITLE
refactor(swap): data structures simplifications

### DIFF
--- a/src/analytics/Properties.tsx
+++ b/src/analytics/Properties.tsx
@@ -1262,12 +1262,19 @@ interface SwapEvent {
   fromToken: string | null | undefined
   fromTokenId: string
   fromTokenNetworkId: string
+  /**
+   * Starting with v1.74, this amount is always in decimal format
+   * Before that it was in token smallest unit or decimal format depending on the event.
+   */
   amount: string | null
   amountType: 'buyAmount' | 'sellAmount'
 }
 
 type SwapQuoteEvent = SwapEvent & {
   allowanceTarget: string
+  /**
+   * In percentage, between 0 and 100
+   */
   estimatedPriceImpact: string | null
   price: string
   provider: string
@@ -1381,7 +1388,7 @@ interface SwapEventsProperties {
   [SwapEvents.swap_learn_more]: undefined
   [SwapEvents.swap_price_impact_warning_displayed]: SwapEvent & {
     provider: string
-    priceImpact?: string
+    priceImpact: string | null
   }
   [SwapEvents.swap_show_info]: {
     type: SwapShowInfoType

--- a/src/firebase/firebase.ts
+++ b/src/firebase/firebase.ts
@@ -355,7 +355,8 @@ export async function fetchRemoteConfigValues(): Promise<RemoteConfigValues | nu
     twelveWordMnemonicEnabled: flags.twelveWordMnemonicEnabled.asBoolean(),
     dappsMinimalDisclaimerEnabled: flags.dappsMinimalDisclaimerEnabled.asBoolean(),
     guaranteedSwapPriceEnabled: flags.guaranteedSwapPriceEnabled.asBoolean(),
-    priceImpactWarningThreshold: flags.priceImpactWarningThreshold.asNumber(),
+    // Convert to percentage, so we're consistent with the price impact value returned by our swap API
+    priceImpactWarningThreshold: flags.priceImpactWarningThreshold.asNumber() * 100,
     superchargeRewardContractAddress: flags.superchargeRewardContractAddress.asString(),
   }
 }

--- a/src/redux/migrations.test.ts
+++ b/src/redux/migrations.test.ts
@@ -39,6 +39,7 @@ import {
   v171Schema,
   v172Schema,
   v174Schema,
+  v175Schema,
   v17Schema,
   v18Schema,
   v1Schema,
@@ -1476,5 +1477,14 @@ describe('Redux persist migrations', () => {
     expect(moolaToken).not.toHaveProperty('isCoreToken')
     expect(moolaToken).not.toHaveProperty('isFeeCurrency')
     expect(moolaToken).not.toHaveProperty('canTransferWithComment')
+  })
+
+  it('works from 175 to 176', () => {
+    const oldSchema = v175Schema
+    const migratedSchema = migrations[176](oldSchema)
+    const expectedSchema: any = _.cloneDeep(oldSchema)
+    expectedSchema.swap.priceImpactWarningThreshold =
+      expectedSchema.swap.priceImpactWarningThreshold * 100
+    expect(migratedSchema).toStrictEqual(expectedSchema)
   })
 })

--- a/src/redux/migrations.ts
+++ b/src/redux/migrations.ts
@@ -1473,4 +1473,13 @@ export const migrations = {
       }),
     },
   }),
+  176: (state: any) => ({
+    ...state,
+    swap: {
+      ...state.swap,
+      ...(state.swap.priceImpactWarningThreshold && {
+        priceImpactWarningThreshold: state.swap.priceImpactWarningThreshold * 100,
+      }),
+    },
+  }),
 }

--- a/src/redux/store.test.ts
+++ b/src/redux/store.test.ts
@@ -98,7 +98,7 @@ describe('store state', () => {
       {
         "_persist": {
           "rehydrated": true,
-          "version": 175,
+          "version": 176,
         },
         "account": {
           "acceptedTerms": false,
@@ -331,7 +331,7 @@ describe('store state', () => {
         "swap": {
           "currentSwap": null,
           "guaranteedSwapPriceEnabled": false,
-          "priceImpactWarningThreshold": 0.04,
+          "priceImpactWarningThreshold": 4,
         },
         "tokens": {
           "error": false,

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -23,7 +23,7 @@ const persistConfig: PersistConfig<RootState> = {
   key: 'root',
   // default is -1, increment as we make migrations
   // See https://github.com/valora-inc/wallet/tree/main/WALLET.md#redux-state-migration
-  version: 175,
+  version: 176,
   keyPrefix: `reduxStore-`, // the redux-persist default is `persist:` which doesn't work with some file systems.
   storage: FSStorage(),
   blacklist: ['networkInfo', 'alert', 'imports', 'keylessBackup'],

--- a/src/swap/SwapScreen.test.tsx
+++ b/src/swap/SwapScreen.test.tsx
@@ -457,7 +457,7 @@ describe('SwapScreen', () => {
         fromTokenNetworkId: NetworkId['celo-alfajores'],
         amount: '100000',
         amountType: 'sellAmount',
-        priceImpact: '0.052',
+        priceImpact: '5.2',
         provider: 'someProvider',
       }
     )
@@ -531,7 +531,7 @@ describe('SwapScreen', () => {
         fromTokenNetworkId: NetworkId['celo-alfajores'],
         amount: '100000',
         amountType: 'sellAmount',
-        priceImpact: undefined,
+        priceImpact: null,
         provider: 'someProvider',
       }
     )
@@ -844,7 +844,10 @@ describe('SwapScreen', () => {
           quote: {
             preparedTransactions,
             receivedAt: quoteReceivedTimestamp,
-            rawSwapResponse: defaultQuote as any,
+            price: defaultQuote.unvalidatedSwapTransaction.price,
+            provider: defaultQuote.details.swapProvider,
+            estimatedPriceImpact: defaultQuote.unvalidatedSwapTransaction.estimatedPriceImpact,
+            allowanceTarget: defaultQuote.unvalidatedSwapTransaction.allowanceTarget,
           },
           userInput: {
             toTokenId: mockCusdTokenId,
@@ -894,7 +897,10 @@ describe('SwapScreen', () => {
           quote: {
             preparedTransactions: [preparedTransactions[1]], // no approval transaction
             receivedAt: expect.any(Number),
-            rawSwapResponse: expect.any(Object),
+            price: defaultQuote.unvalidatedSwapTransaction.price,
+            provider: defaultQuote.details.swapProvider,
+            estimatedPriceImpact: defaultQuote.unvalidatedSwapTransaction.estimatedPriceImpact,
+            allowanceTarget: defaultQuote.unvalidatedSwapTransaction.allowanceTarget,
           },
           userInput: {
             toTokenId: mockCeloTokenId,
@@ -938,7 +944,10 @@ describe('SwapScreen', () => {
           quote: {
             preparedTransactions,
             receivedAt: quoteReceivedTimestamp,
-            rawSwapResponse: defaultQuote as any,
+            price: defaultQuote.unvalidatedSwapTransaction.price,
+            provider: defaultQuote.details.swapProvider,
+            estimatedPriceImpact: defaultQuote.unvalidatedSwapTransaction.estimatedPriceImpact,
+            allowanceTarget: defaultQuote.unvalidatedSwapTransaction.allowanceTarget,
           },
           userInput: {
             toTokenId: mockCusdTokenId,

--- a/src/swap/SwapScreen.tsx
+++ b/src/swap/SwapScreen.tsx
@@ -237,7 +237,7 @@ export function SwapScreen({ route }: Props) {
 
       if (
         !exchangeRate.estimatedPriceImpact ||
-        exchangeRate.estimatedPriceImpact.gte(priceImpactWarningThreshold)
+        new BigNumber(exchangeRate.estimatedPriceImpact).gte(priceImpactWarningThreshold)
       ) {
         ValoraAnalytics.track(SwapEvents.swap_price_impact_warning_displayed, {
           toToken: toToken.address,
@@ -248,7 +248,7 @@ export function SwapScreen({ route }: Props) {
           fromTokenNetworkId: fromToken?.networkId,
           amount: parsedSwapAmount[updatedField].toString(),
           amountType: updatedField === Field.FROM ? 'sellAmount' : 'buyAmount',
-          priceImpact: exchangeRate.estimatedPriceImpact?.toString(),
+          priceImpact: exchangeRate.estimatedPriceImpact,
           provider: exchangeRate.provider,
         })
       }
@@ -290,8 +290,7 @@ export function SwapScreen({ route }: Props) {
     }
 
     const swapAmountParam = updatedField === Field.FROM ? 'sellAmount' : 'buyAmount'
-    const { estimatedPriceImpact, price, allowanceTarget } =
-      exchangeRate.rawSwapResponse.unvalidatedSwapTransaction
+    const { estimatedPriceImpact, price, allowanceTarget } = exchangeRate
 
     const resultType = exchangeRate.preparedTransactions.type
     switch (resultType) {
@@ -331,7 +330,10 @@ export function SwapScreen({ route }: Props) {
                 exchangeRate.preparedTransactions.transactions
               ),
               receivedAt: exchangeRate.receivedAt,
-              rawSwapResponse: exchangeRate.rawSwapResponse,
+              price: exchangeRate.price,
+              provider: exchangeRate.provider,
+              estimatedPriceImpact,
+              allowanceTarget,
             },
             userInput,
           })
@@ -486,7 +488,9 @@ export function SwapScreen({ route }: Props) {
   const showPriceImpactWarning =
     !confirmSwapFailed &&
     !exchangeRateUpdatePending &&
-    !!exchangeRate?.estimatedPriceImpact?.gte(priceImpactWarningThreshold)
+    (exchangeRate?.estimatedPriceImpact
+      ? new BigNumber(exchangeRate.estimatedPriceImpact).gte(priceImpactWarningThreshold)
+      : false)
   const showMissingPriceImpactWarning =
     !confirmSwapFailed &&
     !exchangeRateUpdatePending &&

--- a/src/swap/slice.ts
+++ b/src/swap/slice.ts
@@ -14,13 +14,16 @@ interface SwapTask {
 export interface State {
   currentSwap: SwapTask | null
   guaranteedSwapPriceEnabled: boolean
+  /**
+   * In percentage, between 0 and 100
+   */
   priceImpactWarningThreshold: number
 }
 
 const initialState: State = {
   currentSwap: null,
   guaranteedSwapPriceEnabled: false,
-  priceImpactWarningThreshold: 0.04,
+  priceImpactWarningThreshold: 4, // 4% by default
 }
 
 function updateCurrentSwapStatus(currentSwap: SwapTask | null, swapId: string, status: SwapStatus) {

--- a/src/swap/types.ts
+++ b/src/swap/types.ts
@@ -37,7 +37,6 @@ export interface SwapTransaction {
    */
   estimatedPriceImpact: string | null
   gas: string
-  gasPrice: string
   to: string
   value: string
   data: string

--- a/src/swap/types.ts
+++ b/src/swap/types.ts
@@ -65,7 +65,10 @@ export interface SwapTransaction {
   data: string
   decodedUniqueId: string
   estimatedGas: string
-  estimatedPriceImpact: string
+  /**
+   * In percentage, between 0 and 100
+   */
+  estimatedPriceImpact: string | null
   expectedSlippage: string | null
   from: string
   gas: string
@@ -97,10 +100,10 @@ export interface SwapInfo {
   quote: {
     preparedTransactions: SerializableTransactionRequest[]
     receivedAt: number
-    /**
-     * @deprecated Temporary until we remove the swap review screen
-     */
-    rawSwapResponse: FetchQuoteResponse
+    price: string
+    provider: string
+    estimatedPriceImpact: string | null
+    allowanceTarget: string
   }
 }
 

--- a/src/swap/types.ts
+++ b/src/swap/types.ts
@@ -23,75 +23,26 @@ export interface SwapUserInput {
   updatedField: Field
 }
 
-interface Fill {
-  adjustedOutput: string
-  gas: number
-  input: string
-  outPut: string
-}
-
-interface FillData {
-  router: string
-  tokenAddress: Array<string>
-  makerAmount?: string
-  makerToken?: string
-  takerAmount?: string
-  takerToken?: string
-  type?: number
-}
-
-interface Order {
-  type: number
-  source: string
-  makerToken: string
-  takeToken: string
-  makerAmount: string
-  takerAmount: string
-  fill: Fill
-  fillData: FillData
-}
-
-interface Source {
-  name: string
-  proportion: string
-}
-
 export interface SwapTransaction {
-  allowanceTarget: string
-  buyAmount: string
-  buyTokenAddress: string
-  buyTokenToEthRate: string
   chainId: number
-  data: string
-  decodedUniqueId: string
-  estimatedGas: string
+  buyAmount: string
+  sellAmount: string
+  buyTokenAddress: string
+  sellTokenAddress: string
+  // be careful -- price means different things when using sellAmount vs buyAmount
+  price: string
+  guaranteedPrice: string
   /**
    * In percentage, between 0 and 100
    */
   estimatedPriceImpact: string | null
-  expectedSlippage: string | null
-  from: string
   gas: string
   gasPrice: string
-  guaranteedPrice: string
-  minimumProtocolFee: string
-  orders: Array<Order>
-  // be careful -- price means different things when using sellAmount vs buyAmount
-  price: string
-  protocolFee: string
-  sellAmount: string
-  sellTokenAddress: string
-  sellTokenToEthRate: string
-  sources: Array<Source>
   to: string
   value: string
-}
-export interface ApproveTransaction {
-  chainId: number
   data: string
   from: string
-  gas: string
-  to: string
+  allowanceTarget: string
 }
 
 export interface SwapInfo {
@@ -108,7 +59,6 @@ export interface SwapInfo {
 }
 
 export interface FetchQuoteResponse {
-  approveTransaction: ApproveTransaction
   unvalidatedSwapTransaction: SwapTransaction
   details: {
     swapProvider: string

--- a/src/swap/useSwapQuote.ts
+++ b/src/swap/useSwapQuote.ts
@@ -29,12 +29,9 @@ export interface QuoteResult {
   swapAmount: BigNumber
   price: string
   provider: string
-  estimatedPriceImpact: BigNumber | null
+  estimatedPriceImpact: string | null
+  allowanceTarget: string
   preparedTransactions: PreparedTransactionsResult
-  /**
-   * @deprecated Temporary until we remove the swap review screen
-   */
-  rawSwapResponse: FetchQuoteResponse
   receivedAt: number
 }
 
@@ -197,13 +194,10 @@ function useSwapQuote(networkId: NetworkId, slippagePercentage: string) {
         fromTokenId: fromToken.tokenId,
         swapAmount: swapAmount[updatedField],
         price,
-
         provider: quote.details.swapProvider,
-        estimatedPriceImpact: estimatedPriceImpact
-          ? new BigNumber(estimatedPriceImpact).dividedBy(100)
-          : null,
+        estimatedPriceImpact,
+        allowanceTarget: quote.unvalidatedSwapTransaction.allowanceTarget,
         preparedTransactions,
-        rawSwapResponse: quote,
         receivedAt: Date.now(),
       }
 

--- a/test/RootStateSchema.json
+++ b/test/RootStateSchema.json
@@ -3818,6 +3818,7 @@
                     "type": "boolean"
                 },
                 "priceImpactWarningThreshold": {
+                    "description": "In percentage, between 0 and 100",
                     "type": "number"
                 }
             },

--- a/test/schemas.ts
+++ b/test/schemas.ts
@@ -2892,6 +2892,18 @@ export const v175Schema = {
   },
 }
 
+export const v176Schema = {
+  ...v175Schema,
+  _persist: {
+    ...v175Schema._persist,
+    version: 176,
+  },
+  swap: {
+    ...v175Schema.swap,
+    priceImpactWarningThreshold: v175Schema.swap.priceImpactWarningThreshold * 100,
+  },
+}
+
 export function getLatestSchema(): Partial<RootState> {
-  return v175Schema as Partial<RootState>
+  return v176Schema as Partial<RootState>
 }


### PR DESCRIPTION
### Description

This refactors swaps to simplify a few things around the data structures used.

It contains the following changes:
- stop passing and using `rawSwapResponse`
  - instead we pass the fields that are needed
- made `estimatedPriceImpact` consistent by being always between 0 and 100
  - previously the unit was either between 0 and 1 or 0 and 100 depending on the swap event
- made the swap `amount` analytics property always decimal
  - previously it was either in token smallest unit or in decimal depending on the event
- the standby in/out values are now the same as what we display in the swap screen
  - it doesn't use the `guaranteedPrice` anymore, we should use `guaranteedSwapPriceEnabled` if we want to avoid surprises, or make it the default as @kathaypacific is proposing in [this thread](https://valora-app.slack.com/archives/C029Z1QMD7B/p1697017573119649?thread_ts=1697017142.969239&cid=C029Z1QMD7B).
- sync'ed the `SwapTransaction` type with [our API](https://github.com/valora-inc/valora-rest-api/blob/14e7ab9a1514aaf724be2b8964e05bdcc09ca434/src/swaps/providers/types.ts#L32-L53)
  - there were a bunch of fields we didn't use or were only for 0x

### Test plan

- Updated tests

### Related issues

- Fixes RET-950

### Backwards compatibility

Yes. Except some analytics properties unit were made consistent:
- `estimatedPriceImpact` now always between 0 and 100
- `amount` now always in decimal
