### PR TITLE
feat(fees): get proper baseFeePerGas on Celo for the estimated gas fee

### DIFF
--- a/src/viem/estimateFeesPerGas.ts
+++ b/src/viem/estimateFeesPerGas.ts
@@ -47,7 +47,7 @@ export async function estimateFeesPerGas(
 
 // Get gas price with optional fee currency, this is Celo specific
 // See https://docs.celo.org/developer/viem#gas-price
-export async function getGasPrice(client: Client, feeCurrency: Address | undefined) {
+async function getGasPrice(client: Client, feeCurrency: Address | undefined) {
   const priceHex = await client.request({
     method: 'eth_gasPrice',
     ...((feeCurrency ? { params: [feeCurrency] } : {}) as object),
@@ -56,7 +56,7 @@ export async function getGasPrice(client: Client, feeCurrency: Address | undefin
 }
 
 // Get max priority fee per gas with optional fee currency, this is Celo specific
-export async function getMaxPriorityFeePerGas(client: Client, feeCurrency?: Address) {
+async function getMaxPriorityFeePerGas(client: Client, feeCurrency?: Address) {
   const maxPriorityFeePerGasHex = await client.request({
     method: 'eth_maxPriorityFeePerGas',
     ...((feeCurrency ? { params: [feeCurrency] } : {}) as object),
@@ -65,7 +65,7 @@ export async function getMaxPriorityFeePerGas(client: Client, feeCurrency?: Addr
 }
 
 // Get gas price minimum with optional fee currency, this is Celo specific
-export async function getCeloGasPriceMinimum(client: Client, feeCurrency: Address | undefined) {
+async function getCeloGasPriceMinimum(client: Client, feeCurrency: Address | undefined) {
   const gasPriceMinimum = await readContract(client, {
     address: networkConfig.celoGasPriceMinimumAddress,
     // Extracted the ABI from https://unpkg.com/browse/@celo/abis@10.0.0/dist/GasPriceMinimum.json

--- a/src/viem/estimateFeesPerGas.ts
+++ b/src/viem/estimateFeesPerGas.ts
@@ -1,6 +1,10 @@
 import networkConfig from 'src/web3/networkConfig'
 import { Address, Client, hexToBigInt } from 'viem'
-import { estimateFeesPerGas as defaultEstimateFeesPerGas, getBlock } from 'viem/actions'
+import {
+  estimateFeesPerGas as defaultEstimateFeesPerGas,
+  getBlock,
+  readContract,
+} from 'viem/actions'
 
 export async function estimateFeesPerGas(
   client: Client,
@@ -12,13 +16,14 @@ export async function estimateFeesPerGas(
     // The gasPrice returned on Celo is already roughly 2x baseFeePerGas
     // See this thread for more context:
     // https://valora-app.slack.com/archives/CNJ7KTHQU/p1697717100995909?thread_ts=1697647756.662059&cid=CNJ7KTHQU
-    const [gasPrice, maxPriorityFeePerGas] = await Promise.all([
+    const [gasPrice, maxPriorityFeePerGas, gasPriceMinimum] = await Promise.all([
       getGasPrice(client, feeCurrency),
       getMaxPriorityFeePerGas(client, feeCurrency),
+      getGasPriceMinimum(client, feeCurrency),
     ])
     const maxFeePerGas = gasPrice + maxPriorityFeePerGas
-    // TODO: properly calculate baseFeePerGas
-    return { maxFeePerGas, maxPriorityFeePerGas, baseFeePerGas: BigInt(maxFeePerGas) }
+
+    return { maxFeePerGas, maxPriorityFeePerGas, baseFeePerGas: gasPriceMinimum }
   }
 
   if (feeCurrency) {
@@ -57,4 +62,29 @@ export async function getMaxPriorityFeePerGas(client: Client, feeCurrency?: Addr
     ...((feeCurrency ? { params: [feeCurrency] } : {}) as object),
   })
   return hexToBigInt(maxPriorityFeePerGasHex)
+}
+
+// Get gas price minimum with optional fee currency, this is Celo specific
+export async function getGasPriceMinimum(client: Client, feeCurrency: Address | undefined) {
+  const gasPriceMinimum = await readContract(client, {
+    address: networkConfig.celoGasPriceMinimumAddress,
+    // Extracted the ABI from https://unpkg.com/browse/@celo/abis@10.0.0/dist/GasPriceMinimum.json
+    abi: [
+      {
+        constant: true,
+        inputs: [{ internalType: 'address', name: 'tokenAddress', type: 'address' }],
+        name: 'getGasPriceMinimum',
+        outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+        payable: false,
+        stateMutability: 'view',
+        type: 'function',
+      },
+    ] as const,
+    functionName: 'getGasPriceMinimum',
+    // The contract doesn't accept an undefined or empty feeCurrency for the native token
+    // Unlike eth_gasPrice or eth_maxPriorityFeePerGas
+    args: [feeCurrency ?? networkConfig.celoTokenAddress],
+  })
+
+  return gasPriceMinimum
 }

--- a/src/viem/estimateFeesPerGas.ts
+++ b/src/viem/estimateFeesPerGas.ts
@@ -19,7 +19,7 @@ export async function estimateFeesPerGas(
     const [gasPrice, maxPriorityFeePerGas, gasPriceMinimum] = await Promise.all([
       getGasPrice(client, feeCurrency),
       getMaxPriorityFeePerGas(client, feeCurrency),
-      getGasPriceMinimum(client, feeCurrency),
+      getCeloGasPriceMinimum(client, feeCurrency),
     ])
     const maxFeePerGas = gasPrice + maxPriorityFeePerGas
 
@@ -65,7 +65,7 @@ export async function getMaxPriorityFeePerGas(client: Client, feeCurrency?: Addr
 }
 
 // Get gas price minimum with optional fee currency, this is Celo specific
-export async function getGasPriceMinimum(client: Client, feeCurrency: Address | undefined) {
+export async function getCeloGasPriceMinimum(client: Client, feeCurrency: Address | undefined) {
   const gasPriceMinimum = await readContract(client, {
     address: networkConfig.celoGasPriceMinimumAddress,
     // Extracted the ABI from https://unpkg.com/browse/@celo/abis@10.0.0/dist/GasPriceMinimum.json

--- a/src/web3/networkConfig.ts
+++ b/src/web3/networkConfig.ts
@@ -1,9 +1,9 @@
-import { Address } from '@celo/base'
 import { Environment as PersonaEnvironment } from 'react-native-persona'
 import { BIDALI_URL, DEFAULT_FORNO_URL, DEFAULT_TESTNET, RECAPTCHA_SITE_KEY } from 'src/config'
 import { Network, NetworkId } from 'src/transactions/types'
 import Logger from 'src/utils/Logger'
 import { CiCoCurrency, Currency } from 'src/utils/currencies'
+import { Address } from 'viem'
 import {
   Chain as ViemChain,
   celo,
@@ -67,7 +67,8 @@ interface NetworkConfig {
   currencyToTokenId: {
     [key in CiCoCurrency | Currency]: string
   }
-  celoTokenAddress: string
+  celoTokenAddress: Address
+  celoGasPriceMinimumAddress: Address
   alchemyEthereumRpcUrl: string
   cusdTokenId: string
   ceurTokenId: string
@@ -95,6 +96,10 @@ export type NetworkIdToNetwork = {
 
 const CELO_TOKEN_ADDRESS_STAGING = '0xf194afdf50b03e69bd7d057c1aa9e10c9954e4c9'
 const CELO_TOKEN_ADDRESS_MAINNET = '0x471ece3750da237f93b8e339c536989b8978a438'
+
+// From https://docs.celo.org/contract-addresses
+const CELO_GAS_PRICE_MINIMUM_ADDRESS_STAGING = '0xd0bf87a5936ee17014a057143a494dc5c5d51e5e'
+const CELO_GAS_PRICE_MINIMUM_ADDRESS_MAINNET = '0xdfca3a8d7699d8bafe656823ad60c17cb8270ecc'
 
 const CELO_TOKEN_ID_STAGING = `${NetworkId['celo-alfajores']}:native`
 const CELO_TOKEN_ID_MAINNET = `${NetworkId['celo-mainnet']}:native`
@@ -287,6 +292,7 @@ const networkConfigs: { [testnet: string]: NetworkConfig } = {
       [Currency.Celo]: CELO_TOKEN_ID_STAGING,
     },
     celoTokenAddress: CELO_TOKEN_ADDRESS_STAGING,
+    celoGasPriceMinimumAddress: CELO_GAS_PRICE_MINIMUM_ADDRESS_STAGING,
     alchemyEthereumRpcUrl: ALCHEMY_ETHEREUM_RPC_URL_STAGING,
     cusdTokenId: CUSD_TOKEN_ID_STAGING,
     ceurTokenId: CEUR_TOKEN_ID_STAGING,
@@ -360,6 +366,7 @@ const networkConfigs: { [testnet: string]: NetworkConfig } = {
       [Currency.Celo]: CELO_TOKEN_ID_MAINNET,
     },
     celoTokenAddress: CELO_TOKEN_ADDRESS_MAINNET,
+    celoGasPriceMinimumAddress: CELO_GAS_PRICE_MINIMUM_ADDRESS_MAINNET,
     alchemyEthereumRpcUrl: ALCHEMY_ETHEREUM_RPC_URL_MAINNET,
     cusdTokenId: CUSD_TOKEN_ID_MAINNET,
     ceurTokenId: CEUR_TOKEN_ID_MAINNET,


### PR DESCRIPTION
### Description

As the title says.

This gets us another ~40% decrease in estimated gas fee on Celo.

Typical `baseFeePerGas` with CELO as a `feeCurrency` is `5 gwei`, when the recommended `maxFeePerGas` is
typically `12 gwei` (10 (`gasPrice`) + 2 (`maxPriorityFeePerGas`)).

So `1 - 7 / 12 = ~0.41`

Of course it's already less than a cent, but now it's right 🤓 

### Test plan

- Updated tests

| Before | After |
|--------|-------|
| ![image](https://github.com/valora-inc/wallet/assets/57791/4d4280c4-b351-46f4-8ec4-868d9020282a) | ![image](https://github.com/valora-inc/wallet/assets/57791/7a3be268-27df-4fb8-9d52-2abe0fccc287) |

### Related issues

- Fixes RET-991

### Backwards compatibility

Yes
