### PR TITLE
fix: prevent approval for CELO native token

### DIFF
--- a/src/swap/useSwapQuote.ts
+++ b/src/swap/useSwapQuote.ts
@@ -55,7 +55,7 @@ async function createBaseSwapTransactions(
 
   // If the sell token is ERC-20, we need to check the allowance and add an
   // approval transaction if necessary
-  if (allowanceTarget !== zeroAddress && fromToken.address) {
+  if (allowanceTarget !== zeroAddress && !fromToken.isNative) {
     const approvedAllowanceForSpender = await publicClient[
       networkIdToNetwork[fromToken.networkId]
     ].readContract({


### PR DESCRIPTION
### Description

I saw an approval that was stuck in pending on my tx feed. On closer inspection, it was an approval tx for CELO. 2 problems that this PR fixes:
1. don't create approval transactions for CELO
2. don't get stuck on confirming the transaction if effectiveGasPrice is null

### Test plan

My tx is no longer stuck after these changes

### Related issues

n/a

### Backwards compatibility

Y
