### PR TITLE
chore(tests): Fixing weird test case in SwapScreen

### DIFF
--- a/test/values.ts
+++ b/test/values.ts
@@ -551,6 +551,7 @@ export const mockTokenBalances: Record<string, StoredTokenBalance> = {
     imageUrl: '',
     balance: '0',
     priceUsd: '1',
+    priceFetchedAt: Date.now(),
   },
 }
 


### PR DESCRIPTION
### Description

The test in SwapScreen `"should show and hide the switched network warning"` doesn't fail when it runs with the full batch of test cases.
But if it runs alone or first, it was failing.

This PR fixes the test case, however it doesn't address the fact that there's some mismanagement of the state between tests.  

### Test plan

Unit tests

### Backwards compatibility

Y

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
