### PR TITLE
feat(bottom-tabs): extend wallet home to support home tab

### DIFF
--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -2174,7 +2174,8 @@
       "title": "My Wallet"
     },
     "home": {
-      "tabName": "Home"
+      "tabName": "Home",
+      "title": "Welcome"
     },
     "discover": {
       "tabName": "Discover"

--- a/src/home/ActionsCarousel.tsx
+++ b/src/home/ActionsCarousel.tsx
@@ -17,7 +17,8 @@ import { Screens } from 'src/navigator/Screens'
 import { isAppSwapsEnabledSelector } from 'src/navigator/selectors'
 import { useSelector } from 'src/redux/hooks'
 import Colors from 'src/styles/colors'
-import fontStyles from 'src/styles/fonts'
+import { typeScale } from 'src/styles/fonts'
+import { Spacing } from 'src/styles/styles'
 
 function ActionsCarousel() {
   const { t } = useTranslation()
@@ -115,12 +116,12 @@ function ActionsCarousel() {
 
 const styles = StyleSheet.create({
   carouselContainer: {
-    paddingHorizontal: 10,
-    marginBottom: 8,
+    paddingHorizontal: Spacing.Regular16,
+    marginBottom: Spacing.Smallest8,
+    gap: Spacing.Regular16,
   },
   card: {
     width: 84,
-    marginHorizontal: 6,
     padding: 0,
     backgroundColor: Colors.successLight,
     borderRadius: 10,
@@ -130,9 +131,9 @@ const styles = StyleSheet.create({
     paddingVertical: 16,
   },
   name: {
-    ...fontStyles.small500,
+    ...typeScale.labelSmall,
     lineHeight: 17,
-    paddingTop: 8,
+    paddingTop: Spacing.Smallest8,
     color: Colors.successDark,
   },
 })

--- a/src/home/WalletHome.tsx
+++ b/src/home/WalletHome.tsx
@@ -1,8 +1,16 @@
 import { useIsFocused } from '@react-navigation/native'
+import { NativeStackScreenProps } from '@react-navigation/native-stack'
 import _ from 'lodash'
 import React, { useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
-import { RefreshControl, RefreshControlProps, SectionList, StyleSheet, View } from 'react-native'
+import {
+  RefreshControl,
+  RefreshControlProps,
+  SectionList,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native'
 import Animated from 'react-native-reanimated'
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context'
 import { showMessage } from 'src/alert/actions'
@@ -35,6 +43,8 @@ import NftReward from 'src/home/celebration/NftReward'
 import { showNftCelebrationSelector, showNftRewardSelector } from 'src/home/selectors'
 import { importContacts } from 'src/identity/actions'
 import DrawerTopBar from 'src/navigator/DrawerTopBar'
+import { Screens } from 'src/navigator/Screens'
+import { StackParamList } from 'src/navigator/types'
 import { phoneRecipientCacheSelector } from 'src/recipients/reducer'
 import { useDispatch, useSelector } from 'src/redux/hooks'
 import { initializeSentryUserContext } from 'src/sentry/actions'
@@ -42,6 +52,7 @@ import { getExperimentParams, getFeatureGate } from 'src/statsig'
 import { ExperimentConfigs } from 'src/statsig/constants'
 import { StatsigExperiments, StatsigFeatureGates } from 'src/statsig/types'
 import colors from 'src/styles/colors'
+import { typeScale } from 'src/styles/fonts'
 import { Spacing } from 'src/styles/styles'
 import { celoAddressSelector, coreTokensSelector } from 'src/tokens/selectors'
 import TransactionFeed from 'src/transactions/feed/TransactionFeed'
@@ -50,7 +61,9 @@ import { userInSanctionedCountrySelector } from 'src/utils/countryFeatures'
 
 const AnimatedSectionList = Animated.createAnimatedComponent(SectionList)
 
-function WalletHome() {
+type Props = NativeStackScreenProps<StackParamList, Screens.WalletHome | Screens.TabHome>
+
+function WalletHome({ route }: Props) {
   const { t } = useTranslation()
 
   const appState = useSelector(appStateSelector)
@@ -61,6 +74,10 @@ function WalletHome() {
   const celoAddress = useSelector(celoAddressSelector)
   const userInSanctionedCountry = useSelector(userInSanctionedCountrySelector)
   const showNotificationSpotlight = useSelector(showNotificationSpotlightSelector)
+
+  // temporary parameter while we build the tab navigator, should be cleaned up
+  // when we remove the drawer
+  const isTabNavigator = !!route.params?.isTabNavigator
 
   const insets = useSafeAreaInsets()
   const scrollPosition = useRef(new Animated.Value(0)).current
@@ -168,6 +185,13 @@ function WalletHome() {
     <RefreshControl refreshing={isLoading} onRefresh={onRefresh} colors={[colors.primary]} />
   ) as React.ReactElement<RefreshControlProps>
 
+  const homeTabTitleSection = {
+    data: [{}],
+    renderItem: () => (
+      <Text style={styles.homeTabTitle}>{t('bottomTabsNavigator.home.title')}</Text>
+    ),
+  }
+
   const notificationBoxSection = {
     data: [{}],
     renderItem: () => (
@@ -197,13 +221,15 @@ function WalletHome() {
     renderItem: () => <TransactionFeed key={'TransactionList'} />,
   }
 
-  const sections = [
-    notificationBoxSection,
-    tokenBalanceSection,
-    actionsCarouselSection,
-    dappsCarouselSection,
-    transactionFeedSection,
-  ]
+  const sections = isTabNavigator
+    ? [homeTabTitleSection, actionsCarouselSection, notificationBoxSection, transactionFeedSection]
+    : [
+        notificationBoxSection,
+        tokenBalanceSection,
+        actionsCarouselSection,
+        dappsCarouselSection,
+        transactionFeedSection,
+      ]
 
   const showBetaTag = getFeatureGate(StatsigFeatureGates.SHOW_BETA_TAG)
   const topLeftElement = showBetaTag && <BetaTag />
@@ -216,12 +242,18 @@ function WalletHome() {
   )
 
   return (
-    <SafeAreaView testID="WalletHome" style={styles.container} edges={['top']}>
-      <DrawerTopBar
-        leftElement={topLeftElement}
-        rightElement={topRightElements}
-        scrollPosition={scrollPosition}
-      />
+    <SafeAreaView
+      testID="WalletHome"
+      style={styles.container}
+      edges={isTabNavigator ? [] : ['top']}
+    >
+      {!isTabNavigator && (
+        <DrawerTopBar
+          leftElement={topLeftElement}
+          rightElement={topRightElements}
+          scrollPosition={scrollPosition}
+        />
+      )}
       <AnimatedSectionList
         // Workaround iOS setting an incorrect automatic inset at the top
         scrollIndicatorInsets={{ top: 0.01 }}
@@ -236,7 +268,7 @@ function WalletHome() {
         keyExtractor={keyExtractor}
         testID="WalletHome/SectionList"
       />
-      <NotificationBellSpotlight isVisible={showNotificationSpotlight} />
+      {!isTabNavigator && <NotificationBellSpotlight isVisible={showNotificationSpotlight} />}
       {shouldShowCashInBottomSheet() && <CashInBottomSheet />}
       {showNftCelebration && <NftCelebration />}
       {showNftReward && <NftReward />}
@@ -255,6 +287,13 @@ const styles = StyleSheet.create({
   },
   topRightElement: {
     marginLeft: Spacing.Regular16,
+  },
+  homeTabTitle: {
+    ...typeScale.titleMedium,
+    color: colors.black,
+    marginHorizontal: Spacing.Thick24,
+    marginTop: Spacing.Regular16,
+    marginBottom: Spacing.Large32,
   },
 })
 

--- a/src/navigator/TabNavigator.tsx
+++ b/src/navigator/TabNavigator.tsx
@@ -52,7 +52,6 @@ export default function TabNavigator({ route }: Props) {
         }}
       />
       <Tab.Screen
-        // TODO(act-1105) new home tab screen
         name={Screens.TabHome}
         component={WalletHome}
         options={{
@@ -61,6 +60,7 @@ export default function TabNavigator({ route }: Props) {
           tabBarLabel: t('bottomTabsNavigator.home.tabName') as string,
           tabBarIcon: Home,
         }}
+        initialParams={{ isTabNavigator: true }}
       />
       <Tab.Screen
         // TODO(act-1106) discover tab screen

--- a/src/navigator/types.tsx
+++ b/src/navigator/types.tsx
@@ -273,7 +273,7 @@ export type StackParamList = {
     | undefined
   [Screens.SwapScreenWithBack]: { fromTokenId: string } | undefined
   [Screens.TabDiscover]: undefined
-  [Screens.TabHome]: { isTabNavigator?: true } | undefined
+  [Screens.TabHome]: { isTabNavigator?: boolean } | undefined
   [Screens.TabWallet]: { activeAssetTab?: AssetTabType; isWalletTab?: boolean } | undefined
   [Screens.TabNavigator]: {
     initialScreen?: Screens
@@ -309,7 +309,7 @@ export type StackParamList = {
       } & SessionRequestProps)
     | { type: WalletConnectRequestType.TimeOut }
   [Screens.WalletConnectSessions]: undefined
-  [Screens.WalletHome]: { isTabNavigator?: true } | undefined
+  [Screens.WalletHome]: { isTabNavigator?: boolean } | undefined
   [Screens.WalletSecurityPrimer]: undefined
   [Screens.WalletSecurityPrimerDrawer]: { showDrawerTopBar: boolean }
   [Screens.WebViewScreen]: { uri: string; dappkitDeeplink?: string }

--- a/src/navigator/types.tsx
+++ b/src/navigator/types.tsx
@@ -273,7 +273,7 @@ export type StackParamList = {
     | undefined
   [Screens.SwapScreenWithBack]: { fromTokenId: string } | undefined
   [Screens.TabDiscover]: undefined
-  [Screens.TabHome]: undefined
+  [Screens.TabHome]: { isTabNavigator?: true } | undefined
   [Screens.TabWallet]:
     | {
         activeTab: AssetTabType
@@ -313,7 +313,7 @@ export type StackParamList = {
       } & SessionRequestProps)
     | { type: WalletConnectRequestType.TimeOut }
   [Screens.WalletConnectSessions]: undefined
-  [Screens.WalletHome]: undefined
+  [Screens.WalletHome]: { isTabNavigator?: true } | undefined
   [Screens.WalletSecurityPrimer]: undefined
   [Screens.WalletSecurityPrimerDrawer]: { showDrawerTopBar: boolean }
   [Screens.WebViewScreen]: { uri: string; dappkitDeeplink?: string }


### PR DESCRIPTION
### Description

Updating WalletHome component to take a prop denoting whether we're in the tab view, and if so display appropriate components.

### Test plan

Unit tests, manual


https://github.com/valora-inc/wallet/assets/5062591/eb19a647-783c-42ca-91e1-878fe0cd1ac2




<img src="https://github.com/valora-inc/wallet/assets/5062591/5a4734cf-9c97-41cb-b31c-9431a8cabfd6" width="250"/>

Couple of things out of scope for this PR
- Header - will be done in a separate issue
- Horizontal padding - inconsistent between different portions of the home screen, will be in a follow up PR
- Notification bell spotlight - disabled for now for tab view, confirming with product that if we need to carry it forward

### Related issues

- Fixes ACT-1105

### Backwards compatibility

Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
