### PR TITLE
chore: move home action test id to parent custom component

### DIFF
--- a/src/home/ActionsCarousel.test.tsx
+++ b/src/home/ActionsCarousel.test.tsx
@@ -73,7 +73,7 @@ describe('ActionsCarousel', () => {
         within(getByTestId(`HomeAction/Title-${name}`)).getByText(`homeActions.${title}`)
       ).toBeTruthy()
 
-      fireEvent.press(getByTestId(`HomeAction-${name}`))
+      fireEvent.press(getByTestId(`HomeActionTouchable-${name}`))
       expect(navigate).toHaveBeenCalledTimes(1)
       // NOTE: cannot use calledWith(screen, screenOptions) because undefined
       // isn't explicitly passed for screens with no options and the expect fails
@@ -97,7 +97,7 @@ describe('ActionsCarousel', () => {
       within(getByTestId(`HomeAction/Title-${HomeActionName.Add}`)).getByText(`homeActions.add`)
     ).toBeTruthy()
 
-    fireEvent.press(getByTestId(`HomeAction-${HomeActionName.Add}`))
+    fireEvent.press(getByTestId(`HomeActionTouchable-${HomeActionName.Add}`))
     expect(navigateToFiatCurrencySelection).toHaveBeenCalledWith(FiatExchangeFlow.CashIn)
 
     expect(ValoraAnalytics.track).toHaveBeenCalledTimes(1)
@@ -113,7 +113,7 @@ describe('ActionsCarousel', () => {
       </Provider>
     )
     expect(within(getByTestId(`HomeAction/Title-Send`)).getByText(`homeActions.send`)).toBeTruthy()
-    fireEvent.press(getByTestId(`HomeAction-Send`))
+    fireEvent.press(getByTestId(`HomeActionTouchable-Send`))
     expect(navigate).toHaveBeenCalledTimes(1)
     expect(navigate).toHaveBeenCalledWith(Screens.SendSelectRecipient)
   })

--- a/src/home/ActionsCarousel.tsx
+++ b/src/home/ActionsCarousel.tsx
@@ -99,6 +99,7 @@ function ActionsCarousel() {
               }}
               style={styles.touchable}
               borderRadius={8}
+              testID={`HomeActionTouchable-${name}`}
             >
               <>
                 {icon}

--- a/src/home/ActionsCarousel.tsx
+++ b/src/home/ActionsCarousel.tsx
@@ -86,14 +86,18 @@ function ActionsCarousel() {
       {actions
         .filter(({ hidden }) => !hidden)
         .map(({ name, title, icon, onPress }) => (
-          <Card style={styles.card} shadow={null} key={`HomeAction-${name}`}>
+          <Card
+            style={styles.card}
+            shadow={null}
+            key={`HomeAction-${name}`}
+            testID={`HomeAction-${name}`}
+          >
             <Touchable
               onPress={() => {
                 ValoraAnalytics.track(HomeEvents.home_action_pressed, { action: name })
                 onPress()
               }}
               style={styles.touchable}
-              testID={`HomeAction-${name}`}
               borderRadius={8}
             >
               <>


### PR DESCRIPTION
### Description

Moves testId to the parent card custom component so that we are always passing the testId down to a view.
Detox: [Pass testID to your native components](https://wix.github.io/Detox/docs/guide/test-id#pass-testid-to-your-native-components).
 
### Test plan

Tested locally on Android.
Tested in CI.

### Related issues

N/A

### Backwards compatibility

Yes