### PR TITLE
fix(deps): workaround pod install failure with boost

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1110,7 +1110,7 @@ SPEC CHECKSUMS:
   A0Auth0: 5ae918d2f043395f83ac26d6eb85b249bcb54634
   Adjust: cac836ba910f868b38d0350045aaf498f794719a
   Auth0: 64da28fdc5cd499aa516dc4bfd0ace8efae2c1da
-  boost: 57d2868c099736d80fcd648bf211b4431e51a558
+  boost: 7dcd2de282d72e344012f7d6564d024930a6a440
   BVLinearGradient: 880f91a7854faff2df62518f0281afb1c60d49a3
   CleverTap-iOS-SDK: 183b2f5c52ecfcb0d4cc97e0cdfcf080562026f3
   clevertap-react-native: a98a5d6decf8689f084f7a37ec069861d9fd9dda

--- a/patches/react-native+0.71.12.patch
+++ b/patches/react-native+0.71.12.patch
@@ -57,3 +57,18 @@ index 4d58cae..05ba4e2 100644
  #if RCT_NEW_ARCH_ENABLED
    RCTEnableTurboModule(turboModuleEnabled);
  #endif
+diff --git a/node_modules/react-native/third-party-podspecs/boost.podspec b/node_modules/react-native/third-party-podspecs/boost.podspec
+index 3d9331c..4872c2e 100644
+--- a/node_modules/react-native/third-party-podspecs/boost.podspec
++++ b/node_modules/react-native/third-party-podspecs/boost.podspec
+@@ -10,7 +10,9 @@ Pod::Spec.new do |spec|
+   spec.homepage = 'http://www.boost.org'
+   spec.summary = 'Boost provides free peer-reviewed portable C++ source libraries.'
+   spec.authors = 'Rene Rivera'
+-  spec.source = { :http => 'https://boostorg.jfrog.io/artifactory/main/release/1.76.0/source/boost_1_76_0.tar.bz2',
++  # See https://github.com/facebook/react-native/issues/42180
++  # TODO: remove this once the patch for RN 0.71 is released.
++  spec.source = { :http => 'https://archives.boost.io/release/1.76.0/source/boost_1_76_0.tar.bz2',
+                   :sha256 => 'f0397ba6e982c4450f27bf32a2a83292aba035b827a5623a14636ea583318c41' }
+ 
+   # Pinning to the same version as React.podspec.


### PR DESCRIPTION
### Description

iOS builds started [failing](https://valora-app.slack.com/archives/C02D08P412Q/p1704714465137749) in the `pod install` phase.

This is a workaround for the problem.

See https://github.com/facebook/react-native/issues/42180 for more details.

### Test plan

Manually tested `bundle exec pod install` without cached pods now works.

### Related issues

N/A

### Backwards compatibility

Yes
