### PR TITLE
fix(sends): Fix error checking when estimating gas

### DIFF
--- a/src/viem/prepareTransactions.ts
+++ b/src/viem/prepareTransactions.ts
@@ -122,7 +122,8 @@ export async function tryEstimateTransaction({
       e instanceof EstimateGasExecutionError &&
       (e.cause instanceof InsufficientFundsError ||
         (e.cause instanceof ExecutionRevertedError && // viem does not reliably label node errors as InsufficientFundsError when the user has enough to pay for the transfer, but not for the transfer + gas
-          /transfer value exceeded balance of sender/.test(e.cause.details)) ||
+          (/transfer value exceeded balance of sender/.test(e.cause.details) ||
+            /transfer amount exceeds balance/.test(e.cause.details))) ||
         (e.cause instanceof InvalidInputRpcError &&
           /gas required exceeds allowance/.test(e.cause.details)))
     ) {


### PR DESCRIPTION
### Description

Currently, the error strings we check for when estimating gas are not sufficient to catch all types of errors we care about. Basically, what was happening was when a user tries to send MAX balance of some gas-payable asset A, we try to prepare the transaction using asset A (and other gas-payable assets) as gas, and estimation fails when using asset A as gas since gas + transfer amount exceeds balance. This error during estimation wasn't being caught by the `cause` strings we were looking at. This caused gas estimation to hang forever, preventing the user from continuing with the transfer. This PR adds in a new cause string to fix that.

In general, it appears as if this cause string is determined _by the blockchain_ itself, i.e., not by `viem`, and therefore may be liable to change in the wild. This is a temporary fix, but it may be worth revisiting this if it crops up again, and making the errors we check for configurable remotely.

### Test plan

Manual tested.

### Related issues

- Fixes ACT-1045

### Backwards compatibility

<!-- Brief explanation of why these changes are/are not backwards compatible. -->
