### PR TITLE
chore: update Toast component to match recent designs

### DIFF
--- a/src/RevokePhoneNumber.tsx
+++ b/src/RevokePhoneNumber.tsx
@@ -8,7 +8,7 @@ import BottomSheet, { BottomSheetRefType } from 'src/components/BottomSheet'
 import Button, { BtnSizes, BtnTypes } from 'src/components/Button'
 import { NotificationVariant } from 'src/components/InLineNotification'
 import PhoneNumberWithFlag from 'src/components/PhoneNumberWithFlag'
-import ToastWithCTA from 'src/components/ToastWithCTA'
+import Toast from 'src/components/Toast'
 import AttentionIcon from 'src/icons/Attention'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
@@ -92,7 +92,7 @@ export const RevokePhoneNumber = ({ forwardedRef }: Props) => {
           testID="RevokePhoneNumberBottomSheet/PrimaryAction"
         />
       </BottomSheet>
-      <ToastWithCTA
+      <Toast
         showToast={showRevokeSuccess}
         variant={NotificationVariant.Info}
         hideIcon

--- a/src/RevokePhoneNumber.tsx
+++ b/src/RevokePhoneNumber.tsx
@@ -6,6 +6,7 @@ import { SettingsEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import BottomSheet, { BottomSheetRefType } from 'src/components/BottomSheet'
 import Button, { BtnSizes, BtnTypes } from 'src/components/Button'
+import { NotificationVariant } from 'src/components/InLineNotification'
 import PhoneNumberWithFlag from 'src/components/PhoneNumberWithFlag'
 import ToastWithCTA from 'src/components/ToastWithCTA'
 import AttentionIcon from 'src/icons/Attention'
@@ -93,10 +94,11 @@ export const RevokePhoneNumber = ({ forwardedRef }: Props) => {
       </BottomSheet>
       <ToastWithCTA
         showToast={showRevokeSuccess}
-        message={t('revokePhoneNumber.revokeSuccess')}
-        labelCTA={t('revokePhoneNumber.addNewNumberButton')}
-        ctaAlignment="bottom"
-        onPress={handleNavigateToVerifiedNumber}
+        variant={NotificationVariant.Info}
+        hideIcon
+        description={t('revokePhoneNumber.revokeSuccess')}
+        ctaLabel={t('revokePhoneNumber.addNewNumberButton')}
+        onPressCta={handleNavigateToVerifiedNumber}
       />
     </>
   )

--- a/src/alert/AlertBanner.tsx
+++ b/src/alert/AlertBanner.tsx
@@ -5,7 +5,7 @@ import { AlertTypes, hideAlert } from 'src/alert/actions'
 import { Alert, ErrorDisplayType } from 'src/alert/reducer'
 import { NotificationVariant } from 'src/components/InLineNotification'
 import SmartTopAlert from 'src/components/SmartTopAlert'
-import ToastWithCTA from 'src/components/ToastWithCTA'
+import Toast from 'src/components/Toast'
 import { useDispatch, useSelector } from 'src/redux/hooks'
 
 function AlertBanner() {
@@ -56,7 +56,7 @@ function AlertBanner() {
         <SmartTopAlert alert={displayAlert} />
       </View>
 
-      <ToastWithCTA
+      <Toast
         showToast={!!toastAlert?.isActive}
         title={toastAlert?.title || ''}
         variant={NotificationVariant.Warning}

--- a/src/alert/AlertBanner.tsx
+++ b/src/alert/AlertBanner.tsx
@@ -3,6 +3,7 @@ import React, { memo, useMemo, useState } from 'react'
 import { StyleSheet, View } from 'react-native'
 import { AlertTypes, hideAlert } from 'src/alert/actions'
 import { Alert, ErrorDisplayType } from 'src/alert/reducer'
+import { NotificationVariant } from 'src/components/InLineNotification'
 import SmartTopAlert from 'src/components/SmartTopAlert'
 import ToastWithCTA from 'src/components/ToastWithCTA'
 import { useDispatch, useSelector } from 'src/redux/hooks'
@@ -58,9 +59,10 @@ function AlertBanner() {
       <ToastWithCTA
         showToast={!!toastAlert?.isActive}
         title={toastAlert?.title || ''}
-        message={toastAlert?.message || ''}
-        labelCTA={toastAlert?.buttonMessage || ''}
-        onPress={toastAlert?.isActive ? onPressToast : noop}
+        variant={NotificationVariant.Warning}
+        description={toastAlert?.message || ''}
+        ctaLabel={toastAlert?.buttonMessage || ''}
+        onPressCta={toastAlert?.isActive ? onPressToast : noop}
       />
     </>
   )

--- a/src/components/Toast.test.tsx
+++ b/src/components/Toast.test.tsx
@@ -22,7 +22,7 @@ describe('Toast', () => {
     expect(getByText('some cta')).toBeTruthy()
   })
 
-  it('fires the correct callback on press', () => {
+  it('fires the correct callback on CTA press', () => {
     const onPressSpy = jest.fn()
     const { getByText } = render(
       <Toast
@@ -38,5 +38,25 @@ describe('Toast', () => {
     fireEvent.press(getByText('some cta'))
 
     expect(onPressSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('fires the correct callback on modal backdrop press', () => {
+    const onDismissSpy = jest.fn()
+    const { getByTestId } = render(
+      <Toast
+        showToast
+        hideIcon
+        modal
+        onDismiss={onDismissSpy}
+        variant={NotificationVariant.Info}
+        description="some message"
+        ctaLabel="some cta"
+        onPressCta={jest.fn()}
+      />
+    )
+
+    fireEvent.press(getByTestId('Toast/Backdrop'))
+
+    expect(onDismissSpy).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/components/Toast.test.tsx
+++ b/src/components/Toast.test.tsx
@@ -46,7 +46,7 @@ describe('Toast', () => {
       <Toast
         showToast
         hideIcon
-        modal
+        withBackdrop
         onDismiss={onDismissSpy}
         variant={NotificationVariant.Info}
         description="some message"

--- a/src/components/Toast.test.tsx
+++ b/src/components/Toast.test.tsx
@@ -1,12 +1,12 @@
 import { fireEvent, render } from '@testing-library/react-native'
 import React from 'react'
 import { NotificationVariant } from 'src/components/InLineNotification'
-import ToastWithCTA from 'src/components/ToastWithCTA'
+import Toast from 'src/components/Toast'
 
-describe('ToastWithCTA', () => {
+describe('Toast', () => {
   it('renders the correct elements', () => {
     const { getByText } = render(
-      <ToastWithCTA
+      <Toast
         showToast
         hideIcon
         variant={NotificationVariant.Info}
@@ -25,7 +25,7 @@ describe('ToastWithCTA', () => {
   it('fires the correct callback on press', () => {
     const onPressSpy = jest.fn()
     const { getByText } = render(
-      <ToastWithCTA
+      <Toast
         showToast
         hideIcon
         variant={NotificationVariant.Info}

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -14,12 +14,34 @@ import { useShowOrHideAnimation } from 'src/components/useShowOrHideAnimation'
 import Colors from 'src/styles/colors'
 import { Shadow, Spacing, getShadowStyle } from 'src/styles/styles'
 
+type RequiredProps<T, K extends keyof T> = Omit<T, K> & Required<Pick<T, K>>
+
+type DismissHandler = () => void
+
 interface Props extends InLineNotificationProps {
   showToast: boolean
-  modal?: boolean
-  swipeable?: boolean
   position?: 'top' | 'bottom'
-  onDismiss?: () => void
+}
+
+// modal toast must have `onDismiss` handler (fired when user taps on the backdrop)
+interface Modal extends Props {
+  modal: true
+  swipeable?: boolean
+  onDismiss: DismissHandler
+}
+
+// swipeable toast must have `onDismiss` handler (fired when user swipes the toast away)
+interface Swipeable extends Props {
+  swipeable: true
+  modal?: boolean
+  onDismiss: DismissHandler
+}
+
+// if toast isn't modal nor swipeable it must have at least one CTA
+interface MustHaveCTA extends RequiredProps<Props, 'ctaLabel' | 'onPressCta'> {
+  modal?: false
+  swipeable?: false
+  onDismiss?: never
 }
 
 const slidingDirection = {
@@ -34,7 +56,7 @@ const Toast = ({
   position = 'bottom',
   onDismiss,
   ...inLineNotificationProps
-}: Props) => {
+}: Modal | Swipeable | MustHaveCTA) => {
   const [isVisible, setIsVisible] = useState(showToast)
 
   const window = Dimensions.get('window')

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -139,7 +139,7 @@ const Toast = ({
   return (
     <>
       {modal && (
-        <TouchableWithoutFeedback onPress={onDismiss}>
+        <TouchableWithoutFeedback onPress={onDismiss} testID="Toast/Backdrop">
           <Animated.View style={[styles.modal, styles.background, animatedOpacity]} />
         </TouchableWithoutFeedback>
       )}

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -37,7 +37,7 @@ interface Swipeable extends Props {
   onDismiss: DismissHandler
 }
 
-// if toast isn't modal nor swipeable it must have at least one CTA
+// if toast isn't swipeable nor has a backdrop it must have at least one CTA
 interface MustHaveCTA extends RequiredProps<Props, 'ctaLabel' | 'onPressCta'> {
   withBackdrop?: false
   swipeable?: false

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -27,7 +27,7 @@ const slidingDirection = {
   bottom: 1,
 }
 
-const ToastWithCTA = ({
+const Toast = ({
   showToast,
   modal,
   swipeable,
@@ -146,4 +146,4 @@ const styles = StyleSheet.create({
   },
 })
 
-export default ToastWithCTA
+export default Toast

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -23,9 +23,9 @@ interface Props extends InLineNotificationProps {
   position?: 'top' | 'bottom'
 }
 
-// modal toast must have `onDismiss` handler (fired when user taps on the backdrop)
-interface Modal extends Props {
-  modal: true
+// toast with backdrop must have `onDismiss` handler (fired when user taps on the backdrop)
+interface WithBackdrop extends Props {
+  withBackdrop: true
   swipeable?: boolean
   onDismiss: DismissHandler
 }
@@ -33,13 +33,13 @@ interface Modal extends Props {
 // swipeable toast must have `onDismiss` handler (fired when user swipes the toast away)
 interface Swipeable extends Props {
   swipeable: true
-  modal?: boolean
+  withBackdrop?: boolean
   onDismiss: DismissHandler
 }
 
 // if toast isn't modal nor swipeable it must have at least one CTA
 interface MustHaveCTA extends RequiredProps<Props, 'ctaLabel' | 'onPressCta'> {
-  modal?: false
+  withBackdrop?: false
   swipeable?: false
   onDismiss?: never
 }
@@ -51,12 +51,12 @@ const slidingDirection = {
 
 const Toast = ({
   showToast,
-  modal,
+  withBackdrop,
   swipeable,
   position = 'bottom',
   onDismiss,
   ...inLineNotificationProps
-}: Modal | Swipeable | MustHaveCTA) => {
+}: WithBackdrop | Swipeable | MustHaveCTA) => {
   const [isVisible, setIsVisible] = useState(showToast)
 
   const window = Dimensions.get('window')
@@ -126,7 +126,7 @@ const Toast = ({
       onLayout={handleLayout}
     >
       <InLineNotification
-        style={[styles.notification, !modal && getShadowStyle(Shadow.AlertShadow)]}
+        style={[styles.notification, !withBackdrop && getShadowStyle(Shadow.AlertShadow)]}
         {...inLineNotificationProps}
       />
     </Animated.View>
@@ -138,7 +138,7 @@ const Toast = ({
 
   return (
     <>
-      {modal && (
+      {withBackdrop && (
         <TouchableWithoutFeedback onPress={onDismiss} testID="Toast/Backdrop">
           <Animated.View style={[styles.modal, styles.background, animatedOpacity]} />
         </TouchableWithoutFeedback>

--- a/src/components/ToastWithCTA.test.tsx
+++ b/src/components/ToastWithCTA.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render } from '@testing-library/react-native'
 import React from 'react'
+import { NotificationVariant } from 'src/components/InLineNotification'
 import ToastWithCTA from 'src/components/ToastWithCTA'
 
 describe('ToastWithCTA', () => {
@@ -7,10 +8,12 @@ describe('ToastWithCTA', () => {
     const { getByText } = render(
       <ToastWithCTA
         showToast
+        hideIcon
+        variant={NotificationVariant.Info}
         title="some title"
-        message="some message"
-        labelCTA="some cta"
-        onPress={jest.fn()}
+        description="some message"
+        ctaLabel="some cta"
+        onPressCta={jest.fn()}
       />
     )
 
@@ -22,7 +25,14 @@ describe('ToastWithCTA', () => {
   it('fires the correct callback on press', () => {
     const onPressSpy = jest.fn()
     const { getByText } = render(
-      <ToastWithCTA showToast message="some message" labelCTA="some cta" onPress={onPressSpy} />
+      <ToastWithCTA
+        showToast
+        hideIcon
+        variant={NotificationVariant.Info}
+        description="some message"
+        ctaLabel="some cta"
+        onPressCta={onPressSpy}
+      />
     )
 
     fireEvent.press(getByText('some cta'))

--- a/src/components/ToastWithCTA.tsx
+++ b/src/components/ToastWithCTA.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useState } from 'react'
 import { Dimensions, LayoutChangeEvent, StyleSheet } from 'react-native'
 import Animated, { useAnimatedStyle, useSharedValue } from 'react-native-reanimated'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
@@ -7,25 +7,14 @@ import { useShowOrHideAnimation } from 'src/components/useShowOrHideAnimation'
 import Colors from 'src/styles/colors'
 import { Shadow, Spacing, getShadowStyle } from 'src/styles/styles'
 
-interface Props extends InLineNotificationProps {
+type RequiredProps<T, K extends keyof T> = Omit<T, K> & Required<Pick<T, K>>
+
+interface Props extends RequiredProps<InLineNotificationProps, 'ctaLabel' | 'onPressCta'> {
   showToast: boolean
-  position?: 'top' | 'bottom'
   modal?: boolean
-  onUnmount?: () => void
 }
 
-const slidingDirection = {
-  top: -1,
-  bottom: 1,
-}
-
-const ToastWithCTA = ({
-  showToast,
-  position = 'bottom',
-  modal,
-  onUnmount,
-  ...inLineNotificationProps
-}: Props) => {
+const ToastWithCTA = ({ showToast, modal, ...inLineNotificationProps }: Props) => {
   const [isVisible, setIsVisible] = useState(showToast)
 
   const window = Dimensions.get('window')
@@ -33,25 +22,15 @@ const ToastWithCTA = ({
   const [toastHeight, setToastHeight] = useState(safeInitialHeight)
 
   const insets = useSafeAreaInsets()
-  const absolutePosition = Math.max(insets[position], Spacing.Regular16)
+  const absolutePosition = Math.max(insets.bottom, Spacing.Regular16)
 
-  const positionStyle = { [position]: absolutePosition }
+  const positionStyle = { bottom: absolutePosition }
   const slidingHeight = absolutePosition + toastHeight
-
-  useEffect(() => {
-    return () => {
-      if (onUnmount) {
-        onUnmount()
-      }
-    }
-  }, [])
 
   const progress = useSharedValue(0)
   const animatedTransform = useAnimatedStyle(() => {
     return {
-      transform: [
-        { translateY: (1 - progress.value) * slidingHeight * slidingDirection[position] },
-      ],
+      transform: [{ translateY: (1 - progress.value) * slidingHeight }],
     }
   })
   const animatedOpacity = useAnimatedStyle(() => ({

--- a/src/dappsExplorer/useDappFavoritedToast.tsx
+++ b/src/dappsExplorer/useDappFavoritedToast.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { SectionList } from 'react-native'
+import { NotificationVariant } from 'src/components/InLineNotification'
 import ToastWithCTA from 'src/components/ToastWithCTA'
 import { Dapp } from 'src/dapps/types'
 
@@ -34,10 +35,12 @@ const useDappFavoritedToast = (sectionListRef: React.RefObject<SectionList>) => 
     () => (
       <ToastWithCTA
         showToast={showToast}
+        variant={NotificationVariant.Info}
+        hideIcon
         title={favoritedDapp?.name}
-        message={t('dappsScreen.favoritedDappToast.message')}
-        labelCTA={t('dappsScreen.favoritedDappToast.labelCTA')}
-        onPress={onPressToast}
+        description={t('dappsScreen.favoritedDappToast.message')}
+        ctaLabel={t('dappsScreen.favoritedDappToast.labelCTA')}
+        onPressCta={onPressToast}
       />
     ),
     [favoritedDapp, showToast]

--- a/src/dappsExplorer/useDappFavoritedToast.tsx
+++ b/src/dappsExplorer/useDappFavoritedToast.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { SectionList } from 'react-native'
 import { NotificationVariant } from 'src/components/InLineNotification'
-import ToastWithCTA from 'src/components/ToastWithCTA'
+import Toast from 'src/components/Toast'
 import { Dapp } from 'src/dapps/types'
 
 const TOAST_DISMISS_TIMEOUT = 5000
@@ -33,7 +33,7 @@ const useDappFavoritedToast = (sectionListRef: React.RefObject<SectionList>) => 
 
   const DappFavoritedToast = useMemo(
     () => (
-      <ToastWithCTA
+      <Toast
         showToast={showToast}
         variant={NotificationVariant.Info}
         hideIcon

--- a/src/styles/styles.ts
+++ b/src/styles/styles.ts
@@ -16,6 +16,7 @@ export enum Shadow {
   Soft = 'Soft',
   SoftLight = 'SoftLight',
   BarShadow = 'BarShadow',
+  AlertShadow = 'AlertShadow',
 }
 
 export function getShadowStyle(shadow: Shadow) {
@@ -26,6 +27,8 @@ export function getShadowStyle(shadow: Shadow) {
       return styles.softShadowLight
     case Shadow.BarShadow:
       return styles.barShadow
+    case Shadow.AlertShadow:
+      return styles.alertShadow
   }
 }
 
@@ -60,6 +63,13 @@ const styles = StyleSheet.create({
     shadowOpacity: 0.5,
     shadowRadius: 1.5,
     shadowColor: 'rgba(129, 134, 139, 0.5)',
+  },
+  alertShadow: {
+    elevation: 16,
+    shadowOffset: { width: 0, height: 16 },
+    shadowOpacity: 0.15,
+    shadowRadius: 10,
+    shadowColor: 'rgb(80, 80, 80)',
   },
 })
 


### PR DESCRIPTION
### Description

Updates the Toast component to match [recent designs](https://www.figma.com/file/erFfzHvSTm5g1sjK6jWyEH/Working-Design-System-Components?type=design&node-id=1144-35&mode=design&t=kUIyzJiXtW1ebQAL-0).

List of changes:
* leverages visual styling of [`InLineNotifcation`](https://github.com/valora-inc/wallet/blob/main/src/components/InLineNotification.tsx) and properties set of the [`BottomSheetInLineNotification`](https://github.com/valora-inc/wallet/blob/main/src/components/BottomSheetInLineNotification.tsx)
* (optional) user can dismiss it by swiping
* (optional) may open in modal mode with a dimmed backdrop

Potential future development:
* enables implementation of escrow reclaim status UI: 
  * [element 1](https://www.figma.com/file/6sJ4fCxCptTybHB6ZZ7Pqi/Escrow-Feature?type=design&node-id=2251-3336&mode=design&t=6OqVd0y3J1DBkxq1-0)
  * [element 2](https://www.figma.com/file/6sJ4fCxCptTybHB6ZZ7Pqi/Escrow-Feature?type=design&node-id=2225-1599&mode=design&t=6OqVd0y3J1DBkxq1-0)
* may replace [`Modal`](https://github.com/valora-inc/wallet/blob/main/src/components/Modal.tsx) (when opened with a backdrop and with CTAs)
* may replace [`BottomSheetInLineNotification`](https://github.com/valora-inc/wallet/blob/main/src/components/BottomSheetInLineNotification.tsx) (because it's essentially a modal with CTA)

Since the new Toast doesn't always require a CTA, I renamed it to just `Toast`.

### Visual change of existing toasts

#### Error fetching tokens

| Before | After |
|--------|--------|
| ![Simulator Screenshot - iPhone 15 - 2024-03-14 at 14 33 19](https://github.com/valora-inc/wallet/assets/2737872/70e86b9e-65b6-424b-bc6a-fd67a3c3d1f0) |  ![Simulator Screenshot - iPhone 15 - 2024-03-14 at 14 15 35](https://github.com/valora-inc/wallet/assets/2737872/f082a6f9-c6eb-4f30-aa7b-c663a0c2826d) |

#### Favorited dApp

| Before | After |
|--------|--------|
| ![Simulator Screenshot - iPhone 15 - 2024-03-14 at 14 33 40](https://github.com/valora-inc/wallet/assets/2737872/c40325ad-e20d-495a-a1a2-9df3d772100a) | ![Simulator Screenshot - iPhone 15 - 2024-03-14 at 14 15 57](https://github.com/valora-inc/wallet/assets/2737872/6c6ea2fb-65bb-4d43-925b-8fa2854a89cb) |

#### Revoked phone number

| Before | After |
|--------|--------|
| ![Simulator Screenshot - iPhone 15 - 2024-03-14 at 14 38 59](https://github.com/valora-inc/wallet/assets/2737872/3dba42a4-f9dc-4be4-a869-a5e2987b3927) | ![Simulator Screenshot - iPhone 15 - 2024-03-14 at 14 19 09](https://github.com/valora-inc/wallet/assets/2737872/60a250fb-177b-4fd9-8b61-75d642fc71ef) |

### Test plan

* Tested manually
* Updated unit test

### Related issues

- Related to RET-1004

### Backwards compatibility

Y

### Network scalability

NA