### PR TITLE
fix: allow hiding of token balances on new assets screen

### DIFF
--- a/src/components/TokenBalance.tsx
+++ b/src/components/TokenBalance.tsx
@@ -223,7 +223,13 @@ export function AssetsTokenBalance({
             </TouchableOpacity>
           )}
         </View>
-        <TokenBalance style={styles.totalBalance} singleTokenViewEnabled={false} />
+        <TokenBalance
+          showHideHomeBalancesToggle={getFeatureGate(
+            StatsigFeatureGates.SHOW_HIDE_HOME_BALANCES_TOGGLE
+          )}
+          style={styles.totalBalance}
+          singleTokenViewEnabled={false}
+        />
 
         {shouldRenderInfoComponent && (
           <Animated.View style={[styles.totalAssetsInfoContainer, animatedStyles]}>


### PR DESCRIPTION
### Description

Fixes the hide token balances on the assets screen. In some of the rework it appears this was removed. Developers should add their wallet address to the `use_tab_navigator` feature gate in Statsig and navigate to wallet to see this fix.

| Before iOS | After iOS |
| ----- | ----- | 
| ![](https://github.com/valora-inc/wallet/assets/26950305/5a097b1d-9996-4f37-be4a-16b0a84d6ab3) | ![](https://github.com/valora-inc/wallet/assets/26950305/ee43b4e4-c8c6-49cf-be55-b2e921c86e63) |

### Test plan

- Tested locally on iOS
- Tested locally on Android

### Related issues

N/A

### Backwards compatibility

Yes

### Network scalability

N/A