### PR TITLE
fix(dapps): add `key` property to network chips

### DIFF
--- a/src/walletConnect/screens/SessionRequest.tsx
+++ b/src/walletConnect/screens/SessionRequest.tsx
@@ -185,7 +185,9 @@ function NetworkChips({ networkNames }: { networkNames: string[] }) {
   return (
     <View style={styles.networkChipsContainer} testID="SessionRequest/NetworkChips">
       {networkNames.map((networkName) => (
-        <Text style={styles.networkChip}>{networkName}</Text>
+        <Text key={networkName} style={styles.networkChip}>
+          {networkName}
+        </Text>
       ))}
     </View>
   )


### PR DESCRIPTION
### Description

Fixing `Warning: Each child in a list should have a unique “key” prop.`

### Test plan

CI

### Related issues

NA

### Backwards compatibility

Y
