### PR TITLE
fix(cab): import wallet back fix

### DIFF
--- a/src/import/ImportWallet.tsx
+++ b/src/import/ImportWallet.tsx
@@ -53,6 +53,9 @@ function ImportWallet({ navigation, route }: Props) {
   const appConnected = useSelector(isAppConnected)
   const isRecoveringFromStoreWipe = useSelector(recoveringFromStoreWipeSelector)
   const accountToRecoverFromStoreWipe = useSelector(accountToRecoverSelector)
+  const cloudAccountBackupEnabled = getFeatureGate(
+    StatsigFeatureGates.SHOW_CLOUD_ACCOUNT_BACKUP_RESTORE
+  )
 
   const dispatch = useDispatch()
   const { t } = useTranslation()
@@ -69,11 +72,13 @@ function ImportWallet({ navigation, route }: Props) {
   }
 
   const handleNavigateBack = () => {
-    dispatch(cancelCreateOrRestoreAccount())
+    if (cloudAccountBackupEnabled) {
+      navigate(Screens.ImportSelect)
+    } else {
+      dispatch(cancelCreateOrRestoreAccount())
+      navigateClearingStack(Screens.Welcome)
+    }
     ValoraAnalytics.track(OnboardingEvents.restore_account_cancel)
-    getFeatureGate(StatsigFeatureGates.SHOW_CLOUD_ACCOUNT_BACKUP_RESTORE)
-      ? navigate(Screens.ImportSelect)
-      : navigateClearingStack(Screens.Welcome)
   }
 
   useBackHandler(() => {


### PR DESCRIPTION
### Description

Fixes a bug with back navigation on wallet restores.

#### Bug Reproduction Steps (Now fixed)

Prerequisites: Cloud Account Backup (CAB) enabled.

1. Select "I already have a wallet"
2. Enter Pin
3. Select "From recovery phrase"
4. Tap Cancel
5. Select "From recovery phrase"
6. Enter recovery phrase and attempt to restore
7. Observe error.

Workarounds: Close and reopen the app.

### Test plan

- Tested locally on iOS
- Unit tests added

### Related issues

N/A

### Backwards compatibility

Yes

### Network scalability

N/A
