### PR TITLE
fix(jumpstart): use long dynamic link

### DIFF
--- a/src/firebase/dynamicLinks.ts
+++ b/src/firebase/dynamicLinks.ts
@@ -7,7 +7,7 @@ import {
 } from 'src/config'
 import { NetworkId } from 'src/transactions/types'
 
-const commentDynamicLinkParams: Omit<FirebaseDynamicLinksTypes.DynamicLinkParameters, 'link'> = {
+const commonDynamicLinkParams: Omit<FirebaseDynamicLinksTypes.DynamicLinkParameters, 'link'> = {
   domainUriPrefix: baseURI,
   ios: {
     appStoreId,
@@ -20,14 +20,14 @@ const commentDynamicLinkParams: Omit<FirebaseDynamicLinksTypes.DynamicLinkParame
 
 export async function createInviteLink(address: string) {
   return dynamicLinks().buildShortLink({
-    ...commentDynamicLinkParams,
+    ...commonDynamicLinkParams,
     link: `${WEB_LINK}share/${address}`,
   })
 }
 
 export async function createJumpstartLink(privateKey: string, networkId: NetworkId) {
   return dynamicLinks().buildLink({
-    ...commentDynamicLinkParams,
+    ...commonDynamicLinkParams,
     link: `${WEB_LINK}jumpstart/${privateKey}/${networkId}`,
   })
 }

--- a/src/firebase/dynamicLinks.ts
+++ b/src/firebase/dynamicLinks.ts
@@ -1,4 +1,4 @@
-import dynamicLinks from '@react-native-firebase/dynamic-links'
+import dynamicLinks, { FirebaseDynamicLinksTypes } from '@react-native-firebase/dynamic-links'
 import { WEB_LINK } from 'src/brandingConfig'
 import {
   APP_STORE_ID as appStoreId,
@@ -7,24 +7,27 @@ import {
 } from 'src/config'
 import { NetworkId } from 'src/transactions/types'
 
-async function createDynamicLink(link: string) {
-  return dynamicLinks().buildShortLink({
-    link: `${WEB_LINK}${link}`,
-    domainUriPrefix: baseURI,
-    ios: {
-      appStoreId,
-      bundleId,
-    },
-    android: {
-      packageName: bundleId,
-    },
-  })
+const commentDynamicLinkParams: Omit<FirebaseDynamicLinksTypes.DynamicLinkParameters, 'link'> = {
+  domainUriPrefix: baseURI,
+  ios: {
+    appStoreId,
+    bundleId,
+  },
+  android: {
+    packageName: bundleId,
+  },
 }
 
 export async function createInviteLink(address: string) {
-  return createDynamicLink(`share/${address}`)
+  return dynamicLinks().buildShortLink({
+    ...commentDynamicLinkParams,
+    link: `${WEB_LINK}share/${address}`,
+  })
 }
 
 export async function createJumpstartLink(privateKey: string, networkId: NetworkId) {
-  return createDynamicLink(`jumpstart/${privateKey}/${networkId}`)
+  return dynamicLinks().buildLink({
+    ...commentDynamicLinkParams,
+    link: `${WEB_LINK}jumpstart/${privateKey}/${networkId}`,
+  })
 }


### PR DESCRIPTION
### Description

As the title, we should use a long dynamic link to make sure that the links are not stored on a central server / valora should not have access to the links.

### Test plan

Tested that the deep links can be correctly consumed still

### Related issues

- Fixes RET-994

### Backwards compatibility

Y

### Network scalability

Y
