### PR TITLE
chore(logs): Removing noisy error log from transaction watcher

### DIFF
--- a/src/transactions/saga.ts
+++ b/src/transactions/saga.ts
@@ -331,8 +331,11 @@ export function* handleTransactionReceiptReceived(
 
   const feeTokenInfo = feeCurrencyId && tokensById[feeCurrencyId]
 
-  if (!feeTokenInfo) {
-    Logger.error(TAG, `No information found for token ${feeCurrencyId} in network ${networkId}`)
+  if (!!feeCurrencyId && !feeTokenInfo) {
+    Logger.error(
+      TAG,
+      `No information found for fee currency ${feeCurrencyId} in network ${networkId} for transaction ${txId}`
+    )
   }
 
   const gasFeeInSmallestUnit = new BigNumber(receipt.gasUsed.toString()).times(


### PR DESCRIPTION
### Description

The error log was triggered in some normal use cases, generating a lot of noise.
With the new condition, if the error log is present it really means there's some unexpected behavior in the app.

- Fixes #[issue number here]

### Backwards compatibility

Y

### Network scalability

Y
