### PR TITLE
fix(home): consistent padding for all home elements

### DIFF
--- a/src/home/GetStarted.tsx
+++ b/src/home/GetStarted.tsx
@@ -62,7 +62,7 @@ const styles = StyleSheet.create({
   },
   container: {
     gap: 18,
-    margin: Spacing.Thick24,
+    margin: Spacing.Regular16,
   },
   icon: {
     marginBottom: Spacing.Regular16,
@@ -70,7 +70,7 @@ const styles = StyleSheet.create({
     ...typeScale.labelSemiBoldMedium,
   },
   title: {
-    ...typeScale.bodySmall,
+    ...typeScale.labelSemiBoldSmall,
     color: colors.gray4,
   },
 })

--- a/src/home/WalletHome.tsx
+++ b/src/home/WalletHome.tsx
@@ -291,7 +291,7 @@ const styles = StyleSheet.create({
   homeTabTitle: {
     ...typeScale.titleMedium,
     color: colors.black,
-    marginHorizontal: Spacing.Thick24,
+    marginHorizontal: Spacing.Regular16,
     marginTop: Spacing.Regular16,
     marginBottom: Spacing.Large32,
   },


### PR DESCRIPTION
### Description

Use 16 for padding all home elements to be consistent. Also adjusted a style on the Get Started header

### Test plan

Manual

| Before | After |
|--------|--------|
| <img width="300" src="https://github.com/valora-inc/wallet/assets/5062591/f27a26cf-d954-42d1-b090-31dc7497a9bc" /> | <img width="300" src="https://github.com/valora-inc/wallet/assets/5062591/45f63fe0-c80e-4f68-af54-6a94e7db6fd6" /> | 


### Related issues

- Part of ACT-1105

### Backwards compatibility

Yes

### Network scalability

N/A
