### PR TITLE
feat(identity): save contacts

### DIFF
--- a/src/identity/actions.ts
+++ b/src/identity/actions.ts
@@ -144,7 +144,7 @@ export interface AddressVerificationStatusReceivedAction {
   addressVerified: boolean
 }
 
-export interface ContactsSavedAction {
+interface ContactsSavedAction {
   type: Actions.CONTACTS_SAVED
   hash: string
 }

--- a/src/identity/actions.ts
+++ b/src/identity/actions.ts
@@ -32,6 +32,7 @@ export enum Actions {
   UPDATE_ADDRESS_DEK_MAP = 'IDENTITY/UPDATE_ADDRESS_DEK_MAP',
   FETCH_ADDRESS_VERIFICATION_STATUS = 'IDENTITY/FETCH_ADDRESS_VERIFICATION_STATUS',
   ADDRESS_VERIFICATION_STATUS_RECEIVED = 'IDENTITY/ADDRESS_VERIFICATION_STATUS_RECEIVED',
+  CONTACTS_SAVED = 'IDENTITY/CONTACTS_SAVED',
 }
 
 export interface SetHasSeenVerificationNux {
@@ -143,6 +144,11 @@ export interface AddressVerificationStatusReceivedAction {
   addressVerified: boolean
 }
 
+export interface ContactsSavedAction {
+  type: Actions.CONTACTS_SAVED
+  hash: string
+}
+
 export type ActionTypes =
   | SetHasSeenVerificationNux
   | UpdateE164PhoneNumberAddressesAction
@@ -163,6 +169,7 @@ export type ActionTypes =
   | UpdateAddressDekMapAction
   | FetchAddressVerificationAction
   | AddressVerificationStatusReceivedAction
+  | ContactsSavedAction
 
 export const setHasSeenVerificationNux = (status: boolean): SetHasSeenVerificationNux => ({
   type: Actions.SET_SEEN_VERIFICATION_NUX,
@@ -320,4 +327,9 @@ export const updateAddressDekMap = (
   type: Actions.UPDATE_ADDRESS_DEK_MAP,
   address,
   dataEncryptionKey,
+})
+
+export const contactsSaved = (hash: string): ContactsSavedAction => ({
+  type: Actions.CONTACTS_SAVED,
+  hash,
 })

--- a/src/identity/contactMapping.test.ts
+++ b/src/identity/contactMapping.test.ts
@@ -5,39 +5,57 @@ import { call, select } from 'redux-saga/effects'
 import { setUserContactDetails } from 'src/account/actions'
 import { defaultCountryCodeSelector, e164NumberSelector } from 'src/account/selectors'
 import { showError, showErrorOrFallback } from 'src/alert/actions'
+import { IdentityEvents } from 'src/analytics/Events'
+import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import { ErrorMessages } from 'src/app/ErrorMessages'
+import { phoneNumberVerifiedSelector } from 'src/app/selectors'
 import {
+  Actions,
+  addressVerificationStatusReceived,
+  contactsSaved,
+  fetchAddressVerification,
   fetchAddressesAndValidate,
   requireSecureSend,
   updateE164PhoneNumberAddresses,
-  fetchAddressVerification,
-  addressVerificationStatusReceived,
 } from 'src/identity/actions'
 import {
   doImportContactsWrapper,
-  fetchAddressesAndValidateSaga,
   fetchAddressVerificationSaga,
+  fetchAddressesAndValidateSaga,
+  saveContacts,
 } from 'src/identity/contactMapping'
 import { AddressValidationType } from 'src/identity/reducer'
 import {
-  e164NumberToAddressSelector,
-  secureSendPhoneNumberMappingSelector,
   addressToVerificationStatusSelector,
+  e164NumberToAddressSelector,
+  lastSavedContactsHashSelector,
+  secureSendPhoneNumberMappingSelector,
 } from 'src/identity/selectors'
 import { retrieveSignedMessage } from 'src/pincode/authentication'
 import { contactsToRecipients } from 'src/recipients/recipient'
-import { setPhoneRecipientCache } from 'src/recipients/reducer'
+import { phoneRecipientCacheSelector, setPhoneRecipientCache } from 'src/recipients/reducer'
+import { getFeatureGate } from 'src/statsig'
+import Logger from 'src/utils/Logger'
 import { getAllContacts } from 'src/utils/contacts'
+import { checkContactsPermission } from 'src/utils/permissions'
 import networkConfig from 'src/web3/networkConfig'
 import { getConnectedAccount } from 'src/web3/saga'
 import { walletAddressSelector } from 'src/web3/selectors'
-import { mockAccount, mockContactList, mockContactWithPhone2, mockE164Number } from 'test/values'
-import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
-import { IdentityEvents } from 'src/analytics/Events'
+import {
+  mockAccount,
+  mockContactList,
+  mockContactWithPhone2,
+  mockE164Number,
+  mockE164Number2,
+  mockE164Number2Invite,
+  mockE164NumberInvite,
+  mockPhoneRecipientCache,
+} from 'test/values'
 
 const recipients = contactsToRecipients(mockContactList, '+1')
 const mockFetch = fetch as FetchMock
 jest.unmock('src/pincode/authentication')
+jest.mock('src/statsig')
 
 describe('Import Contacts Saga', () => {
   it('imports contacts and creates contact mappings correctly', async () => {
@@ -55,6 +73,7 @@ describe('Import Contacts Saga', () => {
         )
       )
       .put(setPhoneRecipientCache(recipients))
+      .spawn(saveContacts)
       .run()
   })
 
@@ -67,6 +86,7 @@ describe('Import Contacts Saga', () => {
         [select(e164NumberSelector), mockE164Number],
       ])
       .put(showError(ErrorMessages.IMPORT_CONTACTS_FAILED))
+      .not.spawn(saveContacts)
       .run()
   })
 })
@@ -207,5 +227,148 @@ describe('Fetch Address Verification Saga', () => {
     expect(ValoraAnalytics.track).toHaveBeenCalledWith(IdentityEvents.address_lookup_error, {
       error: 'Unable to fetch verification status for this address',
     })
+  })
+})
+
+describe('saveContacts', () => {
+  const warnSpy = jest.spyOn(Logger, 'warn')
+  beforeEach(() => {
+    mockFetch.resetMocks()
+    jest.mocked(getFeatureGate).mockReturnValue(true)
+  })
+
+  it('invokes saveContacts API and saves last posted hash if not already saved', async () => {
+    await expectSaga(saveContacts)
+      .provide([
+        [select(phoneNumberVerifiedSelector), true],
+        [call(checkContactsPermission), true],
+        [select(phoneRecipientCacheSelector), mockPhoneRecipientCache],
+        [select(e164NumberSelector), mockE164Number],
+        [select(lastSavedContactsHashSelector), undefined],
+        [select(walletAddressSelector), '0xxyz'],
+        [call(retrieveSignedMessage), 'some signed message'],
+      ])
+      .put(contactsSaved('72a546e3fc087906f225c620888cae129156a2413bbb1eb0f82f647cedde1350'))
+      .run()
+
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+    expect(mockFetch).toHaveBeenCalledWith(networkConfig.saveContactsUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        authorization: `Valora 0xxyz:some signed message`,
+      },
+      body: JSON.stringify({
+        phoneNumber: mockE164Number,
+        contacts: [mockE164NumberInvite, mockE164Number, mockE164Number2Invite],
+      }),
+      signal: expect.any(AbortSignal),
+    })
+  })
+
+  it('invokes saveContacts API and saves last posted hash if contacts are different', async () => {
+    await expectSaga(saveContacts)
+      .provide([
+        [select(phoneNumberVerifiedSelector), true],
+        [call(checkContactsPermission), true],
+        [
+          select(phoneRecipientCacheSelector),
+          { ...mockPhoneRecipientCache, [mockE164Number2]: {} },
+        ],
+        [select(e164NumberSelector), mockE164Number],
+        [
+          select(lastSavedContactsHashSelector),
+          '72a546e3fc087906f225c620888cae129156a2413bbb1eb0f82f647cedde1350',
+        ],
+        [select(walletAddressSelector), '0xxyz'],
+        [call(retrieveSignedMessage), 'some signed message'],
+      ])
+      .put(contactsSaved('68498dee3633b92eb7b7107201e18a228b4a381b5cf222d59f6eaf75c19cca7d'))
+      .run()
+
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+    expect(mockFetch).toHaveBeenCalledWith(networkConfig.saveContactsUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        authorization: `Valora 0xxyz:some signed message`,
+      },
+      body: JSON.stringify({
+        phoneNumber: mockE164Number,
+        contacts: [mockE164Number2, mockE164NumberInvite, mockE164Number, mockE164Number2Invite],
+      }),
+      signal: expect.any(AbortSignal),
+    })
+  })
+
+  it('skips if last saved contacts is the same as current', async () => {
+    await expectSaga(saveContacts)
+      .provide([
+        [select(phoneNumberVerifiedSelector), true],
+        [call(checkContactsPermission), true],
+        [select(phoneRecipientCacheSelector), mockPhoneRecipientCache],
+        [select(e164NumberSelector), mockE164Number],
+        [
+          select(lastSavedContactsHashSelector),
+          '72a546e3fc087906f225c620888cae129156a2413bbb1eb0f82f647cedde1350',
+        ],
+        [select(walletAddressSelector), '0xxyz'],
+        [call(retrieveSignedMessage), 'some signed message'],
+      ])
+      .not.put.actionType(Actions.CONTACTS_SAVED)
+      .run()
+
+    expect(mockFetch).toHaveBeenCalledTimes(0)
+  })
+
+  it.each([
+    { featureGate: false, phoneVerified: true, contactsEnabled: true, name: 'feature gate' },
+    { featureGate: true, phoneVerified: false, contactsEnabled: true, name: 'phone unverified' },
+    { featureGate: true, phoneVerified: true, contactsEnabled: false, name: 'contacts disabled' },
+  ])(
+    'skips if pre-conditions are not met - $name',
+    async ({ featureGate, phoneVerified, contactsEnabled }) => {
+      jest.mocked(getFeatureGate).mockReturnValue(featureGate)
+      await expectSaga(saveContacts)
+        .provide([
+          [select(phoneNumberVerifiedSelector), phoneVerified],
+          [call(checkContactsPermission), contactsEnabled],
+        ])
+        .not.select(phoneRecipientCacheSelector)
+        .not.select(e164NumberSelector)
+        .run()
+
+      expect(mockFetch).toHaveBeenCalledTimes(0)
+    }
+  )
+
+  it('handles errors gracefully and logs a warning', async () => {
+    mockFetch.mockReject()
+    await expectSaga(saveContacts)
+      .provide([
+        [select(phoneNumberVerifiedSelector), true],
+        [call(checkContactsPermission), true],
+        [select(phoneRecipientCacheSelector), mockPhoneRecipientCache],
+        [select(e164NumberSelector), mockE164Number],
+        [select(lastSavedContactsHashSelector), undefined],
+        [select(walletAddressSelector), '0xxyz'],
+        [call(retrieveSignedMessage), 'some signed message'],
+      ])
+      .not.put.actionType(Actions.CONTACTS_SAVED)
+      .run()
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+    expect(mockFetch).toHaveBeenCalledWith(networkConfig.saveContactsUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        authorization: `Valora 0xxyz:some signed message`,
+      },
+      body: JSON.stringify({
+        phoneNumber: mockE164Number,
+        contacts: [mockE164NumberInvite, mockE164Number, mockE164Number2Invite],
+      }),
+      signal: expect.any(AbortSignal),
+    })
+    expect(warnSpy).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/identity/contactMapping.test.ts
+++ b/src/identity/contactMapping.test.ts
@@ -235,6 +235,7 @@ describe('saveContacts', () => {
   beforeEach(() => {
     mockFetch.resetMocks()
     jest.mocked(getFeatureGate).mockReturnValue(true)
+    jest.clearAllMocks()
   })
 
   it('invokes saveContacts API and saves last posted hash if not already saved', async () => {
@@ -244,7 +245,7 @@ describe('saveContacts', () => {
         [call(checkContactsPermission), true],
         [select(phoneRecipientCacheSelector), mockPhoneRecipientCache],
         [select(e164NumberSelector), mockE164Number],
-        [select(lastSavedContactsHashSelector), undefined],
+        [select(lastSavedContactsHashSelector), null],
         [select(walletAddressSelector), '0xxyz'],
         [call(retrieveSignedMessage), 'some signed message'],
       ])

--- a/src/identity/contactMapping.ts
+++ b/src/identity/contactMapping.ts
@@ -3,6 +3,7 @@ import { AttestationStat, AttestationsWrapper } from '@celo/contractkit/lib/wrap
 import { isValidAddress } from '@celo/utils/lib/address'
 import { isAccountConsideredVerified } from '@celo/utils/lib/attestations'
 import BigNumber from 'bignumber.js'
+import crypto from 'crypto'
 import { Platform } from 'react-native'
 import DeviceInfo from 'react-native-device-info'
 import { setUserContactDetails } from 'src/account/actions'
@@ -11,16 +12,18 @@ import { showErrorOrFallback } from 'src/alert/actions'
 import { IdentityEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import { ErrorMessages } from 'src/app/ErrorMessages'
+import { phoneNumberVerifiedSelector } from 'src/app/selectors'
 import {
   Actions,
-  FetchAddressesAndValidateAction,
   FetchAddressVerificationAction,
+  FetchAddressesAndValidateAction,
+  addressVerificationStatusReceived,
+  contactsSaved,
   endFetchingAddresses,
   endImportContacts,
   requireSecureSend,
   updateE164PhoneNumberAddresses,
   updateImportContactsProgress,
-  addressVerificationStatusReceived,
 } from 'src/identity/actions'
 import {
   AddressToE164NumberType,
@@ -30,26 +33,29 @@ import {
 } from 'src/identity/reducer'
 import { checkIfValidationRequired } from 'src/identity/secureSend'
 import {
-  e164NumberToAddressSelector,
-  secureSendPhoneNumberMappingSelector,
   addressToVerificationStatusSelector,
+  e164NumberToAddressSelector,
+  lastSavedContactsHashSelector,
+  secureSendPhoneNumberMappingSelector,
 } from 'src/identity/selectors'
 import { ImportContactsStatus } from 'src/identity/types'
 import { retrieveSignedMessage } from 'src/pincode/authentication'
 import { NumberToRecipient, contactsToRecipients } from 'src/recipients/recipient'
-import { setPhoneRecipientCache } from 'src/recipients/reducer'
+import { phoneRecipientCacheSelector, setPhoneRecipientCache } from 'src/recipients/reducer'
 import { SentryTransactionHub } from 'src/sentry/SentryTransactionHub'
 import { SentryTransaction } from 'src/sentry/SentryTransactions'
+import { getFeatureGate } from 'src/statsig'
+import { StatsigFeatureGates } from 'src/statsig/types'
 import Logger from 'src/utils/Logger'
 import { getAllContacts } from 'src/utils/contacts'
 import { ensureError } from 'src/utils/ensureError'
+import { fetchWithTimeout } from 'src/utils/fetchWithTimeout'
 import { checkContactsPermission } from 'src/utils/permissions'
 import { getContractKit } from 'src/web3/contracts'
 import networkConfig from 'src/web3/networkConfig'
 import { getConnectedAccount } from 'src/web3/saga'
 import { walletAddressSelector } from 'src/web3/selectors'
-import { call, delay, put, race, select, take } from 'typed-redux-saga'
-import { fetchWithTimeout } from 'src/utils/fetchWithTimeout'
+import { call, delay, put, race, select, spawn, take } from 'typed-redux-saga'
 
 const TAG = 'identity/contactMapping'
 export const IMPORT_CONTACTS_TIMEOUT = 1 * 60 * 1000 // 1 minute
@@ -122,6 +128,8 @@ function* doImportContacts() {
 
   ValoraAnalytics.track(IdentityEvents.contacts_processing_complete)
   SentryTransactionHub.finishTransaction(SentryTransaction.import_contacts)
+
+  yield* spawn(saveContacts)
 
   return true
 }
@@ -410,4 +418,65 @@ export function getAddressFromPhoneNumber(
 
   // Normal case when there is only one address in the mapping
   return addresses[0]
+}
+
+function calculateHash(str: string) {
+  const hash = crypto.createHash('sha256')
+  hash.update(str)
+  return hash.digest('hex')
+}
+
+export function* saveContacts() {
+  try {
+    const saveContactsGate = getFeatureGate(StatsigFeatureGates.SAVE_CONTACTS)
+    const phoneVerified = yield* select(phoneNumberVerifiedSelector)
+    // TODO(satish): use rn permissions
+    const contactsEnabled: boolean = yield* call(checkContactsPermission)
+
+    if (!saveContactsGate || !phoneVerified || !contactsEnabled) {
+      Logger.debug(`${TAG}/saveContacts`, "Skipping because pre conditions aren't met", {
+        saveContactsGate,
+        phoneVerified,
+        contactsEnabled,
+      })
+      return
+    }
+
+    const recipientCache = yield* select(phoneRecipientCacheSelector)
+    const ownPhoneNumber = yield* select(e164NumberSelector)
+    const contacts = Object.keys(recipientCache).sort()
+    const lastSavedContactsHash = yield* select(lastSavedContactsHashSelector)
+
+    const hash = calculateHash(`${ownPhoneNumber}:${contacts.join(',')}`)
+
+    if (hash === lastSavedContactsHash) {
+      Logger.debug(
+        `${TAG}/saveContacts`,
+        'Skipping because contacts have not changed since last post'
+      )
+      return
+    }
+
+    const walletAddress = yield* select(walletAddressSelector)
+    const signedMessage = yield* call(retrieveSignedMessage)
+
+    const response: Response = yield* call(fetchWithTimeout, `${networkConfig.saveContactsUrl}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        authorization: `Valora ${walletAddress}:${signedMessage}`,
+      },
+      body: JSON.stringify({ phoneNumber: ownPhoneNumber, contacts }),
+    })
+
+    if (!response.ok) {
+      throw new Error(
+        `Failed to post contacts: ${response.status} ${yield* call([response, 'text'])}`
+      )
+    }
+
+    yield* put(contactsSaved(hash))
+  } catch (err) {
+    Logger.warn(`${TAG}/saveContacts`, 'Post contacts failed', err)
+  }
 }

--- a/src/identity/reducer.ts
+++ b/src/identity/reducer.ts
@@ -89,6 +89,7 @@ export interface State {
   secureSendPhoneNumberMapping: SecureSendPhoneNumberMapping
   // Mapping of address to verification status; undefined entries represent a loading state
   addressToVerificationStatus: AddressToVerificationStatus
+  lastSavedContactsHash: string | undefined
 }
 
 const initialState: State = {
@@ -107,6 +108,7 @@ const initialState: State = {
   },
   secureSendPhoneNumberMapping: {},
   addressToVerificationStatus: {},
+  lastSavedContactsHash: undefined,
 }
 
 export const reducer = (
@@ -281,6 +283,11 @@ export const reducer = (
           ...state.addressToVerificationStatus,
           [action.address]: action.addressVerified,
         },
+      }
+    case Actions.CONTACTS_SAVED:
+      return {
+        ...state,
+        lastSavedContactsHash: action.hash,
       }
     default:
       return state

--- a/src/identity/reducer.ts
+++ b/src/identity/reducer.ts
@@ -89,7 +89,7 @@ export interface State {
   secureSendPhoneNumberMapping: SecureSendPhoneNumberMapping
   // Mapping of address to verification status; undefined entries represent a loading state
   addressToVerificationStatus: AddressToVerificationStatus
-  lastSavedContactsHash: string | undefined
+  lastSavedContactsHash: string | null
 }
 
 const initialState: State = {
@@ -108,7 +108,7 @@ const initialState: State = {
   },
   secureSendPhoneNumberMapping: {},
   addressToVerificationStatus: {},
-  lastSavedContactsHash: undefined,
+  lastSavedContactsHash: null,
 }
 
 export const reducer = (

--- a/src/identity/saga.ts
+++ b/src/identity/saga.ts
@@ -10,8 +10,9 @@ import {
 import { checkTxsForIdentityMetadata } from 'src/identity/commentEncryption'
 import {
   doImportContactsWrapper,
-  fetchAddressesAndValidateSaga,
   fetchAddressVerificationSaga,
+  fetchAddressesAndValidateSaga,
+  saveContacts,
 } from 'src/identity/contactMapping'
 import { AddressValidationType } from 'src/identity/reducer'
 import { validateAndReturnMatch } from 'src/identity/secureSend'
@@ -123,6 +124,7 @@ export function* identitySaga() {
     yield* spawn(watchNewFeedTransactions)
     yield* spawn(watchFetchDataEncryptionKey)
     yield* spawn(watchFetchAddressVerification)
+    yield* spawn(saveContacts)
   } catch (error) {
     Logger.error(TAG, 'Error initializing identity sagas', error)
   } finally {

--- a/src/identity/saga.ts
+++ b/src/identity/saga.ts
@@ -124,7 +124,7 @@ export function* identitySaga() {
     yield* spawn(watchNewFeedTransactions)
     yield* spawn(watchFetchDataEncryptionKey)
     yield* spawn(watchFetchAddressVerification)
-    yield* spawn(saveContacts)
+    yield* spawn(saveContacts) // save contacts on app start
   } catch (error) {
     Logger.error(TAG, 'Error initializing identity sagas', error)
   } finally {

--- a/src/identity/selectors.ts
+++ b/src/identity/selectors.ts
@@ -33,3 +33,6 @@ export const identifierToE164NumberSelector = createSelector(
     return identifierToE164Numbers
   }
 )
+
+export const lastSavedContactsHashSelector = (state: RootState) =>
+  state.identity.lastSavedContactsHash

--- a/src/redux/migrations.ts
+++ b/src/redux/migrations.ts
@@ -1473,4 +1473,11 @@ export const migrations = {
       }),
     },
   }),
+  176: (state: any) => ({
+    ...state,
+    identity: {
+      ...state.identity,
+      lastSavedContactsHash: undefined,
+    },
+  }),
 }

--- a/src/redux/migrations.ts
+++ b/src/redux/migrations.ts
@@ -1477,7 +1477,7 @@ export const migrations = {
     ...state,
     identity: {
       ...state.identity,
-      lastSavedContactsHash: undefined,
+      lastSavedContactsHash: null,
     },
   }),
 }

--- a/src/redux/store.test.ts
+++ b/src/redux/store.test.ts
@@ -98,7 +98,7 @@ describe('store state', () => {
       {
         "_persist": {
           "rehydrated": true,
-          "version": 175,
+          "version": 176,
         },
         "account": {
           "acceptedTerms": false,
@@ -262,6 +262,7 @@ describe('store state', () => {
             "status": 0,
             "total": 0,
           },
+          "lastSavedContactsHash": null,
           "secureSendPhoneNumberMapping": {},
           "walletToAccountAddress": {},
         },

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -23,7 +23,7 @@ const persistConfig: PersistConfig<RootState> = {
   key: 'root',
   // default is -1, increment as we make migrations
   // See https://github.com/valora-inc/wallet/tree/main/WALLET.md#redux-state-migration
-  version: 175,
+  version: 176,
   keyPrefix: `reduxStore-`, // the redux-persist default is `persist:` which doesn't work with some file systems.
   storage: FSStorage(),
   blacklist: ['networkInfo', 'alert', 'imports', 'keylessBackup'],

--- a/src/statsig/constants.ts
+++ b/src/statsig/constants.ts
@@ -24,6 +24,7 @@ export const FeatureGates = {
   [StatsigFeatureGates.USE_CICO_CURRENCY_BOTTOM_SHEET]: false,
   [StatsigFeatureGates.SHOW_MULTICHAIN_BETA_SCREEN]: false,
   [StatsigFeatureGates.SHOW_BETA_TAG]: false,
+  [StatsigFeatureGates.SAVE_CONTACTS]: false,
 }
 
 export const ExperimentConfigs = {

--- a/src/statsig/types.ts
+++ b/src/statsig/types.ts
@@ -30,6 +30,7 @@ export enum StatsigFeatureGates {
   USE_CICO_CURRENCY_BOTTOM_SHEET = 'use_cico_currency_bottom_sheet',
   SHOW_MULTICHAIN_BETA_SCREEN = 'show_multichain_beta_screen',
   SHOW_BETA_TAG = 'show_beta_tag',
+  SAVE_CONTACTS = 'save_contacts',
 }
 
 export enum StatsigExperiments {

--- a/src/web3/networkConfig.ts
+++ b/src/web3/networkConfig.ts
@@ -72,6 +72,7 @@ interface NetworkConfig {
   crealTokenId: string
   celoTokenId: string
   spendTokenIds: string[]
+  saveContactsUrl: string
 }
 
 const ALCHEMY_ETHEREUM_RPC_URL_STAGING = 'https://eth-sepolia.g.alchemy.com/v2/'
@@ -204,6 +205,9 @@ const CAB_STORE_ENCRYPTED_MNEMONIC_MAINNET = `${CLOUD_FUNCTIONS_MAINNET}/storeEn
 const CAB_ISSUE_VALORA_KEYSHARE_ALFAJORES = `${CLOUD_FUNCTIONS_STAGING}/issueValoraKeyshare`
 const CAB_ISSUE_VALORA_KEYSHARE_MAINNET = `${CLOUD_FUNCTIONS_MAINNET}/issueValoraKeyshare`
 
+const SAVE_CONTACTS_ALFAJORES = `${CLOUD_FUNCTIONS_STAGING}/saveContacts`
+const SAVE_CONTACTS_MAINNET = `${CLOUD_FUNCTIONS_MAINNET}/saveContacts`
+
 const networkConfigs: { [testnet: string]: NetworkConfig } = {
   [Testnets.alfajores]: {
     networkId: '44787',
@@ -275,6 +279,7 @@ const networkConfigs: { [testnet: string]: NetworkConfig } = {
     crealTokenId: CREAL_TOKEN_ID_STAGING,
     celoTokenId: CELO_TOKEN_ID_STAGING,
     spendTokenIds: [CUSD_TOKEN_ID_STAGING, CEUR_TOKEN_ID_STAGING],
+    saveContactsUrl: SAVE_CONTACTS_ALFAJORES,
   },
   [Testnets.mainnet]: {
     networkId: '42220',
@@ -345,6 +350,7 @@ const networkConfigs: { [testnet: string]: NetworkConfig } = {
     crealTokenId: CREAL_TOKEN_ID_MAINNET,
     celoTokenId: CELO_TOKEN_ID_MAINNET,
     spendTokenIds: [CUSD_TOKEN_ID_MAINNET, CEUR_TOKEN_ID_MAINNET],
+    saveContactsUrl: SAVE_CONTACTS_MAINNET,
   },
 }
 

--- a/test/RootStateSchema.json
+++ b/test/RootStateSchema.json
@@ -4147,6 +4147,9 @@
                 "importContactsProgress": {
                     "$ref": "#/definitions/ImportContactProgress"
                 },
+                "lastSavedContactsHash": {
+                    "type": "string"
+                },
                 "secureSendPhoneNumberMapping": {
                     "$ref": "#/definitions/SecureSendPhoneNumberMapping"
                 },
@@ -4164,6 +4167,7 @@
                 "e164NumberToSalt",
                 "hasSeenVerificationNux",
                 "importContactsProgress",
+                "lastSavedContactsHash",
                 "secureSendPhoneNumberMapping",
                 "walletToAccountAddress"
             ],

--- a/test/RootStateSchema.json
+++ b/test/RootStateSchema.json
@@ -4148,7 +4148,10 @@
                     "$ref": "#/definitions/ImportContactProgress"
                 },
                 "lastSavedContactsHash": {
-                    "type": "string"
+                    "type": [
+                        "null",
+                        "string"
+                    ]
                 },
                 "secureSendPhoneNumberMapping": {
                     "$ref": "#/definitions/SecureSendPhoneNumberMapping"

--- a/test/schemas.ts
+++ b/test/schemas.ts
@@ -2900,7 +2900,7 @@ export const v176Schema = {
   },
   identity: {
     ...v175Schema.identity,
-    lastSavedContactsHash: undefined,
+    lastSavedContactsHash: null,
   },
 }
 

--- a/test/schemas.ts
+++ b/test/schemas.ts
@@ -2892,6 +2892,18 @@ export const v175Schema = {
   },
 }
 
+export const v176Schema = {
+  ...v175Schema,
+  _persist: {
+    ...v175Schema._persist,
+    version: 176,
+  },
+  identity: {
+    ...v175Schema.identity,
+    lastSavedContactsHash: undefined,
+  },
+}
+
 export function getLatestSchema(): Partial<RootState> {
-  return v175Schema as Partial<RootState>
+  return v176Schema as Partial<RootState>
 }


### PR DESCRIPTION
### Description

Invoke identity-service API to save contacts on app load and whenever contacts are imported. Only makes requests if phone number is verified, contacts permission is given and contacts have changed since the last post. Also behind a [statsig feature gate](https://console.statsig.com/4plizaPmWwPL21ASV4QAO0/gates/save_contacts)

### Test plan

Unit tests, manually tested by enabling feature gate

### Related issues

- Fixes ACT-994

### Backwards compatibility

N/A
