### PR TITLE
ci: prevent merge queue jobs from being cancelled from concurrency

### DIFF
--- a/.github/workflows/check-translation-files-pr.yml
+++ b/.github/workflows/check-translation-files-pr.yml
@@ -5,11 +5,11 @@ on:
   pull_request:
   merge_group:
 
-# Cancel any in progress run of the workflow for a given PR
+# Cancel any non merge queue in progress run of the workflow for a given PR
 # This avoids building outdated code
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
 
 jobs:
   check-translation-files:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,12 +13,12 @@ on:
   schedule:
     - cron: '30 20 * * *'
 
-# Cancel any in progress run of the workflow for a given PR
+# Cancel any non merge queue in progress run of the workflow for a given PR
 # This avoids building outdated code
 concurrency:
   # Fallback used github.ref_name as it is always defined
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
 
 jobs:
   vulnerability:

--- a/.github/workflows/e2e-pr.yml
+++ b/.github/workflows/e2e-pr.yml
@@ -5,11 +5,11 @@ on:
       - main
   merge_group:
 
-# Cancel any in progress run of the workflow for a given PR
+# Cancel any non merge queue in progress run of the workflow for a given PR
 # This avoids building outdated code
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
 
 jobs:
   android:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,11 +9,11 @@ on:
   pull_request:
   merge_group:
 
-# Cancel any in progress run of the workflow for a given PR
+# Cancel any non merge queue in progress run of the workflow for a given PR
 # This avoids building outdated code
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
 
 jobs:
   mobile:


### PR DESCRIPTION
### Description

Prevents concurrency checks from cancelling jobs in the merge queue. Follow up to: #4998, #4999, #5002 and #5015🤞. 

### Test plan

Test in CI.

### Related issues

N/A

### Backwards compatibility

N/A

### Network scalability

N/A
