### PR TITLE
ci(merge-queue): add required trigger for github actions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -5,9 +5,10 @@ on:
   push:
     branches:
       - main
-  # ..and any pull request.
+  # ..any pull request, workflow dispatch and merge queue
   pull_request:
   workflow_dispatch:
+  merge_group:
   # Cron job to run checks @ 8:30 pm daily on the latest commit on the default branch - main
   schedule:
     - cron: '30 20 * * *'

--- a/.github/workflows/e2e-pr.yml
+++ b/.github/workflows/e2e-pr.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     branches:
       - main
+  merge_group:
 
 # Cancel any in progress run of the workflow for a given PR
 # This avoids building outdated code

--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -7,6 +7,7 @@ on:
       - reopened
       - edited
       - synchronize
+  merge_group:
 
 jobs:
   semantic-pr-title:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,8 +5,9 @@ on:
   push:
     branches:
       - main
-  # ..and any pull request.
+  # ..any pull request and merge queue
   pull_request:
+  merge_group:
 
 # Cancel any in progress run of the workflow for a given PR
 # This avoids building outdated code


### PR DESCRIPTION
### Description

Adds the required trigger for Github Action Merge Queue: [docs](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions).

### Test plan

- Test in CI.

### Related issues

N/A

### Backwards compatibility

Yes

### Network scalability

N/A
