### PR TITLE
fix(wc): handle errors while preparing transactions

### DIFF
--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -1116,6 +1116,10 @@
       "title": "Insufficient gas token balance",
       "description": "You don't have enough {{feeCurrencies}} to cover gas fees. Please add {{feeCurrencies}} to your wallet to complete this transaction."
     },
+    "failedToPrepareTransaction": {
+      "title": "Failed to prepare transaction",
+      "description": "An error occurred while preparing the transaction. See the underlying error for more details.\n\n\"{{errorMessage}}\""
+    },
     "session": {
       "failUnsupportedNamespace": {
         "title": "Unsupported chain",

--- a/src/walletConnect/saga.test.ts
+++ b/src/walletConnect/saga.test.ts
@@ -2,8 +2,8 @@ import { CoreTypes, SessionTypes } from '@walletconnect/types'
 import { buildApprovedNamespaces } from '@walletconnect/utils'
 import { Web3WalletTypes } from '@walletconnect/web3wallet'
 import { expectSaga } from 'redux-saga-test-plan'
-import { EffectProviders, StaticProvider } from 'redux-saga-test-plan/providers'
-import { call, select } from 'redux-saga/effects'
+import { call, select } from 'redux-saga-test-plan/matchers'
+import { EffectProviders, StaticProvider, throwError } from 'redux-saga-test-plan/providers'
 import { showMessage } from 'src/alert/actions'
 import { DappRequestOrigin, WalletConnectPairingOrigin } from 'src/analytics/types'
 import { walletConnectEnabledSelector } from 'src/app/selectors'
@@ -15,6 +15,7 @@ import { getDynamicConfigParams, getFeatureGate } from 'src/statsig'
 import { StatsigFeatureGates } from 'src/statsig/types'
 import { Network } from 'src/transactions/types'
 import { publicClient } from 'src/viem'
+import { prepareTransactions } from 'src/viem/prepareTransactions'
 import {
   Actions,
   acceptSession as acceptSessionAction,
@@ -25,6 +26,7 @@ import {
   _acceptSession,
   _applyIconFixIfNeeded,
   _setClientForTesting,
+  _showActionRequest,
   _showSessionRequest,
   getDefaultSessionTrackedProperties,
   initialiseWalletConnect,
@@ -36,6 +38,7 @@ import { WalletConnectRequestType } from 'src/walletConnect/types'
 import { walletAddressSelector } from 'src/web3/selectors'
 import { createMockStore } from 'test/utils'
 import { mockAccount } from 'test/values'
+import { BaseError } from 'viem'
 import { getTransactionCount } from 'viem/actions'
 
 jest.mock('src/statsig')
@@ -485,6 +488,168 @@ describe('acceptSession', () => {
   })
 })
 
+describe('showActionRequest', () => {
+  const actionRequest: Web3WalletTypes.EventArguments['session_request'] = {
+    id: 1707297778331031,
+    topic: '243b33442b6190b97055201b5a8817f4e604e3f37b5376e78ee0b3715cc6211c',
+    params: {
+      request: {
+        method: 'eth_sendTransaction',
+        params: [
+          {
+            data: '0x580d747a0000000000000000000000007194dfe766a92308880a943fd70f31c8e7c50e66000000000000000000000000000000000000000000000000002386f26fc100000000000000000000000000007c75b0b81a54359e9dccda9cb663ca2e3de6b71000000000000000000000000089d5bd54c43ddd10905a030de6ff02ebb6c51654',
+            from: '0xccc9576F841de93Cd32bEe7B98fE8B9BD3070e3D',
+            to: '0x8D6677192144292870907E3Fa8A5527fE55A7ff6',
+          },
+        ],
+      },
+      chainId: 'eip155:42220',
+    },
+    verifyContext: {
+      verified: {
+        verifyUrl: 'https://verify.walletconnect.com',
+        validation: 'UNKNOWN',
+        origin: 'https://churrito.fi',
+      },
+    },
+  }
+  const session = createSession({
+    url: 'someUrl',
+    icons: ['someIcon'],
+    description: 'someDescription',
+    name: 'someName',
+  })
+
+  let mockClient: any
+
+  beforeEach(() => {
+    mockClient = {
+      approveSession: jest.fn(),
+      getActiveSessions: jest.fn(() => {
+        return Promise.resolve({
+          [actionRequest.topic]: session,
+        })
+      }),
+    }
+    _setClientForTesting(mockClient as any)
+  })
+
+  it('navigates to the screen to approve the request', async () => {
+    const mockPreparedTransactions = {
+      type: 'possible',
+      transactions: [
+        {
+          from: '0xfrom',
+          to: '0xto',
+          data: '0xdata',
+        },
+      ],
+    }
+    const state = createMockStore({}).getState()
+    await expectSaga(_showActionRequest, actionRequest)
+      .withState(state)
+      .provide([
+        [select(walletAddressSelector), mockAccount],
+        [
+          call(getTransactionCount, publicClient[Network.Celo], {
+            address: mockAccount,
+            blockTag: 'pending',
+          }),
+          123,
+        ],
+        [call.fn(prepareTransactions), mockPreparedTransactions],
+      ])
+      .run()
+
+    // 2 calls, one in loading state and one in the action request state
+    expect(navigate).toHaveBeenCalledTimes(2)
+    expect(navigate).toHaveBeenNthCalledWith(1, Screens.WalletConnectRequest, {
+      type: WalletConnectRequestType.Loading,
+      origin: WalletConnectPairingOrigin.Deeplink,
+    })
+    expect(navigate).toHaveBeenNthCalledWith(2, Screens.WalletConnectRequest, {
+      type: WalletConnectRequestType.Action,
+      pendingAction: actionRequest,
+      supportedChains: ['eip155:44787'],
+      version: 2,
+      hasInsufficientGasFunds: false,
+      feeCurrenciesSymbols: [],
+      preparedTransaction: mockPreparedTransactions.transactions[0],
+      prepareTransactionErrorMessage: undefined,
+    })
+  })
+
+  it('navigates to the screen to reject the request when the transaction preparation fails', async () => {
+    const state = createMockStore({}).getState()
+    await expectSaga(_showActionRequest, actionRequest)
+      .withState(state)
+      .provide([
+        [select(walletAddressSelector), mockAccount],
+        [
+          call(getTransactionCount, publicClient[Network.Celo], {
+            address: mockAccount,
+            blockTag: 'pending',
+          }),
+          123,
+        ],
+        [call.fn(prepareTransactions), throwError(new Error('Some error'))],
+      ])
+      .run()
+
+    // 2 calls, one in loading state and one in the action request state
+    expect(navigate).toHaveBeenCalledTimes(2)
+    expect(navigate).toHaveBeenNthCalledWith(1, Screens.WalletConnectRequest, {
+      type: WalletConnectRequestType.Loading,
+      origin: WalletConnectPairingOrigin.Deeplink,
+    })
+    expect(navigate).toHaveBeenNthCalledWith(2, Screens.WalletConnectRequest, {
+      type: WalletConnectRequestType.Action,
+      pendingAction: actionRequest,
+      supportedChains: ['eip155:44787'],
+      version: 2,
+      hasInsufficientGasFunds: false,
+      feeCurrenciesSymbols: [],
+      preparedTransaction: undefined,
+      prepareTransactionErrorMessage: 'Some error',
+    })
+  })
+
+  it('navigates to the screen to reject the request when the transaction preparation fails with a viem error', async () => {
+    const state = createMockStore({}).getState()
+    await expectSaga(_showActionRequest, actionRequest)
+      .withState(state)
+      .provide([
+        [select(walletAddressSelector), mockAccount],
+        [
+          call(getTransactionCount, publicClient[Network.Celo], {
+            address: mockAccount,
+            blockTag: 'pending',
+          }),
+          123,
+        ],
+        [call.fn(prepareTransactions), throwError(new BaseError('viem short message', {}))],
+      ])
+      .run()
+
+    // 2 calls, one in loading state and one in the action request state
+    expect(navigate).toHaveBeenCalledTimes(2)
+    expect(navigate).toHaveBeenNthCalledWith(1, Screens.WalletConnectRequest, {
+      type: WalletConnectRequestType.Loading,
+      origin: WalletConnectPairingOrigin.Deeplink,
+    })
+    expect(navigate).toHaveBeenNthCalledWith(2, Screens.WalletConnectRequest, {
+      type: WalletConnectRequestType.Action,
+      pendingAction: actionRequest,
+      supportedChains: ['eip155:44787'],
+      version: 2,
+      hasInsufficientGasFunds: false,
+      feeCurrenciesSymbols: [],
+      preparedTransaction: undefined,
+      prepareTransactionErrorMessage: 'viem short message',
+    })
+  })
+})
+
 // TODO: use a real connection string
 const v2ConnectionString =
   'wc:79a02f869d0f921e435a5e0643304548ebfa4a0430f9c66fe8b1a9254db7ef77@2?controller=false&publicKey=f661b0a9316a4ce0b6892bdce42bea0f45037f2c1bee9e118a3a4bc868a32a39&relay={"protocol":"waku"}'
@@ -624,6 +789,19 @@ describe('normalizeTransaction', () => {
       data: '0xABC',
       from: '0xTEST',
       nonce: 19,
+    })
+  })
+
+  it('strips `chainId` if present', async () => {
+    expect(
+      await callNormalizeTransaction(
+        { from: '0xTEST', data: '0xABC', chainId: 1 },
+        Network.Ethereum
+      )
+    ).toStrictEqual({
+      data: '0xABC',
+      from: '0xTEST',
+      nonce: 123,
     })
   })
 

--- a/src/walletConnect/screens/ActionRequest.test.tsx
+++ b/src/walletConnect/screens/ActionRequest.test.tsx
@@ -99,6 +99,17 @@ describe('ActionRequest with WalletConnect V2', () => {
     },
   }
 
+  const sendTransactionAction = {
+    ...pendingAction,
+    params: {
+      ...pendingAction.params,
+      request: {
+        ...pendingAction.params.request,
+        method: 'eth_sendTransaction',
+      },
+    },
+  }
+
   const preparedTransaction: SerializableTransactionRequest = {
     from: mockAccount,
     to: mockAccount2,
@@ -136,7 +147,7 @@ describe('ActionRequest with WalletConnect V2', () => {
         <Provider store={store}>
           <ActionRequest
             version={2}
-            pendingAction={pendingAction}
+            pendingAction={sendTransactionAction}
             supportedChains={supportedChains}
             hasInsufficientGasFunds={true}
             feeCurrenciesSymbols={['CELO']}
@@ -154,7 +165,7 @@ describe('ActionRequest with WalletConnect V2', () => {
 
       fireEvent.press(getByText('dismiss'))
       expect(store.getActions()).toEqual([
-        denyRequestV2(pendingAction, getSdkError('USER_REJECTED')),
+        denyRequestV2(sendTransactionAction, getSdkError('USER_REJECTED')),
       ])
     })
 
@@ -163,7 +174,7 @@ describe('ActionRequest with WalletConnect V2', () => {
         <Provider store={store}>
           <ActionRequest
             version={2}
-            pendingAction={pendingAction}
+            pendingAction={sendTransactionAction}
             supportedChains={supportedChains}
             hasInsufficientGasFunds={false}
             feeCurrenciesSymbols={['CELO']}
@@ -183,21 +194,11 @@ describe('ActionRequest with WalletConnect V2', () => {
 
       fireEvent.press(getByText('dismiss'))
       expect(store.getActions()).toEqual([
-        denyRequestV2(pendingAction, getSdkError('USER_REJECTED')),
+        denyRequestV2(sendTransactionAction, getSdkError('USER_REJECTED')),
       ])
     })
 
     it('should accept the request with the prepared transaction', () => {
-      const sendTransactionAction = {
-        ...pendingAction,
-        params: {
-          ...pendingAction.params,
-          request: {
-            ...pendingAction.params.request,
-            method: 'eth_sendTransaction',
-          },
-        },
-      }
       const { getByText, getByTestId } = render(
         <Provider store={store}>
           <ActionRequest

--- a/src/walletConnect/screens/ActionRequest.tsx
+++ b/src/walletConnect/screens/ActionRequest.tsx
@@ -28,6 +28,7 @@ export interface ActionRequestProps {
   hasInsufficientGasFunds: boolean
   feeCurrenciesSymbols: string[]
   preparedTransaction?: SerializableTransactionRequest
+  prepareTransactionErrorMessage?: string
 }
 
 function ActionRequest({
@@ -36,6 +37,7 @@ function ActionRequest({
   hasInsufficientGasFunds,
   feeCurrenciesSymbols,
   preparedTransaction,
+  prepareTransactionErrorMessage,
 }: ActionRequestProps) {
   const { t } = useTranslation()
   const dispatch = useDispatch()
@@ -104,27 +106,55 @@ function ActionRequest({
     )
   }
 
-  if (useViem && hasInsufficientGasFunds) {
-    return (
-      <RequestContent
-        type="dismiss"
-        onDismiss={() => dispatch(denyRequest(pendingAction, getSdkError('USER_REJECTED')))}
-        dappName={dappName}
-        dappImageUrl={dappImageUrl}
-        title={title}
-        description={description}
-        testId="WalletConnectActionRequest"
-      >
-        <InLineNotification
-          severity={Severity.Warning}
-          title={t('walletConnectRequest.notEnoughBalanceForGas.title')}
-          description={t('walletConnectRequest.notEnoughBalanceForGas.description', {
-            feeCurrencies: feeCurrenciesSymbols.join(', '),
-          })}
-          style={styles.warning}
-        />
-      </RequestContent>
-    )
+  if (useViem) {
+    if (hasInsufficientGasFunds) {
+      return (
+        <RequestContent
+          type="dismiss"
+          onDismiss={() => dispatch(denyRequest(pendingAction, getSdkError('USER_REJECTED')))}
+          dappName={dappName}
+          dappImageUrl={dappImageUrl}
+          title={title}
+          description={description}
+          testId="WalletConnectActionRequest"
+        >
+          <InLineNotification
+            severity={Severity.Warning}
+            title={t('walletConnectRequest.notEnoughBalanceForGas.title')}
+            description={t('walletConnectRequest.notEnoughBalanceForGas.description', {
+              feeCurrencies: feeCurrenciesSymbols.join(', '),
+            })}
+            style={styles.warning}
+          />
+        </RequestContent>
+      )
+    } else if (!preparedTransaction) {
+      return (
+        <RequestContent
+          type="dismiss"
+          onDismiss={() => dispatch(denyRequest(pendingAction, getSdkError('USER_REJECTED')))}
+          dappName={dappName}
+          dappImageUrl={dappImageUrl}
+          title={title}
+          description={description}
+          testId="WalletConnectActionRequest"
+        >
+          <ActionRequestPayload
+            session={activeSession}
+            request={pendingAction}
+            preparedTransaction={preparedTransaction}
+          />
+          <InLineNotification
+            severity={Severity.Warning}
+            title={t('walletConnectRequest.failedToPrepareTransaction.title')}
+            description={t('walletConnectRequest.failedToPrepareTransaction.description', {
+              errorMessage: prepareTransactionErrorMessage,
+            })}
+            style={styles.warning}
+          />
+        </RequestContent>
+      )
+    }
   }
 
   return (

--- a/src/walletConnect/screens/ActionRequest.tsx
+++ b/src/walletConnect/screens/ActionRequest.tsx
@@ -62,10 +62,11 @@ function ActionRequest({
   const chainId = pendingAction.params.chainId
   const networkId = walletConnectChainIdToNetworkId[chainId]
   const networkName = NETWORK_NAMES[networkId]
+  const method = pendingAction.params.request.method
 
   const { description, title, action } = getDisplayTextFromAction(
     t,
-    pendingAction.params.request.method as SupportedActions,
+    method as SupportedActions,
     dappName,
     networkName
   )
@@ -73,10 +74,7 @@ function ActionRequest({
   // Reject and warn if the chain is not supported
   // Note: we still allow personal_sign on unsupported chains (Cred Protocol does this)
   // as this does not depend on the chainId
-  if (
-    !supportedChains.includes(chainId) &&
-    pendingAction.params.request.method !== SupportedActions.personal_sign
-  ) {
+  if (!supportedChains.includes(chainId) && method !== SupportedActions.personal_sign) {
     const supportedNetworkNames = supportedChains
       .map((chain) => NETWORK_NAMES[walletConnectChainIdToNetworkId[chain]])
       .join(`, `)
@@ -128,7 +126,11 @@ function ActionRequest({
           />
         </RequestContent>
       )
-    } else if (!preparedTransaction) {
+    } else if (
+      !preparedTransaction &&
+      (method === SupportedActions.eth_signTransaction ||
+        method === SupportedActions.eth_sendTransaction)
+    ) {
       return (
         <RequestContent
           type="dismiss"

--- a/src/walletConnect/screens/ActionRequestPayload.tsx
+++ b/src/walletConnect/screens/ActionRequestPayload.tsx
@@ -34,7 +34,7 @@ function ActionRequestPayload(props: Props) {
     () =>
       method === SupportedActions.eth_signTransaction ||
       method === SupportedActions.eth_sendTransaction
-        ? JSON.stringify(useViem ? props.preparedTransaction : params)
+        ? JSON.stringify(useViem ? props.preparedTransaction ?? params : params)
         : method === SupportedActions.eth_signTypedData ||
             method === SupportedActions.eth_signTypedData_v4
           ? JSON.stringify(params[1])


### PR DESCRIPTION
### Description

This PR handles errors happening while preparing transactions coming from WC.
- `chainId` is now stripped (we don't need it and it was causing an RPC error on Celo)
- `prepareTransactions` is now wrapped in a try/catch and we now surface the error in the `ActionRequest` bottom sheet

### Test plan

- Updated tests
- Manually tested by transacting with the following dapps: Staked Celo, Moola, ChurritoFi
- New error message if transaction preparation fails, with the underlying error message, to help users/builders understand the problem
<img src="https://github.com/valora-inc/wallet/assets/57791/6d59683c-d09d-4d94-a68b-50b977956edb" width="50%" />

Note: the underlying error message won't be translated, but I think it's better than hiding it.

### Related issues

- Fixes RET-1013

### Backwards compatibility

Yes
