### PR TITLE
refactor(keyless-backup): use viem instead ethers for signing

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -38,7 +38,9 @@ module.exports = {
   presets: ['module:metro-react-native-babel-preset'],
   overrides: [
     {
-      test: './node_modules/ethers',
+      // required for any dependency (just fiatconnect-sdk as of 2/8/2024)
+      // requiring ethers@6
+      test: './node_modules/**/ethers',
       plugins: [['@babel/plugin-transform-private-methods', { loose: true }]],
     },
   ],

--- a/package.json
+++ b/package.json
@@ -126,7 +126,6 @@
     "date-fns": "^2.30.0",
     "dot-prop-immutable": "^2.1.1",
     "ethereumjs-util": "^7.1.5",
-    "ethers": "^6.10.0",
     "fast-levenshtein": "^3.0.0",
     "fp-ts": "2.16.2",
     "futoin-hkdf": "^1.5.3",

--- a/src/keylessBackup/encryption.ts
+++ b/src/keylessBackup/encryption.ts
@@ -1,7 +1,8 @@
 import * as secp from '@noble/secp256k1'
 import crypto from 'crypto'
 import hkdf from 'futoin-hkdf'
-import { ethers } from 'ethers'
+import { fromBytes } from 'viem'
+import { privateKeyToAccount } from 'viem/accounts'
 
 /**
  * Derives a key using the HKDF method from two key shares.
@@ -58,7 +59,7 @@ export function getSecp256K1KeyPair(
 }
 
 export function getWalletAddressFromPrivateKey(privateKey: Uint8Array) {
-  return new ethers.Wallet(Buffer.from(privateKey).toString('hex')).address.toLowerCase()
+  return privateKeyToAccount(fromBytes(privateKey, 'hex')).address.toLowerCase()
 }
 
 /**

--- a/src/keylessBackup/index.test.ts
+++ b/src/keylessBackup/index.test.ts
@@ -1,9 +1,9 @@
 import { SiweClient } from '@fiatconnect/fiatconnect-sdk'
-import { ethers } from 'ethers'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import { getEncryptedMnemonic, storeEncryptedMnemonic } from 'src/keylessBackup/index'
 import { fetchWithTimeout } from 'src/utils/fetchWithTimeout'
 import networkConfig from 'src/web3/networkConfig'
+import { generatePrivateKey } from 'viem/accounts'
 
 const mockSiweFetch = jest.fn()
 const mockSiweLogin = jest.fn()
@@ -73,7 +73,7 @@ describe(getEncryptedMnemonic, () => {
     } as any)
     expect(
       await getEncryptedMnemonic({
-        encryptionPrivateKey: ethers.Wallet.createRandom().privateKey,
+        encryptionPrivateKey: generatePrivateKey(),
         encryptionAddress: 'address',
       })
     ).toEqual('encrypted-mnemonic')
@@ -102,7 +102,7 @@ describe(getEncryptedMnemonic, () => {
     } as any)
     await expect(() =>
       getEncryptedMnemonic({
-        encryptionPrivateKey: ethers.Wallet.createRandom().privateKey,
+        encryptionPrivateKey: generatePrivateKey(),
         encryptionAddress: 'address',
       })
     ).rejects.toThrow('Failed to get encrypted mnemonic with status 404, message not found')

--- a/src/keylessBackup/saga.test.ts
+++ b/src/keylessBackup/saga.test.ts
@@ -35,6 +35,7 @@ import { Screens } from 'src/navigator/Screens'
 import { assignAccountFromPrivateKey } from 'src/web3/saga'
 import { walletAddressSelector } from 'src/web3/selectors'
 import { mockPrivateDEK } from 'test/values'
+import { Hex } from 'viem'
 
 describe('keylessBackup saga', () => {
   beforeEach(() => {
@@ -122,6 +123,7 @@ describe('keylessBackup saga', () => {
 
     const mockEncryptionPrivateKey =
       '0da7744e59ab530ebaa3ca5c6e67170fd18276fb1e093ba2eaa48f1d5756ffcb'
+    const mockEncryptionPrivateKeyHex: Hex = `0x${mockEncryptionPrivateKey}`
     const mockEncryptionPrivateKeyBuffer = Buffer.from(mockEncryptionPrivateKey, 'hex')
     const mockEncryptionPublicKeyBuffer = Buffer.from(
       '02e966cd1e93c10d6462e665b1a45039200e1faff289ef5265ecfbf06b5ddb94b2',
@@ -231,7 +233,7 @@ describe('keylessBackup saga', () => {
             ],
             [
               call(getEncryptedMnemonic, {
-                encryptionPrivateKey: mockEncryptionPrivateKey,
+                encryptionPrivateKey: mockEncryptionPrivateKeyHex,
                 encryptionAddress: mockEncryptionAddress,
               }),
               mockEncryptedMnemonic,
@@ -273,7 +275,7 @@ describe('keylessBackup saga', () => {
             ],
             [
               call(getEncryptedMnemonic, {
-                encryptionPrivateKey: mockEncryptionPrivateKey,
+                encryptionPrivateKey: mockEncryptionPrivateKeyHex,
                 encryptionAddress: mockEncryptionAddress,
               }),
               mockEncryptedMnemonic,
@@ -314,7 +316,7 @@ describe('keylessBackup saga', () => {
             ],
             [
               call(getEncryptedMnemonic, {
-                encryptionPrivateKey: mockEncryptionPrivateKey,
+                encryptionPrivateKey: mockEncryptionPrivateKeyHex,
                 encryptionAddress: mockEncryptionAddress,
               }),
               throwError(new Error('mock error getting encrypted mnemonic')),

--- a/src/keylessBackup/saga.ts
+++ b/src/keylessBackup/saga.ts
@@ -30,6 +30,7 @@ import Logger from 'src/utils/Logger'
 import { assignAccountFromPrivateKey } from 'src/web3/saga'
 import { walletAddressSelector } from 'src/web3/selectors'
 import { call, delay, put, race, select, spawn, take, takeLeading } from 'typed-redux-saga'
+import { Hex, fromBytes } from 'viem'
 
 const TAG = 'keylessBackup/saga'
 
@@ -60,7 +61,7 @@ export function* handleValoraKeyshareIssued({
         torusKeyshareBuffer,
         valoraKeyshareBuffer,
         encryptionAddress,
-        encryptionPrivateKey: Buffer.from(encryptionPrivateKey).toString('hex'),
+        encryptionPrivateKey: fromBytes(encryptionPrivateKey, 'hex'),
       })
     }
     ValoraAnalytics.track(KeylessBackupEvents.cab_handle_keyless_backup_success, {
@@ -111,7 +112,7 @@ function* handleKeylessBackupRestore({
 }: {
   torusKeyshareBuffer: Buffer
   valoraKeyshareBuffer: Buffer
-  encryptionPrivateKey: string
+  encryptionPrivateKey: Hex
   encryptionAddress: string
 }) {
   const encryptedMnemonic = yield* call(getEncryptedMnemonic, {


### PR DESCRIPTION
### Description

Replace ethers usages with viem in cloud backup. More context here: https://valora-app.slack.com/archives/C02KBT0DAHJ/p1707385000759899

### Test plan

CI, tested manually that restore still works

### Related issues

N/A

### Backwards compatibility

Yes
