### PR TITLE
fix: new wallets only created with english mnemonics

### DIFF
--- a/src/backup/utils.ts
+++ b/src/backup/utils.ts
@@ -1,8 +1,4 @@
-import {
-  CELO_DERIVATION_PATH_BASE,
-  generateKeys,
-  MnemonicLanguages,
-} from '@celo/cryptographic-utils'
+import { CELO_DERIVATION_PATH_BASE, generateKeys } from '@celo/cryptographic-utils'
 import CryptoJS from 'crypto-js'
 import { useAsync } from 'react-async-hook'
 import * as bip39 from 'react-native-bip39'
@@ -25,20 +21,6 @@ export async function generateKeysFromMnemonic(mnemonic: string) {
   const wordCount = countMnemonicWords(mnemonic)
   const derivationPath = wordCount === 24 ? CELO_DERIVATION_PATH_BASE : ETHEREUM_DERIVATION_PATH
   return generateKeys(mnemonic, undefined, undefined, undefined, bip39, derivationPath)
-}
-
-export function getMnemonicLanguage(language: string | null) {
-  switch (language?.slice(0, 2)) {
-    case 'es': {
-      return MnemonicLanguages.spanish
-    }
-    case 'pt': {
-      return MnemonicLanguages.portuguese
-    }
-    default: {
-      return MnemonicLanguages.english
-    }
-  }
 }
 
 export async function storeMnemonic(mnemonic: string, account: string | null, password?: string) {

--- a/src/web3/saga.test.ts
+++ b/src/web3/saga.test.ts
@@ -78,8 +78,8 @@ describe(getOrCreateAccount, () => {
   it.each`
     appLang             | expectedMnemonicLang
     ${'en-US'}          | ${MnemonicLanguages[MnemonicLanguages.english]}
-    ${'es-419'}         | ${MnemonicLanguages[MnemonicLanguages.spanish]}
-    ${'pt-BR'}          | ${MnemonicLanguages[MnemonicLanguages.portuguese]}
+    ${'es-419'}         | ${MnemonicLanguages[MnemonicLanguages.english]}
+    ${'pt-BR'}          | ${MnemonicLanguages[MnemonicLanguages.english]}
     ${'incorrect-lang'} | ${MnemonicLanguages[MnemonicLanguages.english]}
   `(
     'creates an account with a mnemonic in $expectedMnemonicLang when app language is $appLang',

--- a/src/web3/saga.ts
+++ b/src/web3/saga.ts
@@ -61,12 +61,7 @@ export function* getOrCreateAccount() {
 
     const mnemonicBitLength = MnemonicStrength.s128_12words
     const mnemonicLanguage = MnemonicLanguages.english
-    let mnemonic: string = yield* call(
-      generateMnemonic,
-      mnemonicBitLength,
-      MnemonicLanguages.english,
-      bip39
-    )
+    let mnemonic: string = yield* call(generateMnemonic, mnemonicBitLength, mnemonicLanguage, bip39)
 
     // Ensure no duplicates in mnemonic
     const checkDuplicate = (someString: string) => {

--- a/src/web3/saga.ts
+++ b/src/web3/saga.ts
@@ -1,4 +1,4 @@
-import { generateMnemonic, MnemonicStrength } from '@celo/cryptographic-utils'
+import { generateMnemonic, MnemonicLanguages, MnemonicStrength } from '@celo/cryptographic-utils'
 import { privateKeyToAddress } from '@celo/utils/lib/address'
 import { UnlockableWallet } from '@celo/wallet-base'
 import { RpcWalletErrors } from '@celo/wallet-rpc/lib/rpc-wallet'
@@ -6,8 +6,7 @@ import * as bip39 from 'react-native-bip39'
 import { setAccountCreationTime } from 'src/account/actions'
 import { generateSignedMessage } from 'src/account/saga'
 import { ErrorMessages } from 'src/app/ErrorMessages'
-import { generateKeysFromMnemonic, getMnemonicLanguage, storeMnemonic } from 'src/backup/utils'
-import { currentLanguageSelector } from 'src/i18n/selectors'
+import { generateKeysFromMnemonic, storeMnemonic } from 'src/backup/utils'
 import {
   CANCELLED_PIN_INPUT,
   getPasswordSaga,
@@ -61,8 +60,13 @@ export function* getOrCreateAccount() {
     Logger.debug(TAG + '@getOrCreateAccount', 'Creating a new account')
 
     const mnemonicBitLength = MnemonicStrength.s128_12words
-    const mnemonicLanguage = getMnemonicLanguage(yield* select(currentLanguageSelector))
-    let mnemonic: string = yield* call(generateMnemonic, mnemonicBitLength, mnemonicLanguage, bip39)
+    const mnemonicLanguage = MnemonicLanguages.english
+    let mnemonic: string = yield* call(
+      generateMnemonic,
+      mnemonicBitLength,
+      MnemonicLanguages.english,
+      bip39
+    )
 
     // Ensure no duplicates in mnemonic
     const checkDuplicate = (someString: string) => {


### PR DESCRIPTION
### Description

Wallets created when the users language was set to Spanish or Portuguese had mnemonics that were in Spanish or Portuguese. This causes interoperability issues for Valora users who wish to try other wallets: [Slack Thread](https://valora-app.slack.com/archives/C02KBT0DAHJ/p1709917662991769).

### Test plan

- Tested locally on iOS
- Unit tests updated

### Related issues

N/A

### Backwards compatibility

Yes - Users with Spanish and Portuguese mnemonics are still able to restore into Valora.

### Network scalability

N/A