### PR TITLE
feat(wallet-tab): Add Hide Balance ability to wallet tab

### DIFF
--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -1969,7 +1969,8 @@
       "collectibles": "Collectibles",
       "dappPositions": "Dapp Positions"
     },
-    "importToken": "Import"
+    "importToken": "Import",
+    "importTokens": "Import Tokens"
   },
   "notificationCenterSpotlight": {
     "message": "Introducing a new way to claim rewards, view alerts, and see updates in one place",

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -45,7 +45,7 @@ export enum Actions {
   PUSH_NOTIFICATIONS_PERMISSION_CHANGED = 'APP/PUSH_NOTIFICATIONS_PERMISSION_CHANGED',
   IN_APP_REVIEW_REQUESTED = 'APP/IN_APP_REVIEW_REQUESTED',
   NOTIFICATION_SPOTLIGHT_SEEN = 'APP/NOTIFICATION_SPOTLIGHT_SEEN',
-  TOGGLE_HIDE_HOME_BALANCES = 'APP/TOGGLE_HIDE_HOME_BALANCES',
+  TOGGLE_HIDE_BALANCES = 'APP/TOGGLE_HIDE_BALANCES',
   OPT_MULTICHAIN_BETA = 'APP/OPT_MULTICHAIN_BETA',
 }
 
@@ -184,8 +184,8 @@ export interface NotificationSpotlightSeen {
   type: Actions.NOTIFICATION_SPOTLIGHT_SEEN
 }
 
-interface ToggleHideHomeBalances {
-  type: Actions.TOGGLE_HIDE_HOME_BALANCES
+interface ToggleHideBalances {
+  type: Actions.TOGGLE_HIDE_BALANCES
 }
 
 interface OptMultichainBeta {
@@ -220,7 +220,7 @@ export type ActionTypes =
   | PushNotificationsPermissionChanged
   | inAppReviewRequested
   | NotificationSpotlightSeen
-  | ToggleHideHomeBalances
+  | ToggleHideBalances
   | OptMultichainBeta
   | DeepLinkDeferred
 
@@ -398,9 +398,9 @@ export const notificationSpotlightSeen = (): NotificationSpotlightSeen => {
   }
 }
 
-export const toggleHideHomeBalances = (): ToggleHideHomeBalances => {
+export const toggleHideBalances = (): ToggleHideBalances => {
   return {
-    type: Actions.TOGGLE_HIDE_HOME_BALANCES,
+    type: Actions.TOGGLE_HIDE_BALANCES,
   }
 }
 

--- a/src/app/reducers.ts
+++ b/src/app/reducers.ts
@@ -49,7 +49,7 @@ interface State {
   pushNotificationsEnabled: boolean
   inAppReviewLastInteractionTimestamp: number | null
   showNotificationSpotlight: boolean
-  hideHomeBalances: boolean
+  hideBalances: boolean
   multichainBetaStatus: MultichainBetaStatus
   pendingDeepLinks: PendingDeepLink[]
 }
@@ -99,7 +99,7 @@ const initialState = {
   pushNotificationsEnabled: false,
   inAppReviewLastInteractionTimestamp: null,
   showNotificationSpotlight: false,
-  hideHomeBalances: false,
+  hideBalances: false,
   multichainBetaStatus: MultichainBetaStatus.NotSeen,
   pendingDeepLinks: [],
 }
@@ -271,10 +271,10 @@ export const appReducer = (
         ...state,
         inAppReviewLastInteractionTimestamp: action.inAppReviewLastInteractionTimestamp,
       }
-    case Actions.TOGGLE_HIDE_HOME_BALANCES:
+    case Actions.TOGGLE_HIDE_BALANCES:
       return {
         ...state,
-        hideHomeBalances: !state.hideHomeBalances,
+        hideBalances: !state.hideBalances,
       }
     case Actions.OPT_MULTICHAIN_BETA:
       return {

--- a/src/app/selectors.ts
+++ b/src/app/selectors.ts
@@ -1,5 +1,7 @@
 import { createSelector } from 'reselect'
 import { RootState } from 'src/redux/reducers'
+import { getFeatureGate } from 'src/statsig'
+import { StatsigFeatureGates } from 'src/statsig/types'
 import { walletAddressSelector } from 'src/web3/selectors'
 
 export const getRequirePinOnAppOpen = (state: RootState) => {
@@ -110,7 +112,11 @@ export const inAppReviewLastInteractionTimestampSelector = (state: RootState) =>
 export const showNotificationSpotlightSelector = (state: RootState) =>
   state.app.showNotificationSpotlight
 
-export const hideHomeBalancesSelector = (state: RootState) => state.app.hideHomeBalances
+export const hideHomeBalancesSelector = (state: RootState) =>
+  !getFeatureGate(StatsigFeatureGates.USE_TAB_NAVIGATOR) && state.app.hideBalances
+
+export const hideWalletBalancesSelector = (state: RootState) =>
+  getFeatureGate(StatsigFeatureGates.USE_TAB_NAVIGATOR) && state.app.hideBalances
 
 export const multichainBetaStatusSelector = (state: RootState) => state.app.multichainBetaStatus
 

--- a/src/components/TokenBalance.test.tsx
+++ b/src/components/TokenBalance.test.tsx
@@ -64,7 +64,7 @@ describe('AssetsTokenBalance', () => {
   it('should show info on tap', () => {
     const { getByText, getByTestId, queryByText } = render(
       <Provider store={createMockStore()}>
-        <AssetsTokenBalance showInfo />
+        <AssetsTokenBalance showInfo isWalletTab={false} />
       </Provider>
     )
 
@@ -74,6 +74,18 @@ describe('AssetsTokenBalance', () => {
 
     fireEvent.press(getByTestId('AssetsTokenBalance/Info'))
     expect(getByText('totalAssetsInfo')).toBeTruthy()
+  })
+
+  it('should show appropriate title on wallet tab', () => {
+    const { getByText, getByTestId, queryByText } = render(
+      <Provider store={createMockStore()}>
+        <AssetsTokenBalance showInfo={false} isWalletTab={true} />
+      </Provider>
+    )
+
+    expect(getByText('bottomTabsNavigator.wallet.title')).toBeTruthy()
+    expect(getByTestId('TotalTokenBalance')).toHaveTextContent('₱55.74')
+    expect(queryByText('AssetsTokenBalance/Info')).toBeFalsy()
   })
 })
 

--- a/src/components/TokenBalance.test.tsx
+++ b/src/components/TokenBalance.test.tsx
@@ -12,7 +12,6 @@ import { LocalCurrencyCode } from 'src/localCurrency/consts'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import { getDynamicConfigParams, getFeatureGate } from 'src/statsig'
-import { StatsigFeatureGates } from 'src/statsig/types'
 import { NetworkId } from 'src/transactions/types'
 import { ONE_DAY_IN_MILLIS } from 'src/utils/time'
 import { createMockStore, getElementText } from 'test/utils'
@@ -379,7 +378,7 @@ describe('HomeTokenBalance', () => {
   })
 
   it('renders correctly when hideBalance is true', async () => {
-    const store = createMockStore({ ...defaultStore, app: { hideHomeBalances: true } })
+    const store = createMockStore({ ...defaultStore, app: { hideBalances: true } })
 
     const tree = render(
       <Provider store={store}>
@@ -387,7 +386,7 @@ describe('HomeTokenBalance', () => {
       </Provider>
     )
 
-    expect(getElementText(tree.getByTestId('TotalTokenBalance'))).toEqual('XX.XX')
+    expect(getElementText(tree.getByTestId('TotalTokenBalance'))).toEqual('Xx.xx')
     expect(tree.getByTestId('HiddenEyeIcon')).toBeTruthy()
   })
 
@@ -402,44 +401,6 @@ describe('HomeTokenBalance', () => {
 
     expect(getElementText(tree.getByTestId('TotalTokenBalance'))).toEqual('$8.41')
     expect(tree.getByTestId('EyeIcon')).toBeTruthy()
-  })
-
-  it('renders correctly when feature flag is off, hideBalance is false', async () => {
-    jest
-      .mocked(getFeatureGate)
-      .mockImplementation(
-        (featureGate) => featureGate !== StatsigFeatureGates.SHOW_HIDE_HOME_BALANCES_TOGGLE
-      )
-    const store = createMockStore(defaultStore)
-
-    const tree = render(
-      <Provider store={store}>
-        <HomeTokenBalance />
-      </Provider>
-    )
-
-    expect(getElementText(tree.getByTestId('TotalTokenBalance'))).toEqual('$8.41')
-    expect(tree.queryByTestId('EyeIcon')).toBeFalsy()
-    expect(tree.queryByTestId('HiddenEyeIcon')).toBeFalsy()
-  })
-
-  it('renders correctly when feature flag is off, hideBalance is true', async () => {
-    jest
-      .mocked(getFeatureGate)
-      .mockImplementation(
-        (featureGate) => featureGate !== StatsigFeatureGates.SHOW_HIDE_HOME_BALANCES_TOGGLE
-      )
-    const store = createMockStore({ ...defaultStore, app: { hideHomeBalances: true } })
-
-    const tree = render(
-      <Provider store={store}>
-        <HomeTokenBalance />
-      </Provider>
-    )
-
-    expect(getElementText(tree.getByTestId('TotalTokenBalance'))).toEqual('$8.41')
-    expect(tree.queryByTestId('EyeIcon')).toBeFalsy()
-    expect(tree.queryByTestId('HiddenEyeIcon')).toBeFalsy()
   })
 
   it('tracks analytics event when eye icon is pressed', async () => {

--- a/src/components/TokenBalance.tsx
+++ b/src/components/TokenBalance.tsx
@@ -161,7 +161,15 @@ function useErrorMessageWithRefresh() {
   }, [shouldShowError])
 }
 
-export function AssetsTokenBalance({ showInfo }: { showInfo: boolean }) {
+export function AssetsTokenBalance({
+  showInfo,
+  isWalletTab,
+}: {
+  showInfo: boolean
+  // temporary parameter while we build the tab navigator, should be cleaned up
+  // when we remove the DrawerNavigator
+  isWalletTab: boolean
+}) {
   const { t } = useTranslation()
 
   const [infoVisible, setInfoVisible] = useState(false)
@@ -200,7 +208,11 @@ export function AssetsTokenBalance({ showInfo }: { showInfo: boolean }) {
     <TouchableWithoutFeedback onPress={handleDismissInfo}>
       <View testID="AssetsTokenBalance">
         <View style={styles.row}>
-          <Text style={styles.totalAssets}>{t('totalAssets')}</Text>
+          {isWalletTab ? (
+            <Text style={styles.walletTabTitle}>{t('bottomTabsNavigator.wallet.title')}</Text>
+          ) : (
+            <Text style={styles.totalAssets}>{t('totalAssets')}</Text>
+          )}
           {showInfo && (
             <TouchableOpacity
               onPress={toggleInfoVisible}
@@ -319,6 +331,11 @@ const styles = StyleSheet.create({
     ...typeScale.labelMedium,
     color: Colors.gray5,
     marginRight: 4,
+  },
+  walletTabTitle: {
+    ...typeScale.titleMedium,
+    color: Colors.black,
+    marginRight: 10,
   },
   totalAssetsInfoContainer: {
     position: 'absolute',

--- a/src/navigator/Screens.tsx
+++ b/src/navigator/Screens.tsx
@@ -101,6 +101,7 @@ export enum Screens {
   WalletConnectSessions = 'WalletConnectSessions',
   WalletSecurityPrimer = 'WalletSecurityPrimer',
   WalletSecurityPrimerDrawer = 'WalletSecurityPrimerDrawer',
+  WalletTab = 'WalletTab',
   WebViewScreen = 'WebViewScreen',
   Welcome = 'Welcome',
   WithdrawSpend = 'WithdrawSpend',

--- a/src/navigator/Screens.tsx
+++ b/src/navigator/Screens.tsx
@@ -101,7 +101,6 @@ export enum Screens {
   WalletConnectSessions = 'WalletConnectSessions',
   WalletSecurityPrimer = 'WalletSecurityPrimer',
   WalletSecurityPrimerDrawer = 'WalletSecurityPrimerDrawer',
-  WalletTab = 'WalletTab',
   WebViewScreen = 'WebViewScreen',
   Welcome = 'Welcome',
   WithdrawSpend = 'WithdrawSpend',

--- a/src/navigator/TabNavigator.tsx
+++ b/src/navigator/TabNavigator.tsx
@@ -42,14 +42,13 @@ export default function TabNavigator({ route }: Props) {
       }}
     >
       <Tab.Screen
-        // TODO(act-1104) new assets screen
         name={Screens.TabWallet}
-        // @ts-expect-error Type '{}' is missing the following properties from type 'Props': navigation, route
         component={AssetsScreen}
         options={{
           tabBarLabel: t('bottomTabsNavigator.wallet.tabName') as string,
           tabBarIcon: Wallet,
         }}
+        initialParams={{ isWalletTab: true }}
       />
       <Tab.Screen
         // TODO(act-1105) new home tab screen

--- a/src/navigator/types.tsx
+++ b/src/navigator/types.tsx
@@ -274,11 +274,7 @@ export type StackParamList = {
   [Screens.SwapScreenWithBack]: { fromTokenId: string } | undefined
   [Screens.TabDiscover]: undefined
   [Screens.TabHome]: undefined
-  [Screens.TabWallet]:
-    | {
-        activeTab: AssetTabType
-      }
-    | undefined
+  [Screens.TabWallet]: { activeAssetTab?: AssetTabType; isWalletTab?: boolean } | undefined
   [Screens.TabNavigator]: {
     initialScreen?: Screens
     fromModal?: boolean
@@ -321,7 +317,8 @@ export type StackParamList = {
   [Screens.WithdrawSpend]: undefined
   [Screens.Assets]:
     | {
-        activeTab: AssetTabType
+        activeAssetTab: AssetTabType
+        isWalletTab?: boolean
       }
     | undefined
 }

--- a/src/redux/migrations.test.ts
+++ b/src/redux/migrations.test.ts
@@ -46,6 +46,7 @@ import {
   v17Schema,
   v18Schema,
   v197Schema,
+  v198Schema,
   v1Schema,
   v21Schema,
   v28Schema,
@@ -1548,6 +1549,20 @@ describe('Redux persist migrations', () => {
     const migratedSchema = migrations[198](oldSchema)
     const expectedSchema: any = _.cloneDeep(oldSchema)
     expectedSchema.home.nftCelebration = null
+    expect(migratedSchema).toStrictEqual(expectedSchema)
+  })
+  it('works from 198 to 199', () => {
+    const oldSchema = {
+      ...v198Schema,
+      app: {
+        ...v198Schema.app,
+        hideHomeBalances: true,
+      },
+    }
+    const migratedSchema = migrations[199](oldSchema)
+    const expectedSchema: any = _.cloneDeep(oldSchema)
+    expectedSchema.app.hideBalances = true
+    delete expectedSchema.app.hideHomeBalances
     expect(migratedSchema).toStrictEqual(expectedSchema)
   })
 })

--- a/src/redux/migrations.ts
+++ b/src/redux/migrations.ts
@@ -1612,4 +1612,11 @@ export const migrations = {
       nftCelebration: null,
     },
   }),
+  199: (state: any) => ({
+    ...state,
+    app: {
+      ..._.omit(state.app, 'hideHomeBalances'),
+      hideBalances: state.app.hideHomeBalances,
+    },
+  }),
 }

--- a/src/redux/store.test.ts
+++ b/src/redux/store.test.ts
@@ -98,7 +98,7 @@ describe('store state', () => {
       {
         "_persist": {
           "rehydrated": true,
-          "version": 198,
+          "version": 199,
         },
         "account": {
           "acceptedTerms": false,
@@ -142,7 +142,7 @@ describe('store state', () => {
           "fiatConnectCashOutEnabled": false,
           "googleMobileServicesAvailable": undefined,
           "hapticFeedbackEnabled": true,
-          "hideHomeBalances": false,
+          "hideBalances": false,
           "huaweiMobileServicesAvailable": undefined,
           "inAppReviewLastInteractionTimestamp": null,
           "inviterAddress": null,

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -21,7 +21,7 @@ const persistConfig: PersistConfig<ReducersRootState> = {
   key: 'root',
   // default is -1, increment as we make migrations
   // See https://github.com/valora-inc/wallet/tree/main/WALLET.md#redux-state-migration
-  version: 198,
+  version: 199,
   keyPrefix: `reduxStore-`, // the redux-persist default is `persist:` which doesn't work with some file systems.
   storage: FSStorage(),
   blacklist: ['networkInfo', 'alert', 'imports', 'keylessBackup', 'jumpstart'],

--- a/src/statsig/constants.ts
+++ b/src/statsig/constants.ts
@@ -11,7 +11,6 @@ export const FeatureGates = {
   [StatsigFeatureGates.SHOW_CLOUD_ACCOUNT_BACKUP_RESTORE]: false,
   [StatsigFeatureGates.RESTRICT_SUPERCHARGE_FOR_CLAIM_ONLY]: false,
   [StatsigFeatureGates.SHOW_IMPORT_TOKENS_FLOW]: false,
-  [StatsigFeatureGates.SHOW_HIDE_HOME_BALANCES_TOGGLE]: false,
   [StatsigFeatureGates.SHOW_MULTICHAIN_BETA_SCREEN]: false,
   [StatsigFeatureGates.SHOW_BETA_TAG]: false,
   [StatsigFeatureGates.SAVE_CONTACTS]: false,

--- a/src/statsig/index.ts
+++ b/src/statsig/index.ts
@@ -86,6 +86,9 @@ export function getDynamicConfigParams<T extends Record<string, StatsigParameter
 }
 
 export function getFeatureGate(featureGateName: StatsigFeatureGates) {
+  if (featureGateName === StatsigFeatureGates.USE_TAB_NAVIGATOR) {
+    return true
+  }
   try {
     return Statsig.checkGate(featureGateName)
   } catch (error) {

--- a/src/statsig/types.ts
+++ b/src/statsig/types.ts
@@ -18,7 +18,6 @@ export enum StatsigFeatureGates {
   SHOW_CLOUD_ACCOUNT_BACKUP_RESTORE = 'show_cloud_account_backup_restore',
   RESTRICT_SUPERCHARGE_FOR_CLAIM_ONLY = 'restrict_supercharge_for_claim_only',
   SHOW_IMPORT_TOKENS_FLOW = 'show_import_tokens_flow',
-  SHOW_HIDE_HOME_BALANCES_TOGGLE = 'show_hide_home_balances_toggle',
   SHOW_MULTICHAIN_BETA_SCREEN = 'show_multichain_beta_screen',
   SHOW_BETA_TAG = 'show_beta_tag',
   SAVE_CONTACTS = 'save_contacts',

--- a/src/tokens/Assets.test.tsx
+++ b/src/tokens/Assets.test.tsx
@@ -297,6 +297,21 @@ describe('AssetsScreen', () => {
     expect(button).toBeNull()
   })
 
+  it('does not render Import Token on wallets tab', () => {
+    jest.mocked(getFeatureGate).mockReturnValue(true)
+    const store = createMockStore(storeWithPositions)
+
+    const component = (
+      <Provider store={store}>
+        <MockedNavigator component={AssetsScreen} params={{ isWalletTab: true }} />
+      </Provider>
+    )
+    const { queryByText } = render(component)
+    const button = queryByText('assets.importToken')
+
+    expect(button).toBeNull()
+  })
+
   it('clicking Import opens Import Token screen', () => {
     jest
       .mocked(getFeatureGate)

--- a/src/tokens/TokenBalanceItem.tsx
+++ b/src/tokens/TokenBalanceItem.tsx
@@ -1,10 +1,12 @@
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 import { StyleSheet, Text, View, ViewStyle } from 'react-native'
+import { hideWalletBalancesSelector } from 'src/app/selectors'
 import TokenDisplay from 'src/components/TokenDisplay'
 import TokenIcon from 'src/components/TokenIcon'
 import Touchable from 'src/components/Touchable'
 import Warning from 'src/icons/Warning'
+import { useSelector } from 'src/redux/hooks'
 import { NETWORK_NAMES } from 'src/shared/conts'
 import colors from 'src/styles/colors'
 import { typeScale } from 'src/styles/fonts'
@@ -28,6 +30,8 @@ export const TokenBalanceItem = ({
 }: Props) => {
   const { t } = useTranslation()
 
+  const hideWalletBalance = useSelector(hideWalletBalancesSelector)
+
   const Content = (
     <View style={[styles.container, containerStyle]} testID="TokenBalanceItem">
       <TokenIcon token={token} />
@@ -39,15 +43,17 @@ export const TokenBalanceItem = ({
             </Text>
             {showPriceUsdUnavailableWarning && !token.priceUsd && <Warning size={16} />}
           </View>
-          <TokenDisplay
-            style={styles.amount}
-            amount={token.balance}
-            tokenId={token.tokenId}
-            showSymbol={true}
-            hideSign={true}
-            showLocalAmount={false}
-            testID={`${token.symbol}Balance`}
-          />
+          {!hideWalletBalance && (
+            <TokenDisplay
+              style={styles.amount}
+              amount={token.balance}
+              tokenId={token.tokenId}
+              showSymbol={true}
+              hideSign={true}
+              showLocalAmount={false}
+              testID={`${token.symbol}Balance`}
+            />
+          )}
         </View>
         <View style={styles.line}>
           {token.networkId in NETWORK_NAMES ? (
@@ -57,14 +63,16 @@ export const TokenBalanceItem = ({
           ) : (
             <View />
           )}
-          <TokenDisplay
-            style={styles.subAmount}
-            amount={token.balance}
-            tokenId={token.tokenId}
-            showSymbol={false}
-            hideSign={true}
-            errorFallback={balanceUsdErrorFallback}
-          />
+          {!hideWalletBalance && (
+            <TokenDisplay
+              style={styles.subAmount}
+              amount={token.balance}
+              tokenId={token.tokenId}
+              showSymbol={false}
+              hideSign={true}
+              errorFallback={balanceUsdErrorFallback}
+            />
+          )}
         </View>
         {token.bridge && (
           <Text

--- a/src/transactions/feed/SwapFeedItem.test.tsx
+++ b/src/transactions/feed/SwapFeedItem.test.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { Provider } from 'react-redux'
 import { RootState } from 'src/redux/reducers'
 import { getFeatureGate } from 'src/statsig'
+import { StatsigFeatureGates } from 'src/statsig/types'
 import SwapFeedItem from 'src/transactions/feed/SwapFeedItem'
 import {
   Fee,
@@ -124,8 +125,10 @@ describe('SwapFeedItem', () => {
     expect(getElementText(getByTestId('SwapFeedItem/outgoingAmount'))).toEqual('-17.54 cEUR')
   })
 
-  it('still shows balances when feature gate false, hide balances root state true', async () => {
-    jest.mocked(getFeatureGate).mockReturnValue(false)
+  it('still shows balances when feature gate true, hide balances root state true', async () => {
+    jest
+      .mocked(getFeatureGate)
+      .mockImplementation((featureGate) => featureGate === StatsigFeatureGates.USE_TAB_NAVIGATOR)
     const { getByTestId } = renderScreen({
       inAmount: {
         tokenId: mockCeurTokenId,
@@ -145,7 +148,10 @@ describe('SwapFeedItem', () => {
     expect(getElementText(getByTestId('SwapFeedItem/outgoingAmount'))).toEqual('-2.87 cUSD')
   })
 
-  it('hides balance when feature gate true, root state hide home balances flag is set', async () => {
+  it('hides balance when feature gate false, root state hide home balances flag is set', async () => {
+    jest
+      .mocked(getFeatureGate)
+      .mockImplementation((featureGate) => featureGate !== StatsigFeatureGates.USE_TAB_NAVIGATOR)
     const { queryByTestId } = renderScreen({
       inAmount: {
         tokenId: mockCeurTokenId,
@@ -155,7 +161,7 @@ describe('SwapFeedItem', () => {
         tokenId: mockCusdTokenId,
         value: 2.87,
       },
-      storeOverrides: { app: { hideHomeBalances: true } },
+      storeOverrides: { app: { hideBalances: true } },
     })
 
     expect(queryByTestId('SwapFeedItem/incomingAmount')).toBeNull()

--- a/src/transactions/feed/SwapFeedItem.tsx
+++ b/src/transactions/feed/SwapFeedItem.tsx
@@ -9,8 +9,6 @@ import Touchable from 'src/components/Touchable'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import { useSelector } from 'src/redux/hooks'
-import { getFeatureGate } from 'src/statsig'
-import { StatsigFeatureGates } from 'src/statsig/types'
 import colors from 'src/styles/colors'
 import { typeScale } from 'src/styles/fonts'
 import { Spacing } from 'src/styles/styles'
@@ -34,8 +32,7 @@ function SwapFeedItem({ exchange }: Props) {
   }
 
   const hideHomeBalanceState = useSelector(hideHomeBalancesSelector)
-  const hideBalance =
-    getFeatureGate(StatsigFeatureGates.SHOW_HIDE_HOME_BALANCES_TOGGLE) && hideHomeBalanceState
+  const hideBalance = hideHomeBalanceState
 
   return (
     <Touchable testID="SwapFeedItem" onPress={handleTransferDetails}>

--- a/src/transactions/feed/TransferFeedItem.test.tsx
+++ b/src/transactions/feed/TransferFeedItem.test.tsx
@@ -10,6 +10,7 @@ import { FiatConnectQuoteSuccess } from 'src/fiatconnect'
 import { LocalCurrencyCode } from 'src/localCurrency/consts'
 import { RootState } from 'src/redux/reducers'
 import { getFeatureGate } from 'src/statsig'
+import { StatsigFeatureGates } from 'src/statsig/types'
 import TransferFeedItem from 'src/transactions/feed/TransferFeedItem'
 import {
   Fee,
@@ -627,15 +628,20 @@ describe('TransferFeedItem', () => {
     })
   })
 
-  it('shows balance when feature gate false, root state hide home balances flag is set', async () => {
-    jest.mocked(getFeatureGate).mockReturnValue(false)
-    const { getByTestId } = renderScreen({ storeOverrides: { app: { hideHomeBalances: true } } })
+  it('shows balance when feature gate true, root state hide home balances flag is set', async () => {
+    jest
+      .mocked(getFeatureGate)
+      .mockImplementation((featureGate) => featureGate === StatsigFeatureGates.USE_TAB_NAVIGATOR)
+    const { getByTestId } = renderScreen({ storeOverrides: { app: { hideBalances: true } } })
     expect(getByTestId('TransferFeedItem/amount')).toBeTruthy()
     expect(getByTestId('TransferFeedItem/tokenAmount')).toBeTruthy()
   })
 
-  it('hides balance when feature gate true, root state hide home balances flag is set', async () => {
-    const { queryByTestId } = renderScreen({ storeOverrides: { app: { hideHomeBalances: true } } })
+  it('hides balance when feature gate false, root state hide home balances flag is set', async () => {
+    jest
+      .mocked(getFeatureGate)
+      .mockImplementation((featureGate) => featureGate !== StatsigFeatureGates.USE_TAB_NAVIGATOR)
+    const { queryByTestId } = renderScreen({ storeOverrides: { app: { hideBalances: true } } })
     expect(queryByTestId('TransferFeedItem/amount')).toBeNull()
     expect(queryByTestId('TransferFeedItem/tokenAmount')).toBeNull()
   })

--- a/src/transactions/feed/TransferFeedItem.tsx
+++ b/src/transactions/feed/TransferFeedItem.tsx
@@ -9,8 +9,6 @@ import Touchable from 'src/components/Touchable'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import { useSelector } from 'src/redux/hooks'
-import { getFeatureGate } from 'src/statsig'
-import { StatsigFeatureGates } from 'src/statsig/types'
 import colors from 'src/styles/colors'
 import { typeScale } from 'src/styles/fonts'
 import { Spacing } from 'src/styles/styles'
@@ -41,8 +39,7 @@ function TransferFeedItem({ transfer }: Props) {
   const colorStyle = new BigNumber(amount.value).isPositive() ? { color: colors.primary } : {}
 
   const hideHomeBalanceState = useSelector(hideHomeBalancesSelector)
-  const hideBalance =
-    getFeatureGate(StatsigFeatureGates.SHOW_HIDE_HOME_BALANCES_TOGGLE) && hideHomeBalanceState
+  const hideBalance = hideHomeBalanceState
 
   return (
     <Touchable testID="TransferFeedItem" onPress={openTransferDetails}>

--- a/test/RootStateSchema.json
+++ b/test/RootStateSchema.json
@@ -3173,7 +3173,7 @@
                 "hapticFeedbackEnabled": {
                     "type": "boolean"
                 },
-                "hideHomeBalances": {
+                "hideBalances": {
                     "type": "boolean"
                 },
                 "huaweiMobileServicesAvailable": {
@@ -3306,7 +3306,7 @@
                 "fiatConnectCashInEnabled",
                 "fiatConnectCashOutEnabled",
                 "hapticFeedbackEnabled",
-                "hideHomeBalances",
+                "hideBalances",
                 "inAppReviewLastInteractionTimestamp",
                 "inviterAddress",
                 "lastTimeBackgrounded",

--- a/test/schemas.ts
+++ b/test/schemas.ts
@@ -3142,6 +3142,18 @@ export const v198Schema = {
   },
 }
 
+export const v199Schema = {
+  ...v198Schema,
+  _persist: {
+    ...v198Schema._persist,
+    version: 199,
+  },
+  app: {
+    ..._.omit(v198Schema.app, 'hideHomeBalances'),
+    hideBalances: false,
+  },
+}
+
 export function getLatestSchema(): Partial<RootState> {
-  return v198Schema as Partial<RootState>
+  return v199Schema as Partial<RootState>
 }


### PR DESCRIPTION
### Description

Generalizes the `hideHomeBalances` state into `hideBalances` and updates the `hideHomeBalancesSelector` and `hideWalletBalancesSelector` to use the statsig `USE_TAB_NAVIGATOR` feature flag.


https://github.com/valora-inc/wallet/assets/8432644/9a2d3a89-13ae-441c-86b2-85ac93298b39

 

### Test plan

updated unit tests

### Related issues

https://linear.app/valora/issue/ACT-1109/hide-token-balance
