### PR TITLE
ci: don't run jobs on main that already run on the merge queue

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,11 +1,7 @@
 name: Check
 
 on:
-  # Run on pushes to main..
-  push:
-    branches:
-      - main
-  # ..any pull request, workflow dispatch and merge queue
+  # ..any pull request, workflow dispatch and merge queue (covers main)
   pull_request:
   workflow_dispatch:
   merge_group:

--- a/.github/workflows/e2e-main.yml
+++ b/.github/workflows/e2e-main.yml
@@ -22,23 +22,24 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  android:
-    name: Android
-    strategy:
-      max-parallel: 2
-      fail-fast: false
-      matrix:
-        # TODO if/when more CI machines: enable Android sdk 21, 23, 29 and 31
-        # 21 is failing 9 specs
-        # 23 is failing ? spec(s)
-        # 31 is failing ? spec(s)
-        # 24 is currently failing all the time, disabling it for now
-        # 30 is not included as it runs on the merge queue
-        android-api-level: []
-    uses: ./.github/workflows/e2e-android.yml
-    with:
-      android-api-level: ${{ matrix.android-api-level }}
-    secrets: inherit
+  # TODO: enable once we have at least one android-api-level below
+  # android:
+  #   name: Android
+  #   strategy:
+  #     max-parallel: 2
+  #     fail-fast: false
+  #     matrix:
+  #       # TODO if/when more CI machines: enable Android sdk 21, 23, 29 and 31
+  #       # 21 is failing 9 specs
+  #       # 23 is failing ? spec(s)
+  #       # 31 is failing ? spec(s)
+  #       # 24 is currently failing all the time, disabling it for now
+  #       # 30 is not included as it runs on the merge queue
+  #       android-api-level: []
+  #   uses: ./.github/workflows/e2e-android.yml
+  #   with:
+  #     android-api-level: ${{ matrix.android-api-level }}
+  #   secrets: inherit
   ios:
     name: iOS
     strategy:

--- a/.github/workflows/e2e-main.yml
+++ b/.github/workflows/e2e-main.yml
@@ -18,7 +18,7 @@ on:
 # Cancel any in progress run of the workflow for a given PR
 # This avoids building outdated code
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref }}
+  group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/e2e-main.yml
+++ b/.github/workflows/e2e-main.yml
@@ -33,7 +33,8 @@ jobs:
         # 23 is failing ? spec(s)
         # 31 is failing ? spec(s)
         # 24 is currently failing all the time, disabling it for now
-        android-api-level: [30]
+        # 30 is not included as it runs on the merge queue
+        android-api-level: []
     uses: ./.github/workflows/e2e-android.yml
     with:
       android-api-level: ${{ matrix.android-api-level }}
@@ -44,7 +45,8 @@ jobs:
       max-parallel: 2
       fail-fast: false
       matrix:
-        ios-version: ['15.0', '17.2']
+        # 15.0 is not included as it runs on the merge queue
+        ios-version: ['17.2']
     uses: ./.github/workflows/e2e-ios.yml
     with:
       ios-version: ${{ matrix.ios-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,11 +1,7 @@
 name: Test
 
 on:
-  # Run on pushes to main..
-  push:
-    branches:
-      - main
-  # ..any pull request and merge queue
+  # ..any pull request and merge queue (covers main)
   pull_request:
   merge_group:
 


### PR DESCRIPTION
### Description

Now that we have merge queue enabled for main, every PR runs checks at least twice, once on the PR before being added to the queue and once on the merge queue. The commit on the merge queue is the same commit that lands on main, so we don't need to run checks again on main that have already run on the merge queue (see image below on checks running twice on commits on main). This disables `check` and `test` workflows on main, and updates the `e2e-main` workflow to only run tests on OS that have not already run on the merge queue. This should save us some CI time, especially on E2E machines. 

<img width="527" alt="image" src="https://github.com/valora-inc/wallet/assets/5062591/68808134-8330-4975-9d85-0626050681d0">


### Test plan

CI

### Related issues

N/A

### Backwards compatibility

N/A

### Network scalability

N/A
