### PR TITLE
fix: filter out unrecognized network IDs

### DIFF
--- a/src/tokens/utils.test.tsx
+++ b/src/tokens/utils.test.tsx
@@ -5,6 +5,7 @@ import {
   convertLocalToTokenAmount,
   convertTokenToLocalAmount,
   getHigherBalanceCurrency,
+  getSupportedNetworkIdsForTokenBalances,
   getTokenId,
   isHistoricalPriceUpdated,
   sortFirstStableThenCeloThenOthersByUsdBalance,
@@ -14,6 +15,10 @@ import { Currency } from 'src/utils/currencies'
 import { ONE_DAY_IN_MILLIS, ONE_HOUR_IN_MILLIS } from 'src/utils/time'
 import networkConfig from 'src/web3/networkConfig'
 import { mockPoofTokenId, mockTokenBalances } from 'test/values'
+import { getDynamicConfigParams } from 'src/statsig'
+import mocked = jest.mocked
+
+jest.mock('src/statsig')
 
 describe(getHigherBalanceCurrency, () => {
   const tokens = {
@@ -287,5 +292,14 @@ describe(isHistoricalPriceUpdated, () => {
         },
       })
     ).toEqual(true)
+  })
+})
+
+describe('getSupportedNetworkIdsFor*', () => {
+  it('getSupportedNetworkIdsForTokenBalances', () => {
+    mocked(getDynamicConfigParams).mockReturnValueOnce({
+      showBalances: ['celo-mainnet', 'arbitrum-one', 'not-a-valid-chain'],
+    })
+    expect(getSupportedNetworkIdsForTokenBalances()).toEqual(['celo-mainnet', 'arbitrum-one'])
   })
 })

--- a/src/tokens/utils.ts
+++ b/src/tokens/utils.ts
@@ -155,8 +155,9 @@ export function convertTokenToLocalAmount({
 }
 
 export function getSupportedNetworkIdsForTokenBalances(): NetworkId[] {
-  return getDynamicConfigParams(DynamicConfigs[StatsigDynamicConfigs.MULTI_CHAIN_FEATURES])
-    .showBalances
+  return getDynamicConfigParams(
+    DynamicConfigs[StatsigDynamicConfigs.MULTI_CHAIN_FEATURES]
+  ).showBalances.filter((networkId) => networkId in NetworkId)
 }
 
 export function getTokenId(networkId: NetworkId, tokenAddress?: string): string {

--- a/src/transactions/feed/queryHelper.ts
+++ b/src/transactions/feed/queryHelper.ts
@@ -64,8 +64,9 @@ export const deduplicateTransactions = (
 }
 
 export function getAllowedNetworkIds(): Array<NetworkId> {
-  return getDynamicConfigParams(DynamicConfigs[StatsigDynamicConfigs.MULTI_CHAIN_FEATURES])
-    .showTransfers
+  return getDynamicConfigParams(
+    DynamicConfigs[StatsigDynamicConfigs.MULTI_CHAIN_FEATURES]
+  ).showTransfers.filter((networkId) => networkId in NetworkId)
 }
 
 export function useFetchTransactions(): QueryHookResult {


### PR DESCRIPTION
Don't fetch transactions or balances for unrecognized networks IDs.
