### PR TITLE
feat(bottom-tabs): navigate to correct screens based on feature gate

### DIFF
--- a/src/account/saga.ts
+++ b/src/account/saga.ts
@@ -241,7 +241,7 @@ export function* updateStatsigAndNavigate(action: UpdateStatsigAndNavigateAction
   // Wait for wallet address to exist before updating statsig user
   yield* call(getWalletAddress)
   yield* call(patchUpdateStatsigUser)
-  if (action.screen === Screens.WalletHome) {
+  if (action.screen === Screens.TabWallet || action.screen === Screens.WalletHome) {
     navigateHome()
   } else {
     navigate(action.screen)

--- a/src/backup/CancelConfirm.tsx
+++ b/src/backup/CancelConfirm.tsx
@@ -32,7 +32,7 @@ export default function CancelConfirm({ screen }: Props) {
   const onProcrastinate = React.useCallback(() => {
     setOpenState(false)
     // Specify fromModal to avoid app crash
-    navigateHome({ params: { fromModal: true } })
+    navigateHome(true)
     ValoraAnalytics.track(OnboardingEvents.backup_delay_confirm)
   }, [screen, secondaryText])
 

--- a/src/components/TokenBalance.test.tsx
+++ b/src/components/TokenBalance.test.tsx
@@ -147,6 +147,44 @@ describe('FiatExchangeTokenBalance', () => {
     expect(tree.queryByTestId('ViewBalances')).toBeFalsy()
     expect(getElementText(tree.getByTestId('TotalTokenBalance'))).toEqual('$8.41')
   })
+
+  it('navigates to wallet tab if tab navigator gate is true', () => {
+    const store = createMockStore({
+      ...defaultStore,
+      tokens: {
+        // FiatExchangeTokenBalance requires 2 balances to display the View Balances button
+        tokenBalances: {
+          'celo-alfajores:0x00400FcbF0816bebB94654259de7273f4A05c762': {
+            priceUsd: '0.1',
+            tokenId: 'celo-alfajores:0x00400FcbF0816bebB94654259de7273f4A05c762',
+            address: '0x00400FcbF0816bebB94654259de7273f4A05c762',
+            networkId: NetworkId['celo-alfajores'],
+            symbol: 'POOF',
+            balance: '5',
+            priceFetchedAt: Date.now(),
+          },
+          'celo-alfajores:0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F': {
+            priceUsd: '1.16',
+            address: '0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F',
+            tokenId: 'celo-alfajores:0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F',
+            networkId: NetworkId['celo-alfajores'],
+            symbol: 'cEUR',
+            balance: '7',
+            priceFetchedAt: Date.now(),
+          },
+        },
+      },
+    })
+
+    const tree = render(
+      <Provider store={store}>
+        <FiatExchangeTokenBalance />
+      </Provider>
+    )
+
+    fireEvent.press(tree.getByTestId('ViewBalances'))
+    expect(navigate).toHaveBeenCalledWith(Screens.TabWallet)
+  })
 })
 
 // Behavior specific to HomeTokenBalance
@@ -463,7 +501,9 @@ describe.each([
 ])('$name', ({ component: TokenBalanceComponent }) => {
   beforeEach(() => {
     jest.clearAllMocks()
-    jest.mocked(getFeatureGate).mockReturnValue(true)
+    jest
+      .mocked(getFeatureGate)
+      .mockImplementation((gate) => gate === StatsigFeatureGates.SHOW_POSITIONS)
   })
 
   it('renders correctly with multiple token balances and positions', async () => {

--- a/src/components/TokenBalance.tsx
+++ b/src/components/TokenBalance.tsx
@@ -301,7 +301,9 @@ export function FiatExchangeTokenBalance() {
     ValoraAnalytics.track(FiatExchangeEvents.cico_landing_token_balance, {
       totalBalance: totalBalance?.toString(),
     })
-    navigate(Screens.Assets)
+    navigate(
+      getFeatureGate(StatsigFeatureGates.USE_TAB_NAVIGATOR) ? Screens.TabWallet : Screens.Assets
+    )
   }
 
   return (

--- a/src/keylessBackup/KeylessBackupPhoneCodeInput.test.tsx
+++ b/src/keylessBackup/KeylessBackupPhoneCodeInput.test.tsx
@@ -9,7 +9,7 @@ import { ErrorMessages } from 'src/app/ErrorMessages'
 import KeylessBackupPhoneCodeInput from 'src/keylessBackup/KeylessBackupPhoneCodeInput'
 import { valoraKeyshareIssued } from 'src/keylessBackup/slice'
 import { KeylessBackupFlow } from 'src/keylessBackup/types'
-import { navigate } from 'src/navigator/NavigationService'
+import { navigate, navigateHome } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import networkConfig from 'src/web3/networkConfig'
 import MockedNavigator from 'test/MockedNavigator'
@@ -158,14 +158,14 @@ describe('KeylessBackupPhoneCodeInput', () => {
       { keylessBackupFlow: KeylessBackupFlow.Setup }
     )
   })
-  it('goes to WalletHome screen and track analytics event when pressing skip button in setup flow', async () => {
+  it('goes to home screen and track analytics event when pressing skip button in setup flow', async () => {
     const { getByTestId } = renderComponent()
 
     expect(getByTestId('KeylessBackupPhoneCodeInputHelp')).toBeTruthy()
     fireEvent.press(getByTestId('KeylessBackupPhoneCodeInputHelp'))
     expect(getByTestId('KeylessBackupPhoneCodeInput/HelpInfoBottomSheet/Skip')).toBeTruthy()
     fireEvent.press(getByTestId('KeylessBackupPhoneCodeInput/HelpInfoBottomSheet/Skip'))
-    expect(navigate).toHaveBeenCalledWith(Screens.WalletHome)
+    expect(navigateHome).toHaveBeenCalledWith()
     expect(ValoraAnalytics.track).toHaveBeenCalledWith(
       KeylessBackupEvents.cab_phone_verification_help_skip,
       { keylessBackupFlow: KeylessBackupFlow.Setup }

--- a/src/keylessBackup/KeylessBackupPhoneCodeInput.tsx
+++ b/src/keylessBackup/KeylessBackupPhoneCodeInput.tsx
@@ -10,7 +10,7 @@ import TextButton from 'src/components/TextButton'
 import KeylessBackupCancelButton from 'src/keylessBackup/KeylessBackupCancelButton'
 import { useVerifyPhoneNumber } from 'src/keylessBackup/hooks'
 import { KeylessBackupFlow } from 'src/keylessBackup/types'
-import { navigate } from 'src/navigator/NavigationService'
+import { navigate, navigateHome } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import { TopBarTextButton } from 'src/navigator/TopBarButton'
 import { StackParamList } from 'src/navigator/types'
@@ -85,9 +85,7 @@ function KeylessBackupPhoneCodeInput({
     ValoraAnalytics.track(KeylessBackupEvents.cab_phone_verification_help_skip, {
       keylessBackupFlow,
     })
-    navigate(
-      keylessBackupFlow === KeylessBackupFlow.Setup ? Screens.WalletHome : Screens.ImportSelect
-    )
+    keylessBackupFlow === KeylessBackupFlow.Setup ? navigateHome() : navigate(Screens.ImportSelect)
   }
 
   useLayoutEffect(() => {

--- a/src/navigator/NavigationService.ts
+++ b/src/navigator/NavigationService.ts
@@ -225,24 +225,19 @@ export async function isBottomSheetVisible(screen: Screens) {
   return !!state?.routes.find((route: any) => route.name === screen)
 }
 
-interface NavigateHomeOptions {
-  params?: StackParamList[Screens.DrawerNavigator] | StackParamList[Screens.TabNavigator]
-}
-
 /***
  * Navigates to the home screen resetting the navigation stack by default
  * If called from a modal make sure to pass fromModal: true. Otherwise it will cause a null pointer dereference and subsequent app crash
  * TODO: stop using ReactNative modals and switch to react-navigation modals
  */
-export function navigateHome(options?: NavigateHomeOptions) {
-  const { params } = options ?? {}
-  const timeout = params?.fromModal && Platform.OS === 'ios' ? 500 : 0
+export function navigateHome(fromModal?: boolean) {
+  const timeout = fromModal && Platform.OS === 'ios' ? 500 : 0
   setTimeout(() => {
     navigationRef.current?.reset({
       index: 0,
       routes: getFeatureGate(StatsigFeatureGates.USE_TAB_NAVIGATOR)
-        ? [{ name: Screens.TabNavigator, params }]
-        : [{ name: Screens.DrawerNavigator, params }],
+        ? [{ name: Screens.TabNavigator }]
+        : [{ name: Screens.DrawerNavigator }],
     })
   }, timeout)
 }

--- a/src/navigator/types.tsx
+++ b/src/navigator/types.tsx
@@ -100,7 +100,6 @@ export type StackParamList = {
   [Screens.Debug]: undefined
   [Screens.DrawerNavigator]: {
     initialScreen?: Screens
-    fromModal?: boolean
   }
   [Screens.ErrorScreen]: {
     errorMessage?: string
@@ -278,7 +277,6 @@ export type StackParamList = {
   [Screens.TabWallet]: { activeAssetTab?: AssetTabType; isWalletTab?: boolean } | undefined
   [Screens.TabNavigator]: {
     initialScreen?: Screens
-    fromModal?: boolean
   }
   [Screens.TokenDetails]: { tokenId: string }
   [Screens.TokenImport]: undefined

--- a/src/onboarding/ChooseYourAdventure.test.tsx
+++ b/src/onboarding/ChooseYourAdventure.test.tsx
@@ -5,14 +5,16 @@ import { Provider } from 'react-redux'
 import { OnboardingEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import { FiatExchangeFlow } from 'src/fiatExchanges/utils'
-import { navigate, navigateHome } from 'src/navigator/NavigationService'
+import { navigate, navigateClearingStack, navigateHome } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import ChooseYourAdventure from 'src/onboarding/ChooseYourAdventure'
 import { AdventureCardName } from 'src/onboarding/types'
+import { getFeatureGate } from 'src/statsig'
+import { StatsigFeatureGates } from 'src/statsig/types'
 import { createMockStore } from 'test/utils'
-import { mockAccount, mockAccount2 } from 'test/values'
+import { mockAccount, mockAccount2, mockCeloTokenId } from 'test/values'
 
-jest.mock('src/analytics/ValoraAnalytics')
+jest.mock('src/statsig')
 
 describe('ChooseYourAdventure', () => {
   const orderOptions = [
@@ -36,8 +38,22 @@ describe('ChooseYourAdventure', () => {
     },
   ]
 
+  const expectedCardOrder = [
+    AdventureCardName.Dapp,
+    AdventureCardName.Add,
+    AdventureCardName.Learn,
+    AdventureCardName.Profile,
+  ]
+
+  const store = createMockStore({
+    web3: {
+      account: mockAccount,
+    },
+  })
+
   beforeEach(() => {
     jest.clearAllMocks()
+    jest.mocked(getFeatureGate).mockReturnValue(false)
   })
 
   it.each(orderOptions)(
@@ -59,55 +75,105 @@ describe('ChooseYourAdventure', () => {
     }
   )
 
-  it('navigates to the correct screens when clicking all the elements', () => {
-    const store = createMockStore({
-      web3: {
-        account: mockAccount,
-      },
-    })
+  it('navigates to the correct screen for dapp (drawer navigator)', () => {
     const { getByTestId } = render(
       <Provider store={store}>
         <ChooseYourAdventure />
       </Provider>
     )
-    const expectedCardOrder = [
-      AdventureCardName.Dapp,
-      AdventureCardName.Add,
-      AdventureCardName.Learn,
-      AdventureCardName.Profile,
-    ]
 
     fireEvent.press(getByTestId('AdventureCard/0/chooseYourAdventure.options.dapp'))
-    expect(navigateHome).toHaveBeenLastCalledWith({
-      params: { initialScreen: Screens.DAppsExplorerScreen },
+    expect(navigateClearingStack).toHaveBeenLastCalledWith(Screens.DrawerNavigator, {
+      initialScreen: Screens.DAppsExplorerScreen,
     })
     expect(ValoraAnalytics.track).toHaveBeenLastCalledWith(OnboardingEvents.cya_button_press, {
       position: 1,
       cardName: AdventureCardName.Dapp,
       cardOrder: expectedCardOrder,
     })
+  })
+
+  it('navigates to the correct screen for dapp', () => {
+    jest
+      .mocked(getFeatureGate)
+      .mockImplementation((gate) => gate === StatsigFeatureGates.USE_TAB_NAVIGATOR)
+    const { getByTestId } = render(
+      <Provider store={store}>
+        <ChooseYourAdventure />
+      </Provider>
+    )
+
+    fireEvent.press(getByTestId('AdventureCard/0/chooseYourAdventure.options.dapp'))
+    expect(navigateClearingStack).toHaveBeenLastCalledWith(Screens.TabNavigator, {
+      initialScreen: Screens.TabDiscover,
+    })
+    expect(ValoraAnalytics.track).toHaveBeenLastCalledWith(OnboardingEvents.cya_button_press, {
+      position: 1,
+      cardName: AdventureCardName.Dapp,
+      cardOrder: expectedCardOrder,
+    })
+  })
+
+  it('navigates to the correct screen for add', () => {
+    const { getByTestId } = render(
+      <Provider store={store}>
+        <ChooseYourAdventure />
+      </Provider>
+    )
     fireEvent.press(getByTestId('AdventureCard/1/chooseYourAdventure.options.add'))
     expect(navigateHome).toHaveBeenLastCalledWith()
     expect(navigate).toHaveBeenCalledWith(Screens.FiatExchangeCurrencyBottomSheet, {
       flow: FiatExchangeFlow.CashIn,
     })
-
     expect(ValoraAnalytics.track).toHaveBeenLastCalledWith(OnboardingEvents.cya_button_press, {
       position: 2,
       cardName: AdventureCardName.Add,
       cardOrder: expectedCardOrder,
     })
+  })
 
+  it('navigates to the correct screen for learn (drawer navigator)', () => {
+    const { getByTestId } = render(
+      <Provider store={store}>
+        <ChooseYourAdventure />
+      </Provider>
+    )
     fireEvent.press(getByTestId('AdventureCard/2/chooseYourAdventure.options.learn'))
-    expect(navigateHome).toHaveBeenLastCalledWith({
-      params: { initialScreen: Screens.ExchangeHomeScreen },
+    expect(navigateClearingStack).toHaveBeenLastCalledWith(Screens.DrawerNavigator, {
+      initialScreen: Screens.ExchangeHomeScreen,
     })
     expect(ValoraAnalytics.track).toHaveBeenLastCalledWith(OnboardingEvents.cya_button_press, {
       position: 3,
       cardName: AdventureCardName.Learn,
       cardOrder: expectedCardOrder,
     })
+  })
 
+  it('navigates to the correct screen for learn', () => {
+    jest
+      .mocked(getFeatureGate)
+      .mockImplementation((gate) => gate === StatsigFeatureGates.USE_TAB_NAVIGATOR)
+    const { getByTestId } = render(
+      <Provider store={store}>
+        <ChooseYourAdventure />
+      </Provider>
+    )
+    fireEvent.press(getByTestId('AdventureCard/2/chooseYourAdventure.options.learn'))
+    expect(navigateHome).toHaveBeenLastCalledWith()
+    expect(navigate).toHaveBeenLastCalledWith(Screens.TokenDetails, { tokenId: mockCeloTokenId })
+    expect(ValoraAnalytics.track).toHaveBeenLastCalledWith(OnboardingEvents.cya_button_press, {
+      position: 3,
+      cardName: AdventureCardName.Learn,
+      cardOrder: expectedCardOrder,
+    })
+  })
+
+  it('navigates to the correct screen for profile', () => {
+    const { getByTestId } = render(
+      <Provider store={store}>
+        <ChooseYourAdventure />
+      </Provider>
+    )
     fireEvent.press(getByTestId('AdventureCard/3/chooseYourAdventure.options.profile'))
     expect(navigateHome).toHaveBeenLastCalledWith()
     expect(navigate).toHaveBeenLastCalledWith(Screens.Profile)
@@ -116,10 +182,14 @@ describe('ChooseYourAdventure', () => {
       cardName: AdventureCardName.Profile,
       cardOrder: expectedCardOrder,
     })
+  })
 
-    fireEvent.press(getByTestId('AdventureCard/3/chooseYourAdventure.options.profile'))
-    expect(navigateHome).toHaveBeenLastCalledWith()
-
+  it('navigates to the correct screen for later', () => {
+    const { getByTestId } = render(
+      <Provider store={store}>
+        <ChooseYourAdventure />
+      </Provider>
+    )
     fireEvent.press(getByTestId('ChooseYourAdventure/Later'))
     expect(navigateHome).toHaveBeenLastCalledWith()
     expect(ValoraAnalytics.track).toHaveBeenLastCalledWith(OnboardingEvents.cya_later, {

--- a/src/onboarding/ChooseYourAdventure.tsx
+++ b/src/onboarding/ChooseYourAdventure.tsx
@@ -14,14 +14,17 @@ import GraphSparkle from 'src/icons/GraphSparkle'
 import PlusIcon from 'src/icons/PlusIcon'
 import ProfilePlus from 'src/icons/ProfilePlus'
 import { nuxNavigationOptionsNoBackButton } from 'src/navigator/Headers'
-import { navigate, navigateHome } from 'src/navigator/NavigationService'
+import { navigate, navigateClearingStack, navigateHome } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import { AdventureCardName } from 'src/onboarding/types'
 import { useSelector } from 'src/redux/hooks'
+import { getFeatureGate } from 'src/statsig'
+import { StatsigFeatureGates } from 'src/statsig/types'
 import colors from 'src/styles/colors'
 import fontStyles from 'src/styles/fonts'
 import { Shadow, Spacing } from 'src/styles/styles'
 import { shuffle } from 'src/utils/random'
+import networkConfig from 'src/web3/networkConfig'
 import { walletAddressSelector } from 'src/web3/selectors'
 
 const DEFAULT_SEED = '0x0'
@@ -70,7 +73,13 @@ function ChooseYourAdventure() {
     {
       text: t('chooseYourAdventure.options.dapp'),
       goToNextScreen: () => {
-        navigateHome({ params: { initialScreen: Screens.DAppsExplorerScreen } })
+        if (getFeatureGate(StatsigFeatureGates.USE_TAB_NAVIGATOR)) {
+          navigateClearingStack(Screens.TabNavigator, { initialScreen: Screens.TabDiscover })
+        } else {
+          navigateClearingStack(Screens.DrawerNavigator, {
+            initialScreen: Screens.DAppsExplorerScreen,
+          })
+        }
       },
       icon: <GraphSparkle />,
       name: AdventureCardName.Dapp,
@@ -87,7 +96,14 @@ function ChooseYourAdventure() {
     {
       text: t('chooseYourAdventure.options.learn'),
       goToNextScreen: () => {
-        navigateHome({ params: { initialScreen: Screens.ExchangeHomeScreen } })
+        if (getFeatureGate(StatsigFeatureGates.USE_TAB_NAVIGATOR)) {
+          navigateHome()
+          navigate(Screens.TokenDetails, { tokenId: networkConfig.celoTokenId })
+        } else {
+          navigateClearingStack(Screens.DrawerNavigator, {
+            initialScreen: Screens.ExchangeHomeScreen,
+          })
+        }
       },
       icon: <CeloIconNew />,
       name: AdventureCardName.Learn,

--- a/src/onboarding/steps.ts
+++ b/src/onboarding/steps.ts
@@ -20,7 +20,7 @@ import { getExperimentParams, getFeatureGate } from 'src/statsig'
 import { ExperimentConfigs } from 'src/statsig/constants'
 import { StatsigExperiments, StatsigFeatureGates } from 'src/statsig/types'
 
-export const END_OF_ONBOARDING_SCREENS = [Screens.WalletHome, Screens.ChooseYourAdventure]
+export const END_OF_ONBOARDING_SCREENS = [Screens.TabWallet, Screens.ChooseYourAdventure]
 
 interface NavigatorFunctions {
   navigate: typeof NavigationService.navigate
@@ -209,7 +209,12 @@ export function _getStepInfo({ firstScreenInStep, navigator, dispatch, props }: 
     if (props.chooseAdventureEnabled) {
       finishOnboarding(Screens.ChooseYourAdventure)
     } else {
-      finishOnboarding(Screens.WalletHome)
+      // NOTE: We don't need to conditionally navigate here because this screen
+      // is just a marker. `updateStatsigAndNavigate` saga calls `navigateHome`
+      // if the screen is set to `TabWallet` which handles navigating to the
+      // correct home screen. This will be cleaned up when we remove the CYA
+      // experiment code. (ACT-1114)
+      finishOnboarding(Screens.TabWallet)
     }
   }
 
@@ -297,7 +302,11 @@ export function _getStepInfo({ firstScreenInStep, navigator, dispatch, props }: 
         next: () => {
           if (skipVerification) {
             dispatch(setHasSeenVerificationNux(true))
-            finishOnboarding(Screens.WalletHome)
+            // This seems like a bug where we don't go to CYA on
+            // skipping phone verification. Every other case navigates to CYA at
+            // the end of onboarding, including when skipping verification on
+            // the import flow. TODO(ACT-1114): make this consistent with other cases
+            finishOnboarding(Screens.TabWallet)
           } else {
             navigate(Screens.VerificationStartScreen)
           }

--- a/src/swap/saga.test.ts
+++ b/src/swap/saga.test.ts
@@ -4,8 +4,7 @@ import * as matchers from 'redux-saga-test-plan/matchers'
 import { EffectProviders, StaticProvider, dynamic } from 'redux-saga-test-plan/providers'
 import { SwapEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
-import { navigate } from 'src/navigator/NavigationService'
-import { Screens } from 'src/navigator/Screens'
+import { navigate, navigateHome } from 'src/navigator/NavigationService'
 import { getDynamicConfigParams } from 'src/statsig'
 import { swapSubmitSaga } from 'src/swap/saga'
 import { swapCancel, swapError, swapStart, swapSuccess } from 'src/swap/slice'
@@ -416,7 +415,7 @@ describe(swapSubmitSaga, () => {
       expect(mockViemWallet.signTransaction).toHaveBeenCalledTimes(2)
       expect(mockViemWallet.sendRawTransaction).toHaveBeenCalledTimes(2)
       expect(loggerErrorSpy).not.toHaveBeenCalled()
-      expect(navigate).toHaveBeenCalledWith(Screens.WalletHome)
+      expect(navigateHome).toHaveBeenCalledWith()
 
       expect(ValoraAnalytics.track).toHaveBeenCalledTimes(1)
       expect(ValoraAnalytics.track).toHaveBeenCalledWith(SwapEvents.swap_execute_success, {
@@ -557,7 +556,7 @@ describe(swapSubmitSaga, () => {
     expect(mockViemWallet.signTransaction).toHaveBeenCalledTimes(1)
     expect(mockViemWallet.sendRawTransaction).toHaveBeenCalledTimes(1)
     expect(loggerErrorSpy).not.toHaveBeenCalled()
-    expect(navigate).toHaveBeenCalledWith(Screens.WalletHome)
+    expect(navigateHome).toHaveBeenCalledWith()
   })
 
   it('should display the correct standby values for a swap with different decimals', async () => {
@@ -626,7 +625,7 @@ describe(swapSubmitSaga, () => {
     expect(mockViemWallet.signTransaction).toHaveBeenCalledTimes(2)
     expect(mockViemWallet.sendRawTransaction).toHaveBeenCalledTimes(2)
     expect(loggerErrorSpy).not.toHaveBeenCalled()
-    expect(navigate).toHaveBeenCalledWith(Screens.WalletHome)
+    expect(navigateHome).toHaveBeenCalledWith()
 
     expect(ValoraAnalytics.track).toHaveBeenCalledTimes(1)
     expect(ValoraAnalytics.track).toHaveBeenLastCalledWith(

--- a/src/swap/saga.ts
+++ b/src/swap/saga.ts
@@ -10,8 +10,7 @@ import {
   TxReceiptProperties,
 } from 'src/analytics/Properties'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
-import { navigate } from 'src/navigator/NavigationService'
-import { Screens } from 'src/navigator/Screens'
+import { navigateHome } from 'src/navigator/NavigationService'
 import { CANCELLED_PIN_INPUT } from 'src/pincode/authentication'
 import { vibrateError } from 'src/styles/hapticFeedback'
 import { getSwapTxsAnalyticsProperties } from 'src/swap/getSwapTxsAnalyticsProperties'
@@ -323,7 +322,7 @@ export function* swapSubmitSaga(action: PayloadAction<SwapInfo>) {
 
     Logger.debug(TAG, 'Successfully sent swap transaction(s) to the network', txHashes)
 
-    navigate(Screens.WalletHome)
+    navigateHome()
     submitted = true
 
     // wait for the tx receipts, so that we can track them


### PR DESCRIPTION
### Description

As part of switching to bottom tabs from the drawer, update places that navigate to the drawer screens to the bottom tabs screens. (Settings, Invite and Help are out of scope, will be done once the screens without drawer are ready)

### Test plan

Unit tests, manually testing all the affected flows

### Related issues

- Fixes ACT-1110

### Backwards compatibility

Yes

### Network scalability

N/A
