### PR TITLE
chore: inline notification visual tweaks

### DIFF
--- a/src/account/Profile.tsx
+++ b/src/account/Profile.tsx
@@ -12,7 +12,7 @@ import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import { ErrorMessages } from 'src/app/ErrorMessages'
 import Button from 'src/components/Button'
 import CancelButton from 'src/components/CancelButton'
-import InLineNotification, { Variant } from 'src/components/InLineNotification'
+import InLineNotification, { NotificationVariant } from 'src/components/InLineNotification'
 import KeyboardAwareScrollView from 'src/components/KeyboardAwareScrollView'
 import KeyboardSpacer from 'src/components/KeyboardSpacer'
 import TextInput from 'src/components/TextInput'
@@ -110,7 +110,7 @@ function Profile({ navigation, route }: Props) {
         </View>
         <View style={styles.disclaimerContainer}>
           <InLineNotification
-            variant={Variant.Info}
+            variant={NotificationVariant.Info}
             description={t('profileScreen.profilePictureDisclaimer')}
           />
         </View>

--- a/src/account/Profile.tsx
+++ b/src/account/Profile.tsx
@@ -12,7 +12,7 @@ import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import { ErrorMessages } from 'src/app/ErrorMessages'
 import Button from 'src/components/Button'
 import CancelButton from 'src/components/CancelButton'
-import InLineNotification, { Severity } from 'src/components/InLineNotification'
+import InLineNotification, { Variant } from 'src/components/InLineNotification'
 import KeyboardAwareScrollView from 'src/components/KeyboardAwareScrollView'
 import KeyboardSpacer from 'src/components/KeyboardSpacer'
 import TextInput from 'src/components/TextInput'
@@ -110,7 +110,7 @@ function Profile({ navigation, route }: Props) {
         </View>
         <View style={styles.disclaimerContainer}>
           <InLineNotification
-            severity={Severity.Informational}
+            variant={Variant.Info}
             description={t('profileScreen.profilePictureDisclaimer')}
           />
         </View>

--- a/src/account/Settings.tsx
+++ b/src/account/Settings.tsx
@@ -46,9 +46,10 @@ import {
   walletConnectEnabledSelector,
 } from 'src/app/selectors'
 import BottomSheet, { BottomSheetRefType } from 'src/components/BottomSheet'
+import BottomSheetInLineNotification from 'src/components/BottomSheetInLineNotification'
 import Button, { BtnSizes, BtnTypes } from 'src/components/Button'
 import Dialog from 'src/components/Dialog'
-import { Severity } from 'src/components/InLineNotification'
+import { Variant } from 'src/components/InLineNotification'
 import SectionHead from 'src/components/SectionHead'
 import SessionId from 'src/components/SessionId'
 import {
@@ -84,7 +85,6 @@ import { navigateToURI } from 'src/utils/linking'
 import { useRevokeCurrentPhoneNumber } from 'src/verify/hooks'
 import { selectSessions } from 'src/walletConnect/selectors'
 import { walletAddressSelector } from 'src/web3/selectors'
-import BottomSheetInLineNotification from 'src/components/BottomSheetInLineNotification'
 
 type Props = NativeStackScreenProps<StackParamList, Screens.Settings>
 
@@ -554,7 +554,7 @@ export const Account = ({ navigation, route }: Props) => {
         </Dialog>
       </ScrollView>
       <BottomSheetInLineNotification
-        severity={Severity.Warning}
+        variant={Variant.Warning}
         description={t('keylessBackupSettingsDeleteError')}
         showNotification={showDeleteKeylessBackupError}
         onPressCta={onDismissKeylessBackupError}

--- a/src/account/Settings.tsx
+++ b/src/account/Settings.tsx
@@ -49,7 +49,7 @@ import BottomSheet, { BottomSheetRefType } from 'src/components/BottomSheet'
 import BottomSheetInLineNotification from 'src/components/BottomSheetInLineNotification'
 import Button, { BtnSizes, BtnTypes } from 'src/components/Button'
 import Dialog from 'src/components/Dialog'
-import { Variant } from 'src/components/InLineNotification'
+import { NotificationVariant } from 'src/components/InLineNotification'
 import SectionHead from 'src/components/SectionHead'
 import SessionId from 'src/components/SessionId'
 import {
@@ -554,7 +554,7 @@ export const Account = ({ navigation, route }: Props) => {
         </Dialog>
       </ScrollView>
       <BottomSheetInLineNotification
-        variant={Variant.Warning}
+        variant={NotificationVariant.Warning}
         description={t('keylessBackupSettingsDeleteError')}
         showNotification={showDeleteKeylessBackupError}
         onPressCta={onDismissKeylessBackupError}

--- a/src/account/__snapshots__/Profile.test.tsx.snap
+++ b/src/account/__snapshots__/Profile.test.tsx.snap
@@ -429,6 +429,7 @@ exports[`Profile renders correctly 1`] = `
               <svg
                 fill="none"
                 height={20}
+                testID="InLineNotification/Icon"
                 viewBox="0 0 16 16"
                 width={20}
               >
@@ -453,7 +454,7 @@ exports[`Profile renders correctly 1`] = `
                       "fontFamily": "Inter-Regular",
                       "fontSize": 12,
                       "letterSpacing": 0.12,
-                      "lineHeight": 18,
+                      "lineHeight": 16,
                     },
                   ]
                 }

--- a/src/components/InLineNotification.test.tsx
+++ b/src/components/InLineNotification.test.tsx
@@ -1,12 +1,12 @@
 import { fireEvent, render } from '@testing-library/react-native'
 import * as React from 'react'
-import InLineNotification, { Severity } from 'src/components/InLineNotification'
+import InLineNotification, { Variant } from 'src/components/InLineNotification'
 
 describe(InLineNotification, () => {
   it('does not render CTA when onPress function is not provided', async () => {
     const { getByText, queryByText } = render(
       <InLineNotification
-        severity={Severity.Informational}
+        variant={Variant.Info}
         title={'Title'}
         description={'Description'}
         ctaLabel={'Action 1'}
@@ -26,7 +26,7 @@ describe(InLineNotification, () => {
     const fn2 = jest.fn()
     const { getByText } = render(
       <InLineNotification
-        severity={Severity.Informational}
+        variant={Variant.Info}
         title={'Title'}
         description={'Description'}
         ctaLabel={'Action 1'}

--- a/src/components/InLineNotification.test.tsx
+++ b/src/components/InLineNotification.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render } from '@testing-library/react-native'
 import * as React from 'react'
 import InLineNotification, { Variant } from 'src/components/InLineNotification'
+import AttentionIcon from 'src/icons/Attention'
 
 describe(InLineNotification, () => {
   it('does not render CTA when onPress function is not provided', async () => {
@@ -41,5 +42,31 @@ describe(InLineNotification, () => {
 
     expect(fn).toBeCalled()
     expect(fn2).toBeCalled()
+  })
+
+  it('renders the standard icon when the icon is not overridden', () => {
+    const { getByTestId } = render(<InLineNotification variant={Variant.Info} description="Test" />)
+
+    expect(getByTestId('InLineNotification/Icon')).toBeTruthy()
+  })
+
+  it('renders the provided icon when the icon prop is specified', () => {
+    const { getByTestId } = render(
+      <InLineNotification
+        variant={Variant.Warning}
+        description="Test"
+        icon={<AttentionIcon testId="TestIcon" />}
+      />
+    )
+
+    expect(getByTestId('TestIcon')).toBeTruthy()
+  })
+
+  it('does not render the icon when the icon prop is set to null', () => {
+    const { queryByTestId } = render(
+      <InLineNotification variant={Variant.Info} description="Test" icon={null} />
+    )
+
+    expect(queryByTestId('InLineNotification/Icon')).toBeFalsy()
   })
 })

--- a/src/components/InLineNotification.test.tsx
+++ b/src/components/InLineNotification.test.tsx
@@ -52,21 +52,21 @@ describe(InLineNotification, () => {
     expect(getByTestId('InLineNotification/Icon')).toBeTruthy()
   })
 
-  it('renders the provided icon when the icon prop is specified', () => {
+  it('renders the provided icon when a custom icon is specified', () => {
     const { getByTestId } = render(
       <InLineNotification
         variant={NotificationVariant.Warning}
         description="Test"
-        icon={<AttentionIcon testId="TestIcon" />}
+        customIcon={<AttentionIcon testId="TestIcon" />}
       />
     )
 
     expect(getByTestId('TestIcon')).toBeTruthy()
   })
 
-  it('does not render the icon when the icon prop is set to null', () => {
+  it('does not render the icon when `hideIcon` prop is set', () => {
     const { queryByTestId } = render(
-      <InLineNotification variant={NotificationVariant.Info} description="Test" icon={null} />
+      <InLineNotification variant={NotificationVariant.Info} description="Test" hideIcon />
     )
 
     expect(queryByTestId('InLineNotification/Icon')).toBeFalsy()

--- a/src/components/InLineNotification.test.tsx
+++ b/src/components/InLineNotification.test.tsx
@@ -1,13 +1,13 @@
 import { fireEvent, render } from '@testing-library/react-native'
 import * as React from 'react'
-import InLineNotification, { Variant } from 'src/components/InLineNotification'
+import InLineNotification, { NotificationVariant } from 'src/components/InLineNotification'
 import AttentionIcon from 'src/icons/Attention'
 
 describe(InLineNotification, () => {
   it('does not render CTA when onPress function is not provided', async () => {
     const { getByText, queryByText } = render(
       <InLineNotification
-        variant={Variant.Info}
+        variant={NotificationVariant.Info}
         title={'Title'}
         description={'Description'}
         ctaLabel={'Action 1'}
@@ -27,7 +27,7 @@ describe(InLineNotification, () => {
     const fn2 = jest.fn()
     const { getByText } = render(
       <InLineNotification
-        variant={Variant.Info}
+        variant={NotificationVariant.Info}
         title={'Title'}
         description={'Description'}
         ctaLabel={'Action 1'}
@@ -45,7 +45,9 @@ describe(InLineNotification, () => {
   })
 
   it('renders the standard icon when the icon is not overridden', () => {
-    const { getByTestId } = render(<InLineNotification variant={Variant.Info} description="Test" />)
+    const { getByTestId } = render(
+      <InLineNotification variant={NotificationVariant.Info} description="Test" />
+    )
 
     expect(getByTestId('InLineNotification/Icon')).toBeTruthy()
   })
@@ -53,7 +55,7 @@ describe(InLineNotification, () => {
   it('renders the provided icon when the icon prop is specified', () => {
     const { getByTestId } = render(
       <InLineNotification
-        variant={Variant.Warning}
+        variant={NotificationVariant.Warning}
         description="Test"
         icon={<AttentionIcon testId="TestIcon" />}
       />
@@ -64,7 +66,7 @@ describe(InLineNotification, () => {
 
   it('does not render the icon when the icon prop is set to null', () => {
     const { queryByTestId } = render(
-      <InLineNotification variant={Variant.Info} description="Test" icon={null} />
+      <InLineNotification variant={NotificationVariant.Info} description="Test" icon={null} />
     )
 
     expect(queryByTestId('InLineNotification/Icon')).toBeFalsy()

--- a/src/components/InLineNotification.tsx
+++ b/src/components/InLineNotification.tsx
@@ -6,14 +6,16 @@ import Colors from 'src/styles/colors'
 import { typeScale } from 'src/styles/fonts'
 import { Spacing } from 'src/styles/styles'
 
-export enum Severity {
-  Informational,
+export enum Variant {
+  Info,
+  Success,
   Warning,
   Error,
 }
 
 export interface InLineNotificationProps {
-  severity: Severity
+  variant: Variant
+  icon?: JSX.Element | null
   title?: string | null
   description: string | JSX.Element | null
   style?: StyleProp<ViewStyle>
@@ -30,7 +32,8 @@ interface CustomColors {
 }
 
 export function InLineNotification({
-  severity,
+  variant,
+  icon,
   title,
   description,
   style,
@@ -40,7 +43,7 @@ export function InLineNotification({
   onPressCta2,
   testID,
 }: InLineNotificationProps) {
-  const severityColor = severityColors[severity]
+  const variantColor = variantColors[variant]
   const renderCtaLabel = (
     label?: string | null,
     onPress?: (event: GestureResponderEvent) => void,
@@ -52,17 +55,19 @@ export function InLineNotification({
         {label}
       </Text>
     )
-  const Icon = severityIcons[severity]
+  const Icon = variantIcons[variant]
 
   return (
     <View
-      style={[styles.container, { backgroundColor: severityColor.secondary }, style]}
+      style={[styles.container, { backgroundColor: variantColor.secondary }, style]}
       testID={testID}
     >
       <View style={styles.row}>
-        <View style={styles.attentionIcon}>
-          <Icon color={severityColor.primary} size={20} />
-        </View>
+        {icon !== null && (
+          <View style={styles.iconContainer}>
+            {icon ?? <Icon color={variantColor.primary} size={20} />}
+          </View>
+        )}
         <View style={styles.contentContainer}>
           {title && <Text style={styles.titleText}>{title}</Text>}
           <Text style={[styles.bodyText]}>{description}</Text>
@@ -71,8 +76,8 @@ export function InLineNotification({
 
       {(ctaLabel || ctaLabel2) && (
         <View style={[styles.row, styles.ctaRow]}>
-          {renderCtaLabel(ctaLabel, onPressCta, severityColor.primary)}
-          {renderCtaLabel(ctaLabel2, onPressCta2, severityColor.primary)}
+          {renderCtaLabel(ctaLabel, onPressCta, variantColor.primary)}
+          {renderCtaLabel(ctaLabel2, onPressCta2, variantColor.primary)}
         </View>
       )}
     </View>
@@ -96,7 +101,7 @@ const styles = StyleSheet.create({
     justifyContent: 'flex-end',
     gap: Spacing.Smallest8,
   },
-  attentionIcon: {
+  iconContainer: {
     paddingTop: Spacing.Tiny4,
     paddingRight: Spacing.Smallest8,
   },
@@ -106,7 +111,6 @@ const styles = StyleSheet.create({
   },
   bodyText: {
     ...typeScale.bodyXSmall,
-    lineHeight: 18,
     color: Colors.black,
   },
   ctaLabel: {
@@ -117,25 +121,30 @@ const styles = StyleSheet.create({
   },
 })
 
-const severityColors: Record<Severity, CustomColors> = {
-  [Severity.Informational]: {
+const variantColors: Record<Variant, CustomColors> = {
+  [Variant.Info]: {
     primary: Colors.black,
     secondary: Colors.gray1,
   },
-  [Severity.Warning]: {
+  [Variant.Success]: {
+    primary: Colors.successDark,
+    secondary: Colors.successLight,
+  },
+  [Variant.Warning]: {
     primary: Colors.warningDark,
     secondary: Colors.warningLight,
   },
-  [Severity.Error]: {
+  [Variant.Error]: {
     primary: Colors.errorDark,
     secondary: Colors.errorLight,
   },
 }
 
-const severityIcons: Record<Severity, (args: any) => JSX.Element> = {
-  [Severity.Informational]: AttentionIcon,
-  [Severity.Warning]: Warning,
-  [Severity.Error]: Warning,
+const variantIcons: Record<Variant, (args: any) => JSX.Element> = {
+  [Variant.Info]: AttentionIcon,
+  [Variant.Success]: AttentionIcon,
+  [Variant.Warning]: Warning,
+  [Variant.Error]: Warning,
 }
 
 export default InLineNotification

--- a/src/components/InLineNotification.tsx
+++ b/src/components/InLineNotification.tsx
@@ -15,7 +15,8 @@ export enum NotificationVariant {
 
 export interface InLineNotificationProps {
   variant: NotificationVariant
-  icon?: JSX.Element | null
+  hideIcon?: boolean
+  customIcon?: JSX.Element | null
   title?: string | null
   description: string | JSX.Element | null
   style?: StyleProp<ViewStyle>
@@ -33,7 +34,8 @@ interface CustomColors {
 
 export function InLineNotification({
   variant,
-  icon,
+  hideIcon,
+  customIcon,
   title,
   description,
   style,
@@ -63,9 +65,9 @@ export function InLineNotification({
       testID={testID}
     >
       <View style={styles.row}>
-        {icon !== null && (
+        {!hideIcon && (
           <View style={styles.iconContainer}>
-            {icon ?? (
+            {customIcon ?? (
               <Icon color={variantColor.primary} size={20} testId="InLineNotification/Icon" />
             )}
           </View>

--- a/src/components/InLineNotification.tsx
+++ b/src/components/InLineNotification.tsx
@@ -6,7 +6,7 @@ import Colors from 'src/styles/colors'
 import { typeScale } from 'src/styles/fonts'
 import { Spacing } from 'src/styles/styles'
 
-export enum Variant {
+export enum NotificationVariant {
   Info,
   Success,
   Warning,
@@ -14,7 +14,7 @@ export enum Variant {
 }
 
 export interface InLineNotificationProps {
-  variant: Variant
+  variant: NotificationVariant
   icon?: JSX.Element | null
   title?: string | null
   description: string | JSX.Element | null
@@ -123,30 +123,30 @@ const styles = StyleSheet.create({
   },
 })
 
-const variantColors: Record<Variant, CustomColors> = {
-  [Variant.Info]: {
+const variantColors: Record<NotificationVariant, CustomColors> = {
+  [NotificationVariant.Info]: {
     primary: Colors.black,
     secondary: Colors.gray1,
   },
-  [Variant.Success]: {
+  [NotificationVariant.Success]: {
     primary: Colors.successDark,
     secondary: Colors.successLight,
   },
-  [Variant.Warning]: {
+  [NotificationVariant.Warning]: {
     primary: Colors.warningDark,
     secondary: Colors.warningLight,
   },
-  [Variant.Error]: {
+  [NotificationVariant.Error]: {
     primary: Colors.errorDark,
     secondary: Colors.errorLight,
   },
 }
 
-const variantIcons: Record<Variant, (args: any) => JSX.Element> = {
-  [Variant.Info]: AttentionIcon,
-  [Variant.Success]: AttentionIcon,
-  [Variant.Warning]: Warning,
-  [Variant.Error]: Warning,
+const variantIcons: Record<NotificationVariant, (args: any) => JSX.Element> = {
+  [NotificationVariant.Info]: AttentionIcon,
+  [NotificationVariant.Success]: AttentionIcon,
+  [NotificationVariant.Warning]: Warning,
+  [NotificationVariant.Error]: Warning,
 }
 
 export default InLineNotification

--- a/src/components/InLineNotification.tsx
+++ b/src/components/InLineNotification.tsx
@@ -65,7 +65,9 @@ export function InLineNotification({
       <View style={styles.row}>
         {icon !== null && (
           <View style={styles.iconContainer}>
-            {icon ?? <Icon color={variantColor.primary} size={20} />}
+            {icon ?? (
+              <Icon color={variantColor.primary} size={20} testId="InLineNotification/Icon" />
+            )}
           </View>
         )}
         <View style={styles.contentContainer}>

--- a/src/jumpstart/JumpstartEnterAmount.tsx
+++ b/src/jumpstart/JumpstartEnterAmount.tsx
@@ -4,7 +4,7 @@ import { useAsyncCallback } from 'react-async-hook'
 import { useTranslation } from 'react-i18next'
 import { JumpstartEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
-import InLineNotification, { Severity } from 'src/components/InLineNotification'
+import InLineNotification, { Variant } from 'src/components/InLineNotification'
 import { createJumpstartLink } from 'src/firebase/dynamicLinks'
 import { usePrepareJumpstartTransactions } from 'src/jumpstart/usePrepareJumpstartTransactions'
 import { convertDollarsToLocalAmount } from 'src/localCurrency/convert'
@@ -149,7 +149,7 @@ function JumpstartEnterAmount() {
     >
       {sendAmountExceedsThreshold && (
         <InLineNotification
-          severity={Severity.Warning}
+          variant={Variant.Warning}
           title={t('jumpstartEnterAmountScreen.maxAmountWarning.title')}
           description={t('jumpstartEnterAmountScreen.maxAmountWarning.description', {
             maxAmount: maxSendAmountLocalCurrency?.toFormat(2),

--- a/src/jumpstart/JumpstartEnterAmount.tsx
+++ b/src/jumpstart/JumpstartEnterAmount.tsx
@@ -4,7 +4,7 @@ import { useAsyncCallback } from 'react-async-hook'
 import { useTranslation } from 'react-i18next'
 import { JumpstartEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
-import InLineNotification, { Variant } from 'src/components/InLineNotification'
+import InLineNotification, { NotificationVariant } from 'src/components/InLineNotification'
 import { createJumpstartLink } from 'src/firebase/dynamicLinks'
 import { usePrepareJumpstartTransactions } from 'src/jumpstart/usePrepareJumpstartTransactions'
 import { convertDollarsToLocalAmount } from 'src/localCurrency/convert'
@@ -149,7 +149,7 @@ function JumpstartEnterAmount() {
     >
       {sendAmountExceedsThreshold && (
         <InLineNotification
-          variant={Variant.Warning}
+          variant={NotificationVariant.Warning}
           title={t('jumpstartEnterAmountScreen.maxAmountWarning.title')}
           description={t('jumpstartEnterAmountScreen.maxAmountWarning.description', {
             maxAmount: maxSendAmountLocalCurrency?.toFormat(2),

--- a/src/qrcode/QRCode.tsx
+++ b/src/qrcode/QRCode.tsx
@@ -5,7 +5,7 @@ import { StyleSheet, Text, View } from 'react-native'
 import { nameSelector } from 'src/account/selectors'
 import Button from 'src/components/Button'
 import ExchangesBottomSheet from 'src/components/ExchangesBottomSheet'
-import InLineNotification, { Severity } from 'src/components/InLineNotification'
+import InLineNotification, { Variant } from 'src/components/InLineNotification'
 import { ExternalExchangeProvider } from 'src/fiatExchanges/ExternalExchanges'
 import CopyIcon from 'src/icons/CopyIcon'
 import StyledQRCode from 'src/qrcode/StyledQRCode'
@@ -131,7 +131,7 @@ export default function QRCodeDisplay(props: Props) {
       ) : (
         <View style={styles.notificationWrapper}>
           <InLineNotification
-            severity={Severity.Informational}
+            variant={Variant.Info}
             description={description()}
             style={styles.link}
             testID="supportedNetworksNotification"

--- a/src/qrcode/QRCode.tsx
+++ b/src/qrcode/QRCode.tsx
@@ -5,7 +5,7 @@ import { StyleSheet, Text, View } from 'react-native'
 import { nameSelector } from 'src/account/selectors'
 import Button from 'src/components/Button'
 import ExchangesBottomSheet from 'src/components/ExchangesBottomSheet'
-import InLineNotification, { Variant } from 'src/components/InLineNotification'
+import InLineNotification, { NotificationVariant } from 'src/components/InLineNotification'
 import { ExternalExchangeProvider } from 'src/fiatExchanges/ExternalExchanges'
 import CopyIcon from 'src/icons/CopyIcon'
 import StyledQRCode from 'src/qrcode/StyledQRCode'
@@ -131,7 +131,7 @@ export default function QRCodeDisplay(props: Props) {
       ) : (
         <View style={styles.notificationWrapper}>
           <InLineNotification
-            variant={Variant.Info}
+            variant={NotificationVariant.Info}
             description={description()}
             style={styles.link}
             testID="supportedNetworksNotification"

--- a/src/send/EnterAmount.tsx
+++ b/src/send/EnterAmount.tsx
@@ -11,7 +11,7 @@ import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import BackButton from 'src/components/BackButton'
 import { BottomSheetRefType } from 'src/components/BottomSheet'
 import Button, { BtnSizes } from 'src/components/Button'
-import InLineNotification, { Variant } from 'src/components/InLineNotification'
+import InLineNotification, { NotificationVariant } from 'src/components/InLineNotification'
 import KeyboardAwareScrollView from 'src/components/KeyboardAwareScrollView'
 import KeyboardSpacer from 'src/components/KeyboardSpacer'
 import SkeletonPlaceholder from 'src/components/SkeletonPlaceholder'
@@ -300,7 +300,7 @@ function EnterAmount({
 
         {showMaxAmountWarning && (
           <InLineNotification
-            variant={Variant.Warning}
+            variant={NotificationVariant.Warning}
             title={t('sendEnterAmountScreen.maxAmountWarning.title')}
             description={t('sendEnterAmountScreen.maxAmountWarning.description', {
               feeTokenSymbol: prepareTransactionsResult.feeCurrency.symbol,
@@ -311,7 +311,7 @@ function EnterAmount({
         )}
         {showNotEnoughBalanceForGasWarning && (
           <InLineNotification
-            variant={Variant.Warning}
+            variant={NotificationVariant.Warning}
             title={t('sendEnterAmountScreen.notEnoughBalanceForGasWarning.title', {
               feeTokenSymbol: prepareTransactionsResult.feeCurrencies[0].symbol,
             })}
@@ -324,7 +324,7 @@ function EnterAmount({
         )}
         {prepareTransactionError && (
           <InLineNotification
-            variant={Variant.Error}
+            variant={NotificationVariant.Error}
             title={t('sendEnterAmountScreen.prepareTransactionError.title')}
             description={t('sendEnterAmountScreen.prepareTransactionError.description')}
             style={styles.warning}

--- a/src/send/EnterAmount.tsx
+++ b/src/send/EnterAmount.tsx
@@ -11,7 +11,7 @@ import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import BackButton from 'src/components/BackButton'
 import { BottomSheetRefType } from 'src/components/BottomSheet'
 import Button, { BtnSizes } from 'src/components/Button'
-import InLineNotification, { Severity } from 'src/components/InLineNotification'
+import InLineNotification, { Variant } from 'src/components/InLineNotification'
 import KeyboardAwareScrollView from 'src/components/KeyboardAwareScrollView'
 import KeyboardSpacer from 'src/components/KeyboardSpacer'
 import SkeletonPlaceholder from 'src/components/SkeletonPlaceholder'
@@ -300,7 +300,7 @@ function EnterAmount({
 
         {showMaxAmountWarning && (
           <InLineNotification
-            severity={Severity.Warning}
+            variant={Variant.Warning}
             title={t('sendEnterAmountScreen.maxAmountWarning.title')}
             description={t('sendEnterAmountScreen.maxAmountWarning.description', {
               feeTokenSymbol: prepareTransactionsResult.feeCurrency.symbol,
@@ -311,7 +311,7 @@ function EnterAmount({
         )}
         {showNotEnoughBalanceForGasWarning && (
           <InLineNotification
-            severity={Severity.Warning}
+            variant={Variant.Warning}
             title={t('sendEnterAmountScreen.notEnoughBalanceForGasWarning.title', {
               feeTokenSymbol: prepareTransactionsResult.feeCurrencies[0].symbol,
             })}
@@ -324,7 +324,7 @@ function EnterAmount({
         )}
         {prepareTransactionError && (
           <InLineNotification
-            severity={Severity.Error}
+            variant={Variant.Error}
             title={t('sendEnterAmountScreen.prepareTransactionError.title')}
             description={t('sendEnterAmountScreen.prepareTransactionError.description')}
             style={styles.warning}

--- a/src/send/SendSelectRecipient.tsx
+++ b/src/send/SendSelectRecipient.tsx
@@ -9,7 +9,7 @@ import { SendEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import { SendOrigin } from 'src/analytics/types'
 import Button, { BtnSizes } from 'src/components/Button'
-import InLineNotification, { Variant } from 'src/components/InLineNotification'
+import InLineNotification, { NotificationVariant } from 'src/components/InLineNotification'
 import InviteOptionsModal from 'src/components/InviteOptionsModal'
 import KeyboardAwareScrollView from 'src/components/KeyboardAwareScrollView'
 import CircledIcon from 'src/icons/CircledIcon'
@@ -401,7 +401,7 @@ function SendSelectRecipient({ route }: Props) {
       )}
       {showUnknownAddressInfo && (
         <InLineNotification
-          variant={Variant.Info}
+          variant={NotificationVariant.Info}
           description={t('sendSelectRecipient.unknownAddressInfo')}
           testID="UnknownAddressInfo"
           style={styles.unknownAddressInfo}

--- a/src/send/SendSelectRecipient.tsx
+++ b/src/send/SendSelectRecipient.tsx
@@ -9,7 +9,7 @@ import { SendEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import { SendOrigin } from 'src/analytics/types'
 import Button, { BtnSizes } from 'src/components/Button'
-import InLineNotification, { Severity } from 'src/components/InLineNotification'
+import InLineNotification, { Variant } from 'src/components/InLineNotification'
 import InviteOptionsModal from 'src/components/InviteOptionsModal'
 import KeyboardAwareScrollView from 'src/components/KeyboardAwareScrollView'
 import CircledIcon from 'src/icons/CircledIcon'
@@ -401,7 +401,7 @@ function SendSelectRecipient({ route }: Props) {
       )}
       {showUnknownAddressInfo && (
         <InLineNotification
-          severity={Severity.Informational}
+          variant={Variant.Info}
           description={t('sendSelectRecipient.unknownAddressInfo')}
           testID="UnknownAddressInfo"
           style={styles.unknownAddressInfo}

--- a/src/swap/SwapScreen.tsx
+++ b/src/swap/SwapScreen.tsx
@@ -17,7 +17,7 @@ import BackButton from 'src/components/BackButton'
 import BottomSheet, { BottomSheetRefType } from 'src/components/BottomSheet'
 import BottomSheetInLineNotification from 'src/components/BottomSheetInLineNotification'
 import Button, { BtnSizes, BtnTypes } from 'src/components/Button'
-import InLineNotification, { Variant } from 'src/components/InLineNotification'
+import InLineNotification, { NotificationVariant } from 'src/components/InLineNotification'
 import TokenBottomSheet, {
   TokenBalanceItemOption,
   TokenPickerOrigin,
@@ -728,7 +728,7 @@ export function SwapScreen({ route }: Props) {
           />
           {showSwitchedToNetworkWarning && (
             <InLineNotification
-              variant={Variant.Info}
+              variant={NotificationVariant.Info}
               title={t('swapScreen.switchedToNetworkWarning.title', {
                 networkName: switchedToNetworkName,
               })}
@@ -742,7 +742,7 @@ export function SwapScreen({ route }: Props) {
           )}
           {showMaxSwapAmountWarning && (
             <InLineNotification
-              variant={Variant.Warning}
+              variant={NotificationVariant.Warning}
               title={t('swapScreen.maxSwapAmountWarning.titleV1_74', {
                 tokenSymbol: fromToken?.symbol,
               })}
@@ -757,7 +757,7 @@ export function SwapScreen({ route }: Props) {
           )}
           {showPriceImpactWarning && (
             <InLineNotification
-              variant={Variant.Warning}
+              variant={NotificationVariant.Warning}
               title={t('swapScreen.priceImpactWarning.title')}
               description={t('swapScreen.priceImpactWarning.body')}
               style={styles.warning}
@@ -765,7 +765,7 @@ export function SwapScreen({ route }: Props) {
           )}
           {showNoUsdPriceWarning && (
             <InLineNotification
-              variant={Variant.Warning}
+              variant={NotificationVariant.Warning}
               title={t('swapScreen.noUsdPriceWarning.title', { localCurrency })}
               description={t('swapScreen.noUsdPriceWarning.description', {
                 localCurrency,
@@ -776,7 +776,7 @@ export function SwapScreen({ route }: Props) {
           )}
           {showMissingPriceImpactWarning && (
             <InLineNotification
-              variant={Variant.Warning}
+              variant={NotificationVariant.Warning}
               title={t('swapScreen.missingSwapImpactWarning.title')}
               description={t('swapScreen.missingSwapImpactWarning.body')}
               style={styles.warning}
@@ -784,7 +784,7 @@ export function SwapScreen({ route }: Props) {
           )}
           {confirmSwapFailed && (
             <InLineNotification
-              variant={Variant.Warning}
+              variant={NotificationVariant.Warning}
               title={t('swapScreen.confirmSwapFailedWarning.title')}
               description={t('swapScreen.confirmSwapFailedWarning.body')}
               style={styles.warning}
@@ -871,7 +871,7 @@ export function SwapScreen({ route }: Props) {
       </BottomSheet>
       <BottomSheetInLineNotification
         showNotification={!!selectingNoUsdPriceToken}
-        variant={Variant.Warning}
+        variant={NotificationVariant.Warning}
         title={t('swapScreen.noUsdPriceWarning.title', { localCurrency })}
         description={t('swapScreen.noUsdPriceWarning.description', {
           localCurrency,

--- a/src/swap/SwapScreen.tsx
+++ b/src/swap/SwapScreen.tsx
@@ -17,7 +17,7 @@ import BackButton from 'src/components/BackButton'
 import BottomSheet, { BottomSheetRefType } from 'src/components/BottomSheet'
 import BottomSheetInLineNotification from 'src/components/BottomSheetInLineNotification'
 import Button, { BtnSizes, BtnTypes } from 'src/components/Button'
-import InLineNotification, { Severity } from 'src/components/InLineNotification'
+import InLineNotification, { Variant } from 'src/components/InLineNotification'
 import TokenBottomSheet, {
   TokenBalanceItemOption,
   TokenPickerOrigin,
@@ -728,7 +728,7 @@ export function SwapScreen({ route }: Props) {
           />
           {showSwitchedToNetworkWarning && (
             <InLineNotification
-              severity={Severity.Informational}
+              variant={Variant.Info}
               title={t('swapScreen.switchedToNetworkWarning.title', {
                 networkName: switchedToNetworkName,
               })}
@@ -742,7 +742,7 @@ export function SwapScreen({ route }: Props) {
           )}
           {showMaxSwapAmountWarning && (
             <InLineNotification
-              severity={Severity.Warning}
+              variant={Variant.Warning}
               title={t('swapScreen.maxSwapAmountWarning.titleV1_74', {
                 tokenSymbol: fromToken?.symbol,
               })}
@@ -757,7 +757,7 @@ export function SwapScreen({ route }: Props) {
           )}
           {showPriceImpactWarning && (
             <InLineNotification
-              severity={Severity.Warning}
+              variant={Variant.Warning}
               title={t('swapScreen.priceImpactWarning.title')}
               description={t('swapScreen.priceImpactWarning.body')}
               style={styles.warning}
@@ -765,7 +765,7 @@ export function SwapScreen({ route }: Props) {
           )}
           {showNoUsdPriceWarning && (
             <InLineNotification
-              severity={Severity.Warning}
+              variant={Variant.Warning}
               title={t('swapScreen.noUsdPriceWarning.title', { localCurrency })}
               description={t('swapScreen.noUsdPriceWarning.description', {
                 localCurrency,
@@ -776,7 +776,7 @@ export function SwapScreen({ route }: Props) {
           )}
           {showMissingPriceImpactWarning && (
             <InLineNotification
-              severity={Severity.Warning}
+              variant={Variant.Warning}
               title={t('swapScreen.missingSwapImpactWarning.title')}
               description={t('swapScreen.missingSwapImpactWarning.body')}
               style={styles.warning}
@@ -784,7 +784,7 @@ export function SwapScreen({ route }: Props) {
           )}
           {confirmSwapFailed && (
             <InLineNotification
-              severity={Severity.Warning}
+              variant={Variant.Warning}
               title={t('swapScreen.confirmSwapFailedWarning.title')}
               description={t('swapScreen.confirmSwapFailedWarning.body')}
               style={styles.warning}
@@ -871,7 +871,7 @@ export function SwapScreen({ route }: Props) {
       </BottomSheet>
       <BottomSheetInLineNotification
         showNotification={!!selectingNoUsdPriceToken}
-        severity={Severity.Warning}
+        variant={Variant.Warning}
         title={t('swapScreen.noUsdPriceWarning.title', { localCurrency })}
         description={t('swapScreen.noUsdPriceWarning.description', {
           localCurrency,

--- a/src/tokens/TokenImport.tsx
+++ b/src/tokens/TokenImport.tsx
@@ -11,7 +11,7 @@ import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import BackButton from 'src/components/BackButton'
 import Button, { BtnSizes } from 'src/components/Button'
 import Dropdown from 'src/components/Dropdown'
-import InLineNotification, { Severity } from 'src/components/InLineNotification'
+import InLineNotification, { Variant } from 'src/components/InLineNotification'
 import KeyboardAwareScrollView from 'src/components/KeyboardAwareScrollView'
 import TextInput, { TextInputProps } from 'src/components/TextInput'
 import CustomHeader from 'src/components/header/CustomHeader'
@@ -232,10 +232,7 @@ export default function TokenImportScreen(_: Props) {
         title={<Text style={styles.headerTitle}>{t('tokenImport.title')}</Text>}
       />
       <KeyboardAwareScrollView contentContainerStyle={styles.scrollViewContainer}>
-        <InLineNotification
-          severity={Severity.Informational}
-          description={t('tokenImport.notification')}
-        />
+        <InLineNotification variant={Variant.Info} description={t('tokenImport.notification')} />
 
         <View style={styles.inputContainer}>
           {/* Network */}

--- a/src/tokens/TokenImport.tsx
+++ b/src/tokens/TokenImport.tsx
@@ -11,7 +11,7 @@ import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import BackButton from 'src/components/BackButton'
 import Button, { BtnSizes } from 'src/components/Button'
 import Dropdown from 'src/components/Dropdown'
-import InLineNotification, { Variant } from 'src/components/InLineNotification'
+import InLineNotification, { NotificationVariant } from 'src/components/InLineNotification'
 import KeyboardAwareScrollView from 'src/components/KeyboardAwareScrollView'
 import TextInput, { TextInputProps } from 'src/components/TextInput'
 import CustomHeader from 'src/components/header/CustomHeader'
@@ -232,7 +232,10 @@ export default function TokenImportScreen(_: Props) {
         title={<Text style={styles.headerTitle}>{t('tokenImport.title')}</Text>}
       />
       <KeyboardAwareScrollView contentContainerStyle={styles.scrollViewContainer}>
-        <InLineNotification variant={Variant.Info} description={t('tokenImport.notification')} />
+        <InLineNotification
+          variant={NotificationVariant.Info}
+          description={t('tokenImport.notification')}
+        />
 
         <View style={styles.inputContainer}>
           {/* Network */}

--- a/src/walletConnect/screens/ActionRequest.tsx
+++ b/src/walletConnect/screens/ActionRequest.tsx
@@ -3,7 +3,7 @@ import { Web3WalletTypes } from '@walletconnect/web3wallet'
 import React, { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { StyleSheet } from 'react-native'
-import InLineNotification, { Severity } from 'src/components/InLineNotification'
+import InLineNotification, { Variant } from 'src/components/InLineNotification'
 import { useDispatch, useSelector } from 'src/redux/hooks'
 import { NETWORK_NAMES } from 'src/shared/conts'
 import { Spacing } from 'src/styles/styles'
@@ -91,7 +91,7 @@ function ActionRequest({
         testId="WalletConnectActionRequest"
       >
         <InLineNotification
-          severity={Severity.Warning}
+          variant={Variant.Warning}
           title={t('walletConnectRequest.unsupportedChain.title', { dappName, chainId })}
           description={t('walletConnectRequest.unsupportedChain.descriptionV1_74', {
             dappName,
@@ -117,7 +117,7 @@ function ActionRequest({
         testId="WalletConnectActionRequest"
       >
         <InLineNotification
-          severity={Severity.Warning}
+          variant={Variant.Warning}
           title={t('walletConnectRequest.notEnoughBalanceForGas.title')}
           description={t('walletConnectRequest.notEnoughBalanceForGas.description', {
             feeCurrencies: feeCurrenciesSymbols.join(', '),
@@ -149,7 +149,7 @@ function ActionRequest({
           preparedTransaction={preparedTransaction}
         />
         <InLineNotification
-          severity={Severity.Warning}
+          variant={Variant.Warning}
           title={t('walletConnectRequest.failedToPrepareTransaction.title')}
           description={t('walletConnectRequest.failedToPrepareTransaction.description', {
             errorMessage: prepareTransactionErrorMessage,

--- a/src/walletConnect/screens/ActionRequest.tsx
+++ b/src/walletConnect/screens/ActionRequest.tsx
@@ -3,7 +3,7 @@ import { Web3WalletTypes } from '@walletconnect/web3wallet'
 import React, { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { StyleSheet } from 'react-native'
-import InLineNotification, { Variant } from 'src/components/InLineNotification'
+import InLineNotification, { NotificationVariant } from 'src/components/InLineNotification'
 import { useDispatch, useSelector } from 'src/redux/hooks'
 import { NETWORK_NAMES } from 'src/shared/conts'
 import { Spacing } from 'src/styles/styles'
@@ -91,7 +91,7 @@ function ActionRequest({
         testId="WalletConnectActionRequest"
       >
         <InLineNotification
-          variant={Variant.Warning}
+          variant={NotificationVariant.Warning}
           title={t('walletConnectRequest.unsupportedChain.title', { dappName, chainId })}
           description={t('walletConnectRequest.unsupportedChain.descriptionV1_74', {
             dappName,
@@ -117,7 +117,7 @@ function ActionRequest({
         testId="WalletConnectActionRequest"
       >
         <InLineNotification
-          variant={Variant.Warning}
+          variant={NotificationVariant.Warning}
           title={t('walletConnectRequest.notEnoughBalanceForGas.title')}
           description={t('walletConnectRequest.notEnoughBalanceForGas.description', {
             feeCurrencies: feeCurrenciesSymbols.join(', '),
@@ -149,7 +149,7 @@ function ActionRequest({
           preparedTransaction={preparedTransaction}
         />
         <InLineNotification
-          variant={Variant.Warning}
+          variant={NotificationVariant.Warning}
           title={t('walletConnectRequest.failedToPrepareTransaction.title')}
           description={t('walletConnectRequest.failedToPrepareTransaction.description', {
             errorMessage: prepareTransactionErrorMessage,

--- a/src/walletConnect/screens/SessionRequest.tsx
+++ b/src/walletConnect/screens/SessionRequest.tsx
@@ -4,7 +4,7 @@ import { Web3WalletTypes } from '@walletconnect/web3wallet'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 import { StyleSheet, Text, View } from 'react-native'
-import InLineNotification, { Severity } from 'src/components/InLineNotification'
+import InLineNotification, { Variant } from 'src/components/InLineNotification'
 import { useDispatch, useSelector } from 'src/redux/hooks'
 import { SentryTransactionHub } from 'src/sentry/SentryTransactionHub'
 import { SentryTransaction } from 'src/sentry/SentryTransactions'
@@ -81,7 +81,7 @@ function SessionRequest({
         testId="WalletConnectSessionRequest"
       >
         <InLineNotification
-          severity={Severity.Warning}
+          variant={Variant.Warning}
           title={t('walletConnectRequest.session.failUnsupportedNamespace.title', { dappName })}
           description={t('walletConnectRequest.session.failUnsupportedNamespace.descriptionV1_74', {
             dappName,
@@ -173,7 +173,7 @@ function NamespacesWarning({
 
   return (
     <InLineNotification
-      severity={Severity.Warning}
+      variant={Variant.Warning}
       title={title}
       description={description}
       style={styles.warning}

--- a/src/walletConnect/screens/SessionRequest.tsx
+++ b/src/walletConnect/screens/SessionRequest.tsx
@@ -4,7 +4,7 @@ import { Web3WalletTypes } from '@walletconnect/web3wallet'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 import { StyleSheet, Text, View } from 'react-native'
-import InLineNotification, { Variant } from 'src/components/InLineNotification'
+import InLineNotification, { NotificationVariant } from 'src/components/InLineNotification'
 import { useDispatch, useSelector } from 'src/redux/hooks'
 import { SentryTransactionHub } from 'src/sentry/SentryTransactionHub'
 import { SentryTransaction } from 'src/sentry/SentryTransactions'
@@ -81,7 +81,7 @@ function SessionRequest({
         testId="WalletConnectSessionRequest"
       >
         <InLineNotification
-          variant={Variant.Warning}
+          variant={NotificationVariant.Warning}
           title={t('walletConnectRequest.session.failUnsupportedNamespace.title', { dappName })}
           description={t('walletConnectRequest.session.failUnsupportedNamespace.descriptionV1_74', {
             dappName,
@@ -173,7 +173,7 @@ function NamespacesWarning({
 
   return (
     <InLineNotification
-      variant={Variant.Warning}
+      variant={NotificationVariant.Warning}
       title={title}
       description={description}
       style={styles.warning}


### PR DESCRIPTION
### Description

Visual tweaks to accommodate current [design variants](https://www.figma.com/file/erFfzHvSTm5g1sjK6jWyEH/Working-Design-System-Components?type=design&node-id=1144-35&mode=design&t=kUIyzJiXtW1ebQAL-0):
* added `Success` variant (green background)
* added icon override: can provide alternative icon or `null` to render without one

Renames:
* `Severity` -> `NotificationVariant` because from my standpoint it's better aligned with all options it contains
* `Informational` -> `Info` just because it's shorter

### Test plan

* Added unit test for icon override 

### Related issues

- Related to RET-1004

### Backwards compatibility

Y

### Network scalability

NA