### PR TITLE
chore(supercharge): skip fetching rewards for empty wallets

### DIFF
--- a/src/consumerIncentives/saga.test.ts
+++ b/src/consumerIncentives/saga.test.ts
@@ -25,23 +25,16 @@ import {
 } from 'src/consumerIncentives/testValues'
 import { SuperchargePendingReward } from 'src/consumerIncentives/types'
 import { navigateHome } from 'src/navigator/NavigationService'
-import { tokensByAddressSelector } from 'src/tokens/selectors'
+import { tokensByAddressSelector, tokensWithTokenBalanceSelector } from 'src/tokens/selectors'
 import { Actions as TransactionActions } from 'src/transactions/actions'
 import { sendTransaction } from 'src/transactions/send'
-import { NetworkId } from 'src/transactions/types'
 import { fetchWithTimeout } from 'src/utils/fetchWithTimeout'
 import { getContractKit } from 'src/web3/contracts'
-import config from 'src/web3/networkConfig'
+import { default as config, default as networkConfig } from 'src/web3/networkConfig'
 import { getConnectedUnlockedAccount } from 'src/web3/saga'
 import { walletAddressSelector } from 'src/web3/selectors'
 import { createMockStore } from 'test/utils'
-import {
-  mockAccount,
-  mockCeurAddress,
-  mockCeurTokenId,
-  mockCusdAddress,
-  mockCusdTokenId,
-} from 'test/values'
+import { mockAccount, mockCeurAddress, mockCusdAddress } from 'test/values'
 
 const mockBaseNonce = 10
 
@@ -183,27 +176,10 @@ describe('fetchAvailableRewardsSaga', () => {
 
   it('skips fetching rewards in absence of tokens with sufficient balance', async () => {
     await expectSaga(fetchAvailableRewardsSaga, fetchAvailableRewards())
-      .withState(
-        createMockStore({
-          tokens: {
-            tokenBalances: {
-              [mockCusdAddress]: {
-                networkId: NetworkId['celo-alfajores'],
-                tokenId: mockCusdTokenId,
-                balance: '0',
-              },
-              [mockCeurAddress]: {
-                networkId: NetworkId['celo-alfajores'],
-                tokenId: mockCeurTokenId,
-                balance: '0.00000001', // balance must be greater than this
-              },
-            },
-          },
-        }).getState()
-      )
       .provide([
-        [select(phoneNumberVerifiedSelector), true],
         [select(walletAddressSelector), userAddress],
+        [select(tokensWithTokenBalanceSelector, [networkConfig.defaultNetworkId]), []],
+        [select(phoneNumberVerifiedSelector), true],
       ])
       .not.call.fn(fetchWithTimeout)
       .run()

--- a/src/consumerIncentives/saga.test.ts
+++ b/src/consumerIncentives/saga.test.ts
@@ -33,8 +33,7 @@ import { getContractKit } from 'src/web3/contracts'
 import { default as config, default as networkConfig } from 'src/web3/networkConfig'
 import { getConnectedUnlockedAccount } from 'src/web3/saga'
 import { walletAddressSelector } from 'src/web3/selectors'
-import { createMockStore } from 'test/utils'
-import { mockAccount, mockCeurAddress, mockCusdAddress } from 'test/values'
+import { mockAccount, mockCeloTokenBalance, mockCeurAddress, mockCusdAddress } from 'test/values'
 
 const mockBaseNonce = 10
 
@@ -106,10 +105,13 @@ describe('fetchAvailableRewardsSaga', () => {
     const uri = `${config.fetchAvailableSuperchargeRewards}?address=${userAddress}`
 
     await expectSaga(fetchAvailableRewardsSaga, fetchAvailableRewards())
-      .withState(createMockStore({}).getState())
       .provide([
         [select(phoneNumberVerifiedSelector), true],
         [select(walletAddressSelector), userAddress],
+        [
+          select(tokensWithTokenBalanceSelector, [networkConfig.defaultNetworkId]),
+          [mockCeloTokenBalance],
+        ],
         [call(fetchWithTimeout, uri, null, SUPERCHARGE_FETCH_TIMEOUT), mockResponse],
       ])
       .put(setAvailableRewards(expectedRewards))
@@ -126,10 +128,13 @@ describe('fetchAvailableRewardsSaga', () => {
     const uri = `${config.fetchAvailableSuperchargeRewards}?address=${userAddress}`
 
     await expectSaga(fetchAvailableRewardsSaga, fetchAvailableRewards({ forceRefresh: true }))
-      .withState(createMockStore({}).getState())
       .provide([
         [select(phoneNumberVerifiedSelector), true],
         [select(walletAddressSelector), userAddress],
+        [
+          select(tokensWithTokenBalanceSelector, [networkConfig.defaultNetworkId]),
+          [mockCeloTokenBalance],
+        ],
         [
           call(
             fetchWithTimeout,
@@ -150,10 +155,13 @@ describe('fetchAvailableRewardsSaga', () => {
     const uri = `${config.fetchAvailableSuperchargeRewards}?address=${userAddress}`
 
     await expectSaga(fetchAvailableRewardsSaga, fetchAvailableRewards())
-      .withState(createMockStore({}).getState())
       .provide([
         [select(phoneNumberVerifiedSelector), true],
         [select(walletAddressSelector), userAddress],
+        [
+          select(tokensWithTokenBalanceSelector, [networkConfig.defaultNetworkId]),
+          [mockCeloTokenBalance],
+        ],
         [call(fetchWithTimeout, uri, null, SUPERCHARGE_FETCH_TIMEOUT), error],
       ])
       .not.put(setAvailableRewards(expect.anything()))
@@ -165,10 +173,13 @@ describe('fetchAvailableRewardsSaga', () => {
 
   it('skips fetching rewards for an unverified user for supercharge v2', async () => {
     await expectSaga(fetchAvailableRewardsSaga, fetchAvailableRewards())
-      .withState(createMockStore({}).getState())
       .provide([
         [select(phoneNumberVerifiedSelector), false],
         [select(walletAddressSelector), userAddress],
+        [
+          select(tokensWithTokenBalanceSelector, [networkConfig.defaultNetworkId]),
+          [mockCeloTokenBalance],
+        ],
       ])
       .not.call.fn(fetchWithTimeout)
       .run()
@@ -178,8 +189,8 @@ describe('fetchAvailableRewardsSaga', () => {
     await expectSaga(fetchAvailableRewardsSaga, fetchAvailableRewards())
       .provide([
         [select(walletAddressSelector), userAddress],
-        [select(tokensWithTokenBalanceSelector, [networkConfig.defaultNetworkId]), []],
         [select(phoneNumberVerifiedSelector), true],
+        [select(tokensWithTokenBalanceSelector, [networkConfig.defaultNetworkId]), []],
       ])
       .not.call.fn(fetchWithTimeout)
       .run()
@@ -187,10 +198,13 @@ describe('fetchAvailableRewardsSaga', () => {
 
   it('displays an error if a user is not properly verified for supercharge v2', async () => {
     await expectSaga(fetchAvailableRewardsSaga, fetchAvailableRewards())
-      .withState(createMockStore({}).getState())
       .provide([
         [select(phoneNumberVerifiedSelector), true],
         [select(walletAddressSelector), userAddress],
+        [
+          select(tokensWithTokenBalanceSelector, [networkConfig.defaultNetworkId]),
+          [mockCeloTokenBalance],
+        ],
         [
           call(
             fetchWithTimeout,

--- a/src/consumerIncentives/saga.ts
+++ b/src/consumerIncentives/saga.ts
@@ -19,8 +19,8 @@ import { SuperchargePendingReward } from 'src/consumerIncentives/types'
 import i18n from 'src/i18n'
 import { navigateHome } from 'src/navigator/NavigationService'
 import { vibrateSuccess } from 'src/styles/hapticFeedback'
-import { tokensByAddressSelector } from 'src/tokens/selectors'
-import { getTokenId } from 'src/tokens/utils'
+import { tokensByAddressSelector, tokensWithTokenBalanceSelector } from 'src/tokens/selectors'
+import { getSupportedNetworkIdsForTokenBalances, getTokenId } from 'src/tokens/utils'
 import { addStandbyTransaction } from 'src/transactions/actions'
 import { sendTransaction } from 'src/transactions/send'
 import { TokenTransactionTypeV2, newTransactionContext } from 'src/transactions/types'
@@ -149,6 +149,16 @@ export function* fetchAvailableRewardsSaga({ payload }: ReturnType<typeof fetchA
   const address = yield* select(walletAddressSelector)
   if (!address) {
     Logger.debug(TAG, 'Skipping fetching available rewards since no address was found')
+    return
+  }
+
+  const supportedNetworkIds = yield* call(getSupportedNetworkIdsForTokenBalances)
+  const tokensWithTokenBalance = yield* select(tokensWithTokenBalanceSelector, supportedNetworkIds)
+  if (tokensWithTokenBalance.length === 0) {
+    Logger.debug(
+      TAG,
+      'Skipping fetching available rewards due to lack of tokens with sufficient balance'
+    )
     return
   }
 

--- a/src/consumerIncentives/saga.ts
+++ b/src/consumerIncentives/saga.ts
@@ -20,7 +20,7 @@ import i18n from 'src/i18n'
 import { navigateHome } from 'src/navigator/NavigationService'
 import { vibrateSuccess } from 'src/styles/hapticFeedback'
 import { tokensByAddressSelector, tokensWithTokenBalanceSelector } from 'src/tokens/selectors'
-import { getSupportedNetworkIdsForTokenBalances, getTokenId } from 'src/tokens/utils'
+import { getTokenId } from 'src/tokens/utils'
 import { addStandbyTransaction } from 'src/transactions/actions'
 import { sendTransaction } from 'src/transactions/send'
 import { TokenTransactionTypeV2, newTransactionContext } from 'src/transactions/types'
@@ -152,7 +152,7 @@ export function* fetchAvailableRewardsSaga({ payload }: ReturnType<typeof fetchA
     return
   }
 
-  const supportedNetworkIds = yield* call(getSupportedNetworkIdsForTokenBalances)
+  const supportedNetworkIds = [networkConfig.defaultNetworkId] // rewards are only availabe on Celo
   const tokensWithTokenBalance = yield* select(tokensWithTokenBalanceSelector, supportedNetworkIds)
   if (tokensWithTokenBalance.length === 0) {
     Logger.debug(


### PR DESCRIPTION
### Description

To potentially reduce pressure on the backend from empty wallets this PR proposes not make a backend request for fetching available rewards, if the wallet doesn't have any token with balance greater than [TOKEN_MIN_AMOUNT](https://github.com/valora-inc/wallet/blob/d5149c7e0b8d3e948c45ddf606f657aa50c23a15/src/config.ts#L59).

Potentially it could save several thousands requests per day in peak periods like reward campaigns.

Data: [unique users with 0 tokens](https://mixpanel.com/project/2786968/view/3321744/app/insights#n4zbVy2TMznC)

Context: https://valora-app.slack.com/archives/C029Z1QMD7B/p1702630218806749

### Test plan

* Updated unit tests

### Related issues

- Fixes RET-951

### Backwards compatibility

Y