### PR TITLE
chore: visual tweaks for `BottomSheetInLineNotification`

### DIFF
--- a/src/components/BottomSheetInLineNotification.test.tsx
+++ b/src/components/BottomSheetInLineNotification.test.tsx
@@ -1,0 +1,54 @@
+import { render } from '@testing-library/react-native'
+import React from 'react'
+import { StyleSheet } from 'react-native'
+import { Severity } from 'src/components/InLineNotification'
+import BottomSheetInLineNotification from './BottomSheetInLineNotification'
+
+describe('BottomSheetInLineNotification', () => {
+  it('renders correctly when showNotification is true', () => {
+    const { getByText } = render(
+      <BottomSheetInLineNotification
+        severity={Severity.Warning}
+        description="Test description"
+        showNotification={true}
+      />
+    )
+    expect(getByText('Test description')).toBeTruthy()
+  })
+
+  it('does not render when showNotification is false', () => {
+    const { queryByText } = render(
+      <BottomSheetInLineNotification
+        severity={Severity.Warning}
+        description="Test description"
+        showNotification={false}
+      />
+    )
+    expect(queryByText('Test description')).toBeNull()
+  })
+
+  it.each(['top', 'bottom'])('renders with a %s position when it is defined', (position: any) => {
+    const { getByTestId } = render(
+      <BottomSheetInLineNotification
+        severity={Severity.Warning}
+        description="Test"
+        showNotification={true}
+        position={position}
+      />
+    )
+    const style = StyleSheet.flatten(getByTestId('notificationContainer').props.style)
+    expect(style).toHaveProperty(position)
+  })
+
+  it('renders with a bottom position when position property is absent', () => {
+    const { getByTestId } = render(
+      <BottomSheetInLineNotification
+        severity={Severity.Warning}
+        description="Test"
+        showNotification={true}
+      />
+    )
+    const style = StyleSheet.flatten(getByTestId('notificationContainer').props.style)
+    expect(style).toHaveProperty('bottom')
+  })
+})

--- a/src/components/BottomSheetInLineNotification.tsx
+++ b/src/components/BottomSheetInLineNotification.tsx
@@ -9,6 +9,7 @@ import { Spacing } from 'src/styles/styles'
 
 interface Props extends InLineNotificationProps {
   showNotification: boolean
+  position?: 'top' | 'bottom'
 }
 
 // this value is used to animate the notification on and off the screen. the
@@ -16,19 +17,27 @@ interface Props extends InLineNotificationProps {
 // otherwise the notication will not transition smoothly.
 const NOTIFICATION_HEIGHT = 500
 
-// for now, this notification is launched from the bottom of the screen only
-const BottomSheetInLineNotification = ({ showNotification, ...inLineNotificationProps }: Props) => {
+const direction = { top: -1, bottom: 1 }
+const margin = { top: Spacing.Regular16, bottom: Spacing.Large32 }
+
+const BottomSheetInLineNotification = ({
+  showNotification,
+  position = 'bottom',
+  ...inLineNotificationProps
+}: Props) => {
   const [isVisible, setIsVisible] = useState(showNotification)
 
   const progress = useSharedValue(0)
   const animatedStyle = useAnimatedStyle(() => {
     return {
-      transform: [{ translateY: (1 - progress.value) * NOTIFICATION_HEIGHT }],
+      transform: [{ translateY: (1 - progress.value) * NOTIFICATION_HEIGHT * direction[position] }],
     }
   })
   const animatedOpacity = useAnimatedStyle(() => ({
     opacity: 0.5 * progress.value,
   }))
+
+  const marginStyle = { [position]: margin[position] }
 
   useShowOrHideAnimation(
     progress,
@@ -46,9 +55,12 @@ const BottomSheetInLineNotification = ({ showNotification, ...inLineNotification
   }
 
   return (
-    <SafeAreaView edges={['bottom']} style={[styles.modal, styles.container]}>
+    <SafeAreaView edges={[position]} style={[styles.modal, styles.container]}>
       <Animated.View style={[styles.modal, styles.background, animatedOpacity]} />
-      <Animated.View style={[styles.notificationContainer, animatedStyle]}>
+      <Animated.View
+        style={[styles.notificationContainer, marginStyle, animatedStyle]}
+        testID="notificationContainer"
+      >
         <InLineNotification {...inLineNotificationProps} />
       </Animated.View>
     </SafeAreaView>
@@ -68,7 +80,6 @@ const styles = StyleSheet.create({
   },
   notificationContainer: {
     position: 'absolute',
-    bottom: Spacing.Large32,
     width: '100%',
   },
 })

--- a/src/components/InLineNotification.test.tsx
+++ b/src/components/InLineNotification.test.tsx
@@ -42,4 +42,20 @@ describe(InLineNotification, () => {
     expect(fn).toBeCalled()
     expect(fn2).toBeCalled()
   })
+
+  it('renders the icon when showIcon is true', () => {
+    const { getByTestId } = render(
+      <InLineNotification severity={Severity.Warning} description="Test" showIcon={true} />
+    )
+
+    expect(getByTestId('attentionIcon').children.length).toBeGreaterThan(0)
+  })
+
+  it('does not render the icon when showIcon is false', () => {
+    const { getByTestId } = render(
+      <InLineNotification severity={Severity.Warning} description="Test" showIcon={false} />
+    )
+
+    expect(getByTestId('attentionIcon').children.length).toBe(0)
+  })
 })

--- a/src/components/InLineNotification.tsx
+++ b/src/components/InLineNotification.tsx
@@ -17,6 +17,7 @@ export interface InLineNotificationProps {
   title?: string | null
   description: string | JSX.Element | null
   style?: StyleProp<ViewStyle>
+  showIcon?: boolean
   ctaLabel?: string | null
   onPressCta?: (event: GestureResponderEvent) => void
   ctaLabel2?: string | null
@@ -34,6 +35,7 @@ export function InLineNotification({
   title,
   description,
   style,
+  showIcon = true,
   ctaLabel,
   onPressCta,
   ctaLabel2,
@@ -60,8 +62,8 @@ export function InLineNotification({
       testID={testID}
     >
       <View style={styles.row}>
-        <View style={styles.attentionIcon}>
-          <Icon color={severityColor.primary} size={20} />
+        <View style={styles.attentionIcon} testID="attentionIcon">
+          {showIcon && <Icon color={severityColor.primary} size={20} />}
         </View>
         <View style={styles.contentContainer}>
           {title && <Text style={styles.titleText}>{title}</Text>}


### PR DESCRIPTION
### Description

I want to reuse `BottomSheetInLineNotification` to implement [this design](https://www.figma.com/file/rXBDplfMHHqYmuu6EkgMEo/Gamification-experiments?type=design&node-id=96-3560&mode=design&t=WxCtC0CqGJMX4xV5-0).

To achieve that, I've added two optional properties:
* `showIcon: boolean` (default: `true`)
* `position: 'top' | 'bottom'` (default: `'bottom'`)

### Test plan

* Added unit tests

### Related issues

- Related to RET-1000

### Backwards compatibility

Y
