### PR TITLE
chore: update pending requests firebase node read only

### DIFF
--- a/src/firebase/db-rules.json
+++ b/src/firebase/db-rules.json
@@ -42,7 +42,7 @@
     },
     "pendingRequests": {
       ".read": "auth.uid != null && (query.orderByChild == 'requesterAddress' || query.orderByChild == 'requesteeAddress') && query.equalTo == root.child('users').child(auth.uid).child('address').val()",
-      ".write": true,
+      ".write": false,
       ".indexOn": ["requesterAddress", "requesteeAddress"]
     },
     "exchangeRates": {


### PR DESCRIPTION
### Description

Updates `src/firebase/db-rules.json` which is the  "source of truth" for what is being used in Alfajores and Mainnet: [Slack Thread](https://valora-app.slack.com/archives/C025V1D6F3J/p1638958161157300); related PR for cloud functions: https://github.com/valora-inc/cloud-functions/pull/288.

### Related issues

- Fixes ACT-940

### Backwards compatibility

Yes

### Network scalability

N/A
