### PR TITLE
fix(onboarding): revert default of CPV screen to be in onboarding

### DIFF
--- a/src/RevokePhoneNumber.tsx
+++ b/src/RevokePhoneNumber.tsx
@@ -51,7 +51,7 @@ export const RevokePhoneNumber = ({ forwardedRef }: Props) => {
   }, [revokeNumberAsync.status])
 
   const handleNavigateToVerifiedNumber = () => {
-    navigate(Screens.VerificationStartScreen)
+    navigate(Screens.VerificationStartScreen, { hasOnboarded: true })
   }
 
   const handleRevokePhoneNumber = async () => {

--- a/src/account/Settings.tsx
+++ b/src/account/Settings.tsx
@@ -116,7 +116,7 @@ export const Account = ({ navigation, route }: Props) => {
 
   const goToConfirmNumber = () => {
     ValoraAnalytics.track(SettingsEvents.settings_verify_number)
-    navigate(Screens.VerificationStartScreen)
+    navigate(Screens.VerificationStartScreen, { hasOnboarded: true })
   }
 
   const goToLanguageSetting = () => {

--- a/src/consumerIncentives/ConsumerIncentivesHomeScreen.test.tsx
+++ b/src/consumerIncentives/ConsumerIncentivesHomeScreen.test.tsx
@@ -228,7 +228,7 @@ describe('ConsumerIncentivesHomeScreen', () => {
 
     fireEvent.press(getByTestId('ConsumerIncentives/CTA'))
 
-    expect(navigate).toHaveBeenCalledWith(Screens.VerificationStartScreen)
+    expect(navigate).toHaveBeenCalledWith(Screens.VerificationStartScreen, { hasOnboarded: true })
   })
 
   it('opens a WebView when Learn More is tapped', () => {

--- a/src/consumerIncentives/ConsumerIncentivesHomeScreen.tsx
+++ b/src/consumerIncentives/ConsumerIncentivesHomeScreen.tsx
@@ -262,7 +262,7 @@ export default function ConsumerIncentivesHomeScreen() {
         buttonPressed: RewardsScreenCta.CashIn,
       })
     } else {
-      navigate(Screens.VerificationStartScreen)
+      navigate(Screens.VerificationStartScreen, { hasOnboarded: true })
       ValoraAnalytics.track(RewardsEvents.rewards_screen_cta_pressed, {
         buttonPressed: RewardsScreenCta.VerifyPhone,
       })

--- a/src/home/NotificationBox.test.tsx
+++ b/src/home/NotificationBox.test.tsx
@@ -162,7 +162,7 @@ describe('NotificationBox', () => {
     expect(getByText('reverifyUsingCPVHomecard.description')).toBeTruthy()
 
     fireEvent.press(getByText('reverifyUsingCPVHomecard.buttonLabel'))
-    expect(navigate).toHaveBeenCalledWith(Screens.VerificationStartScreen)
+    expect(navigate).toHaveBeenCalledWith(Screens.VerificationStartScreen, { hasOnboarded: true })
   })
 
   it('renders educations when not complete yet', () => {

--- a/src/home/NotificationBox.tsx
+++ b/src/home/NotificationBox.tsx
@@ -149,7 +149,7 @@ export function useSimpleActions() {
               notificationId: NotificationType.reverify_using_CPV,
               notificationPositionInList: params?.index,
             })
-            navigate(Screens.VerificationStartScreen)
+            navigate(Screens.VerificationStartScreen, { hasOnboarded: true })
           },
         },
       ],
@@ -282,7 +282,7 @@ export function useSimpleActions() {
               notificationId: NotificationType.verification_prompt,
               notificationPositionInList: params?.index,
             })
-            navigate(Screens.VerificationStartScreen)
+            navigate(Screens.VerificationStartScreen, { hasOnboarded: true })
           },
         },
         {

--- a/src/home/NotificationCenter.test.tsx
+++ b/src/home/NotificationCenter.test.tsx
@@ -294,7 +294,7 @@ describe('NotificationCenter', () => {
       expect(getByText('reverifyUsingCPVHomecard.description')).toBeTruthy()
 
       fireEvent.press(getByText('reverifyUsingCPVHomecard.buttonLabel'))
-      expect(navigate).toHaveBeenCalledWith(Screens.VerificationStartScreen)
+      expect(navigate).toHaveBeenCalledWith(Screens.VerificationStartScreen, { hasOnboarded: true })
     })
 
     it('emits correct analytics event when CTA button is pressed', () => {

--- a/src/keylessBackup/LinkPhoneNumber.test.tsx
+++ b/src/keylessBackup/LinkPhoneNumber.test.tsx
@@ -26,7 +26,7 @@ describe('LinkPhoneNumber', () => {
 
     expect(navigate).toHaveBeenCalledTimes(1)
     expect(navigate).toHaveBeenCalledWith(Screens.VerificationStartScreen, {
-      isOnboarding: false,
+      hasOnboarded: false,
     })
     expect(ValoraAnalytics.track).toHaveBeenCalledWith(OnboardingEvents.link_phone_number)
   })

--- a/src/keylessBackup/LinkPhoneNumber.tsx
+++ b/src/keylessBackup/LinkPhoneNumber.tsx
@@ -31,7 +31,7 @@ export default function LinkPhoneNumber({ navigation }: Props) {
 
   const continueButtonOnPress = async () => {
     ValoraAnalytics.track(OnboardingEvents.link_phone_number)
-    navigate(Screens.VerificationStartScreen, { isOnboarding: false })
+    navigate(Screens.VerificationStartScreen, { hasOnboarded: false })
   }
   const laterButtonOnPress = async () => {
     ValoraAnalytics.track(OnboardingEvents.link_phone_number_later)

--- a/src/navigator/types.tsx
+++ b/src/navigator/types.tsx
@@ -296,7 +296,7 @@ export type StackParamList = {
   [Screens.ValidateRecipientAccount]: ValidateRecipientParams
   [Screens.VerificationStartScreen]:
     | {
-        isOnboarding?: boolean
+        hasOnboarded?: boolean
         selectedCountryCodeAlpha2?: string
       }
     | undefined

--- a/src/onboarding/steps.test.ts
+++ b/src/onboarding/steps.test.ts
@@ -27,11 +27,11 @@ describe('onboarding steps', () => {
       chooseAdventureEnabled: false,
     },
     screens: [
-      { screen: Screens.NameAndPicture, props: undefined },
-      { screen: Screens.PincodeSet, props: undefined },
-      { screen: Screens.EnableBiometry, props: undefined },
-      { screen: Screens.ProtectWallet, props: undefined },
-      { screen: Screens.VerificationStartScreen, props: { isOnboarding: true } },
+      Screens.NameAndPicture,
+      Screens.PincodeSet,
+      Screens.EnableBiometry,
+      Screens.ProtectWallet,
+      Screens.VerificationStartScreen,
     ],
     name: 'newUserFlowWithEverythingEnabled',
     finalScreen: Screens.WalletHome,
@@ -47,10 +47,10 @@ describe('onboarding steps', () => {
       onboardingNameScreenEnabled: false,
     },
     screens: [
-      { screen: Screens.PincodeSet, props: undefined },
-      { screen: Screens.EnableBiometry, props: undefined },
-      { screen: Screens.ProtectWallet, props: undefined },
-      { screen: Screens.VerificationStartScreen, props: { isOnboarding: true } },
+      Screens.PincodeSet,
+      Screens.EnableBiometry,
+      Screens.ProtectWallet,
+      Screens.VerificationStartScreen,
     ],
     name: 'newUserChooseAdventure',
     finalScreen: Screens.ChooseYourAdventure,
@@ -64,11 +64,7 @@ describe('onboarding steps', () => {
       recoveringFromStoreWipe: false,
       chooseAdventureEnabled: false,
     },
-    screens: [
-      { screen: Screens.NameAndPicture, props: undefined },
-      { screen: Screens.PincodeSet, props: undefined },
-      { screen: Screens.ProtectWallet, props: undefined },
-    ],
+    screens: [Screens.NameAndPicture, Screens.PincodeSet, Screens.ProtectWallet],
     name: 'newUserFlowWithEverythingDisabled',
     finalScreen: Screens.WalletHome,
   }
@@ -83,11 +79,11 @@ describe('onboarding steps', () => {
       chooseAdventureEnabled: false,
     },
     screens: [
-      { screen: Screens.NameAndPicture, props: undefined },
-      { screen: Screens.PincodeSet, props: undefined },
-      { screen: Screens.EnableBiometry, props: undefined },
-      { screen: Screens.ImportWallet, props: undefined },
-      { screen: Screens.VerificationStartScreen, props: { isOnboarding: true } },
+      Screens.NameAndPicture,
+      Screens.PincodeSet,
+      Screens.EnableBiometry,
+      Screens.ImportWallet,
+      Screens.VerificationStartScreen,
     ],
     name: 'importWalletFlowEverythingEnabled',
     finalScreen: Screens.WalletHome,
@@ -106,7 +102,7 @@ describe('onboarding steps', () => {
     'goToNextOnboardingScreen and getOnboardingStepValues work as expected for $name',
     ({ onboardingProps, screens, name, finalScreen }) => {
       const expectedTotalSteps = screens.length
-      screens.forEach(({ screen, props }, index) => {
+      screens.forEach((screen, index) => {
         const { totalSteps, step } = getOnboardingStepValues(screen, onboardingProps)
         // Checking that the step number is correct
         try {
@@ -130,16 +126,12 @@ describe('onboarding steps', () => {
             updateStatsigAndNavigate(finalScreen as keyof StackParamList)
           )
         } else {
-          const args: any[] = [screens[index + 1].screen]
-          if (screens[index + 1].props) {
-            args.push(screens[index + 1].props)
-          }
           try {
             // eslint-disable-next-line jest/no-conditional-expect
-            expect(navigate).toHaveBeenCalledWith(...args)
+            expect(navigate).toHaveBeenCalledWith(screens[index + 1])
           } catch {
             // eslint-disable-next-line jest/no-conditional-expect
-            expect(navigateClearingStack).toHaveBeenCalledWith(...args)
+            expect(navigateClearingStack).toHaveBeenCalledWith(screens[index + 1])
           }
         }
       })
@@ -298,9 +290,7 @@ describe('onboarding steps', () => {
           },
         })
         expect(mockStore.dispatch).not.toHaveBeenCalled()
-        expect(navigate).toHaveBeenCalledWith(Screens.VerificationStartScreen, {
-          isOnboarding: true,
-        })
+        expect(navigate).toHaveBeenCalledWith(Screens.VerificationStartScreen)
       })
     })
     describe('Screens.VerificationStartScreen', () => {
@@ -344,9 +334,7 @@ describe('onboarding steps', () => {
           },
         })
         expect(mockStore.dispatch).not.toHaveBeenCalled()
-        expect(navigate).toHaveBeenCalledWith(Screens.VerificationStartScreen, {
-          isOnboarding: true,
-        })
+        expect(navigate).toHaveBeenCalledWith(Screens.VerificationStartScreen)
       })
     })
   })

--- a/src/onboarding/steps.ts
+++ b/src/onboarding/steps.ts
@@ -279,7 +279,7 @@ export function _getStepInfo({ firstScreenInStep, navigator, dispatch, props }: 
             navigateHomeOrChooseAdventure()
           } else {
             // DO NOT CLEAR NAVIGATION STACK HERE - breaks restore flow on initial app open in native-stack v6
-            navigate(Screens.VerificationStartScreen, { isOnboarding: true })
+            navigate(Screens.VerificationStartScreen)
           }
         },
       }
@@ -298,7 +298,7 @@ export function _getStepInfo({ firstScreenInStep, navigator, dispatch, props }: 
             dispatch(setHasSeenVerificationNux(true))
             finishOnboarding(Screens.WalletHome)
           } else {
-            navigate(Screens.VerificationStartScreen, { isOnboarding: true })
+            navigate(Screens.VerificationStartScreen)
           }
         },
       }

--- a/src/send/SelectRecipientButtons.test.tsx
+++ b/src/send/SelectRecipientButtons.test.tsx
@@ -105,7 +105,7 @@ describe('SelectRecipientButtons', () => {
       expect(getByTestId('SelectRecipient/PhoneNumberModal')).not.toBeVisible()
     })
     await waitFor(() => {
-      expect(navigate).toHaveBeenCalledWith(Screens.VerificationStartScreen)
+      expect(navigate).toHaveBeenCalledWith(Screens.VerificationStartScreen, { hasOnboarded: true })
     })
   })
 

--- a/src/send/SelectRecipientButtons.tsx
+++ b/src/send/SelectRecipientButtons.tsx
@@ -130,7 +130,7 @@ export default function SelectRecipientButtons({ onContactsPermissionGranted }: 
       // reset state so the next time the modal is dismissed, this doesn't end
       // up navigating
       setNavigateToPhoneVerification(false)
-      navigate(Screens.VerificationStartScreen)
+      navigate(Screens.VerificationStartScreen, { hasOnboarded: true })
     }
   }
 

--- a/src/send/Send.tsx
+++ b/src/send/Send.tsx
@@ -192,7 +192,7 @@ function Send({ route }: Props) {
   }
 
   const onPressStartVerification = () => {
-    navigate(Screens.VerificationStartScreen)
+    navigate(Screens.VerificationStartScreen, { hasOnboarded: true })
   }
 
   const onPressContactsSettings = () => {

--- a/src/verify/VerificationStartScreen.test.tsx
+++ b/src/verify/VerificationStartScreen.test.tsx
@@ -39,7 +39,7 @@ const renderComponent = (
         component={VerificationStartScreen}
         params={{
           selectedCountryCodeAlpha2: 'NL',
-          isOnboarding: false,
+          hasOnboarded: true,
           ...navParams,
         }}
       />
@@ -81,7 +81,7 @@ describe('VerificationStartScreen', () => {
       service: 'service',
       storage: 'storage',
     })
-    const { getByText, getByTestId } = renderComponent({ isOnboarding: true })
+    const { getByText, getByTestId } = renderComponent({ hasOnboarded: false })
 
     await act(() => {
       jest.advanceTimersByTime(5000)
@@ -106,7 +106,7 @@ describe('VerificationStartScreen', () => {
       service: 'service',
       storage: 'storage',
     })
-    const { getByText, getByTestId, queryByTestId } = renderComponent({ isOnboarding: true }, true)
+    const { getByText, getByTestId, queryByTestId } = renderComponent({ hasOnboarded: false }, true)
 
     await act(() => {
       jest.advanceTimersByTime(5000)
@@ -152,7 +152,7 @@ describe('VerificationStartScreen', () => {
   })
 
   it('skip button works', async () => {
-    const { getByText } = renderComponent({ isOnboarding: true })
+    const { getByText } = renderComponent({ hasOnboarded: false })
 
     await act(() => {
       fireEvent.press(getByText('skip'))
@@ -171,7 +171,7 @@ describe('VerificationStartScreen', () => {
       service: 'service',
       storage: 'storage',
     })
-    const { getByText, getByTestId } = renderComponent({ isOnboarding: true })
+    const { getByText, getByTestId } = renderComponent({ hasOnboarded: false })
 
     await act(() => {
       jest.advanceTimersByTime(5000)
@@ -196,7 +196,7 @@ describe('VerificationStartScreen', () => {
       service: 'service',
       storage: 'storage',
     })
-    const { getByText, getByTestId } = renderComponent({ isOnboarding: true }, true)
+    const { getByText, getByTestId } = renderComponent({ hasOnboarded: false }, true)
 
     await act(() => {
       jest.advanceTimersByTime(5000)

--- a/src/verify/VerificationStartScreen.tsx
+++ b/src/verify/VerificationStartScreen.tsx
@@ -71,7 +71,7 @@ function VerificationStartScreen({
     onboardingProps
   )
   const choseToRestoreAccount = useSelector(choseToRestoreAccountSelector)
-  const showSteps = route.params?.isOnboarding && !choseToRestoreAccount
+  const showSteps = !route.params?.hasOnboarded && !choseToRestoreAccount
 
   const countries = useMemo(() => new Countries(i18n.language), [i18n.language])
   const country = phoneNumberInfo.countryCodeAlpha2
@@ -121,7 +121,7 @@ function VerificationStartScreen({
     navigation.setOptions({
       headerTitle: title,
       headerRight: () =>
-        route.params?.isOnboarding && (
+        !route.params?.hasOnboarded && (
           <TopBarTextButton
             title={t('skip')}
             testID="PhoneVerificationSkipHeader"
@@ -129,15 +129,15 @@ function VerificationStartScreen({
             titleStyle={{ color: colors.onboardingBrownLight }}
           />
         ),
-      headerLeft: () => !route.params?.isOnboarding && <BackButton />,
+      headerLeft: () => route.params?.hasOnboarded && <BackButton />,
       // Disable iOS back during onboarding
-      gestureEnabled: !route.params?.isOnboarding,
+      gestureEnabled: !!route.params?.hasOnboarded,
     })
   }, [navigation, step, totalSteps, route.params, showSteps])
 
   // Prevent device back on Android during onboarding
   useEffect(() => {
-    if (route.params?.isOnboarding) {
+    if (!route.params?.hasOnboarded) {
       const backPressListener = () => true
       BackHandler.addEventListener('hardwareBackPress', backPressListener)
       return () => BackHandler.removeEventListener('hardwareBackPress', backPressListener)
@@ -184,7 +184,7 @@ function VerificationStartScreen({
       selectedCountryCodeAlpha2: phoneNumberInfo.countryCodeAlpha2,
       onSelectCountry: (countryCodeAlpha2: string) => {
         navigate(Screens.VerificationStartScreen, {
-          isOnboarding: !!route.params?.isOnboarding,
+          hasOnboarded: !!route.params?.hasOnboarded,
           selectedCountryCodeAlpha2: countryCodeAlpha2,
         })
       },


### PR DESCRIPTION
### Description

Fixes a bug introduced in #4834 , where VerificationStartScreen defaulted to being not in onboarding. This causes an issue if a user bails on the screen during onboarding. On restart, the screen is loaded in the already onboarded mode where the back button does nothing and there's no option to skip (see before video below). This PR reverts the default to be in onboarding as it doesn't seem trivial to pass props on the initialRoute.

### Test plan

Unit tests and manual

Before:

https://github.com/valora-inc/wallet/assets/5062591/496876ec-4adf-48b8-8a12-72d9030f3e37


After:

https://github.com/valora-inc/wallet/assets/5062591/8d345432-4fcb-439f-b63a-03806d5959e0


### Related issues

N/A

### Backwards compatibility

Yes
