### PR TITLE
ci: disable Android e2e test for API level 24 on main

### DIFF
--- a/.github/workflows/e2e-main.yml
+++ b/.github/workflows/e2e-main.yml
@@ -32,7 +32,8 @@ jobs:
         # 21 is failing 9 specs
         # 23 is failing ? spec(s)
         # 31 is failing ? spec(s)
-        android-api-level: [24, 30]
+        # 24 is currently failing all the time, disabling it for now
+        android-api-level: [30]
     uses: ./.github/workflows/e2e-android.yml
     with:
       android-api-level: ${{ matrix.android-api-level }}


### PR DESCRIPTION
It's failing all the time. See Slack [thread](https://valora-app.slack.com/archives/C02E2FE98P2/p1709116393221949).

Disabling to avoid the wasted cost of 25 mins with namespace on each run.

Will investigate and try to re-enable later.
