### PR TITLE
refactor(send): update button text from send to continue on recipient selection

### DIFF
--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -1974,7 +1974,11 @@
       "title": "Connect your phone number",
       "description": "You need to connect your phone number so you can start sending crypto to your friends"
     },
-    "unknownAddressInfo": "Please make sure this address supports the asset you are trying to send. Your funds may not be recoverable if this address is invalid."
+    "unknownAddressInfo": "Please make sure this address supports the asset you are trying to send. Your funds may not be recoverable if this address is invalid.",
+    "buttons": {
+      "send": "Continue",
+      "invite": "Invite"
+    }
   },
   "transactionStatus": {
     "transactionIsCompleted": "Completed",

--- a/src/send/SendSelectRecipient.test.tsx
+++ b/src/send/SendSelectRecipient.test.tsx
@@ -192,6 +192,7 @@ describe('SendSelectRecipient', () => {
     })
 
     expect(getByTestId('SendOrInviteButton')).toBeTruthy()
+    expect(getByTestId('SendOrInviteButton')).toHaveTextContent('sendSelectRecipient.buttons.send')
 
     await act(() => {
       fireEvent.press(getByTestId('SendOrInviteButton'))
@@ -203,15 +204,13 @@ describe('SendSelectRecipient', () => {
       }
     )
 
-    // Uncomment once we can actually navigate to this screen
-
-    // expect(navigate).toHaveBeenCalledWith(Screens.SendEnterAmount, {
-    //   isFromScan: false,
-    //   defaultTokenIdOverride: undefined,
-    //   forceTokenId: undefined,
-    //   recipient: expect.any(Object),
-    //   origin: SendOrigin.AppSendFlow,
-    // })
+    expect(navigate).toHaveBeenCalledWith(Screens.SendEnterAmount, {
+      isFromScan: false,
+      defaultTokenIdOverride: undefined,
+      forceTokenId: undefined,
+      recipient: expect.any(Object),
+      origin: SendOrigin.AppSendFlow,
+    })
   })
   it('navigates to send amount when address recipient is pressed', async () => {
     const store = createMockStore(defaultStore)
@@ -231,10 +230,17 @@ describe('SendSelectRecipient', () => {
     })
 
     expect(getByTestId('SendOrInviteButton')).toBeTruthy()
+    expect(getByTestId('SendOrInviteButton')).toHaveTextContent('sendSelectRecipient.buttons.send')
 
     await act(() => {
       fireEvent.press(getByTestId('SendOrInviteButton'))
     })
+    expect(ValoraAnalytics.track).toHaveBeenCalledWith(
+      SendEvents.send_select_recipient_send_press,
+      {
+        recipientType: RecipientType.Address,
+      }
+    )
     expect(navigate).toHaveBeenCalledWith(Screens.SendEnterAmount, {
       isFromScan: false,
       defaultTokenIdOverride: undefined,
@@ -265,6 +271,9 @@ describe('SendSelectRecipient', () => {
     })
 
     expect(getByTestId('SendOrInviteButton')).toBeTruthy()
+    expect(getByTestId('SendOrInviteButton')).toHaveTextContent(
+      'sendSelectRecipient.buttons.invite'
+    )
 
     await act(() => {
       fireEvent.press(getByTestId('SendOrInviteButton'))

--- a/src/send/SendSelectRecipient.tsx
+++ b/src/send/SendSelectRecipient.tsx
@@ -168,7 +168,11 @@ function SendOrInviteButton({
       style={styles.sendOrInviteButton}
       onPress={() => onPress(shouldInviteRecipient)}
       disabled={sendOrInviteButtonDisabled}
-      text={shouldInviteRecipient ? t('invite') : t('send')}
+      text={
+        shouldInviteRecipient
+          ? t('sendSelectRecipient.buttons.invite')
+          : t('sendSelectRecipient.buttons.send')
+      }
       size={BtnSizes.FULL}
     />
   )


### PR DESCRIPTION
### Description

Per Laura's request. Updated this button on selecting a recipient with address to Continue instead of Send. Also, made specific translation keys so this can be updated OTA

### Test plan

Unit tests, manual

### Related issues

N/A

### Backwards compatibility

Yes
