### PR TITLE
fix: update payment sent tx details screen to prioritise token units

### DIFF
--- a/src/fees/hooks.ts
+++ b/src/fees/hooks.ts
@@ -7,29 +7,11 @@ import { feeEstimatesSelector } from 'src/fees/selectors'
 import useSelector from 'src/redux/useSelector'
 import { useTokenInfo, useUsdToTokenAmount } from 'src/tokens/hooks'
 import { celoAddressSelector, tokensByUsdBalanceSelector } from 'src/tokens/selectors'
-import { Fee, FeeType as TransactionFeeType } from 'src/transactions/types'
 import { ONE_HOUR_IN_MILLIS } from 'src/utils/time'
 
 export function useFeeCurrency(): string | undefined {
   const tokens = useSelector(tokensByUsdBalanceSelector)
   return fetchFeeCurrency(tokens)
-}
-
-export function usePaidFees(fees: Fee[]) {
-  const securityFeeAmount = fees.find((fee) => fee.type === TransactionFeeType.SecurityFee)
-  const dekFeeAmount = fees.find((fee) => fee.type === TransactionFeeType.EncryptionFee)
-
-  const securityFee = securityFeeAmount ? new BigNumber(securityFeeAmount.amount.value) : undefined
-  const dekFee = dekFeeAmount ? new BigNumber(dekFeeAmount.amount.value) : undefined
-  const totalFeeOrZero = new BigNumber(0).plus(securityFee ?? 0).plus(dekFee ?? 0)
-  const totalFee = totalFeeOrZero.isZero() ? undefined : totalFeeOrZero
-
-  return {
-    securityFeeTokenId: securityFeeAmount?.amount.tokenId,
-    securityFee,
-    dekFee,
-    totalFee,
-  }
 }
 
 /**

--- a/src/transactions/feed/TransactionDetailsScreen.test.tsx
+++ b/src/transactions/feed/TransactionDetailsScreen.test.tsx
@@ -178,7 +178,7 @@ describe('TransactionDetailsScreen', () => {
   }
 
   it('renders correctly for sends', async () => {
-    const { getByTestId } = renderScreen({
+    const { getByTestId, getByText } = renderScreen({
       transaction: tokenTransfer({
         type: TokenTransactionTypeV2.Sent,
         address: mockAddress,
@@ -206,10 +206,13 @@ describe('TransactionDetailsScreen', () => {
     const numberComponent = getByTestId('TransferSent/number')
     expect(getElementText(numberComponent)).toEqual(mockDisplayNumber2)
 
-    const amountComponent = getByTestId('SentAmount')
-    expect(getElementText(amountComponent)).toEqual('€4.00')
-    const totalComponent = getByTestId('TotalLineItem/Total')
-    expect(getElementText(totalComponent)).toEqual('€4.04')
+    expect(getByTestId('TransactionDetails/NetworkFee')).toHaveTextContent('0.01 CELO')
+    expect(getByTestId('TransactionDetails/NetworkFeeLocalCurrency')).toHaveTextContent('₱0.067')
+
+    expect(getByText('amountSent')).toBeTruthy()
+    expect(getByTestId('TransferSent/AmountSentValue')).toHaveTextContent('10.00 cUSD')
+    expect(getByTestId('TransferSent/TransferTokenExchangeRate')).toHaveTextContent('₱1.33')
+    expect(getByTestId('TransferSent/AmountSentValueFiat')).toHaveTextContent('₱13.30')
   })
 
   it('renders correctly for receives', async () => {

--- a/src/transactions/feed/detailContent/TransferSentContent.tsx
+++ b/src/transactions/feed/detailContent/TransferSentContent.tsx
@@ -1,40 +1,37 @@
 import BigNumber from 'bignumber.js'
 import React from 'react'
-import { useTranslation } from 'react-i18next'
+import { Trans, useTranslation } from 'react-i18next'
+import { StyleSheet } from 'react-native'
 import HorizontalLine from 'src/components/HorizontalLine'
-import LegacyFeeDrawer from 'src/components/LegacyFeeDrawer'
 import LineItemRow from 'src/components/LineItemRow'
 import TokenDisplay from 'src/components/TokenDisplay'
-import TokenTotalLineItem from 'src/components/TokenTotalLineItem'
-import { usePaidFees } from 'src/fees/hooks'
 import { getRecipientFromAddress } from 'src/recipients/recipient'
 import { recipientInfoSelector } from 'src/recipients/reducer'
 import useSelector from 'src/redux/useSelector'
+import Colors from 'src/styles/colors'
+import { typeScale } from 'src/styles/fonts'
+import { Spacing } from 'src/styles/styles'
 import { useTokenInfo } from 'src/tokens/hooks'
 import CommentSection from 'src/transactions/CommentSection'
 import TransferAvatars from 'src/transactions/TransferAvatars'
 import UserSection from 'src/transactions/UserSection'
+import NetworkFeeRowItem from 'src/transactions/feed/detailContent/NetworkFeeRowItem'
 import { TokenTransfer } from 'src/transactions/types'
 import { Currency } from 'src/utils/currencies'
 import networkConfig from 'src/web3/networkConfig'
 
 // Note that this is tested from TransactionDetailsScreen.test.tsx
 function TransferSentContent({ transfer }: { transfer: TokenTransfer }) {
-  const { amount, metadata, address, fees } = transfer
+  const { amount, metadata, address } = transfer
 
   const { t } = useTranslation()
   const info = useSelector(recipientInfoSelector)
 
   const celoTokenId = useTokenInfo(networkConfig.currencyToTokenId[Currency.Celo])?.tokenId
+  const transferTokenInfo = useTokenInfo(transfer.amount.tokenId)
 
   const isCeloWithdrawal = amount.tokenId === celoTokenId
   const recipient = getRecipientFromAddress(address, info, metadata.title, metadata.image)
-
-  const { securityFee, dekFee, totalFee, securityFeeTokenId } = usePaidFees(fees)
-  const totalFromFeesInLocal = fees.reduce(
-    (sum, fee) => sum.plus(fee.amount?.localAmount?.value ?? 0),
-    new BigNumber(0)
-  )
 
   return (
     <>
@@ -46,44 +43,62 @@ function TransferSentContent({ transfer }: { transfer: TokenTransfer }) {
       />
       <CommentSection comment={metadata.comment} isSend={true} />
       <HorizontalLine />
+      <NetworkFeeRowItem fees={transfer.fees} transactionStatus={transfer.status} />
       <LineItemRow
-        title={isCeloWithdrawal ? t('amountCeloWithdrawn') : t('amountSent')}
+        title={t('amountSent')}
+        textStyle={typeScale.labelSemiBoldMedium}
+        style={styles.amountSentContainer}
         amount={
           <TokenDisplay
-            amount={amount.value}
-            tokenId={amount.tokenId}
-            localAmount={amount.localAmount}
+            amount={transfer.amount.value}
+            tokenId={transfer.amount.tokenId}
+            showLocalAmount={false}
             hideSign={true}
-            testID="SentAmount"
+            testID="TransferSent/AmountSentValue"
           />
         }
       />
-      <LegacyFeeDrawer
-        securityFeeTokenId={securityFeeTokenId}
-        securityFee={securityFee}
-        dekFee={dekFee}
-        totalFee={totalFee}
-        showLocalAmount={true}
-      />
-      <TokenTotalLineItem
-        tokenAmount={new BigNumber(amount.value)}
-        tokenId={amount.tokenId}
-        localAmount={
-          amount.localAmount
-            ? {
-                ...amount.localAmount,
-                value: new BigNumber(amount.localAmount.value)
-                  .absoluteValue()
-                  .plus(totalFromFeesInLocal)
-                  .toString(),
-              }
-            : undefined
+      <LineItemRow
+        title={
+          <Trans
+            i18nKey={'tokenExchangeRateApprox'}
+            tOptions={{ symbol: transferTokenInfo?.symbol }}
+          >
+            <TokenDisplay
+              amount={new BigNumber(1)}
+              tokenId={transfer.amount.tokenId}
+              showLocalAmount={true}
+              testID="TransferSent/TransferTokenExchangeRate"
+            />
+          </Trans>
         }
-        feeToAddInUsd={undefined}
-        hideSign={true}
+        amount={
+          <TokenDisplay
+            amount={transfer.amount.value}
+            tokenId={transfer.amount.tokenId}
+            showLocalAmount={true}
+            hideSign={true}
+            testID="TransferSent/AmountSentValueFiat"
+          />
+        }
+        style={styles.tokenFiatValueContainer}
+        textStyle={styles.tokenFiatValueText}
       />
     </>
   )
 }
+
+const styles = StyleSheet.create({
+  amountSentContainer: {
+    marginTop: Spacing.Small12,
+  },
+  tokenFiatValueContainer: {
+    marginTop: -Spacing.Tiny4,
+  },
+  tokenFiatValueText: {
+    ...typeScale.bodySmall,
+    color: Colors.gray4,
+  },
+})
 
 export default TransferSentContent


### PR DESCRIPTION
### Description

Context https://valora-app.slack.com/archives/C0684TXDR3K/p1704303258842509
Design https://www.figma.com/file/LrAxu4ywFL8Uslve7o2FoF/Activity-Feed?type=design&node-id=2160-5077&mode=design&t=y54cJ68cIhqH7FVl-0

This PR updates the values of the payment sent tx details screen to show only network fees and sent amount (prioritising token units) to be consistent with other types of tx details screens and to avoid showing an incorrect "total" tx value.

### Test plan

![Simulator Screenshot - iPhone 14 Pro - 2024-01-09 at 09 50 25](https://github.com/valora-inc/wallet/assets/20150449/c097d0ac-dbd3-413f-8a87-e848b08d16d8)


### Related issues

- Fixes RET-960

### Backwards compatibility

Y
