### PR TITLE
feat(jumpstart): get jumpstart contract address from dynamic config

### DIFF
--- a/src/jumpstart/jumpstartLinkHandler.test.ts
+++ b/src/jumpstart/jumpstartLinkHandler.test.ts
@@ -1,3 +1,5 @@
+import { getDynamicConfigParams } from 'src/statsig'
+import Logger from 'src/utils/Logger'
 import { fetchWithTimeout } from 'src/utils/fetchWithTimeout'
 import { mockAccount, mockAccount2 } from 'test/values'
 import { jumpstartLinkHandler } from './jumpstartLinkHandler'
@@ -27,6 +29,8 @@ jest.mock('src/web3/utils', () => ({
   })),
 }))
 jest.mock('src/utils/fetchWithTimeout')
+jest.mock('src/statsig')
+jest.mock('src/utils/Logger')
 
 describe('jumpstartLinkHandler', () => {
   const privateKey = '0x1234567890abcdef'
@@ -39,6 +43,7 @@ describe('jumpstartLinkHandler', () => {
     ;(fetchWithTimeout as jest.Mock).mockImplementation(() => ({
       ok: true,
     }))
+    jest.mocked(getDynamicConfigParams).mockReturnValue({ celo: { contractAddress: '0xTEST' } })
 
     await jumpstartLinkHandler(privateKey, mockAccount2)
 
@@ -48,5 +53,14 @@ describe('jumpstartLinkHandler', () => {
       expect.any(Object),
       expect.any(Number)
     )
+  })
+
+  it('fails when contract address is not provided in dynamic config', async () => {
+    jest.mocked(getDynamicConfigParams).mockReturnValue({})
+
+    await jumpstartLinkHandler(privateKey, mockAccount2)
+
+    expect(fetchWithTimeout).not.toHaveBeenCalled()
+    expect(Logger.error).toHaveBeenCalled()
   })
 })

--- a/src/statsig/constants.ts
+++ b/src/statsig/constants.ts
@@ -1,4 +1,5 @@
 import { StatsigDynamicConfigs, StatsigExperiments, StatsigFeatureGates } from 'src/statsig/types'
+import { Network } from 'src/transactions/types'
 import networkConfig from 'src/web3/networkConfig'
 
 export const FeatureGates = {
@@ -104,5 +105,9 @@ export const DynamicConfigs = {
     defaultValues: {
       tokenInfo: {} as { [tokenId: string]: { cicoOrder: number } },
     },
+  },
+  [StatsigDynamicConfigs.WALLET_JUMPSTART_CONFIG]: {
+    configName: StatsigDynamicConfigs.WALLET_JUMPSTART_CONFIG,
+    defaultValues: {} as { [key in Network]?: { contractAddress?: string } },
   },
 }

--- a/src/statsig/types.ts
+++ b/src/statsig/types.ts
@@ -5,6 +5,7 @@ export enum StatsigDynamicConfigs {
   DAPP_WEBVIEW_CONFIG = 'dapp_webview_config',
   SWAP_CONFIG = 'swap_config',
   CICO_TOKEN_INFO = 'cico_token_info',
+  WALLET_JUMPSTART_CONFIG = 'wallet_jumpstart_config',
 }
 
 export enum StatsigFeatureGates {

--- a/src/web3/networkConfig.ts
+++ b/src/web3/networkConfig.ts
@@ -40,7 +40,6 @@ interface NetworkConfig {
   nftsValoraAppUrl: string
   getSwapQuoteUrl: string
   walletJumpstartUrl: string
-  walletJumpstartAddress: string
   verifyPhoneNumberUrl: string
   verifySmsCodeUrl: string
   getPublicDEKUrl: string
@@ -194,9 +193,6 @@ const HOOKS_API_URL_ALFAJORES = `${CLOUD_FUNCTIONS_STAGING}/hooks-api`
 const JUMPSTART_CLAIM_URL_ALFAJORES = `${CLOUD_FUNCTIONS_STAGING}/walletJumpstart`
 const JUMPSTART_CLAIM_URL_MAINNET = `${CLOUD_FUNCTIONS_MAINNET}/walletJumpstart`
 
-const JUMPSTART_ADDRESS_ALFAJORES = '0xf25a016E53644EEfe4A167Ff05482213BCd627ED'
-const JUMPSTART_ADDRESS_MAINNET = '0x22Bac00dB51FfD2eb5a02e58974b64726c684BaA'
-
 const GET_NFTS_BY_OWNER_ADDRESS_ALFAJORES = `${CLOUD_FUNCTIONS_STAGING}/getNfts`
 const GET_NFTS_BY_OWNER_ADDRESS_MAINNET = `${CLOUD_FUNCTIONS_MAINNET}/getNfts`
 
@@ -255,7 +251,6 @@ const networkConfigs: { [testnet: string]: NetworkConfig } = {
     nftsValoraAppUrl: NFTS_VALORA_APP_URL,
     getSwapQuoteUrl: GET_SWAP_QUOTE_URL,
     walletJumpstartUrl: JUMPSTART_CLAIM_URL_ALFAJORES,
-    walletJumpstartAddress: JUMPSTART_ADDRESS_ALFAJORES,
     verifyPhoneNumberUrl: VERIFY_PHONE_NUMBER_ALFAJORES,
     verifySmsCodeUrl: VERIFY_SMS_CODE_ALFAJORES,
     getPublicDEKUrl: GET_PUBLIC_DEK_ALFAJORES,
@@ -328,7 +323,6 @@ const networkConfigs: { [testnet: string]: NetworkConfig } = {
     nftsValoraAppUrl: NFTS_VALORA_APP_URL,
     getSwapQuoteUrl: GET_SWAP_QUOTE_URL,
     walletJumpstartUrl: JUMPSTART_CLAIM_URL_MAINNET,
-    walletJumpstartAddress: JUMPSTART_ADDRESS_MAINNET,
     verifyPhoneNumberUrl: VERIFY_PHONE_NUMBER_MAINNET,
     verifySmsCodeUrl: VERIFY_SMS_CODE_MAINNET,
     getPublicDEKUrl: GET_PUBLIC_DEK_MAINNET,


### PR DESCRIPTION
### Description

Get WalletJumpstart contract address from dynamic config rather than hardcode it.

### Test plan

Updated unit test.

### Related issues

- Fixes RET-999

### Backwards compatibility

Y
