### PR TITLE
fix(keylessBackup): fix hasSeenVerification for linkPhone number and when homecard is shown

### DIFF
--- a/src/home/NotificationBox.test.tsx
+++ b/src/home/NotificationBox.test.tsx
@@ -332,6 +332,7 @@ describe('NotificationBox', () => {
     const store = createMockStore({
       account: {
         backupCompleted: false,
+        cloudBackupCompleted: false,
       },
     })
     jest.mocked(getFeatureGate).mockReturnValue(true)

--- a/src/home/NotificationBox.tsx
+++ b/src/home/NotificationBox.tsx
@@ -101,8 +101,8 @@ export function useSimpleActions() {
   const cloudBackupCompleted = useSelector(cloudBackupCompletedSelector)
 
   const actions: SimpleAction[] = []
-  if (!backupCompleted) {
-    if (showKeylessBackup && !cloudBackupCompleted) {
+  if (!backupCompleted && !cloudBackupCompleted) {
+    if (showKeylessBackup) {
       actions.push({
         id: NotificationType.keyless_backup_prompt,
         type: NotificationType.keyless_backup_prompt,

--- a/src/home/NotificationBox.tsx
+++ b/src/home/NotificationBox.tsx
@@ -8,7 +8,7 @@ import {
   dismissKeepSupercharging,
   dismissStartSupercharging,
 } from 'src/account/actions'
-import { celoEducationCompletedSelector } from 'src/account/selectors'
+import { celoEducationCompletedSelector, cloudBackupCompletedSelector } from 'src/account/selectors'
 import { HomeEvents, RewardsEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import { ScrollDirection } from 'src/analytics/types'
@@ -98,10 +98,11 @@ export function useSimpleActions() {
   }, [])
 
   const superchargeRewards = useSelector((state) => state.supercharge.availableRewards)
+  const cloudBackupCompleted = useSelector(cloudBackupCompletedSelector)
 
   const actions: SimpleAction[] = []
   if (!backupCompleted) {
-    if (showKeylessBackup) {
+    if (showKeylessBackup && !cloudBackupCompleted) {
       actions.push({
         id: NotificationType.keyless_backup_prompt,
         type: NotificationType.keyless_backup_prompt,

--- a/src/keylessBackup/LinkPhoneNumber.tsx
+++ b/src/keylessBackup/LinkPhoneNumber.tsx
@@ -3,14 +3,18 @@ import React, { useLayoutEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { StyleSheet, Text, View } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
+import { useSelector } from 'react-redux'
 import { OnboardingEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import BackButton from 'src/components/BackButton'
 import Button, { BtnSizes, BtnTypes } from 'src/components/Button'
+import { setHasSeenVerificationNux } from 'src/identity/actions'
 
-import { navigate, navigateHome } from 'src/navigator/NavigationService'
+import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import { StackParamList } from 'src/navigator/types'
+import { goToNextOnboardingScreen, onboardingPropsSelector } from 'src/onboarding/steps'
+import { useDispatch } from 'src/redux/hooks'
 import colors from 'src/styles/colors'
 import { typeScale } from 'src/styles/fonts'
 import { Spacing } from 'src/styles/styles'
@@ -19,7 +23,8 @@ type Props = NativeStackScreenProps<StackParamList, Screens.LinkPhoneNumber>
 
 export default function LinkPhoneNumber({ navigation }: Props) {
   const { t } = useTranslation()
-
+  const dispatch = useDispatch()
+  const onboardingProps = useSelector(onboardingPropsSelector)
   useLayoutEffect(() => {
     navigation.setOptions({
       headerLeft: () => <BackButton />,
@@ -35,7 +40,11 @@ export default function LinkPhoneNumber({ navigation }: Props) {
   }
   const laterButtonOnPress = async () => {
     ValoraAnalytics.track(OnboardingEvents.link_phone_number_later)
-    navigateHome()
+    dispatch(setHasSeenVerificationNux(true))
+    goToNextOnboardingScreen({
+      firstScreenInCurrentStep: Screens.VerificationStartScreen,
+      onboardingProps,
+    })
   }
 
   return (


### PR DESCRIPTION
### Description

* Homecard should not be shown if the user restored with keylessBackup
* If verification is skipped after keylessbackup, set the state correctly so the user isn't shown verification next time they open the app

### Test plan

Unit tests, manual test
