### PR TITLE
feat: support fee currency adapters

### DIFF
--- a/src/tokens/selectors.test.ts
+++ b/src/tokens/selectors.test.ts
@@ -513,6 +513,16 @@ describe('feeCurrenciesSelector', () => {
           isFeeCurrency: true,
           balance: '0',
         },
+        ['celo-alfajores:0xstbltest']: {
+          tokenId: 'celo-alfajores:0xstbltest',
+          networkId: NetworkId['celo-alfajores'],
+          name: 'STBLTEST',
+          address: '0xstbltest',
+          balance: '10',
+          symbol: 'STBLTEST',
+          priceFetchedAt: mockDate,
+          feeCurrencyAdapterAddress: '0xstbltest',
+        },
         [mockCeloTokenId]: {
           ...mockTokenBalances[mockCeloTokenId],
           isFeeCurrency: true,
@@ -535,6 +545,7 @@ describe('feeCurrenciesSelector', () => {
       mockCeloTokenId,
       'celo-alfajores:0xusd',
       'celo-alfajores:0xeur',
+      'celo-alfajores:0xstbltest',
     ])
   })
 
@@ -567,6 +578,16 @@ describe('feeCurrenciesWithPositiveBalancesSelector', () => {
           ...state.tokens.tokenBalances['celo-alfajores:0xeur'],
           isFeeCurrency: true,
           balance: '0',
+        },
+        ['celo-alfajores:0xstbltest']: {
+          tokenId: 'celo-alfajores:0xstbltest',
+          networkId: NetworkId['celo-alfajores'],
+          name: 'STBLTEST',
+          address: '0xstbltest',
+          balance: '0',
+          symbol: 'STBLTEST',
+          priceFetchedAt: mockDate,
+          feeCurrencyAdapterAddress: '0xstbltest',
         },
         [mockCeloTokenId]: {
           ...mockTokenBalances[mockCeloTokenId],

--- a/src/tokens/selectors.ts
+++ b/src/tokens/selectors.ts
@@ -23,6 +23,7 @@ import { Currency } from 'src/utils/currencies'
 import { isVersionBelowMinimum } from 'src/utils/versionCheck'
 import networkConfig from 'src/web3/networkConfig'
 import {
+  isFeeCurrency,
   sortByUsdBalance,
   sortFirstStableThenCeloThenOthersByUsdBalance,
   usdBalance,
@@ -447,7 +448,7 @@ const feeCurrenciesByNetworkIdSelector = createSelector(
     const feeCurrenciesByNetworkId: { [key in NetworkId]?: TokenBalance[] } = {}
     // collect fee currencies
     Object.values(tokens).forEach((token) => {
-      if (token?.isNative || token?.isFeeCurrency) {
+      if (isFeeCurrency(token)) {
         feeCurrenciesByNetworkId[token.networkId] = [
           ...(feeCurrenciesByNetworkId[token.networkId] ?? []),
           token,

--- a/src/tokens/slice.ts
+++ b/src/tokens/slice.ts
@@ -3,6 +3,7 @@ import BigNumber from 'bignumber.js'
 import { REHYDRATE, RehydrateAction } from 'redux-persist'
 import { getRehydratePayload } from 'src/redux/persist-helper'
 import { NetworkId } from 'src/transactions/types'
+import { Address } from 'viem'
 
 export interface BaseToken {
   address: string | null
@@ -15,6 +16,8 @@ export interface BaseToken {
   priceFetchedAt?: number
   isNative?: boolean
   isFeeCurrency?: boolean
+  feeCurrencyAdapterAddress?: Address
+  feeCurrencyAdapterDecimals?: number
   canTransferWithComment?: boolean
   // Deprecated: This flag enables swapping the token in all the releases, use minimumAppVersionToSwap instead.
   isSwappable?: boolean

--- a/src/tokens/utils.ts
+++ b/src/tokens/utils.ts
@@ -8,6 +8,7 @@ import { Network, NetworkId } from 'src/transactions/types'
 import { Currency } from 'src/utils/currencies'
 import { ONE_DAY_IN_MILLIS, ONE_HOUR_IN_MILLIS } from 'src/utils/time'
 import networkConfig from 'src/web3/networkConfig'
+import { Address } from 'viem'
 import { TokenBalance } from './slice'
 
 export function getHigherBalanceCurrency(
@@ -212,4 +213,8 @@ export function isHistoricalPriceUpdated(token: TokenBalance) {
     ONE_HOUR_IN_MILLIS >
       Math.abs(token.historicalPricesUsd.lastDay.at - (Date.now() - ONE_DAY_IN_MILLIS))
   )
+}
+
+export function isFeeCurrency(token: TokenBalance | undefined): token is TokenBalance {
+  return token?.isNative || !!token?.isFeeCurrency || !!token?.feeCurrencyAdapterAddress
 }

--- a/src/transactions/saga.ts
+++ b/src/transactions/saga.ts
@@ -373,7 +373,11 @@ function buildGasFees(feeCurrencyInfo: BaseToken, gasFeeInSmallestUnit: BigNumbe
     {
       type: 'SECURITY_FEE',
       amount: {
-        value: gasFeeInSmallestUnit.shiftedBy(-feeCurrencyInfo.decimals).toFixed(),
+        // TODO: would be more correct to check the actual fee currency (ERC20 or adapter) set in the TX
+        // in the meantime, this is good enough
+        value: gasFeeInSmallestUnit
+          .shiftedBy(-(feeCurrencyInfo.feeCurrencyAdapterDecimals ?? feeCurrencyInfo.decimals))
+          .toFixed(),
         tokenId: feeCurrencyInfo.tokenId,
       },
     },

--- a/src/viem/prepareTransactions.ts
+++ b/src/viem/prepareTransactions.ts
@@ -3,7 +3,14 @@ import { TransactionRequestCIP42 } from 'node_modules/viem/_types/chains/celo/ty
 import erc20 from 'src/abis/IERC20'
 import stableToken from 'src/abis/StableToken'
 import { STATIC_GAS_PADDING } from 'src/config'
-import { NativeTokenBalance, TokenBalance, TokenBalanceWithAddress } from 'src/tokens/slice'
+import {
+  NativeTokenBalance,
+  TokenBalance,
+  TokenBalanceWithAddress,
+  TokenBalances,
+} from 'src/tokens/slice'
+import { getTokenId } from 'src/tokens/utils'
+import { NetworkId } from 'src/transactions/types'
 import Logger from 'src/utils/Logger'
 import { estimateFeesPerGas } from 'src/viem/estimateFeesPerGas'
 import { publicClient } from 'src/viem/index'
@@ -85,8 +92,30 @@ export function getEstimatedGasFee(txs: TransactionRequest[]): BigNumber {
   return new BigNumber(estimatedGasFee.toString())
 }
 
-export function getFeeCurrencyAddress(feeCurrency: TokenBalance) {
-  return !feeCurrency.isNative ? (feeCurrency.address as Address) : undefined
+export function getFeeCurrencyAddress(feeCurrency: TokenBalance): Address | undefined {
+  if (feeCurrency.isNative) {
+    // No address for native currency
+    return undefined
+  }
+
+  // Direct fee currency
+  if (feeCurrency.isFeeCurrency) {
+    if (!feeCurrency.address) {
+      // This should never happen
+      throw new Error(`Fee currency address is missing for fee currency ${feeCurrency.tokenId}`)
+    }
+    return feeCurrency.address as Address
+  }
+
+  // Fee currency adapter
+  if (feeCurrency.feeCurrencyAdapterAddress) {
+    return feeCurrency.feeCurrencyAdapterAddress
+  }
+
+  // This should never happen
+  throw new Error(
+    `Unable to determine fee currency address for fee currency ${feeCurrency.tokenId}`
+  )
 }
 
 /**
@@ -279,10 +308,11 @@ export async function prepareTransactions({
       // Not enough balance to pay for gas, try next fee currency
       continue
     }
+    const feeDecimals = getFeeDecimals(estimatedTransactions, feeCurrency)
     const maxGasFee = getMaxGasFee(estimatedTransactions)
-    const maxGasFeeInDecimal = maxGasFee.shiftedBy(-feeCurrency.decimals)
+    const maxGasFeeInDecimal = maxGasFee.shiftedBy(-feeDecimals)
     const estimatedGasFee = getEstimatedGasFee(estimatedTransactions)
-    const estimatedGasFeeInDecimal = estimatedGasFee?.shiftedBy(-feeCurrency.decimals)
+    const estimatedGasFeeInDecimal = estimatedGasFee?.shiftedBy(-feeDecimals)
     gasFees.push({ feeCurrency, maxGasFeeInDecimal, estimatedGasFeeInDecimal })
     if (maxGasFeeInDecimal.isGreaterThan(feeCurrency.balance)) {
       // Not enough balance to pay for gas, try next fee currency
@@ -487,11 +517,10 @@ export function getFeeCurrencyAndAmounts(
   let estimatedFeeAmount = undefined
   if (prepareTransactionsResult?.type === 'possible') {
     feeCurrency = prepareTransactionsResult.feeCurrency
-    maxFeeAmount = getMaxGasFee(prepareTransactionsResult.transactions).shiftedBy(
-      -feeCurrency.decimals
-    )
+    const feeDecimals = getFeeDecimals(prepareTransactionsResult.transactions, feeCurrency)
+    maxFeeAmount = getMaxGasFee(prepareTransactionsResult.transactions).shiftedBy(-feeDecimals)
     estimatedFeeAmount = getEstimatedGasFee(prepareTransactionsResult.transactions).shiftedBy(
-      -feeCurrency.decimals
+      -feeDecimals
     )
   } else if (prepareTransactionsResult?.type === 'need-decrease-spend-amount-for-gas') {
     feeCurrency = prepareTransactionsResult.feeCurrency
@@ -507,6 +536,7 @@ export function getFeeCurrencyAndAmounts(
 
 /**
  * Given prepared transaction(s), get the fee currency set.
+ * IMPORTANT: it can be a fee currency adapter address, not the actual fee currency address
  *
  * NOTE: throws if the fee currency is not the same for all transactions
  */
@@ -534,4 +564,68 @@ function _getFeeCurrency(prepareTransaction: TransactionRequest): Address | unde
   }
 
   return undefined
+}
+
+export function getFeeCurrencyToken(
+  preparedTransactions: TransactionRequest[],
+  networkId: NetworkId,
+  tokensById: TokenBalances
+): TokenBalance | undefined {
+  const feeCurrencyAdapterOrAddress = getFeeCurrency(preparedTransactions)
+
+  // First try to find the fee currency token by its address (most common case)
+  const feeCurrencyToken = tokensById[getTokenId(networkId, feeCurrencyAdapterOrAddress)]
+  if (feeCurrencyToken) {
+    return feeCurrencyToken
+  }
+
+  // Then try finding the fee currency token by its fee currency adapter address
+  if (feeCurrencyAdapterOrAddress) {
+    return Object.values(tokensById).find(
+      (token) =>
+        token &&
+        token.networkId === networkId &&
+        token.feeCurrencyAdapterAddress === feeCurrencyAdapterOrAddress
+    )
+  }
+
+  // This indicates we're missing some data
+  Logger.warn(TAG, `Could not find fee currency token for prepared transactions`, {
+    feeCurrencyAdapterOrAddress,
+    networkId,
+  })
+  return undefined
+}
+
+export function getFeeDecimals(
+  preparedTransactions: TransactionRequest[],
+  feeCurrency: TokenBalance
+): number {
+  const feeCurrencyAdapterOrAddress = getFeeCurrency(preparedTransactions)
+  if (!feeCurrencyAdapterOrAddress) {
+    if (!feeCurrency.isNative) {
+      // This should never happen
+      throw new Error(`Passed fee currency (${feeCurrency.tokenId}) must be native`)
+    }
+    return feeCurrency.decimals
+  }
+
+  if (feeCurrencyAdapterOrAddress === feeCurrency.feeCurrencyAdapterAddress) {
+    if (feeCurrency.feeCurrencyAdapterDecimals === undefined) {
+      // This should never happen
+      throw new Error(
+        `Passed fee currency (${feeCurrency.tokenId}) does not have 'feeCurrencyAdapterDecimals' set`
+      )
+    }
+    return feeCurrency.feeCurrencyAdapterDecimals
+  }
+
+  if (feeCurrencyAdapterOrAddress === feeCurrency.address) {
+    return feeCurrency.decimals
+  }
+
+  // This should never happen
+  throw new Error(
+    `Passed fee currency (${feeCurrency.tokenId}) does not match the fee currency of the prepared transactions (${feeCurrencyAdapterOrAddress})`
+  )
 }

--- a/src/viem/saga.test.ts
+++ b/src/viem/saga.test.ts
@@ -642,27 +642,8 @@ describe('sendPayment', () => {
       comment: '',
       preparedTransaction: mockEthPreparedTransaction,
     }
-    const mockUSDCTokenBalance = {
-      name: 'USDC coin',
-      networkId: NetworkId['ethereum-sepolia'],
-      tokenId: mockUSDCTokenId,
-      address: mockUSDCAddress,
-      symbol: 'USDC',
-      decimals: 18,
-      imageUrl: '',
-      balance: '10',
-      priceUsd: '1',
-    }
     await expectSaga(sendPayment, mockSendUSDCPaymentArgs)
-      .withState(
-        createMockStore({
-          tokens: {
-            tokenBalances: {
-              [mockUSDCTokenId]: mockUSDCTokenBalance,
-            },
-          },
-        }).getState()
-      )
+      .withState(storeStateWithTokens.getState())
       .provide([
         [matchers.call.fn(getViemWallet), mockViemWallet],
         [matchers.call.fn(unlockAccount), UnlockResult.SUCCESS],

--- a/src/viem/saga.ts
+++ b/src/viem/saga.ts
@@ -9,6 +9,7 @@ import { FeeInfo } from 'src/fees/saga'
 import { encryptComment } from 'src/identity/commentEncryption'
 import { buildSendTx } from 'src/send/saga'
 import { getTokenInfo, tokenAmountInSmallestUnit } from 'src/tokens/saga'
+import { tokensByIdSelector } from 'src/tokens/selectors'
 import {
   TokenBalanceWithAddress,
   fetchTokenBalances,
@@ -23,7 +24,7 @@ import Logger from 'src/utils/Logger'
 import { ensureError } from 'src/utils/ensureError'
 import { publicClient } from 'src/viem'
 import { ViemWallet } from 'src/viem/getLockableWallet'
-import { TransactionRequest, getFeeCurrency } from 'src/viem/prepareTransactions'
+import { TransactionRequest, getFeeCurrencyToken } from 'src/viem/prepareTransactions'
 import {
   SerializableTransactionRequest,
   getPreparedTransaction,
@@ -32,7 +33,7 @@ import { getViemWallet } from 'src/web3/contracts'
 import networkConfig from 'src/web3/networkConfig'
 import { unlockAccount } from 'src/web3/saga'
 import { getNetworkFromNetworkId } from 'src/web3/utils'
-import { call, put } from 'typed-redux-saga'
+import { call, put, select } from 'typed-redux-saga'
 import { Hash, TransactionReceipt, WriteContractParameters, getAddress } from 'viem'
 
 const TAG = 'viem/saga'
@@ -100,9 +101,11 @@ export function* sendPayment({
     yield* call(unlockAccount, wallet.account.address)
   }
 
-  const feeCurrency: string | undefined =
-    preparedTransaction && getFeeCurrency(getPreparedTransaction(preparedTransaction))
-  const feeCurrencyId = getTokenId(networkId, feeCurrency)
+  const tokensById = yield* select((state) => tokensByIdSelector(state, [networkId]))
+  const feeCurrencyId = preparedTransaction
+    ? getFeeCurrencyToken([getPreparedTransaction(preparedTransaction)], networkId, tokensById)
+        ?.tokenId
+    : getTokenId(networkId)
 
   const addPendingStandbyTransaction = function* (hash: string) {
     yield* put(

--- a/src/walletConnect/screens/EstimatedNetworkFee.tsx
+++ b/src/walletConnect/screens/EstimatedNetworkFee.tsx
@@ -1,17 +1,20 @@
-import BigNumber from 'bignumber.js'
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import { StyleSheet, Text, View } from 'react-native'
 import TokenDisplay from 'src/components/TokenDisplay'
+import useSelector from 'src/redux/useSelector'
 import { NETWORK_NAMES } from 'src/shared/conts'
 import Colors from 'src/styles/colors'
 import { typeScale } from 'src/styles/fonts'
 import { Spacing } from 'src/styles/styles'
-import { useTokenInfo } from 'src/tokens/hooks'
-import { getTokenId } from 'src/tokens/utils'
+import { tokensByIdSelector } from 'src/tokens/selectors'
 import { NetworkId } from 'src/transactions/types'
 import Logger from 'src/utils/Logger'
-import { SerializableTransactionRequest } from 'src/viem/preparedTransactionSerialization'
+import { getFeeCurrencyToken, getFeeDecimals, getMaxGasFee } from 'src/viem/prepareTransactions'
+import {
+  SerializableTransactionRequest,
+  getPreparedTransaction,
+} from 'src/viem/preparedTransactionSerialization'
 
 interface Props {
   networkId: NetworkId
@@ -21,12 +24,9 @@ interface Props {
 export default function EstimatedNetworkFee({ networkId, transaction }: Props) {
   const { t } = useTranslation()
 
-  const feeTokenId =
-    'feeCurrency' in transaction
-      ? getTokenId(networkId, transaction.feeCurrency)
-      : getTokenId(networkId)
-
-  const feeTokenInfo = useTokenInfo(feeTokenId)
+  const tokensById = useSelector((state) => tokensByIdSelector(state, [networkId]))
+  const preparedTransaction = getPreparedTransaction(transaction)
+  const feeTokenInfo = getFeeCurrencyToken([preparedTransaction], networkId, tokensById)
 
   const networkName = NETWORK_NAMES[networkId]
 
@@ -39,10 +39,9 @@ export default function EstimatedNetworkFee({ networkId, transaction }: Props) {
     return null
   }
 
-  // fee value in base units
-  const feeValue = BigNumber(transaction.gas)
-    .times(BigNumber(transaction.maxFeePerGas))
-    .shiftedBy(-feeTokenInfo.decimals)
+  const feeDecimals = getFeeDecimals([preparedTransaction], feeTokenInfo)
+  // in base units
+  const maxFeeAmount = getMaxGasFee([preparedTransaction]).shiftedBy(-feeDecimals)
 
   return (
     <View style={styles.container} testID="EstimatedNetworkFee">
@@ -51,16 +50,16 @@ export default function EstimatedNetworkFee({ networkId, transaction }: Props) {
       </Text>
       <TokenDisplay
         style={styles.amountPrimaryText}
-        amount={feeValue}
-        tokenId={feeTokenId}
+        amount={maxFeeAmount}
+        tokenId={feeTokenInfo.tokenId}
         showLocalAmount={false}
         showSymbol={true}
         hideSign={true}
       />
       <TokenDisplay
         style={styles.amountSecondaryText}
-        amount={feeValue}
-        tokenId={feeTokenId}
+        amount={maxFeeAmount}
+        tokenId={feeTokenInfo.tokenId}
         showLocalAmount={true}
         showSymbol={true}
         hideSign={true}


### PR DESCRIPTION
### Description

This adds support for fee currency adapters.

### Test plan

- Updated tests
- Manually tested

### Related issues

- Fixes #RET-1009

### Backwards compatibility

Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
