### PR TITLE
ci: adjust concurrency checks to support a merge queue

### DIFF
--- a/.github/workflows/check-translation-files-pr.yml
+++ b/.github/workflows/check-translation-files-pr.yml
@@ -8,9 +8,8 @@ on:
 # Cancel any in progress run of the workflow for a given PR
 # This avoids building outdated code
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref }}
-  if: ${{ github.event_name != 'merge_group' }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
 
 jobs:
   check-translation-files:

--- a/.github/workflows/check-translation-files-pr.yml
+++ b/.github/workflows/check-translation-files-pr.yml
@@ -9,6 +9,7 @@ on:
 # This avoids building outdated code
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}
+  if: ${{ github.event_name != 'merge_group' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/check-translation-files-pr.yml
+++ b/.github/workflows/check-translation-files-pr.yml
@@ -9,7 +9,7 @@ on:
 # This avoids building outdated code
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
-  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+  cancel-in-progress: true
 
 jobs:
   check-translation-files:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -18,6 +18,7 @@ on:
 concurrency:
   # Fallback used github.head_ref as it only defined on pull_request
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  if: ${{ github.event_name != 'merge_group' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -18,7 +18,7 @@ on:
 concurrency:
   # Fallback used github.ref_name as it is always defined
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
-  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+  cancel-in-progress: true
 
 jobs:
   vulnerability:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -16,10 +16,9 @@ on:
 # Cancel any in progress run of the workflow for a given PR
 # This avoids building outdated code
 concurrency:
-  # Fallback used github.head_ref as it only defined on pull_request
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  if: ${{ github.event_name != 'merge_group' }}
-  cancel-in-progress: true
+  # Fallback used github.ref_name as it is always defined
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
 
 jobs:
   vulnerability:

--- a/.github/workflows/e2e-pr.yml
+++ b/.github/workflows/e2e-pr.yml
@@ -9,6 +9,7 @@ on:
 # This avoids building outdated code
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}
+  if: ${{ github.event_name != 'merge_group' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/e2e-pr.yml
+++ b/.github/workflows/e2e-pr.yml
@@ -9,7 +9,7 @@ on:
 # This avoids building outdated code
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
-  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+  cancel-in-progress: true
 
 jobs:
   android:

--- a/.github/workflows/e2e-pr.yml
+++ b/.github/workflows/e2e-pr.yml
@@ -8,9 +8,8 @@ on:
 # Cancel any in progress run of the workflow for a given PR
 # This avoids building outdated code
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref }}
-  if: ${{ github.event_name != 'merge_group' }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
 
 jobs:
   android:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ on:
 # This avoids building outdated code
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
-  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+  cancel-in-progress: true
 
 jobs:
   mobile:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,9 +12,8 @@ on:
 # Cancel any in progress run of the workflow for a given PR
 # This avoids building outdated code
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref }}
-  if: ${{ github.event_name != 'merge_group' }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
 
 jobs:
   mobile:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,7 @@ on:
 # This avoids building outdated code
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}
+  if: ${{ github.event_name != 'merge_group' }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
### Description

Prevents concurrency checks from cancelling earlier jobs in the merge queue. Follow up to: #4998, #4999 and #5002.

### Test plan

Test in CI.

### Related issues

N/A

### Backwards compatibility

N/A

### Network scalability

N/A
