### PR TITLE
fix: the NFT reward bottom sheet unexpectedly reappears after CTA button is pressed

### DIFF
--- a/src/home/celebration/NftReward.test.tsx
+++ b/src/home/celebration/NftReward.test.tsx
@@ -5,6 +5,7 @@ import { Provider } from 'react-redux'
 import { HomeEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import { openDeepLink } from 'src/app/actions'
+import { nftRewardDisplayed } from 'src/home/actions'
 import { getFeatureGate } from 'src/statsig/index'
 import Colors from 'src/styles/colors'
 import { createMockStore } from 'test/utils'
@@ -41,6 +42,8 @@ describe('NftReward', () => {
     expect(store.dispatch).toHaveBeenCalledWith(
       openDeepLink(mockStoreRewardReady.home.nftCelebration.deepLink, true)
     )
+
+    expect(store.dispatch).toHaveBeenCalledWith(nftRewardDisplayed())
 
     expect(ValoraAnalytics.track).toHaveBeenCalledWith(HomeEvents.nft_reward_accept, {
       networkId: mockNftAllFields.networkId,

--- a/src/home/celebration/NftReward.tsx
+++ b/src/home/celebration/NftReward.tsx
@@ -71,22 +71,20 @@ export default function NftRewardBottomSheet() {
     }
   }, [isVisible])
 
-  const handleBottomSheetPositionChange = (index: number) => {
+  const handleBottomSheetClose = () => {
     if (!nftCelebration) {
       return // This should never happen
     }
 
-    if (index === -1) {
-      if (!rewardAccepted) {
-        ValoraAnalytics.track(HomeEvents.nft_reward_dismiss, {
-          networkId: nftCelebration.networkId,
-          contractAddress: nftCelebration.contractAddress,
-          remainingDays: differenceInDays(rewardExpirationDate, Date.now()),
-        })
-      }
-
-      dispatch(nftRewardDisplayed())
+    if (!rewardAccepted) {
+      ValoraAnalytics.track(HomeEvents.nft_reward_dismiss, {
+        networkId: nftCelebration.networkId,
+        contractAddress: nftCelebration.contractAddress,
+        remainingDays: differenceInDays(rewardExpirationDate, Date.now()),
+      })
     }
+
+    dispatch(nftRewardDisplayed())
   }
 
   const handleCtaPress = () => {
@@ -115,7 +113,7 @@ export default function NftRewardBottomSheet() {
   }
 
   return (
-    <BottomSheetBase forwardedRef={bottomSheetRef} onChange={handleBottomSheetPositionChange}>
+    <BottomSheetBase forwardedRef={bottomSheetRef} onClose={handleBottomSheetClose}>
       <BottomSheetView style={[styles.container, insetsStyle]}>
         <View style={[styles.pill, pillStyle]} testID="NftReward/Pill">
           <Text style={[styles.pillLabel, labelStyle]} testID="NftReward/PillLabel">

--- a/src/home/celebration/NftReward.tsx
+++ b/src/home/celebration/NftReward.tsx
@@ -71,20 +71,22 @@ export default function NftRewardBottomSheet() {
     }
   }, [isVisible])
 
-  const handleBottomSheetClose = () => {
+  const handleBottomSheetPositionChange = (index: number) => {
     if (!nftCelebration) {
       return // This should never happen
     }
 
-    if (!rewardAccepted) {
-      ValoraAnalytics.track(HomeEvents.nft_reward_dismiss, {
-        networkId: nftCelebration.networkId,
-        contractAddress: nftCelebration.contractAddress,
-        remainingDays: differenceInDays(rewardExpirationDate, Date.now()),
-      })
-    }
+    if (index === -1) {
+      if (!rewardAccepted) {
+        ValoraAnalytics.track(HomeEvents.nft_reward_dismiss, {
+          networkId: nftCelebration.networkId,
+          contractAddress: nftCelebration.contractAddress,
+          remainingDays: differenceInDays(rewardExpirationDate, Date.now()),
+        })
 
-    dispatch(nftRewardDisplayed())
+        dispatch(nftRewardDisplayed())
+      }
+    }
   }
 
   const handleCtaPress = () => {
@@ -106,6 +108,8 @@ export default function NftRewardBottomSheet() {
       const isSecureOrigin = true
       dispatch(openDeepLink(nftCelebration.deepLink, isSecureOrigin))
     }
+
+    dispatch(nftRewardDisplayed())
   }
 
   if (!isVisible) {
@@ -113,7 +117,7 @@ export default function NftRewardBottomSheet() {
   }
 
   return (
-    <BottomSheetBase forwardedRef={bottomSheetRef} onClose={handleBottomSheetClose}>
+    <BottomSheetBase forwardedRef={bottomSheetRef} onChange={handleBottomSheetPositionChange}>
       <BottomSheetView style={[styles.container, insetsStyle]}>
         <View style={[styles.pill, pillStyle]} testID="NftReward/Pill">
           <Text style={[styles.pillLabel, labelStyle]} testID="NftReward/PillLabel">

--- a/src/home/celebration/NftReward.tsx
+++ b/src/home/celebration/NftReward.tsx
@@ -100,14 +100,14 @@ export default function NftRewardBottomSheet() {
       remainingDays: differenceInDays(rewardExpirationDate, Date.now()),
     })
 
-    setRewardAccepted(true)
-
-    bottomSheetRef.current?.close()
-
     if (nftCelebration?.deepLink) {
       const isSecureOrigin = true
       dispatch(openDeepLink(nftCelebration.deepLink, isSecureOrigin))
     }
+
+    setRewardAccepted(true)
+
+    bottomSheetRef.current?.close()
 
     dispatch(nftRewardDisplayed())
   }


### PR DESCRIPTION
### Description

On the iOS production build the NFT reward bottom sheet unexpectedly reappears after CTA button is pressed.
The hypothesis is that `onChange` event isn't fired for some reason when the bottom sheet is closed programmatically.

The fix is to fire `dispatch` on CTA press handler instead of relying on `onChange` event.

Another possible option is to rely on `onClose` event. But unfortunately it is called when component unmounts on Android.

### Test plan

Tested manually on:
* Android emulator
* iOS simulator
* dev iOS build on device

Planing to additionally test on the nightly iOS build.

### Related issues

- Related to  RET-1002

### Backwards compatibility

Y

### Network scalability

NA