### PR TITLE
fix(payments): create and pass a preparedTx to confirmation screen

### DIFF
--- a/src/send/SendConfirmation.tsx
+++ b/src/send/SendConfirmation.tsx
@@ -135,10 +135,12 @@ function SendConfirmation(props: Props) {
   const feeType = FeeType.SEND
   const feeEstimate = tokenAddress ? feeEstimates[tokenAddress]?.[feeType] : undefined
 
-  // for new send flow, preparedTransaction must be present
+  // for new send flow, preparedTransaction is expected to be present except for
+  // payment requests (which may not include one if a tx is not possible, e.g.,
+  // amount > balance, not enough for gas, etc).
   // for old send flow, feeEstimate must be present if network is celo
-  // when old send flow is cleaned up, we can make preparedTransaction a
-  // required field and remove this check
+  // We could consider making the preparedTx a required field if we handle those
+  // scenarios differently after the old send flow is cleaned up
   const isFeeAvailable = newSendScreen
     ? !!preparedTransaction
     : tokenNetwork !== Network.Celo || !!feeEstimate?.feeInfo

--- a/src/send/SendEnterAmount.tsx
+++ b/src/send/SendEnterAmount.tsx
@@ -25,7 +25,6 @@ import TokenDisplay from 'src/components/TokenDisplay'
 import TokenIcon, { IconSize } from 'src/components/TokenIcon'
 import Touchable from 'src/components/Touchable'
 import CustomHeader from 'src/components/header/CustomHeader'
-import { MAX_ENCRYPTED_COMMENT_LENGTH_APPROX } from 'src/config'
 import DownArrowIcon from 'src/icons/DownArrowIcon'
 import { getLocalCurrencyCode, usdToLocalCurrencyRateSelector } from 'src/localCurrency/selectors'
 import { navigate } from 'src/navigator/NavigationService'
@@ -34,6 +33,7 @@ import { StackParamList } from 'src/navigator/types'
 import useSelector from 'src/redux/useSelector'
 import { lastUsedTokenIdSelector } from 'src/send/selectors'
 import { usePrepareSendTransactions } from 'src/send/usePrepareSendTransactions'
+import { COMMENT_PLACEHOLDER_FOR_FEE_ESTIMATE } from 'src/send/utils'
 import { NETWORK_NAMES } from 'src/shared/conts'
 import Colors from 'src/styles/colors'
 import { typeScale } from 'src/styles/fonts'
@@ -54,7 +54,6 @@ type Props = NativeStackScreenProps<StackParamList, Screens.SendEnterAmount>
 
 const TOKEN_SELECTOR_BORDER_RADIUS = 100
 const MAX_BORDER_RADIUS = 96
-const COMMENT_PLACEHOLDER_FOR_FEE_ESTIMATE = ' '.repeat(MAX_ENCRYPTED_COMMENT_LENGTH_APPROX)
 
 const TAG = 'SendEnterAmount'
 

--- a/src/send/usePrepareSendTransactions.test.ts
+++ b/src/send/usePrepareSendTransactions.test.ts
@@ -2,7 +2,7 @@ import { renderHook } from '@testing-library/react-native'
 import BigNumber from 'bignumber.js'
 import { act } from 'react-test-renderer'
 import {
-  _prepareSendTransactionsCallback,
+  prepareSendTransactionsCallback,
   usePrepareSendTransactions,
 } from 'src/send/usePrepareSendTransactions'
 import { tokenSupportsComments } from 'src/tokens/utils'
@@ -49,7 +49,7 @@ describe('usePrepareSendTransactions', () => {
   describe('_prepareSendTransactionsCallback', () => {
     it('returns undefined if amount is 0', async () => {
       expect(
-        await _prepareSendTransactionsCallback({
+        await prepareSendTransactionsCallback({
           amount: new BigNumber(0),
           token: mockCeloTokenBalance,
           recipientAddress: '0xabc',
@@ -60,7 +60,7 @@ describe('usePrepareSendTransactions', () => {
     })
     it('returns undefined if balance of token to send 0', async () => {
       expect(
-        await _prepareSendTransactionsCallback({
+        await prepareSendTransactionsCallback({
           amount: new BigNumber(5),
           token: { ...mockCeloTokenBalance, balance: new BigNumber(0) },
           recipientAddress: '0xabc',
@@ -77,7 +77,7 @@ describe('usePrepareSendTransactions', () => {
       }
       mocked(prepareERC20TransferTransaction).mockResolvedValue(mockPrepareTransactionsResult)
       expect(
-        await _prepareSendTransactionsCallback({
+        await prepareSendTransactionsCallback({
           amount: new BigNumber(1),
           token: mockCeloTokenBalance,
           recipientAddress: '0xabc',
@@ -101,7 +101,7 @@ describe('usePrepareSendTransactions', () => {
       }
       mocked(prepareTransferWithCommentTransaction).mockResolvedValue(mockPrepareTransactionsResult)
       expect(
-        await _prepareSendTransactionsCallback({
+        await prepareSendTransactionsCallback({
           amount: new BigNumber(20),
           token: mockCeloTokenBalance,
           recipientAddress: '0xabc',
@@ -127,7 +127,7 @@ describe('usePrepareSendTransactions', () => {
       }
       mocked(prepareSendNativeAssetTransaction).mockResolvedValue(mockPrepareTransactionsResult)
       expect(
-        await _prepareSendTransactionsCallback({
+        await prepareSendTransactionsCallback({
           amount: new BigNumber(0.05),
           token: mockEthTokenBalance,
           recipientAddress: '0xabc',

--- a/src/send/usePrepareSendTransactions.ts
+++ b/src/send/usePrepareSendTransactions.ts
@@ -1,21 +1,20 @@
+import BigNumber from 'bignumber.js'
 import { useState } from 'react'
+import { useAsyncCallback } from 'react-async-hook'
+import { tokenAmountInSmallestUnit } from 'src/tokens/saga'
+import { TokenBalance, isNativeTokenBalance, tokenBalanceHasAddress } from 'src/tokens/slice'
+import { tokenSupportsComments } from 'src/tokens/utils'
+import Logger from 'src/utils/Logger'
 import {
   PreparedTransactionsResult,
   prepareERC20TransferTransaction,
   prepareSendNativeAssetTransaction,
   prepareTransferWithCommentTransaction,
 } from 'src/viem/prepareTransactions'
-import { TokenBalance, tokenBalanceHasAddress, isNativeTokenBalance } from 'src/tokens/slice'
-import BigNumber from 'bignumber.js'
-import { useAsyncCallback } from 'react-async-hook'
-import { tokenSupportsComments } from 'src/tokens/utils'
-import Logger from 'src/utils/Logger'
-import { tokenAmountInSmallestUnit } from 'src/tokens/saga'
 
 const TAG = 'src/send/usePrepareSendTransactions'
 
-// just exported for testing
-export async function _prepareSendTransactionsCallback({
+export async function prepareSendTransactionsCallback({
   amount,
   token,
   recipientAddress,
@@ -70,7 +69,7 @@ export function usePrepareSendTransactions() {
     PreparedTransactionsResult | undefined
   >()
 
-  const prepareTransactions = useAsyncCallback(_prepareSendTransactionsCallback, {
+  const prepareTransactions = useAsyncCallback(prepareSendTransactionsCallback, {
     onError: (error) => {
       Logger.error(TAG, `prepareTransactionsOutput: ${error}`)
     },

--- a/src/send/utils.test.ts
+++ b/src/send/utils.test.ts
@@ -11,13 +11,23 @@ import { Screens } from 'src/navigator/Screens'
 import { UriData, urlFromUriData } from 'src/qrcode/schema'
 import { RecipientType } from 'src/recipients/recipient'
 import { TransactionDataInput } from 'src/send/SendAmount'
-import { handlePaymentDeeplink, handleSendPaymentData } from 'src/send/utils'
+import { prepareSendTransactionsCallback } from 'src/send/usePrepareSendTransactions'
+import {
+  handlePaymentDeeplink,
+  handleSendPaymentData,
+  preparePaymentRequestTransaction,
+} from 'src/send/utils'
 import { getDynamicConfigParams, getFeatureGate } from 'src/statsig'
+import { feeCurrenciesSelector } from 'src/tokens/selectors'
 import { NetworkId } from 'src/transactions/types'
+import { PreparedTransactionsResult } from 'src/viem/prepareTransactions'
+import { walletAddressSelector } from 'src/web3/selectors'
 import { createMockStore } from 'test/utils'
 import {
+  mockAccount,
   mockAccount2,
   mockCeloAddress,
+  mockCeloTokenBalance,
   mockCeloTokenId,
   mockCeurAddress,
   mockCeurTokenId,
@@ -30,7 +40,7 @@ import {
 jest.mock('src/statsig')
 
 describe('send/utils', () => {
-  describe('handlePaymentDeeplink', () => {
+  describe('handleSendPaymentData', () => {
     beforeEach(() => {
       jest.clearAllMocks()
       jest.mocked(getFeatureGate).mockReturnValue(true)
@@ -131,6 +141,16 @@ describe('send/utils', () => {
     })
 
     it('should navigate to SendConfirmation screen when amount and token are sent', async () => {
+      const mockState = createMockStore({}).getState()
+      const expectedTokenBalance = mockState.tokens.tokenBalances[mockCeurTokenId]
+      const expectedToken = {
+        ...expectedTokenBalance,
+        priceUsd: new BigNumber(expectedTokenBalance?.priceUsd ?? 0),
+        balance: new BigNumber(expectedTokenBalance?.balance ?? 0),
+        lastKnownPriceUsd: new BigNumber(expectedTokenBalance?.priceUsd ?? 0),
+      }
+      // 1 PHP in cEUR: 1 (input) / 1.33 (PHP price) / 1.2 (cEUR price)
+      const expectedTokenAmount = new BigNumber('0.62656641604010025063')
       await expectSaga(
         handleSendPaymentData,
         // When currencyCode is not set, the amount is assumed to be in the currently selected local currency.
@@ -139,10 +159,23 @@ describe('send/utils', () => {
         false,
         undefined
       )
-        .withState(createMockStore({}).getState())
+        .withState(mockState)
         .provide([
           [matchers.call.fn(fetchExchangeRate), '1.33'], // USD to PHP
+          [
+            matchers.call.fn(preparePaymentRequestTransaction),
+            {
+              preparedTransaction: 'mock-prepared-tx',
+              feeAmount: '0.1',
+              feeTokenId: mockCeloTokenId,
+            },
+          ],
         ])
+        .call(preparePaymentRequestTransaction, {
+          amount: expectedTokenAmount,
+          token: expectedToken,
+          recipientAddress: mockData.address,
+        })
         .run()
       expect(navigate).toHaveBeenCalledWith(
         Screens.SendConfirmation,
@@ -152,16 +185,28 @@ describe('send/utils', () => {
             inputAmount: new BigNumber(1), // 1 PHP
             amountIsInLocalCurrency: true,
             tokenAddress: mockCeurAddress,
-            // 1 PHP in cEUR: 1 (input) / 1.33 (PHP price) / 1.2 (cEUR price)
-            tokenAmount: new BigNumber('0.62656641604010025063'),
+            tokenAmount: expectedTokenAmount,
             tokenId: mockCeurTokenId,
           },
           origin: SendOrigin.AppSendFlow,
+          preparedTransaction: 'mock-prepared-tx',
+          feeAmount: '0.1',
+          feeTokenId: mockCeloTokenId,
         })
       )
     })
 
     it('should navigate to SendConfirmation screen defaulting to cUSD when amount is sent but token isnt', async () => {
+      const mockState = createMockStore({}).getState()
+      const expectedTokenBalance = mockState.tokens.tokenBalances[mockCusdTokenId]
+      const expectedToken = {
+        ...expectedTokenBalance,
+        priceUsd: new BigNumber(expectedTokenBalance?.priceUsd ?? 0),
+        balance: new BigNumber(expectedTokenBalance?.balance ?? 0),
+        lastKnownPriceUsd: new BigNumber(expectedTokenBalance?.priceUsd ?? 0),
+      }
+      // 1 PHP in cUSD: 1 (input) / 1.33 (PHP price)
+      const expectedTokenAmount = new BigNumber('0.75187969924812030075')
       await expectSaga(
         handleSendPaymentData,
         // When currencyCode is not set, the amount is assumed to be in the currently selected local currency.
@@ -171,10 +216,23 @@ describe('send/utils', () => {
         false,
         undefined
       )
-        .withState(createMockStore({}).getState())
+        .withState(mockState)
         .provide([
           [matchers.call.fn(fetchExchangeRate), '1.33'], // USD to PHP
+          [
+            matchers.call.fn(preparePaymentRequestTransaction),
+            {
+              preparedTransaction: 'mock-prepared-tx',
+              feeAmount: '0.1',
+              feeTokenId: mockCeloTokenId,
+            },
+          ],
         ])
+        .call(preparePaymentRequestTransaction, {
+          amount: expectedTokenAmount,
+          token: expectedToken,
+          recipientAddress: mockData.address,
+        })
         .run()
       expect(navigate).toHaveBeenCalledWith(
         Screens.SendConfirmation,
@@ -185,33 +243,31 @@ describe('send/utils', () => {
             amountIsInLocalCurrency: true,
             tokenAddress: mockCusdAddress,
             tokenId: mockCusdTokenId,
-            // 1 PHP in cUSD: 1 (input) / 1.33 (PHP price)
-            tokenAmount: new BigNumber('0.75187969924812030075'),
+            tokenAmount: expectedTokenAmount,
           },
           origin: SendOrigin.AppSendFlow,
+          preparedTransaction: 'mock-prepared-tx',
+          feeAmount: '0.1',
+          feeTokenId: mockCeloTokenId,
         })
       )
     })
 
-    it('should call handleSendPaymentData with parsed payment data', async () => {
-      const data = {
-        address: '0xf7f551752A78Ce650385B58364225e5ec18D96cB',
-        displayName: 'Super 8',
-        currencyCode: 'PHP' as LocalCurrencyCode,
-        amount: '500',
-        comment: '92a53156-c0f2-11ea-b3de-0242ac13000',
-      }
-
-      const deeplink = urlFromUriData(data)
-      const parsed: UriData = {
-        ...data,
-        e164PhoneNumber: undefined,
-        token: undefined,
-      }
-      await expectSaga(handlePaymentDeeplink, deeplink)
+    it('should navigate to SendEnterAmount screen when an unsupported token is given', async () => {
+      await expectSaga(handleSendPaymentData, mockUriData[2], false, undefined)
         .withState(createMockStore({}).getState())
-        .provide([[matchers.call.fn(handleSendPaymentData), parsed]])
         .run()
+      expect(navigate).toHaveBeenCalledWith(
+        Screens.SendEnterAmount,
+        expect.objectContaining({
+          origin: SendOrigin.AppSendFlow,
+          recipient: {
+            address: mockUriData[2].address.toLowerCase(),
+            recipientType: RecipientType.Address,
+          },
+          forceTokenId: false,
+        })
+      )
     })
 
     describe('deeplinks for sending cUSD', () => {
@@ -247,6 +303,14 @@ describe('send/utils', () => {
           .withState(createMockStore({}).getState())
           .provide([
             [matchers.call.fn(fetchExchangeRate), '1'], // USD to USD (currencyCode of mockUriData[4] is USD)
+            [
+              matchers.call.fn(preparePaymentRequestTransaction),
+              {
+                preparedTransaction: 'mock-prepared-tx',
+                feeAmount: '0.1',
+                feeTokenId: mockCeloTokenId,
+              },
+            ],
           ])
           .run()
         expect(navigate).toHaveBeenCalledWith(
@@ -254,6 +318,9 @@ describe('send/utils', () => {
           expect.objectContaining({
             origin: SendOrigin.AppSendFlow,
             transactionData: mockTransactionData,
+            preparedTransaction: 'mock-prepared-tx',
+            feeAmount: '0.1',
+            feeTokenId: mockCeloTokenId,
           })
         )
       })
@@ -272,6 +339,14 @@ describe('send/utils', () => {
           .withState(createMockStore({}).getState())
           .provide([
             [matchers.call.fn(fetchExchangeRate), '1'], // USD to USD (currencyCode of mockUriData[5] is USD)
+            [
+              matchers.call.fn(preparePaymentRequestTransaction),
+              {
+                preparedTransaction: 'mock-prepared-tx',
+                feeAmount: '0.1',
+                feeTokenId: mockCusdTokenId,
+              },
+            ],
           ])
           .run()
         expect(navigate).toHaveBeenCalledWith(
@@ -279,6 +354,9 @@ describe('send/utils', () => {
           expect.objectContaining({
             origin: SendOrigin.AppSendFlow,
             transactionData: mockTransactionData,
+            preparedTransaction: 'mock-prepared-tx',
+            feeAmount: '0.1',
+            feeTokenId: mockCusdTokenId,
           })
         )
       })
@@ -294,6 +372,14 @@ describe('send/utils', () => {
           .withState(createMockStore({}).getState())
           .provide([
             [matchers.call.fn(fetchExchangeRate), '1'], // USD to USD (currencyCode of mockUriData[0] is USD)
+            [
+              matchers.call.fn(preparePaymentRequestTransaction),
+              {
+                preparedTransaction: 'mock-prepared-tx',
+                feeAmount: '0.1',
+                feeTokenId: mockCeloTokenId,
+              },
+            ],
           ])
           .run()
         expect(navigate).toHaveBeenCalledWith(
@@ -311,6 +397,9 @@ describe('send/utils', () => {
               inputAmount: new BigNumber(mockUriData[0].amount!).times(1.33), // 1 USD in PHP
               amountIsInLocalCurrency: true,
             },
+            preparedTransaction: 'mock-prepared-tx',
+            feeAmount: '0.1',
+            feeTokenId: mockCeloTokenId,
           })
         )
       })
@@ -332,23 +421,97 @@ describe('send/utils', () => {
           })
         )
       })
-
-      it('should navigate to SendEnterAmount screen when an unsupported token is given', async () => {
-        await expectSaga(handleSendPaymentData, mockUriData[2], false, undefined)
-          .withState(createMockStore({}).getState())
-          .run()
-        expect(navigate).toHaveBeenCalledWith(
-          Screens.SendEnterAmount,
-          expect.objectContaining({
-            origin: SendOrigin.AppSendFlow,
-            recipient: {
-              address: mockUriData[2].address.toLowerCase(),
-              recipientType: RecipientType.Address,
-            },
-            forceTokenId: false,
-          })
-        )
-      })
     })
+  })
+
+  describe('handlePaymentDeeplink', () => {
+    it('should call handleSendPaymentData with parsed payment data', async () => {
+      const data = {
+        address: '0xf7f551752A78Ce650385B58364225e5ec18D96cB',
+        displayName: 'Super 8',
+        currencyCode: 'PHP' as LocalCurrencyCode,
+        amount: '500',
+        comment: '92a53156-c0f2-11ea-b3de-0242ac13000',
+      }
+
+      const deeplink = urlFromUriData(data)
+      const parsed: UriData = {
+        ...data,
+        e164PhoneNumber: undefined,
+        token: undefined,
+      }
+      await expectSaga(handlePaymentDeeplink, deeplink)
+        .withState(createMockStore({}).getState())
+        .provide([[matchers.call.fn(handleSendPaymentData), undefined]])
+        .call(handleSendPaymentData, parsed, true)
+        .run()
+    })
+  })
+
+  describe('preparePaymentRequestTransaction', () => {
+    it('returns serialized preparedTransaction and fee info if tx is possible', async () => {
+      const mockPossibleResult: PreparedTransactionsResult = {
+        type: 'possible',
+        transactions: [
+          {
+            from: '0xfrom',
+            to: '0xto',
+            data: '0xdata',
+            gas: BigInt(500),
+            maxFeePerGas: BigInt(10000),
+            maxPriorityFeePerGas: undefined,
+            _baseFeePerGas: BigInt(1000),
+          },
+        ],
+        feeCurrency: mockCeloTokenBalance,
+      }
+      await expectSaga(preparePaymentRequestTransaction, {
+        amount: new BigNumber('10'),
+        token: mockCeloTokenBalance,
+        recipientAddress: mockAccount,
+      })
+        .provide([
+          [select(walletAddressSelector), mockAccount2],
+          [select(feeCurrenciesSelector, NetworkId['celo-alfajores']), [mockCeloTokenBalance]],
+          [matchers.call.fn(prepareSendTransactionsCallback), mockPossibleResult],
+        ])
+        .returns({
+          preparedTransaction: {
+            from: '0xfrom',
+            to: '0xto',
+            data: '0xdata',
+            gas: '500',
+            maxFeePerGas: '10000',
+            maxPriorityFeePerGas: undefined,
+            _baseFeePerGas: '1000',
+          },
+          feeAmount: '5e-12',
+          feeTokenId: mockCeloTokenId,
+        })
+        .run()
+    })
+  })
+
+  it('returns undefined serialized preparedTransaction and fee info if tx is not possible', async () => {
+    const mockPossibleResult: PreparedTransactionsResult = {
+      type: 'not-enough-balance-for-gas',
+      feeCurrencies: [mockCeloTokenBalance],
+    }
+    await expectSaga(preparePaymentRequestTransaction, {
+      amount: new BigNumber('10'),
+      token: mockCeloTokenBalance,
+      recipientAddress: mockAccount,
+    })
+      .provide([
+        [select(walletAddressSelector), mockAccount2],
+        [select(feeCurrenciesSelector, NetworkId['celo-alfajores']), [mockCeloTokenBalance]],
+        [matchers.call.fn(prepareSendTransactionsCallback), mockPossibleResult],
+      ])
+      .returns({
+        preparedTransaction: undefined,
+        feeAmount: undefined,
+        feeTokenId: undefined,
+      })
+      .run()
   })
 })

--- a/src/send/utils.test.ts
+++ b/src/send/utils.test.ts
@@ -514,4 +514,23 @@ describe('send/utils', () => {
       })
       .run()
   })
+
+  it('returns undefined serialized preparedTransaction and fee info if preparing tx throws', async () => {
+    await expectSaga(preparePaymentRequestTransaction, {
+      amount: new BigNumber('10'),
+      token: mockCeloTokenBalance,
+      recipientAddress: mockAccount,
+    })
+      .provide([
+        [select(walletAddressSelector), mockAccount2],
+        [select(feeCurrenciesSelector, NetworkId['celo-alfajores']), [mockCeloTokenBalance]],
+        [matchers.call.fn(prepareSendTransactionsCallback), new Error('not enough balance')],
+      ])
+      .returns({
+        preparedTransaction: undefined,
+        feeAmount: undefined,
+        feeTokenId: undefined,
+      })
+      .run()
+  })
 })

--- a/src/send/utils.ts
+++ b/src/send/utils.ts
@@ -164,27 +164,33 @@ export function* preparePaymentRequestTransaction({
     throw new Error('wallet address not found')
   }
 
-  const prepareTransactionsResult = yield* call(prepareSendTransactionsCallback, {
-    amount,
-    token,
-    recipientAddress,
-    walletAddress,
-    feeCurrencies,
-    comment: COMMENT_PLACEHOLDER_FOR_FEE_ESTIMATE, // use placeholder since comment can be edited on the confirmation screen
-  })
+  try {
+    const prepareTransactionsResult = yield* call(prepareSendTransactionsCallback, {
+      amount,
+      token,
+      recipientAddress,
+      walletAddress,
+      feeCurrencies,
+      comment: COMMENT_PLACEHOLDER_FOR_FEE_ESTIMATE, // use placeholder since comment can be edited on the confirmation screen
+    })
 
-  if (
-    prepareTransactionsResult?.type === 'possible' &&
-    prepareTransactionsResult.transactions.length > 0
-  ) {
-    preparedTransaction = getSerializablePreparedTransaction(
-      prepareTransactionsResult.transactions[0]
-    )
-    const { maxFeeAmount, feeCurrency } = getFeeCurrencyAndAmounts(prepareTransactionsResult)
-    feeAmount = maxFeeAmount?.toString()
-    feeTokenId = feeCurrency?.tokenId
+    if (
+      prepareTransactionsResult?.type === 'possible' &&
+      prepareTransactionsResult.transactions.length > 0
+    ) {
+      preparedTransaction = getSerializablePreparedTransaction(
+        prepareTransactionsResult.transactions[0]
+      )
+      const { maxFeeAmount, feeCurrency } = getFeeCurrencyAndAmounts(prepareTransactionsResult)
+      feeAmount = maxFeeAmount?.toString()
+      feeTokenId = feeCurrency?.tokenId
+    }
+  } catch (err) {
+    Logger.warn(`${TAG}/preparePaymentRequestTransaction`, 'Unable to prepare transaction', err)
   }
 
+  // if a tx cannot be prepared or is not possible, return undefined, so the
+  // Send button in the SendConfirmation screen is disabled
   return {
     preparedTransaction,
     feeAmount,

--- a/src/send/utils.ts
+++ b/src/send/utils.ts
@@ -1,4 +1,6 @@
+import BigNumber from 'bignumber.js'
 import { SendOrigin } from 'src/analytics/types'
+import { MAX_ENCRYPTED_COMMENT_LENGTH_APPROX } from 'src/config'
 import { LocalCurrencyCode } from 'src/localCurrency/consts'
 import {
   convertDollarsToLocalAmount,
@@ -14,14 +16,23 @@ import { AddressRecipient, Recipient, RecipientType } from 'src/recipients/recip
 import { updateValoraRecipientCache } from 'src/recipients/reducer'
 import { canSendTokensSelector } from 'src/send/selectors'
 import { TransactionDataInput } from 'src/send/SendAmount'
+import { prepareSendTransactionsCallback } from 'src/send/usePrepareSendTransactions'
 import { getFeatureGate } from 'src/statsig'
 import { StatsigFeatureGates } from 'src/statsig/types'
-import { tokensListSelector } from 'src/tokens/selectors'
+import { feeCurrenciesSelector, tokensListSelector } from 'src/tokens/selectors'
 import { TokenBalance } from 'src/tokens/slice'
 import { convertLocalToTokenAmount, getSupportedNetworkIdsForSend } from 'src/tokens/utils'
 import { Currency } from 'src/utils/currencies'
 import Logger from 'src/utils/Logger'
+import {
+  getSerializablePreparedTransaction,
+  SerializableTransactionRequest,
+} from 'src/viem/preparedTransactionSerialization'
+import { getFeeCurrencyAndAmounts } from 'src/viem/prepareTransactions'
+import { walletAddressSelector } from 'src/web3/selectors'
 import { call, put, select } from 'typed-redux-saga'
+
+export const COMMENT_PLACEHOLDER_FOR_FEE_ESTIMATE = ' '.repeat(MAX_ENCRYPTED_COMMENT_LENGTH_APPROX)
 
 const TAG = 'send/utils'
 
@@ -91,10 +102,23 @@ export function* handleSendPaymentData(
       tokenId: tokenInfo.tokenId,
       comment: data.comment,
     }
+
+    const { preparedTransaction, feeAmount, feeTokenId } = yield* call(
+      preparePaymentRequestTransaction,
+      {
+        amount: tokenAmount,
+        token: tokenInfo,
+        recipientAddress: recipient.address,
+      }
+    )
+
     navigate(Screens.SendConfirmation, {
       transactionData,
       isFromScan,
       origin: SendOrigin.AppSendFlow,
+      preparedTransaction,
+      feeAmount,
+      feeTokenId,
     })
   } else {
     const canSendTokens: boolean = yield* select(canSendTokensSelector)
@@ -117,5 +141,53 @@ export function* handlePaymentDeeplink(deeplink: string) {
     yield* call(handleSendPaymentData, paymentData, true)
   } catch (e) {
     Logger.warn('handlePaymentDeepLink', `deeplink ${deeplink} failed with ${e}`)
+  }
+}
+
+export function* preparePaymentRequestTransaction({
+  amount,
+  token,
+  recipientAddress,
+}: {
+  amount: BigNumber
+  token: TokenBalance
+  recipientAddress: string
+}) {
+  let preparedTransaction: SerializableTransactionRequest | undefined = undefined
+  let feeAmount: string | undefined = undefined
+  let feeTokenId: string | undefined = undefined
+  const feeCurrencies = yield* select(feeCurrenciesSelector, token.networkId)
+  const walletAddress = yield* select(walletAddressSelector)
+
+  if (!walletAddress) {
+    // should never happen
+    throw new Error('wallet address not found')
+  }
+
+  const prepareTransactionsResult = yield* call(prepareSendTransactionsCallback, {
+    amount,
+    token,
+    recipientAddress,
+    walletAddress,
+    feeCurrencies,
+    comment: COMMENT_PLACEHOLDER_FOR_FEE_ESTIMATE, // use placeholder since comment can be edited on the confirmation screen
+  })
+
+  if (
+    prepareTransactionsResult?.type === 'possible' &&
+    prepareTransactionsResult.transactions.length > 0
+  ) {
+    preparedTransaction = getSerializablePreparedTransaction(
+      prepareTransactionsResult.transactions[0]
+    )
+    const { maxFeeAmount, feeCurrency } = getFeeCurrencyAndAmounts(prepareTransactionsResult)
+    feeAmount = maxFeeAmount?.toString()
+    feeTokenId = feeCurrency?.tokenId
+  }
+
+  return {
+    preparedTransaction,
+    feeAmount,
+    feeTokenId,
   }
 }


### PR DESCRIPTION
### Description

Bidali and deeplink payments were broken with the new send flow because a prepared transaction object wasn't passed to the SendConfirmation screen. This prepares a transaction and passes it on to the SendConfirmation screen. If a transaction is not possible, it still navigates to the screen, but the Send button would be disabled (In the old send flow, if a tx is not possible, Send was still clickable, but the tx will fail)

### Test plan

Unit tests, manual. Also E2E tests currently failing in #4845 passes with this fix

Payment deeplink:

https://github.com/valora-inc/wallet/assets/5062591/4774c91c-557a-40f3-916c-4f8c33c87952

Bidali payment:

https://github.com/valora-inc/wallet/assets/5062591/aaeb8b80-471c-4e12-a83c-5aa17710d284

Exceeds balance:

https://github.com/valora-inc/wallet/assets/5062591/4373dae8-5672-4bb8-830d-0b0c22e77fd1


### Related issues

- Fixes ACT-1089

### Backwards compatibility

Yes
