### PR TITLE
ci(check-translation-files): don't run on merge group events

### DIFF
--- a/.github/workflows/check-translation-files-pr.yml
+++ b/.github/workflows/check-translation-files-pr.yml
@@ -27,7 +27,7 @@ jobs:
             locales/base/translation.json
             ios/celo/Base.lproj/InfoPlist.strings
       - name: Fail if translation files are changed
-        if: ${{ github.event_name != 'merge_group' }} && ${{ (github.head_ref != 'l10n/main') && (steps.changed-files.outputs.any_changed == 'true') }}
+        if: ${{ (github.event_name != 'merge_group') && (github.head_ref != 'l10n/main') && (steps.changed-files.outputs.any_changed == 'true') }}
         run: |
           echo "❌ Only the base translation files should be modified in non-Crowdin PR's!"
           echo "These translation files should not have been modified:"

--- a/.github/workflows/check-translation-files-pr.yml
+++ b/.github/workflows/check-translation-files-pr.yml
@@ -27,7 +27,7 @@ jobs:
             locales/base/translation.json
             ios/celo/Base.lproj/InfoPlist.strings
       - name: Fail if translation files are changed
-        if: ${{ (github.head_ref != 'l10n/main') && (steps.changed-files.outputs.any_changed == 'true') }}
+        if: ${{ github.event_name != 'merge_group' }} && ${{ (github.head_ref != 'l10n/main') && (steps.changed-files.outputs.any_changed == 'true') }}
         run: |
           echo "❌ Only the base translation files should be modified in non-Crowdin PR's!"
           echo "These translation files should not have been modified:"

--- a/locales/en-US/translation.json
+++ b/locales/en-US/translation.json
@@ -1,5 +1,5 @@
 {
-  "invite": "Invite ",
+  "invite": "Invite",
   "celoRewards": "Celo Rewards",
   "languageSettings": "Language",
   "localCurrencySetting": "Currency",

--- a/locales/en-US/translation.json
+++ b/locales/en-US/translation.json
@@ -1,5 +1,5 @@
 {
-  "invite": "Invite",
+  "invite": "Invite ",
   "celoRewards": "Celo Rewards",
   "languageSettings": "Language",
   "localCurrencySetting": "Currency",


### PR DESCRIPTION
### Description

Crowd-in PR (#5014) fails the check since the branch name on merge queue doesn't match the expected branch name (https://github.com/valora-inc/wallet/pull/5014#event-11973800593). We can skip this check on merge queue requests and just let it pass. Any incorrect pushes will be flagged by the pull request run so don't need another check on the merge queue

### Test plan

Ensured this still fails on PRs https://github.com/valora-inc/wallet/pull/5020/commits/0243c61f521ea895f7fde6b0848a617b18210ef0 , ensure #5014 merges after this merges

### Related issues

N/A

### Backwards compatibility

N/A


