### PR TITLE
fix(nft): show correct block explorer link for nfts

### DIFF
--- a/src/navigator/types.tsx
+++ b/src/navigator/types.tsx
@@ -16,7 +16,7 @@ import { TransactionDataInput } from 'src/send/SendAmount'
 import { QrCode } from 'src/send/types'
 import { AssetTabType } from 'src/tokens/Assets'
 import { AssetViewType } from 'src/tokens/TokenBalances'
-import { TokenTransaction } from 'src/transactions/types'
+import { NetworkId, TokenTransaction } from 'src/transactions/types'
 import { Currency } from 'src/utils/currencies'
 import { SerializableTransactionRequest } from 'src/viem/preparedTransactionSerialization'
 import { ActionRequestProps } from 'src/walletConnect/screens/ActionRequest'
@@ -205,7 +205,7 @@ export type StackParamList = {
   [Screens.MultichainBeta]: undefined
   [Screens.NotificationCenter]: undefined
   [Screens.NftGallery]: undefined
-  [Screens.NftsInfoCarousel]: { nfts: Nft[] }
+  [Screens.NftsInfoCarousel]: { nfts: Nft[]; networkId: NetworkId }
   [Screens.KycLanding]: KycLandingProps
   [Screens.PincodeEnter]: {
     withVerification?: boolean

--- a/src/nfts/NftGallery.test.tsx
+++ b/src/nfts/NftGallery.test.tsx
@@ -1,9 +1,12 @@
-import { render } from '@testing-library/react-native'
+import { fireEvent, render } from '@testing-library/react-native'
 import React from 'react'
 import { Provider } from 'react-redux'
 import { NftEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
+import { navigate } from 'src/navigator/NavigationService'
+import { Screens } from 'src/navigator/Screens'
 import NftGallery from 'src/nfts/NftGallery'
+import { NetworkId } from 'src/transactions/types'
 import networkConfig from 'src/web3/networkConfig'
 import { createMockStore } from 'test/utils'
 import {
@@ -108,6 +111,22 @@ describe('NftGallery', () => {
 
     expect(ValoraAnalytics.track).toHaveBeenCalledWith(NftEvents.nft_gallery_screen_open, {
       numNfts: 2,
+    })
+  })
+
+  it('selecting NFT navigates to nft info screen', () => {
+    const { getAllByTestId } = render(
+      <Provider store={defaultStore}>
+        <NftGallery />
+      </Provider>
+    )
+
+    expect(getAllByTestId('NftGallery/NftImage')).toHaveLength(2)
+    fireEvent.press(getAllByTestId('NftGallery/NftImage')[0])
+    expect(navigate).toHaveBeenCalledTimes(1)
+    expect(navigate).toHaveBeenCalledWith(Screens.NftsInfoCarousel, {
+      nfts: [mockNftAllFields],
+      networkId: NetworkId['celo-alfajores'],
     })
   })
 })

--- a/src/nfts/NftGallery.tsx
+++ b/src/nfts/NftGallery.tsx
@@ -24,6 +24,7 @@ import colors from 'src/styles/colors'
 import fontStyles from 'src/styles/fonts'
 import { Spacing } from 'src/styles/styles'
 import variables from 'src/styles/variables'
+import networkConfig from 'src/web3/networkConfig'
 
 // This is used instead of a gap between the images because the gap is not supported in RN yet.
 const imageSize = (variables.width - Spacing.Regular16 * 3) / 2
@@ -80,7 +81,12 @@ export default function NftGallery() {
             >
               <Touchable
                 borderless={false}
-                onPress={() => navigate(Screens.NftsInfoCarousel, { nfts: [item] })}
+                onPress={() =>
+                  navigate(Screens.NftsInfoCarousel, {
+                    nfts: [item],
+                    networkId: networkConfig.defaultNetworkId, // TODO(satish): pass the correct network id once we fetch nfts for all networks
+                  })
+                }
                 style={styles.touchableIcon}
               >
                 <NftMedia

--- a/src/nfts/NftsInfoCarousel.test.tsx
+++ b/src/nfts/NftsInfoCarousel.test.tsx
@@ -4,6 +4,7 @@ import { Provider } from 'react-redux'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import NftsInfoCarousel from 'src/nfts/NftsInfoCarousel'
+import { NetworkId } from 'src/transactions/types'
 import networkConfig from 'src/web3/networkConfig'
 import { createMockStore, getMockStackScreenProps } from 'test/utils'
 import { mockNftAllFields, mockNftMinimumFields, mockNftNullMetadata } from 'test/values'
@@ -19,7 +20,10 @@ describe('NftsInfoCarousel', () => {
     const { queryByTestId, getByTestId, getByText } = render(
       <Provider store={createMockStore()}>
         <NftsInfoCarousel
-          {...getMockStackScreenProps(Screens.NftsInfoCarousel, { nfts: [mockNftAllFields] })}
+          {...getMockStackScreenProps(Screens.NftsInfoCarousel, {
+            nfts: [mockNftAllFields],
+            networkId: NetworkId['celo-alfajores'],
+          })}
         />
       </Provider>
     )
@@ -48,6 +52,7 @@ describe('NftsInfoCarousel', () => {
         <NftsInfoCarousel
           {...getMockStackScreenProps(Screens.NftsInfoCarousel, {
             nfts: [mockNftAllFields, mockNftMinimumFields],
+            networkId: NetworkId['celo-alfajores'],
           })}
         />
       </Provider>
@@ -98,7 +103,12 @@ describe('NftsInfoCarousel', () => {
   it('renders full screen error when no Nft(s)', () => {
     const { getByTestId, queryByTestId } = render(
       <Provider store={createMockStore()}>
-        <NftsInfoCarousel {...getMockStackScreenProps(Screens.NftsInfoCarousel, { nfts: [] })} />
+        <NftsInfoCarousel
+          {...getMockStackScreenProps(Screens.NftsInfoCarousel, {
+            nfts: [],
+            networkId: NetworkId['celo-alfajores'],
+          })}
+        />
       </Provider>
     )
 
@@ -110,7 +120,10 @@ describe('NftsInfoCarousel', () => {
     const { getByText } = render(
       <Provider store={createMockStore()}>
         <NftsInfoCarousel
-          {...getMockStackScreenProps(Screens.NftsInfoCarousel, { nfts: [mockNftNullMetadata] })}
+          {...getMockStackScreenProps(Screens.NftsInfoCarousel, {
+            nfts: [mockNftNullMetadata],
+            networkId: NetworkId['celo-alfajores'],
+          })}
         />
       </Provider>
     )
@@ -123,6 +136,7 @@ describe('NftsInfoCarousel', () => {
         <NftsInfoCarousel
           {...getMockStackScreenProps(Screens.NftsInfoCarousel, {
             nfts: [mockNftAllFields, mockNftNullMetadata],
+            networkId: NetworkId['celo-alfajores'],
           })}
         />
       </Provider>
@@ -142,18 +156,39 @@ describe('NftsInfoCarousel', () => {
     expect(getByText('nftInfoCarousel.viewOnCeloExplorer')).toBeTruthy()
   })
 
-  it('opens link for Explorer', () => {
+  it('opens link for Explorer for celo nfts', () => {
     const { getByTestId } = render(
       <Provider store={createMockStore()}>
         <NftsInfoCarousel
-          {...getMockStackScreenProps(Screens.NftsInfoCarousel, { nfts: [mockNftMinimumFields] })}
+          {...getMockStackScreenProps(Screens.NftsInfoCarousel, {
+            nfts: [mockNftMinimumFields],
+            networkId: NetworkId['celo-alfajores'],
+          })}
         />
       </Provider>
     )
 
     fireEvent.press(getByTestId('ViewOnExplorer'))
     expect(navigate).toHaveBeenCalledWith(Screens.WebViewScreen, {
-      uri: `${networkConfig.celoExplorerBaseNFTUrl}${mockNftMinimumFields.contractAddress}/instance/${mockNftMinimumFields.tokenId}/metadata`,
+      uri: `https://explorer.celo.org/alfajores/token/${mockNftMinimumFields.contractAddress}/instance/${mockNftMinimumFields.tokenId}/metadata`,
+    })
+  })
+
+  it('opens link for Explorer for ethereum nfts and hex token id', () => {
+    const { getByTestId } = render(
+      <Provider store={createMockStore()}>
+        <NftsInfoCarousel
+          {...getMockStackScreenProps(Screens.NftsInfoCarousel, {
+            nfts: [{ ...mockNftMinimumFields, tokenId: '0x0000004c' }],
+            networkId: NetworkId['ethereum-sepolia'],
+          })}
+        />
+      </Provider>
+    )
+
+    fireEvent.press(getByTestId('ViewOnExplorer'))
+    expect(navigate).toHaveBeenCalledWith(Screens.WebViewScreen, {
+      uri: `https://sepolia.etherscan.io/nft/${mockNftMinimumFields.contractAddress}/76`,
     })
   })
 
@@ -163,7 +198,10 @@ describe('NftsInfoCarousel', () => {
     const { queryByTestId } = render(
       <Provider store={createMockStore()}>
         <NftsInfoCarousel
-          {...getMockStackScreenProps(Screens.NftsInfoCarousel, { nfts: [noTokenId] })}
+          {...getMockStackScreenProps(Screens.NftsInfoCarousel, {
+            nfts: [noTokenId],
+            networkId: NetworkId['celo-alfajores'],
+          })}
         />
       </Provider>
     )

--- a/src/nfts/NftsInfoCarousel.tsx
+++ b/src/nfts/NftsInfoCarousel.tsx
@@ -1,5 +1,5 @@
 import { NativeStackScreenProps } from '@react-navigation/native-stack'
-import React, { useState } from 'react'
+import React, { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ScrollView, StyleSheet, Text, View } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
@@ -16,7 +16,8 @@ import colors from 'src/styles/colors'
 import fontStyles from 'src/styles/fonts'
 import { Spacing } from 'src/styles/styles'
 import variables from 'src/styles/variables'
-import networkConfig from 'src/web3/networkConfig'
+import { NetworkId } from 'src/transactions/types'
+import { blockExplorerUrls } from 'src/web3/networkConfig'
 
 const DEFAULT_HEIGHT = 360
 
@@ -99,17 +100,39 @@ function NftImageCarousel({ nfts, handleOnPress, activeNft }: NftImageCarouselPr
   )
 }
 
+const EXPLORER_LINK_TRANSLATION_STRINGS: Record<NetworkId, string> = {
+  [NetworkId['celo-mainnet']]: 'nftInfoCarousel.viewOnCeloExplorer',
+  [NetworkId['celo-alfajores']]: 'nftInfoCarousel.viewOnCeloExplorer',
+  [NetworkId['ethereum-mainnet']]: 'viewOnEthereumBlockExplorer',
+  [NetworkId['ethereum-sepolia']]: 'viewOnEthereumBlockExplorer',
+}
+
 type Props = NativeStackScreenProps<StackParamList, Screens.NftsInfoCarousel>
 
 export default function NftsInfoCarousel({ route }: Props) {
-  const { nfts } = route.params
-  const [activeNft, setActiveNft] = useState(nfts[0] ?? null)
+  const { nfts, networkId } = route.params
+  const [activeNft, setActiveNft] = useState<Nft | null>(nfts[0] ?? null)
   const { t } = useTranslation()
 
+  const blockExplorerUri = useMemo(() => {
+    if (!activeNft) {
+      return null
+    }
+    // tokenId could be decimal or hex string, do a parseInt to be safe
+    const tokenId = parseInt(activeNft.tokenId)
+    switch (networkId) {
+      case NetworkId['celo-mainnet']:
+      case NetworkId['celo-alfajores']:
+        return `${blockExplorerUrls[networkId].baseNftUrl}${activeNft.contractAddress}/instance/${tokenId}/metadata`
+      default:
+        return `${blockExplorerUrls[networkId].baseNftUrl}${activeNft.contractAddress}/${tokenId}`
+    }
+  }, [activeNft, networkId])
+
   function pressExplorerLink() {
-    navigate(Screens.WebViewScreen, {
-      uri: `${networkConfig.celoExplorerBaseNFTUrl}${activeNft.contractAddress}/instance/${activeNft.tokenId}/metadata`,
-    })
+    if (blockExplorerUri) {
+      navigate(Screens.WebViewScreen, { uri: blockExplorerUri })
+    }
   }
 
   function handleThumbnailPress(nft: Nft) {
@@ -117,7 +140,7 @@ export default function NftsInfoCarousel({ route }: Props) {
   }
 
   // Full page error screen shown when ntfs === []
-  if (nfts.length === 0) {
+  if (!activeNft) {
     return <NftsLoadError testID="NftsInfoCarousel/NftsLoadErrorScreen" />
   }
 
@@ -183,7 +206,9 @@ export default function NftsInfoCarousel({ route }: Props) {
           <View style={[styles.sectionContainer, styles.sectionContainerLast]}>
             <Touchable onPress={pressExplorerLink} testID="ViewOnExplorer">
               <View style={styles.explorerLinkContainer}>
-                <Text style={styles.explorerLink}>{t('nftInfoCarousel.viewOnCeloExplorer')}</Text>
+                <Text style={styles.explorerLink}>
+                  {t(EXPLORER_LINK_TRANSLATION_STRINGS[networkId])}
+                </Text>
                 <OpenLinkIcon color={colors.successDark} />
               </View>
             </Touchable>

--- a/src/tokens/Assets.test.tsx
+++ b/src/tokens/Assets.test.tsx
@@ -278,6 +278,28 @@ describe('AssetsScreen', () => {
     expect(ValoraAnalytics.track).toHaveBeenCalledTimes(1)
   })
 
+  it('clicking an NFT navigates to the nfts info screen', async () => {
+    jest.mocked(getFeatureGate).mockReturnValue(false)
+    const store = createMockStore(storeWithNfts)
+
+    const { getAllByTestId, getByText } = render(
+      <Provider store={store}>
+        <MockedNavigator component={AssetsScreen} />
+      </Provider>
+    )
+
+    fireEvent.press(getByText('assets.tabBar.collectibles'))
+
+    expect(getAllByTestId('NftItem')).toHaveLength(2)
+
+    fireEvent.press(getAllByTestId('NftGallery/NftImage')[0])
+    expect(navigate).toHaveBeenCalledTimes(1)
+    expect(navigate).toHaveBeenCalledWith(Screens.NftsInfoCarousel, {
+      nfts: [mockNftAllFields],
+      networkId: NetworkId['celo-alfajores'],
+    })
+  })
+
   it('hides claim rewards if feature gate is false', () => {
     jest
       .mocked(getFeatureGate)

--- a/src/tokens/Assets.tsx
+++ b/src/tokens/Assets.tsx
@@ -60,6 +60,7 @@ import { useTokenPricesAreStale, useTotalTokenBalance } from 'src/tokens/hooks'
 import { tokensWithNonZeroBalanceAndShowZeroBalanceSelector } from 'src/tokens/selectors'
 import { TokenBalance } from 'src/tokens/slice'
 import { getSupportedNetworkIdsForTokenBalances, getTokenAnalyticsProps } from 'src/tokens/utils'
+import networkConfig from 'src/web3/networkConfig'
 
 const DEVICE_WIDTH_BREAKPOINT = 340
 const NUM_OF_NFTS_PER_ROW = 2
@@ -337,7 +338,12 @@ function AssetsScreen({ navigation, route }: Props) {
       <View testID="NftItem" style={styles.nftsTouchableContainer}>
         <Touchable
           borderless={false}
-          onPress={() => navigate(Screens.NftsInfoCarousel, { nfts: [item] })}
+          onPress={() =>
+            navigate(Screens.NftsInfoCarousel, {
+              nfts: [item],
+              networkId: networkConfig.defaultNetworkId, // todo(satish): pass the correct value
+            })
+          }
           style={styles.nftsTouchableIcon}
         >
           <NftMedia

--- a/src/transactions/feed/NftFeedItem.test.tsx
+++ b/src/transactions/feed/NftFeedItem.test.tsx
@@ -100,6 +100,7 @@ describe('NftFeedItem', () => {
 
     expect(navigate).toHaveBeenCalledWith(Screens.NftsInfoCarousel, {
       nfts: [mockNftAllFields],
+      networkId: NetworkId['celo-alfajores'],
     })
   })
 

--- a/src/transactions/feed/NftFeedItem.tsx
+++ b/src/transactions/feed/NftFeedItem.tsx
@@ -34,7 +34,7 @@ function NftFeedItem({ transaction }: Props) {
 
   const openNftTransactionDetails = () => {
     showNftsInApp
-      ? navigate(Screens.NftsInfoCarousel, { nfts })
+      ? navigate(Screens.NftsInfoCarousel, { nfts, networkId: transaction.networkId })
       : navigate(Screens.WebViewScreen, {
           uri: `${networkConfig.nftsValoraAppUrl}?address=${walletAddress}&hide-header=true`,
         })

--- a/src/web3/networkConfig.ts
+++ b/src/web3/networkConfig.ts
@@ -38,7 +38,6 @@ interface NetworkConfig {
   setRegistrationPropertiesUrl: string
   fetchExchangesUrl: string
   nftsValoraAppUrl: string
-  celoExplorerBaseNFTUrl: string
   getSwapQuoteUrl: string
   walletJumpstartUrl: string
   walletJumpstartAddress: string
@@ -83,6 +82,7 @@ export type BlockExplorerUrls = {
     baseTxUrl: string
     baseAddressUrl: string
     baseTokenUrl: string
+    baseNftUrl: string
   }
 }
 
@@ -241,7 +241,6 @@ const networkConfigs: { [testnet: string]: NetworkConfig } = {
     setRegistrationPropertiesUrl: SET_REGISTRATION_PROPERTIES_ALFAJORES,
     fetchExchangesUrl: FETCH_EXCHANGES_URL_ALFAJORES,
     nftsValoraAppUrl: NFTS_VALORA_APP_URL,
-    celoExplorerBaseNFTUrl: 'https://explorer.celo.org/alfajores/token/',
     getSwapQuoteUrl: GET_SWAP_QUOTE_URL,
     walletJumpstartUrl: JUMPSTART_CLAIM_URL_ALFAJORES,
     walletJumpstartAddress: JUMPSTART_ADDRESS_ALFAJORES,
@@ -312,7 +311,6 @@ const networkConfigs: { [testnet: string]: NetworkConfig } = {
     setRegistrationPropertiesUrl: SET_REGISTRATION_PROPERTIES_MAINNET,
     fetchExchangesUrl: FETCH_EXCHANGES_URL_MAINNET,
     nftsValoraAppUrl: NFTS_VALORA_APP_URL,
-    celoExplorerBaseNFTUrl: 'https://explorer.celo.org/mainnet/token/',
     getSwapQuoteUrl: GET_SWAP_QUOTE_URL,
     walletJumpstartUrl: JUMPSTART_CLAIM_URL_MAINNET,
     walletJumpstartAddress: JUMPSTART_ADDRESS_MAINNET,
@@ -365,21 +363,25 @@ export const blockExplorerUrls: BlockExplorerUrls = {
     baseTxUrl: `${CELOSCAN_BASE_URL_MAINNET}/tx/`,
     baseAddressUrl: `${CELOSCAN_BASE_URL_MAINNET}/address/`,
     baseTokenUrl: `${CELOSCAN_BASE_URL_MAINNET}/token/`,
+    baseNftUrl: 'https://explorer.celo.org/mainnet/token/',
   },
   [NetworkId['celo-alfajores']]: {
     baseTxUrl: `${CELOSCAN_BASE_URL_ALFAJORES}/tx/`,
     baseAddressUrl: `${CELOSCAN_BASE_URL_ALFAJORES}/address/`,
     baseTokenUrl: `${CELOSCAN_BASE_URL_ALFAJORES}/token/`,
+    baseNftUrl: 'https://explorer.celo.org/alfajores/token/',
   },
   [NetworkId['ethereum-mainnet']]: {
     baseTxUrl: `${ETHERSCAN_BASE_URL_MAINNET}/tx/`,
     baseAddressUrl: `${ETHERSCAN_BASE_URL_MAINNET}/address/`,
     baseTokenUrl: `${ETHERSCAN_BASE_URL_MAINNET}/token/`,
+    baseNftUrl: `${ETHERSCAN_BASE_URL_MAINNET}/nft/`,
   },
   [NetworkId['ethereum-sepolia']]: {
     baseTxUrl: `${ETHERSCAN_BASE_URL_SEPOLIA}/tx/`,
     baseAddressUrl: `${ETHERSCAN_BASE_URL_SEPOLIA}/address/`,
     baseTokenUrl: `${ETHERSCAN_BASE_URL_SEPOLIA}/token/`,
+    baseNftUrl: `${ETHERSCAN_BASE_URL_SEPOLIA}/nft/`,
   },
 }
 


### PR DESCRIPTION
### Description

The block explorer link on NFTs was hardcoded to celo explorer. This is now displayed based on the network id of the NFT

### Test plan

Unit tests, manual


https://github.com/valora-inc/wallet/assets/5062591/55564978-f680-465d-98a5-b62844750c0c



### Related issues

- Part of ACT-1017

### Backwards compatibility

Yes
