### PR TITLE
test(e2e): increase funded amount for FC tests

### DIFF
--- a/e2e/src/usecases/FiatConnectTransferOut.js
+++ b/e2e/src/usecases/FiatConnectTransferOut.js
@@ -170,7 +170,7 @@ export const fiatConnectNonKycTransferOut = () => {
   it('FiatConnect cash out', async () => {
     // ******** First time experience ************
     const cashOutAmount = 0.02
-    const gasAmount = 0.01
+    const gasAmount = 0.015
     const fundingAmount = `${2 * cashOutAmount + gasAmount}`
     const token = 'cUSD'
     await onboardAndBeginTransferOut(token, fundingAmount, cashOutAmount)
@@ -194,7 +194,7 @@ export const fiatConnectKycTransferOut = () => {
   it('FiatConnect cash out', async () => {
     // ******** First time experience ************
     const cashOutAmount = 0.01
-    const gasAmount = 0.01
+    const gasAmount = 0.015
     const fundingAmount = `${2 * cashOutAmount + gasAmount}`
     const token = 'cUSD'
     const walletAddress = await onboardAndBeginTransferOut(token, fundingAmount, cashOutAmount)


### PR DESCRIPTION
### Description

FiatConnect e2e tests have been failing with a non enough funds for transfer out message. This is because the estimated fee seems to be higher than the balance - amount withdrawn, even though eventually the actual fee used falls within the balance. So bumping the funded amount for gas for now to unblock. 

We should eventually switch FC to use viem (and get better fee estimates) and revert this change

### Test plan

Local, CI

### Related issues

- N/A

### Backwards compatibility

N/A

