### PR TITLE
feat(bottom-tabs): extend assets screen to support wallet tab

### DIFF
--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -1969,7 +1969,8 @@
       "collectibles": "Collectibles",
       "dappPositions": "Dapp Positions"
     },
-    "importToken": "Import"
+    "importToken": "Import",
+    "importTokens": "Import Tokens"
   },
   "notificationCenterSpotlight": {
     "message": "Introducing a new way to claim rewards, view alerts, and see updates in one place",

--- a/src/components/TokenBalance.test.tsx
+++ b/src/components/TokenBalance.test.tsx
@@ -64,7 +64,7 @@ describe('AssetsTokenBalance', () => {
   it('should show info on tap', () => {
     const { getByText, getByTestId, queryByText } = render(
       <Provider store={createMockStore()}>
-        <AssetsTokenBalance showInfo />
+        <AssetsTokenBalance showInfo isWalletTab={false} />
       </Provider>
     )
 
@@ -74,6 +74,18 @@ describe('AssetsTokenBalance', () => {
 
     fireEvent.press(getByTestId('AssetsTokenBalance/Info'))
     expect(getByText('totalAssetsInfo')).toBeTruthy()
+  })
+
+  it('should show appropriate title on wallet tab', () => {
+    const { getByText, getByTestId, queryByText } = render(
+      <Provider store={createMockStore()}>
+        <AssetsTokenBalance showInfo={false} isWalletTab={true} />
+      </Provider>
+    )
+
+    expect(getByText('bottomTabsNavigator.wallet.title')).toBeTruthy()
+    expect(getByTestId('TotalTokenBalance')).toHaveTextContent('₱55.74')
+    expect(queryByText('AssetsTokenBalance/Info')).toBeFalsy()
   })
 })
 

--- a/src/components/TokenBalance.tsx
+++ b/src/components/TokenBalance.tsx
@@ -161,7 +161,15 @@ function useErrorMessageWithRefresh() {
   }, [shouldShowError])
 }
 
-export function AssetsTokenBalance({ showInfo }: { showInfo: boolean }) {
+export function AssetsTokenBalance({
+  showInfo,
+  isWalletTab,
+}: {
+  showInfo: boolean
+  // temporary parameter while we build the tab navigator, should be cleaned up
+  // when we remove the DrawerNavigator
+  isWalletTab: boolean
+}) {
   const { t } = useTranslation()
 
   const [infoVisible, setInfoVisible] = useState(false)
@@ -200,7 +208,11 @@ export function AssetsTokenBalance({ showInfo }: { showInfo: boolean }) {
     <TouchableWithoutFeedback onPress={handleDismissInfo}>
       <View testID="AssetsTokenBalance">
         <View style={styles.row}>
-          <Text style={styles.totalAssets}>{t('totalAssets')}</Text>
+          {isWalletTab ? (
+            <Text style={styles.walletTabTitle}>{t('bottomTabsNavigator.wallet.title')}</Text>
+          ) : (
+            <Text style={styles.totalAssets}>{t('totalAssets')}</Text>
+          )}
           {showInfo && (
             <TouchableOpacity
               onPress={toggleInfoVisible}
@@ -319,6 +331,11 @@ const styles = StyleSheet.create({
     ...typeScale.labelMedium,
     color: Colors.gray5,
     marginRight: 4,
+  },
+  walletTabTitle: {
+    ...typeScale.titleMedium,
+    color: Colors.black,
+    marginRight: 10,
   },
   totalAssetsInfoContainer: {
     position: 'absolute',

--- a/src/navigator/Screens.tsx
+++ b/src/navigator/Screens.tsx
@@ -101,6 +101,7 @@ export enum Screens {
   WalletConnectSessions = 'WalletConnectSessions',
   WalletSecurityPrimer = 'WalletSecurityPrimer',
   WalletSecurityPrimerDrawer = 'WalletSecurityPrimerDrawer',
+  WalletTab = 'WalletTab',
   WebViewScreen = 'WebViewScreen',
   Welcome = 'Welcome',
   WithdrawSpend = 'WithdrawSpend',

--- a/src/navigator/Screens.tsx
+++ b/src/navigator/Screens.tsx
@@ -101,7 +101,6 @@ export enum Screens {
   WalletConnectSessions = 'WalletConnectSessions',
   WalletSecurityPrimer = 'WalletSecurityPrimer',
   WalletSecurityPrimerDrawer = 'WalletSecurityPrimerDrawer',
-  WalletTab = 'WalletTab',
   WebViewScreen = 'WebViewScreen',
   Welcome = 'Welcome',
   WithdrawSpend = 'WithdrawSpend',

--- a/src/navigator/TabNavigator.tsx
+++ b/src/navigator/TabNavigator.tsx
@@ -42,14 +42,13 @@ export default function TabNavigator({ route }: Props) {
       }}
     >
       <Tab.Screen
-        // TODO(act-1104) new assets screen
         name={Screens.TabWallet}
-        // @ts-expect-error Type '{}' is missing the following properties from type 'Props': navigation, route
         component={AssetsScreen}
         options={{
           tabBarLabel: t('bottomTabsNavigator.wallet.tabName') as string,
           tabBarIcon: Wallet,
         }}
+        initialParams={{ isWalletTab: true }}
       />
       <Tab.Screen
         // TODO(act-1105) new home tab screen

--- a/src/navigator/types.tsx
+++ b/src/navigator/types.tsx
@@ -274,11 +274,7 @@ export type StackParamList = {
   [Screens.SwapScreenWithBack]: { fromTokenId: string } | undefined
   [Screens.TabDiscover]: undefined
   [Screens.TabHome]: undefined
-  [Screens.TabWallet]:
-    | {
-        activeTab: AssetTabType
-      }
-    | undefined
+  [Screens.TabWallet]: { activeAssetTab?: AssetTabType; isWalletTab?: boolean } | undefined
   [Screens.TabNavigator]: {
     initialScreen?: Screens
     fromModal?: boolean
@@ -321,7 +317,8 @@ export type StackParamList = {
   [Screens.WithdrawSpend]: undefined
   [Screens.Assets]:
     | {
-        activeTab: AssetTabType
+        activeAssetTab: AssetTabType
+        isWalletTab?: boolean
       }
     | undefined
 }

--- a/src/tokens/Assets.test.tsx
+++ b/src/tokens/Assets.test.tsx
@@ -297,6 +297,21 @@ describe('AssetsScreen', () => {
     expect(button).toBeNull()
   })
 
+  it('does not render Import Token on wallets tab', () => {
+    jest.mocked(getFeatureGate).mockReturnValue(true)
+    const store = createMockStore(storeWithPositions)
+
+    const component = (
+      <Provider store={store}>
+        <MockedNavigator component={AssetsScreen} params={{ isWalletTab: true }} />
+      </Provider>
+    )
+    const { queryByText } = render(component)
+    const button = queryByText('assets.importToken')
+
+    expect(button).toBeNull()
+  })
+
   it('clicking Import opens Import Token screen', () => {
     jest
       .mocked(getFeatureGate)


### PR DESCRIPTION
### Description

Adds a temporary isWalletTab param to Assets screen and its sub components to support the wallet tab screen.

### Test plan

Unit tests, manual on both iOS and Android


https://github.com/valora-inc/wallet/assets/5062591/eb619ae3-ca86-4f44-8a8a-b250997fb510

Ignore header for now, will be addressed in a follow up issue

### Related issues

- Fixes ACT-1104

### Backwards compatibility

Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
