### PR TITLE
fix(saveContacts): add deviceId to saveContacts call

### DIFF
--- a/src/identity/contactMapping.test.ts
+++ b/src/identity/contactMapping.test.ts
@@ -264,6 +264,7 @@ describe('saveContacts', () => {
         contacts: [mockE164NumberInvite, mockE164Number, mockE164Number2Invite],
         clientPlatform: 'android',
         clientVersion: '0.0.1',
+        deviceId: 'abc-def-123',
       }),
       signal: expect.any(AbortSignal),
     })
@@ -301,6 +302,7 @@ describe('saveContacts', () => {
         contacts: [mockE164Number2, mockE164NumberInvite, mockE164Number, mockE164Number2Invite],
         clientPlatform: 'android',
         clientVersion: '0.0.1',
+        deviceId: 'abc-def-123',
       }),
       signal: expect.any(AbortSignal),
     })
@@ -373,6 +375,7 @@ describe('saveContacts', () => {
         contacts: [mockE164NumberInvite, mockE164Number, mockE164Number2Invite],
         clientPlatform: 'android',
         clientVersion: '0.0.1',
+        deviceId: 'abc-def-123',
       }),
       signal: expect.any(AbortSignal),
     })

--- a/src/identity/contactMapping.ts
+++ b/src/identity/contactMapping.ts
@@ -459,6 +459,7 @@ export function* saveContacts() {
 
     const walletAddress = yield* select(walletAddressSelector)
     const signedMessage = yield* call(retrieveSignedMessage)
+    const deviceId = yield* call(DeviceInfo.getUniqueId)
 
     const response: Response = yield* call(fetchWithTimeout, `${networkConfig.saveContactsUrl}`, {
       method: 'POST',
@@ -471,6 +472,7 @@ export function* saveContacts() {
         contacts,
         clientPlatform: Platform.OS,
         clientVersion: DeviceInfo.getVersion(),
+        deviceId,
       }),
     })
 


### PR DESCRIPTION
### Description

Per the latest [changes on the API side](https://github.com/valora-inc/identity-service/commit/3a891f7caeda69dc780f8fcb8cae8c13bb3599d6) 

### Test plan

Tested manually on alfajores with a successful save. 

### Related issues

https://linear.app/valora/issue/ACT-995/identity-service-api-endpoint-for-users-contacts
