### PR TITLE
feat: nft reward feature gate

### DIFF
--- a/src/home/selectors.test.ts
+++ b/src/home/selectors.test.ts
@@ -8,6 +8,7 @@ import {
   showNftRewardSelector,
 } from 'src/home/selectors'
 import { getFeatureGate } from 'src/statsig'
+import { StatsigFeatureGates } from 'src/statsig/types'
 import { NetworkId } from 'src/transactions/types'
 import { getMockStoreData } from 'test/utils'
 import { mockCleverTapInboxMessage } from 'test/values'
@@ -198,7 +199,9 @@ describe('showNftCelebrationSelector', () => {
   })
 
   it('should return false when feature gate is disabled', () => {
-    jest.mocked(getFeatureGate).mockReturnValueOnce(false)
+    jest
+      .mocked(getFeatureGate)
+      .mockImplementation((featureGate) => featureGate !== StatsigFeatureGates.SHOW_NFT_CELEBRATION)
 
     const state = getMockStoreData({
       home: {
@@ -252,7 +255,9 @@ describe('showNftRewardSelector', () => {
   })
 
   it('should return false when feature gate is disabled', () => {
-    jest.mocked(getFeatureGate).mockReturnValueOnce(false)
+    jest
+      .mocked(getFeatureGate)
+      .mockImplementation((featureGate) => featureGate !== StatsigFeatureGates.SHOW_NFT_REWARD)
 
     const state = getMockStoreData({
       home: {

--- a/src/home/selectors.ts
+++ b/src/home/selectors.ts
@@ -55,7 +55,7 @@ export const showNftCelebrationSelector = (state: RootState) => {
 }
 
 export const showNftRewardSelector = (state: RootState) => {
-  const featureGateEnabled = getFeatureGate(StatsigFeatureGates.SHOW_NFT_CELEBRATION)
+  const featureGateEnabled = getFeatureGate(StatsigFeatureGates.SHOW_NFT_REWARD)
   if (!featureGateEnabled) {
     return false
   }

--- a/src/nfts/saga.test.tsx
+++ b/src/nfts/saga.test.tsx
@@ -9,6 +9,7 @@ import * as nftSaga from 'src/nfts/saga'
 import { handleFetchNfts, watchFirstFetchCompleted } from 'src/nfts/saga'
 import { fetchNftsCompleted, fetchNftsFailed } from 'src/nfts/slice'
 import { getDynamicConfigParams, getFeatureGate } from 'src/statsig'
+import { StatsigFeatureGates } from 'src/statsig/types'
 import { NetworkId } from 'src/transactions/types'
 import Logger from 'src/utils/Logger'
 import { walletAddressSelector } from 'src/web3/selectors'
@@ -172,7 +173,11 @@ describe('Given Nfts saga', () => {
     it('should not put celebrated NFT if feature gate is closed', () => {
       const mockAction = fetchNftsCompleted({ nfts: [mockNftAllFields] })
 
-      jest.mocked(getFeatureGate).mockReturnValue(false)
+      jest
+        .mocked(getFeatureGate)
+        .mockImplementation(
+          (featureGate) => featureGate !== StatsigFeatureGates.SHOW_NFT_CELEBRATION
+        )
       jest.mocked(getDynamicConfigParams).mockReturnValue(mockExpiredRemoteConfig)
 
       return expectSaga(nftSaga.findCelebratedNft, mockAction)
@@ -215,7 +220,9 @@ describe('Given Nfts saga', () => {
     it('should not set status "reward ready" if feature gate is closed', () => {
       const mockAction = fetchNftsCompleted({ nfts: [mockNftAllFields] })
 
-      jest.mocked(getFeatureGate).mockReturnValue(false)
+      jest
+        .mocked(getFeatureGate)
+        .mockImplementation((featureGate) => featureGate !== StatsigFeatureGates.SHOW_NFT_REWARD)
       jest.mocked(getDynamicConfigParams).mockReturnValue(mockExpiredRemoteConfig)
 
       return expectSaga(nftSaga.findCelebratedNft, mockAction)

--- a/src/nfts/saga.ts
+++ b/src/nfts/saga.ts
@@ -114,7 +114,7 @@ export function* findCelebratedNft({ payload: { nfts } }: PayloadAction<FetchNft
 }
 
 export function* findNftReward({ payload: { nfts } }: PayloadAction<FetchNftsCompletedAction>) {
-  const featureGateEnabled = getFeatureGate(StatsigFeatureGates.SHOW_NFT_CELEBRATION)
+  const featureGateEnabled = getFeatureGate(StatsigFeatureGates.SHOW_NFT_REWARD)
   if (!featureGateEnabled) {
     return
   }

--- a/src/statsig/constants.ts
+++ b/src/statsig/constants.ts
@@ -21,6 +21,7 @@ export const FeatureGates = {
   [StatsigFeatureGates.SHOW_SWAP_TOKEN_FILTERS]: false,
   [StatsigFeatureGates.SHUFFLE_SWAP_TOKENS_ORDER]: false,
   [StatsigFeatureGates.SHOW_NFT_CELEBRATION]: false,
+  [StatsigFeatureGates.SHOW_NFT_REWARD]: false,
   [StatsigFeatureGates.SHOW_JUMPSTART_SEND]: false,
 }
 

--- a/src/statsig/types.ts
+++ b/src/statsig/types.ts
@@ -28,6 +28,7 @@ export enum StatsigFeatureGates {
   SHOW_SWAP_TOKEN_FILTERS = 'show_swap_token_filters',
   SHUFFLE_SWAP_TOKENS_ORDER = 'shuffle_swap_tokens_order',
   SHOW_NFT_CELEBRATION = 'show_nft_celebration',
+  SHOW_NFT_REWARD = 'show_nft_reward',
   SHOW_JUMPSTART_SEND = 'show_jumpstart_send',
 }
 


### PR DESCRIPTION
### Description

We want to show the nft reward bottom sheet to a slightly different audience than the nft celebration. So, the reward bottom sheet should be gated with its own feature flag.

Context: https://valora-app.slack.com/archives/C06NA9MBJSG/p1709747619306969

### Test plan

* Updated unit tests

### Related issues

- Related to RET-1002

### Backwards compatibility

Y

### Network scalability

NA