### PR TITLE
feat(cash-in): add multichain support to coinbasepay

### DIFF
--- a/src/fiatExchanges/CoinbasePaymentSection.test.tsx
+++ b/src/fiatExchanges/CoinbasePaymentSection.test.tsx
@@ -64,7 +64,7 @@ describe('CoinbasePaymentSection', () => {
       assets: ['ETH'],
     },
   ])(
-    'calls generateOnRampURL with correct params',
+    'calls generateOnRampURL with correct params for $tokenId',
     async ({ tokenId, supportedNetworks, assets }) => {
       jest.mocked(generateOnRampURL).mockReturnValue(FAKE_URL)
       render(

--- a/src/fiatExchanges/CoinbasePaymentSection.tsx
+++ b/src/fiatExchanges/CoinbasePaymentSection.tsx
@@ -14,8 +14,9 @@ import { Screens } from 'src/navigator/Screens'
 import colors from 'src/styles/colors'
 import fontStyles from 'src/styles/fonts'
 import { useTokenInfo } from 'src/tokens/hooks'
+import Logger from 'src/utils/Logger'
+import { networkIdToNetwork } from 'src/web3/networkConfig'
 import { walletAddressSelector } from 'src/web3/selectors'
-import { getNetworkFromNetworkId } from 'src/web3/utils'
 
 export interface CoinbasePaymentSectionProps {
   cryptoAmount: number
@@ -38,11 +39,12 @@ export function CoinbasePaymentSection({
 
   if (!tokenInfo) {
     // should never happen
+    Logger.debug('CoinbasePaymentSection', 'Token info not found for token: ' + tokenId)
     return null
   }
-  // Using 'CGLD' as temp replacement for CiCoCurrency.CELO – digitalAsset
 
-  const network = getNetworkFromNetworkId(tokenInfo.networkId)!
+  const network = networkIdToNetwork[tokenInfo.networkId]
+  // Coinbase still thinks CELO is CGLD
   const symbol = tokenInfo.symbol === 'CELO' ? 'CGLD' : tokenInfo.symbol
 
   const coinbasePayURL = generateOnRampURL({

--- a/src/fiatExchanges/CoinbasePaymentSection.tsx
+++ b/src/fiatExchanges/CoinbasePaymentSection.tsx
@@ -13,13 +13,16 @@ import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import colors from 'src/styles/colors'
 import fontStyles from 'src/styles/fonts'
+import { useTokenInfo } from 'src/tokens/hooks'
 import { walletAddressSelector } from 'src/web3/selectors'
+import { getNetworkFromNetworkId } from 'src/web3/utils'
 
 export interface CoinbasePaymentSectionProps {
   cryptoAmount: number
   coinbaseProvider: FetchProvidersOutput
   appId: string
   analyticsData: ProviderSelectionAnalyticsData
+  tokenId: string
 }
 
 export function CoinbasePaymentSection({
@@ -27,14 +30,26 @@ export function CoinbasePaymentSection({
   coinbaseProvider,
   appId,
   analyticsData,
+  tokenId,
 }: CoinbasePaymentSectionProps) {
   const { t } = useTranslation()
   const walletAddress = useSelector(walletAddressSelector)!
+  const tokenInfo = useTokenInfo(tokenId)
 
+  if (!tokenInfo) {
+    // should never happen
+    return null
+  }
   // Using 'CGLD' as temp replacement for CiCoCurrency.CELO – digitalAsset
+
+  const network = getNetworkFromNetworkId(tokenInfo.networkId)!
+  const symbol = tokenInfo.symbol === 'CELO' ? 'CGLD' : tokenInfo.symbol
+
   const coinbasePayURL = generateOnRampURL({
     appId,
-    destinationWallets: [{ address: walletAddress, blockchains: ['celo'], assets: ['CGLD'] }],
+    destinationWallets: [
+      { address: walletAddress, supportedNetworks: [network], assets: [symbol] },
+    ],
     presetCryptoAmount: cryptoAmount,
   })
 

--- a/src/fiatExchanges/SelectProvider.tsx
+++ b/src/fiatExchanges/SelectProvider.tsx
@@ -318,6 +318,7 @@ export default function SelectProviderScreen({ route, navigation }: Props) {
           coinbaseProvider={coinbaseProvider}
           appId={appId}
           analyticsData={analyticsData}
+          tokenId={tokenInfo.tokenId}
         />
       )}
       <ExchangesSection


### PR DESCRIPTION
### Description

Makes the coinbase pay module more flexible for adding ETH specifically and other assets in the future.

https://github.com/valora-inc/wallet/assets/8432644/94ef56b7-d3e1-4354-9c4d-ef8f26739054



### Test plan

Walked through manually. see screenshots

### Related issues

https://linear.app/valora/issue/ACT-899/fetch-quotes-from-remaining-external-providers

