### PR TITLE
fix(wc): incorrect normalization of transaction fields

### DIFF
--- a/src/walletConnect/saga.test.ts
+++ b/src/walletConnect/saga.test.ts
@@ -659,7 +659,7 @@ describe('normalizeTransaction', () => {
     it(`accepts \`${bigIntKey}\` as a number`, async () => {
       expect(
         await callNormalizeTransaction(
-          { from: '0xTEST', data: '0xABC', [bigIntKey]: '19' },
+          { from: '0xTEST', data: '0xABC', [bigIntKey]: 19 },
           Network.Ethereum
         )
       ).toStrictEqual({

--- a/src/walletConnect/saga.test.ts
+++ b/src/walletConnect/saga.test.ts
@@ -533,7 +533,7 @@ describe('normalizeTransaction', () => {
       .then((result) => result.returnValue)
   }
 
-  it('ensures `gasLimit` value is removed and used as gas instead', async () => {
+  it('ensures `gasLimit` value is removed and used as `gas` instead', async () => {
     expect(
       await callNormalizeTransaction(
         {

--- a/src/walletConnect/saga.ts
+++ b/src/walletConnect/saga.ts
@@ -347,25 +347,42 @@ function getSupportedChains() {
   })
 }
 
-function convertGasParamToExpectedType(gasParam: any) {
-  return isHex(gasParam)
-    ? hexToBigInt(gasParam)
-    : // make sure that we can safely parse the param as a BigInt
-    typeof gasParam === 'string' || typeof gasParam === 'number' || typeof gasParam === 'bigint'
-    ? BigInt(gasParam)
+function convertToBigInt(value: any) {
+  return isHex(value)
+    ? hexToBigInt(value)
+    : // make sure that we can safely parse the value as a BigInt
+    typeof value === 'string' || typeof value === 'number' || typeof value === 'bigint'
+    ? BigInt(value)
     : undefined
 }
 
+function convertToNumber(value: any) {
+  const bigValue = convertToBigInt(value)
+  return bigValue !== undefined ? Number(bigValue) : undefined
+}
+
+// Normalize the raw request into a usable format (bigint, etc) for viem
+// Note: the raw request should be in RPC format (fields in hex string)
+// but sometimes we've seen fields with numbers instead of hex strings
+// i.e. don't trust the raw request to be in the correct format, since it comes from the dapp
 export function* normalizeTransaction(rawTx: any, network: Network) {
-  const tx: TransactionRequest = { ...rawTx }
+  const tx: TransactionRequest = {
+    ...rawTx,
+    gas: convertToBigInt(rawTx.gas),
+    gasPrice: convertToBigInt(rawTx.gasPrice),
+    maxFeePerGas: convertToBigInt(rawTx.maxFeePerGas),
+    maxPriorityFeePerGas: convertToBigInt(rawTx.maxPriorityFeePerGas),
+    nonce: convertToNumber(rawTx.nonce),
+    value: convertToBigInt(rawTx.value),
+  }
 
   // Handle `gasLimit` as a misnomer for `gas`, it usually comes through in hex format
   if ('gasLimit' in tx && tx.gas === undefined) {
-    tx.gas = convertGasParamToExpectedType(tx.gasLimit)
+    tx.gas = convertToBigInt(tx.gasLimit)
     delete tx.gasLimit
   }
 
-  // re-calculate the feeCurrency and gas since it is not possible to tell from
+  // On Celo, re-calculate the feeCurrency and gas since it is not possible to tell from
   // the request payload if the feeCurrency is set to undefined (native
   // currency) explicitly or due to lack of feeCurrency support
   if (network === Network.Celo) {
@@ -373,8 +390,6 @@ export function* normalizeTransaction(rawTx: any, network: Network) {
     if ('feeCurrency' in tx) {
       delete tx.feeCurrency
     }
-  } else {
-    tx.gas = convertGasParamToExpectedType(tx.gas)
   }
 
   // Force upgrade legacy tx to EIP-1559/CIP-42/CIP-64
@@ -394,6 +409,13 @@ export function* normalizeTransaction(rawTx: any, network: Network) {
       blockTag: 'pending',
     }
     tx.nonce = yield* call(getTransactionCount, publicClient[network], txCountParams)
+  }
+
+  // Strip undefined keys, just to avoid noise in the logs or tests
+  for (const key of Object.keys(tx) as Array<keyof TransactionRequest>) {
+    if (tx[key] === undefined) {
+      delete tx[key]
+    }
   }
 
   return tx
@@ -444,18 +466,27 @@ function* showActionRequest(request: Web3WalletTypes.EventArguments['session_req
     method === SupportedActions.eth_signTransaction ||
     method === SupportedActions.eth_sendTransaction
   ) {
+    const rawTx = request.params.request.params[0]
+    Logger.debug(TAG + '@showActionRequest', 'Received transaction', rawTx)
     const network = walletConnectChainIdToNetwork[request.params.chainId]
-    const normalizedTx = yield* call(
-      normalizeTransaction,
-      request.params.request.params[0],
-      network
-    )
+    const normalizedTx = yield* call(normalizeTransaction, rawTx, network)
     preparedTransactionsResult = yield* call(prepareTransactions, {
       feeCurrencies,
       decreasedAmountGasFeeMultiplier: 1,
       baseTransactions: [normalizedTx],
     })
   }
+
+  const preparedTransaction =
+    preparedTransactionsResult?.type === 'possible'
+      ? getSerializablePreparedTransaction(preparedTransactionsResult.transactions[0])
+      : undefined
+  Logger.debug(
+    TAG + '@showActionRequest',
+    'Prepared transaction',
+    preparedTransactionsResult?.type,
+    preparedTransaction
+  )
 
   navigate(Screens.WalletConnectRequest, {
     type: WalletConnectRequestType.Action,
@@ -464,10 +495,7 @@ function* showActionRequest(request: Web3WalletTypes.EventArguments['session_req
     version: 2,
     hasInsufficientGasFunds: preparedTransactionsResult?.type === 'not-enough-balance-for-gas',
     feeCurrenciesSymbols: feeCurrencies.map((token) => token.symbol),
-    preparedTransaction:
-      preparedTransactionsResult?.type === 'possible'
-        ? getSerializablePreparedTransaction(preparedTransactionsResult.transactions[0])
-        : undefined,
+    preparedTransaction,
   })
 }
 


### PR DESCRIPTION
### Description

Fixes unable to correctly send/sign transactions with some dapps when using viem.

Although Valora was able to successfully sign/send the TX from its point of view, it was actually producing a TX with a really high `nonce` value, when the dapp was providing the `nonce` value as a hex string.

This was the problematic case:
1. Dapp asks to send a TX with `nonce` set to `"0x19"` which is a valid format
2. Valora receives it and keeps the `nonce` as is while [normalizing](https://github.com/valora-inc/wallet/blob/ed4d4266e2e5bfb87297fabab8e497b9a11eb8f1/src/walletConnect/saga.ts#L360)
3. However the output of the normalization should be a fully valid viem TX, which expects some fields as `bigint` and `nonce` as a `number`.
4. Then later when we call the viem client to send or sign, it uses the `"0x19"` nonce thinking it's a `number` and ends up producing an incorrect serialized value for it, which is different and way higher.

To fix this, we're now ensuring the result of the normalization converts all needed fields in the types expected by viem (usually `bigint` or `number`).

Also added more logs to help debug this type of issue.

See also these Slack threads:
- [thread 1](https://valora-app.slack.com/archives/C05BHD5AGSW/p1704311206430959?thread_ts=1704306964.565909&cid=C05BHD5AGSW)
- [thread 2](https://valora-app.slack.com/archives/C05BHD5AGSW/p1704787988979889?thread_ts=1704748140.888959&cid=C05BHD5AGSW)

Note: many dapps on Celo don't pass `nonce`, so it wasn't directly apparent there. But Celo dapps are also affected.

### Test plan

- Updated unit tests
- Manually tested interactions with https://app.safe.global work
- Manually tested with https://react-app.walletconnect.com/
  - Note that this one doesn't surface the nonce issue and happily reports that the received hash is valid

### Related issues

N/A

### Backwards compatibility

Yes
