### PR TITLE
refactor(i18n): use static translation keys

### DIFF
--- a/src/nfts/NftsInfoCarousel.tsx
+++ b/src/nfts/NftsInfoCarousel.tsx
@@ -18,7 +18,6 @@ import { Spacing } from 'src/styles/styles'
 import variables from 'src/styles/variables'
 import { NetworkId } from 'src/transactions/types'
 import { blockExplorerUrls } from 'src/web3/networkConfig'
-import { NFT_EXPLORER_LINK_TRANSLATION_STRINGS } from 'src/shared/conts'
 
 const DEFAULT_HEIGHT = 360
 
@@ -143,6 +142,17 @@ export default function NftsInfoCarousel({ route }: Props) {
     return <NftsLoadError testID="NftsInfoCarousel/NftsLoadErrorScreen" />
   }
 
+  const networkIdToExplorerString: Record<NetworkId, string> = {
+    [NetworkId['celo-mainnet']]: t('nftInfoCarousel.viewOnCeloExplorer'),
+    [NetworkId['celo-alfajores']]: t('nftInfoCarousel.viewOnCeloExplorer'),
+    [NetworkId['ethereum-mainnet']]: t('viewOnEthereumBlockExplorer'),
+    [NetworkId['ethereum-sepolia']]: t('viewOnEthereumBlockExplorer'),
+    [NetworkId['arbitrum-one']]: t('viewOnArbiscan'),
+    [NetworkId['arbitrum-sepolia']]: t('viewOnArbiscan'),
+    [NetworkId['op-mainnet']]: t('viewOnOPMainnetExplorer'),
+    [NetworkId['op-sepolia']]: t('viewOnOPSepoliaExplorer'),
+  }
+
   return (
     <SafeAreaView edges={['top']} style={styles.safeAreaView} testID="NftsInfoCarousel">
       <ScrollView>
@@ -205,9 +215,7 @@ export default function NftsInfoCarousel({ route }: Props) {
           <View style={[styles.sectionContainer, styles.sectionContainerLast]}>
             <Touchable onPress={pressExplorerLink} testID="ViewOnExplorer">
               <View style={styles.explorerLinkContainer}>
-                <Text style={styles.explorerLink}>
-                  {t(NFT_EXPLORER_LINK_TRANSLATION_STRINGS[networkId])}
-                </Text>
+                <Text style={styles.explorerLink}>{networkIdToExplorerString[networkId]}</Text>
                 <OpenLinkIcon color={colors.successDark} />
               </View>
             </Touchable>

--- a/src/shared/conts.ts
+++ b/src/shared/conts.ts
@@ -10,21 +10,3 @@ export const NETWORK_NAMES: Record<NetworkId, string> = {
   [NetworkId['op-mainnet']]: 'Optimism',
   [NetworkId['op-sepolia']]: 'Optimism Sepolia',
 }
-
-export const NFT_EXPLORER_LINK_TRANSLATION_STRINGS: Record<NetworkId, string> = {
-  [NetworkId['celo-mainnet']]: 'nftInfoCarousel.viewOnCeloExplorer', // NOTE: this is celo explorer, not celo scan!
-  [NetworkId['celo-alfajores']]: 'nftInfoCarousel.viewOnCeloExplorer',
-  [NetworkId['ethereum-mainnet']]: 'viewOnEthereumBlockExplorer',
-  [NetworkId['ethereum-sepolia']]: 'viewOnEthereumBlockExplorer',
-  [NetworkId['arbitrum-one']]: 'viewOnArbiscan',
-  [NetworkId['arbitrum-sepolia']]: 'viewOnArbiscan',
-  [NetworkId['op-mainnet']]: 'viewOnOPMainnetExplorer',
-  [NetworkId['op-sepolia']]: 'viewOnOPSepoliaExplorer',
-}
-
-export const TX_EXPLORER_LINK_TRANSLATION_STRINGS: Record<NetworkId, string> = {
-  // same as for NFTs, but uses Celo Scan for Celo
-  ...NFT_EXPLORER_LINK_TRANSLATION_STRINGS,
-  [NetworkId['celo-mainnet']]: 'viewOnCeloScan',
-  [NetworkId['celo-alfajores']]: 'viewOnCeloScan',
-}

--- a/src/transactions/feed/TransactionDetailsScreen.tsx
+++ b/src/transactions/feed/TransactionDetailsScreen.tsx
@@ -40,7 +40,6 @@ import networkConfig, { blockExplorerUrls } from 'src/web3/networkConfig'
 import RewardReceivedContent from './detailContent/RewardReceivedContent'
 import SwapContent from './detailContent/SwapContent'
 import TransferReceivedContent from './detailContent/TransferReceivedContent'
-import { TX_EXPLORER_LINK_TRANSLATION_STRINGS } from 'src/shared/conts'
 
 type Props = NativeStackScreenProps<StackParamList, Screens.TransactionDetailsScreen>
 
@@ -150,6 +149,17 @@ function TransactionDetailsScreen({ navigation, route }: Props) {
   const primaryActionHanlder =
     transaction.status === TransactionStatus.Failed ? retryHandler : openBlockExplorerHandler
 
+  const networkIdToExplorerString: Record<NetworkId, string> = {
+    [NetworkId['celo-mainnet']]: t('viewOnCeloScan'),
+    [NetworkId['celo-alfajores']]: t('viewOnCeloScan'),
+    [NetworkId['ethereum-mainnet']]: t('viewOnEthereumBlockExplorer'),
+    [NetworkId['ethereum-sepolia']]: t('viewOnEthereumBlockExplorer'),
+    [NetworkId['arbitrum-one']]: t('viewOnArbiscan'),
+    [NetworkId['arbitrum-sepolia']]: t('viewOnArbiscan'),
+    [NetworkId['op-mainnet']]: t('viewOnOPMainnetExplorer'),
+    [NetworkId['op-sepolia']]: t('viewOnOPSepoliaExplorer'),
+  }
+
   return (
     <ScrollView contentContainerStyle={styles.container}>
       <SafeAreaView edges={['bottom']}>
@@ -187,7 +197,7 @@ function TransactionDetailsScreen({ navigation, route }: Props) {
             >
               <View style={styles.rowContainer}>
                 <Text style={styles.blockExplorerLink}>
-                  {t(TX_EXPLORER_LINK_TRANSLATION_STRINGS[transaction.networkId])}
+                  {networkIdToExplorerString[transaction.networkId]}
                 </Text>
                 <ArrowRightThick size={16} />
               </View>


### PR DESCRIPTION
### Description

...instead of values known only at runtime. This would make it easier to run static extraction of translatable strings later if we want. 

Meant to address pr comment from @jeanregisser [here](https://github.com/valora-inc/wallet/pull/4842/files#r1484091599)

### Test plan

ci

### Related issues

na

### Backwards compatibility

na