### PR TITLE
fix(jumpstart): ensure that jumpstart transactions are prepared correctly

### DIFF
--- a/src/jumpstart/JumpstartEnterAmount.test.tsx
+++ b/src/jumpstart/JumpstartEnterAmount.test.tsx
@@ -124,7 +124,7 @@ describe('JumpstartEnterAmount', () => {
 
     await waitFor(() => expect(executeSpy).toHaveBeenCalledTimes(1))
     expect(executeSpy).toHaveBeenCalledWith({
-      amount: new BigNumber('0.25'),
+      sendTokenAmountInSmallestUnit: new BigNumber('250000000000000000'),
       token: mockStoreBalancesToTokenBalances([tokenBalances[mockCeurTokenId]])[0],
       walletAddress: mockAccount.toLowerCase(),
       publicKey: '0x2CEc3C5e83eE37261F9f9BB050B2Fbf59d13eEc0', // matches mock private key
@@ -177,7 +177,7 @@ describe('JumpstartEnterAmount', () => {
         link: mockLink,
         sendAmount: '0.25',
         tokenId: mockCeurTokenId,
-        preparedTransactions: getSerializablePreparedTransactions(mockTransactions),
+        serializablePreparedTransactions: getSerializablePreparedTransactions(mockTransactions),
       })
     )
     expect(ValoraAnalytics.track).toHaveBeenCalledWith(

--- a/src/jumpstart/JumpstartEnterAmount.tsx
+++ b/src/jumpstart/JumpstartEnterAmount.tsx
@@ -16,6 +16,7 @@ import EnterAmount from 'src/send/EnterAmount'
 import { getDynamicConfigParams } from 'src/statsig'
 import { DynamicConfigs } from 'src/statsig/constants'
 import { StatsigDynamicConfigs } from 'src/statsig/types'
+import { tokenAmountInSmallestUnit } from 'src/tokens/saga'
 import { jumpstartSendTokensSelector } from 'src/tokens/selectors'
 import { TokenBalance } from 'src/tokens/slice'
 import Logger from 'src/utils/Logger'
@@ -84,7 +85,7 @@ function JumpstartEnterAmount() {
           link,
           sendAmount: parsedAmount.toString(),
           tokenId: token.tokenId,
-          preparedTransactions: getSerializablePreparedTransactions(
+          serializablePreparedTransactions: getSerializablePreparedTransactions(
             prepareJumpstartTransactions.result.transactions
           ),
         })
@@ -108,7 +109,7 @@ function JumpstartEnterAmount() {
   const prepareJumpstartTransactions = usePrepareJumpstartTransactions()
 
   const handleRefreshPreparedTransactions = (
-    amount: BigNumber,
+    userInputAmount: BigNumber,
     token: TokenBalance,
     feeCurrencies: TokenBalance[]
   ) => {
@@ -117,7 +118,8 @@ function JumpstartEnterAmount() {
       return
     }
 
-    const sendAmountUsd = amount.multipliedBy(token.priceUsd ?? 0)
+    const sendTokenAmountInSmallestUnit = tokenAmountInSmallestUnit(userInputAmount, token.decimals)
+    const sendAmountUsd = userInputAmount.multipliedBy(token.priceUsd ?? 0)
     const sendAmountExceedsMax = sendAmountUsd.isGreaterThan(jumpstartSendThreshold)
     setSendAmountExceedsThreshold(sendAmountExceedsMax)
     if (sendAmountExceedsMax) {
@@ -129,7 +131,7 @@ function JumpstartEnterAmount() {
     }
 
     return prepareJumpstartTransactions.execute({
-      amount,
+      sendTokenAmountInSmallestUnit,
       token,
       walletAddress,
       feeCurrencies,

--- a/src/jumpstart/JumpstartEnterAmount.tsx
+++ b/src/jumpstart/JumpstartEnterAmount.tsx
@@ -131,7 +131,7 @@ function JumpstartEnterAmount() {
     }
 
     return prepareJumpstartTransactions.execute({
-      sendTokenAmountInSmallestUnit,
+      sendTokenAmountInSmallestUnit: new BigNumber(sendTokenAmountInSmallestUnit),
       token,
       walletAddress,
       feeCurrencies,

--- a/src/jumpstart/usePrepareJumpstartTransactions.test.ts
+++ b/src/jumpstart/usePrepareJumpstartTransactions.test.ts
@@ -26,7 +26,7 @@ describe('usePrepareJumpstartTransactions', () => {
   const walletAddress = '0x123'
   const jumpstartContractAddress = '0xjumpstart'
   const publicKey = '0xpublicKey'
-  const spendAmount = 1
+  const sendTokenAmountInSmallestUnit = '10000000000000000'
 
   beforeEach(() => {
     jest.clearAllMocks()
@@ -34,6 +34,7 @@ describe('usePrepareJumpstartTransactions', () => {
       jumpstartContracts: {
         'celo-alfajores': {
           contractAddress: jumpstartContractAddress,
+          depositERC20GasEstimate: '300000',
         },
       },
     })
@@ -56,6 +57,7 @@ describe('usePrepareJumpstartTransactions', () => {
         to: jumpstartContractAddress,
         value: BigInt(0),
         data: '0xtransferEncodedData',
+        gas: BigInt(300000),
       },
     ]
     const expectedPreparedTransactionsResult: PreparedTransactionsResult = {
@@ -69,7 +71,7 @@ describe('usePrepareJumpstartTransactions', () => {
 
     await act(async () => {
       await result.current.execute({
-        amount: new BigNumber(spendAmount),
+        sendTokenAmountInSmallestUnit: new BigNumber(sendTokenAmountInSmallestUnit),
         token: mockCeloTokenBalance,
         walletAddress,
         feeCurrencies: [mockCeloTokenBalance],
@@ -82,7 +84,7 @@ describe('usePrepareJumpstartTransactions', () => {
     expect(prepareTransactions).toHaveBeenCalledWith({
       feeCurrencies: [mockCeloTokenBalance],
       spendToken: mockCeloTokenBalance,
-      spendTokenAmount: new BigNumber(spendAmount),
+      spendTokenAmount: new BigNumber(sendTokenAmountInSmallestUnit),
       baseTransactions: expectedBaseTransactions,
     })
     expect(publicClient.celo.readContract).toHaveBeenCalledTimes(1)
@@ -95,12 +97,12 @@ describe('usePrepareJumpstartTransactions', () => {
     expect(encodeFunctionData).toHaveBeenNthCalledWith(1, {
       abi: erc20.abi,
       functionName: 'approve',
-      args: [jumpstartContractAddress, BigInt(spendAmount)],
+      args: [jumpstartContractAddress, BigInt(sendTokenAmountInSmallestUnit)],
     })
     expect(encodeFunctionData).toHaveBeenNthCalledWith(2, {
       abi: jumpstart.abi,
       functionName: 'depositERC20',
-      args: [publicKey, mockCeloTokenBalance.address, BigInt(spendAmount)],
+      args: [publicKey, mockCeloTokenBalance.address, BigInt(sendTokenAmountInSmallestUnit)],
     })
   })
 
@@ -112,7 +114,7 @@ describe('usePrepareJumpstartTransactions', () => {
     await act(async () => {
       await expect(async () => {
         await result.current.execute({
-          amount: new BigNumber(spendAmount),
+          sendTokenAmountInSmallestUnit: new BigNumber(sendTokenAmountInSmallestUnit),
           token: mockCeloTokenBalance,
           walletAddress,
           feeCurrencies: [mockCeloTokenBalance],

--- a/src/jumpstart/usePrepareJumpstartTransactions.ts
+++ b/src/jumpstart/usePrepareJumpstartTransactions.ts
@@ -17,14 +17,15 @@ const TAG = 'src/send/usePrepareJumpstartTransactions'
 
 async function createBaseJumpstartTransactions(
   jumpstartContractAddress: string,
-  spendTokenAmount: BigNumber,
+  sendTokenAmountInSmallestUnit: string,
   spendTokenAddress: string,
   networkId: NetworkId,
   walletAddress: string,
-  publicKey: string
+  publicKey: string,
+  depositERC20GasEstimate: string
 ) {
   const baseTransactions: TransactionRequest[] = []
-  const spendAmount = BigInt(spendTokenAmount.toFixed(0))
+  const spendAmount = BigInt(sendTokenAmountInSmallestUnit)
 
   const approvedAllowanceForSpender = await publicClient[
     networkIdToNetwork[networkId]
@@ -57,6 +58,7 @@ async function createBaseJumpstartTransactions(
       functionName: 'depositERC20',
       args: [publicKey as Address, spendTokenAddress as Address, spendAmount],
     }),
+    gas: BigInt(depositERC20GasEstimate),
   }
   baseTransactions.push(transferTx)
 
@@ -66,19 +68,20 @@ async function createBaseJumpstartTransactions(
 export function usePrepareJumpstartTransactions() {
   return useAsyncCallback(
     async ({
-      amount,
+      sendTokenAmountInSmallestUnit,
       token,
       walletAddress,
       feeCurrencies,
       publicKey,
     }: {
       publicKey: string
-      amount: BigNumber
+      sendTokenAmountInSmallestUnit: string
       token: TokenBalance
       walletAddress: string
       feeCurrencies: TokenBalance[]
     }) => {
-      if (amount.isLessThanOrEqualTo(0)) {
+      const sendAmount = new BigNumber(sendTokenAmountInSmallestUnit)
+      if (sendAmount.isLessThanOrEqualTo(0)) {
         return
       }
 
@@ -87,27 +90,32 @@ export function usePrepareJumpstartTransactions() {
         throw new Error(`jumpstart send token ${tokenId} has undefined address`)
       }
 
-      const jumpstartContractAddress = getDynamicConfigParams(
+      const jumpstartContractConfig = getDynamicConfigParams(
         DynamicConfigs[StatsigDynamicConfigs.WALLET_JUMPSTART_CONFIG]
-      ).jumpstartContracts?.[networkId]?.contractAddress
-      if (!jumpstartContractAddress) {
+      ).jumpstartContracts?.[networkId]
+      if (
+        !jumpstartContractConfig?.contractAddress ||
+        !jumpstartContractConfig?.depositERC20GasEstimate
+      ) {
         throw new Error(
-          `jumpstart contract for send token ${tokenId} on network ${networkId} is not provided in dynamic config`
+          `jumpstart contract address or deposit gas estimate on network ${networkId} is not provided in dynamic config`
         )
       }
 
       const baseTransactions = await createBaseJumpstartTransactions(
-        jumpstartContractAddress,
-        amount,
+        jumpstartContractConfig.contractAddress,
+        sendTokenAmountInSmallestUnit,
         address,
         networkId,
         walletAddress,
-        publicKey
+        publicKey,
+        jumpstartContractConfig.depositERC20GasEstimate
       )
+
       return prepareTransactions({
         feeCurrencies,
         spendToken: token,
-        spendTokenAmount: amount,
+        spendTokenAmount: sendAmount,
         baseTransactions,
       })
     },

--- a/src/jumpstart/usePrepareJumpstartTransactions.ts
+++ b/src/jumpstart/usePrepareJumpstartTransactions.ts
@@ -17,7 +17,7 @@ const TAG = 'src/send/usePrepareJumpstartTransactions'
 
 async function createBaseJumpstartTransactions(
   jumpstartContractAddress: string,
-  sendTokenAmountInSmallestUnit: string,
+  sendTokenAmountInSmallestUnit: BigNumber,
   spendTokenAddress: string,
   networkId: NetworkId,
   walletAddress: string,
@@ -25,7 +25,7 @@ async function createBaseJumpstartTransactions(
   depositERC20GasEstimate: string
 ) {
   const baseTransactions: TransactionRequest[] = []
-  const spendAmount = BigInt(sendTokenAmountInSmallestUnit)
+  const spendAmount = BigInt(sendTokenAmountInSmallestUnit.toFixed(0, 0))
 
   const approvedAllowanceForSpender = await publicClient[
     networkIdToNetwork[networkId]
@@ -75,13 +75,12 @@ export function usePrepareJumpstartTransactions() {
       publicKey,
     }: {
       publicKey: string
-      sendTokenAmountInSmallestUnit: string
+      sendTokenAmountInSmallestUnit: BigNumber
       token: TokenBalance
       walletAddress: string
       feeCurrencies: TokenBalance[]
     }) => {
-      const sendAmount = new BigNumber(sendTokenAmountInSmallestUnit)
-      if (sendAmount.isLessThanOrEqualTo(0)) {
+      if (sendTokenAmountInSmallestUnit.isLessThanOrEqualTo(0)) {
         return
       }
 
@@ -115,7 +114,7 @@ export function usePrepareJumpstartTransactions() {
       return prepareTransactions({
         feeCurrencies,
         spendToken: token,
-        spendTokenAmount: sendAmount,
+        spendTokenAmount: sendTokenAmountInSmallestUnit,
         baseTransactions,
       })
     },

--- a/src/navigator/types.tsx
+++ b/src/navigator/types.tsx
@@ -258,7 +258,7 @@ export type StackParamList = {
     link: string
     sendAmount: string
     tokenId: string
-    preparedTransactions: SerializableTransactionRequest[]
+    serializablePreparedTransactions: SerializableTransactionRequest[]
   }
   [Screens.Settings]: { promptConfirmRemovalModal?: boolean } | undefined
   [Screens.SignInWithEmail]: {

--- a/src/statsig/constants.ts
+++ b/src/statsig/constants.ts
@@ -101,7 +101,7 @@ export const DynamicConfigs = {
     configName: StatsigDynamicConfigs.WALLET_JUMPSTART_CONFIG,
     defaultValues: {
       jumpstartContracts: {} as {
-        [key in NetworkId]?: { contractAddress?: string }
+        [key in NetworkId]?: { contractAddress?: string; depositERC20GasEstimate: string }
       },
       maxAllowedSendAmountUsd: 100,
     },

--- a/src/transactions/saga.test.ts
+++ b/src/transactions/saga.test.ts
@@ -162,7 +162,7 @@ describe('watchPendingTransactions', () => {
   function createDefaultProviders(network: Network) {
     const defaultProviders: (EffectProviders | StaticProvider)[] = [
       [
-        call([publicClient[network], 'getTransactionReceipt'], { hash: transactionHash }),
+        call([publicClient[network], 'waitForTransactionReceipt'], { hash: transactionHash }),
         successReceipt,
       ],
       [
@@ -190,7 +190,7 @@ describe('watchPendingTransactions', () => {
       )
       .provide([
         [
-          call([publicClient.celo, 'getTransactionReceipt'], { hash: transactionHash }),
+          call([publicClient.celo, 'waitForTransactionReceipt'], { hash: transactionHash }),
           {
             ...successReceipt,
             status: 'reverted',
@@ -298,7 +298,7 @@ describe('watchPendingTransactions', () => {
         }).getState()
       )
       .provide([
-        [call([publicClient.celo, 'getTransactionReceipt'], { hash: transactionHash }), null],
+        [call([publicClient.celo, 'waitForTransactionReceipt'], { hash: transactionHash }), null],
         ...createDefaultProviders(Network.Celo),
       ])
       .not.put(transactionConfirmed(expect.any(String), expect.any(Object), expect.any(Number)))

--- a/src/transactions/saga.ts
+++ b/src/transactions/saga.ts
@@ -256,7 +256,7 @@ export function* getTransactionReceipt(
   const { feeCurrencyId, transactionHash } = transaction
 
   try {
-    const receipt = yield* call([publicClient[network], 'getTransactionReceipt'], {
+    const receipt = yield* call([publicClient[network], 'waitForTransactionReceipt'], {
       hash: transactionHash as Hash,
     })
 


### PR DESCRIPTION
### Description

We were using an incorrect address for the jumpstart contract previously so didn't catch these issues. This PR:
- fixes some approval transactions not added to the prepared transactions. the enter amount screen was passing the user input token amount to prepare transactions, however it needs to be the token amount in smallest units. the incorrect units were causing the approval transaction to never be added because the spend amount would get rounded to 0 for entered values under 1.
- add dynamic config for the transaction gas estimate, since we cannot estimate gas for a transaction without approval

### Test plan

No visual changes, manually verified that the transactions created are using the expected values.

### Related issues

- Related to RET-994

### Backwards compatibility

Y

### Network scalability

Y
