### PR TITLE
chore(swap): cleanup guaranteedSwapPriceEnabled experiment

### DIFF
--- a/src/app/saga.ts
+++ b/src/app/saga.ts
@@ -263,7 +263,6 @@ export interface RemoteConfigValues {
   celoNews: CeloNewsConfig
   twelveWordMnemonicEnabled: boolean
   dappsMinimalDisclaimerEnabled: boolean
-  guaranteedSwapPriceEnabled: boolean
   priceImpactWarningThreshold: number
   superchargeRewardContractAddress: string
 }

--- a/src/firebase/firebase.ts
+++ b/src/firebase/firebase.ts
@@ -354,7 +354,6 @@ export async function fetchRemoteConfigValues(): Promise<RemoteConfigValues | nu
     celoNews: celoNewsString ? JSON.parse(celoNewsString) : {},
     twelveWordMnemonicEnabled: flags.twelveWordMnemonicEnabled.asBoolean(),
     dappsMinimalDisclaimerEnabled: flags.dappsMinimalDisclaimerEnabled.asBoolean(),
-    guaranteedSwapPriceEnabled: flags.guaranteedSwapPriceEnabled.asBoolean(),
     // Convert to percentage, so we're consistent with the price impact value returned by our swap API
     priceImpactWarningThreshold: flags.priceImpactWarningThreshold.asNumber() * 100,
     superchargeRewardContractAddress: flags.superchargeRewardContractAddress.asString(),

--- a/src/firebase/remoteConfigValuesDefaults.e2e.ts
+++ b/src/firebase/remoteConfigValuesDefaults.e2e.ts
@@ -60,7 +60,6 @@ export const REMOTE_CONFIG_VALUES_DEFAULTS: Omit<
   celoNews: JSON.stringify({} as RemoteConfigValues['celoNews']),
   twelveWordMnemonicEnabled: true,
   dappsMinimalDisclaimerEnabled: false,
-  guaranteedSwapPriceEnabled: false,
   priceImpactWarningThreshold: 0.04,
   superchargeRewardContractAddress: '',
 }

--- a/src/firebase/remoteConfigValuesDefaults.ts
+++ b/src/firebase/remoteConfigValuesDefaults.ts
@@ -62,7 +62,6 @@ export const REMOTE_CONFIG_VALUES_DEFAULTS: Omit<
   celoNews: JSON.stringify({} as RemoteConfigValues['celoNews']),
   twelveWordMnemonicEnabled: false,
   dappsMinimalDisclaimerEnabled: false,
-  guaranteedSwapPriceEnabled: false,
   priceImpactWarningThreshold: 0.04,
   superchargeRewardContractAddress: '',
 }

--- a/src/redux/migrations.test.ts
+++ b/src/redux/migrations.test.ts
@@ -40,6 +40,7 @@ import {
   v172Schema,
   v174Schema,
   v176Schema,
+  v177Schema,
   v17Schema,
   v18Schema,
   v1Schema,
@@ -1485,6 +1486,14 @@ describe('Redux persist migrations', () => {
     const expectedSchema: any = _.cloneDeep(oldSchema)
     expectedSchema.swap.priceImpactWarningThreshold =
       expectedSchema.swap.priceImpactWarningThreshold * 100
+    expect(migratedSchema).toStrictEqual(expectedSchema)
+  })
+
+  it('works from 177 to 178', () => {
+    const oldSchema = v177Schema
+    const migratedSchema = migrations[178](oldSchema)
+    const expectedSchema: any = _.cloneDeep(oldSchema)
+    delete expectedSchema.swap.guaranteedSwapPriceEnabled
     expect(migratedSchema).toStrictEqual(expectedSchema)
   })
 })

--- a/src/redux/migrations.ts
+++ b/src/redux/migrations.ts
@@ -1044,7 +1044,7 @@ export const migrations = {
     ...state,
     swap: {
       ...state.swap,
-      guaranteedSwapPriceEnabled: REMOTE_CONFIG_VALUES_DEFAULTS.guaranteedSwapPriceEnabled,
+      guaranteedSwapPriceEnabled: false,
     },
   }),
   111: (state: any) => state,
@@ -1488,5 +1488,9 @@ export const migrations = {
         priceImpactWarningThreshold: state.swap.priceImpactWarningThreshold * 100,
       }),
     },
+  }),
+  178: (state: any) => ({
+    ...state,
+    swap: _.omit(state.swap, 'guaranteedSwapPriceEnabled'),
   }),
 }

--- a/src/redux/store.test.ts
+++ b/src/redux/store.test.ts
@@ -98,7 +98,7 @@ describe('store state', () => {
       {
         "_persist": {
           "rehydrated": true,
-          "version": 177,
+          "version": 178,
         },
         "account": {
           "acceptedTerms": false,
@@ -331,7 +331,6 @@ describe('store state', () => {
         },
         "swap": {
           "currentSwap": null,
-          "guaranteedSwapPriceEnabled": false,
           "priceImpactWarningThreshold": 4,
         },
         "tokens": {

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -23,7 +23,7 @@ const persistConfig: PersistConfig<RootState> = {
   key: 'root',
   // default is -1, increment as we make migrations
   // See https://github.com/valora-inc/wallet/tree/main/WALLET.md#redux-state-migration
-  version: 177,
+  version: 178,
   keyPrefix: `reduxStore-`, // the redux-persist default is `persist:` which doesn't work with some file systems.
   storage: FSStorage(),
   blacklist: ['networkInfo', 'alert', 'imports', 'keylessBackup'],

--- a/src/swap/selectors.ts
+++ b/src/swap/selectors.ts
@@ -2,8 +2,5 @@ import { RootState } from 'src/redux/reducers'
 
 export const currentSwapSelector = (state: RootState) => state.swap.currentSwap
 
-export const guaranteedSwapPriceEnabledSelector = (state: RootState) =>
-  state.swap.guaranteedSwapPriceEnabled
-
 export const priceImpactWarningThresholdSelector = (state: RootState) =>
   state.swap.priceImpactWarningThreshold

--- a/src/swap/slice.ts
+++ b/src/swap/slice.ts
@@ -13,7 +13,6 @@ interface SwapTask {
 
 export interface State {
   currentSwap: SwapTask | null
-  guaranteedSwapPriceEnabled: boolean
   /**
    * In percentage, between 0 and 100
    */
@@ -22,7 +21,6 @@ export interface State {
 
 const initialState: State = {
   currentSwap: null,
-  guaranteedSwapPriceEnabled: false,
   priceImpactWarningThreshold: 4, // 4% by default
 }
 
@@ -58,7 +56,6 @@ export const slice = createSlice({
       .addCase(
         AppActions.UPDATE_REMOTE_CONFIG_VALUES,
         (state, action: UpdateConfigValuesAction) => {
-          state.guaranteedSwapPriceEnabled = action.configValues.guaranteedSwapPriceEnabled
           state.priceImpactWarningThreshold = action.configValues.priceImpactWarningThreshold
         }
       )

--- a/src/swap/useSwapQuote.ts
+++ b/src/swap/useSwapQuote.ts
@@ -2,7 +2,6 @@ import BigNumber from 'bignumber.js'
 import { useAsyncCallback } from 'react-async-hook'
 import erc20 from 'src/abis/IERC20'
 import useSelector from 'src/redux/useSelector'
-import { guaranteedSwapPriceEnabledSelector } from 'src/swap/selectors'
 import { FetchQuoteResponse, Field, ParsedSwapAmount, SwapTransaction } from 'src/swap/types'
 import { feeCurrenciesSelector } from 'src/tokens/selectors'
 import { TokenBalance } from 'src/tokens/slice'
@@ -125,7 +124,6 @@ async function prepareSwapTransactions(
 
 function useSwapQuote(networkId: NetworkId, slippagePercentage: string) {
   const walletAddress = useSelector(walletAddressSelector)
-  const useGuaranteedPrice = useSelector(guaranteedSwapPriceEnabledSelector)
   const feeCurrencies = useSelector((state) => feeCurrenciesSelector(state, networkId))
 
   const refreshQuote = useAsyncCallback(
@@ -172,9 +170,7 @@ function useSwapQuote(networkId: NetworkId, slippagePercentage: string) {
       }
 
       const quote: FetchQuoteResponse = await response.json()
-      const swapPrice = useGuaranteedPrice
-        ? quote.unvalidatedSwapTransaction.guaranteedPrice
-        : quote.unvalidatedSwapTransaction.price
+      const swapPrice = quote.unvalidatedSwapTransaction.price
       const price =
         updatedField === Field.FROM
           ? swapPrice

--- a/test/RootStateSchema.json
+++ b/test/RootStateSchema.json
@@ -3814,9 +3814,6 @@
                         }
                     ]
                 },
-                "guaranteedSwapPriceEnabled": {
-                    "type": "boolean"
-                },
                 "priceImpactWarningThreshold": {
                     "description": "In percentage, between 0 and 100",
                     "type": "number"
@@ -3824,7 +3821,6 @@
             },
             "required": [
                 "currentSwap",
-                "guaranteedSwapPriceEnabled",
                 "priceImpactWarningThreshold"
             ],
             "type": "object"

--- a/test/schemas.ts
+++ b/test/schemas.ts
@@ -2916,6 +2916,15 @@ export const v177Schema = {
   },
 }
 
+export const v178Schema = {
+  ...v177Schema,
+  _persist: {
+    ...v177Schema._persist,
+    version: 178,
+  },
+  swap: _.omit(v172Schema.swap, 'guaranteedSwapPriceEnabled'),
+}
+
 export function getLatestSchema(): Partial<RootState> {
-  return v177Schema as Partial<RootState>
+  return v178Schema as Partial<RootState>
 }

--- a/test/schemas.ts
+++ b/test/schemas.ts
@@ -2922,7 +2922,7 @@ export const v178Schema = {
     ...v177Schema._persist,
     version: 178,
   },
-  swap: _.omit(v172Schema.swap, 'guaranteedSwapPriceEnabled'),
+  swap: _.omit(v177Schema.swap, 'guaranteedSwapPriceEnabled'),
 }
 
 export function getLatestSchema(): Partial<RootState> {


### PR DESCRIPTION
### Description

Removing the `guaranteedSwapPriceEnabled` experiment as it was never used.

### Test plan

- Tests pass

### Related issues

- Fixes RET-950

### Backwards compatibility

Yes
