### PR TITLE
chore(jumpstart): add `claim` to the names of claim-related actions and selectors

### DIFF
--- a/src/jumpstart/selectors.test.ts
+++ b/src/jumpstart/selectors.test.ts
@@ -1,4 +1,4 @@
-import { showJumstartError, showJumstartLoading } from 'src/jumpstart/selectors'
+import { showJumstartClaimError, showJumstartClaimLoading } from 'src/jumpstart/selectors'
 
 describe('jumpstart selectors', () => {
   it('should return the correct value for showJumpstartLoading', () => {
@@ -7,7 +7,7 @@ describe('jumpstart selectors', () => {
         claimStatus: 'loading',
       },
     }
-    expect(showJumstartLoading(state)).toEqual(true)
+    expect(showJumstartClaimLoading(state)).toEqual(true)
   })
 
   it('should return the correct value for showJumpstartError', () => {
@@ -16,6 +16,6 @@ describe('jumpstart selectors', () => {
         claimStatus: 'error',
       },
     }
-    expect(showJumstartError(state)).toEqual(true)
+    expect(showJumstartClaimError(state)).toEqual(true)
   })
 })

--- a/src/jumpstart/selectors.ts
+++ b/src/jumpstart/selectors.ts
@@ -1,10 +1,10 @@
 import { RootState } from 'src/redux/reducers'
 
-export const showJumstartLoading = (state: RootState) => {
+export const showJumstartClaimLoading = (state: RootState) => {
   return state.jumpstart.claimStatus === 'loading'
 }
 
-export const showJumstartError = (state: RootState) => {
+export const showJumstartClaimError = (state: RootState) => {
   return state.jumpstart.claimStatus === 'error'
 }
 

--- a/src/jumpstart/slice.test.ts
+++ b/src/jumpstart/slice.test.ts
@@ -1,9 +1,9 @@
 import reducer, {
+  jumpstartClaimErrorDismissed,
   jumpstartClaimFailed,
+  jumpstartClaimLoadingDismissed,
   jumpstartClaimStarted,
   jumpstartClaimSucceeded,
-  jumpstartErrorDismissed,
-  jumpstartLoadingDismissed,
 } from 'src/jumpstart/slice'
 
 describe('Wallet Jumpstart', () => {
@@ -26,13 +26,13 @@ describe('Wallet Jumpstart', () => {
   })
 
   it('should handle jumpstart loading dismiss', () => {
-    const updatedState = reducer(undefined, jumpstartLoadingDismissed())
+    const updatedState = reducer(undefined, jumpstartClaimLoadingDismissed())
 
     expect(updatedState).toHaveProperty('claimStatus', 'idle')
   })
 
   it('should handle jumpstart error dismiss', () => {
-    const updatedState = reducer(undefined, jumpstartErrorDismissed())
+    const updatedState = reducer(undefined, jumpstartClaimErrorDismissed())
 
     expect(updatedState).toHaveProperty('claimStatus', 'idle')
   })

--- a/src/jumpstart/slice.ts
+++ b/src/jumpstart/slice.ts
@@ -36,12 +36,12 @@ const slice = createSlice({
       claimStatus: 'error',
     }),
 
-    jumpstartLoadingDismissed: (state) => ({
+    jumpstartClaimLoadingDismissed: (state) => ({
       ...state,
       claimStatus: 'idle',
     }),
 
-    jumpstartErrorDismissed: (state) => ({
+    jumpstartClaimErrorDismissed: (state) => ({
       ...state,
       claimStatus: 'idle',
     }),
@@ -79,8 +79,8 @@ export const {
   jumpstartClaimStarted,
   jumpstartClaimSucceeded,
   jumpstartClaimFailed,
-  jumpstartLoadingDismissed,
-  jumpstartErrorDismissed,
+  jumpstartClaimLoadingDismissed,
+  jumpstartClaimErrorDismissed,
   depositTransactionFlowStarted,
   depositTransactionStarted,
   depositTransactionSucceeded,


### PR DESCRIPTION
### Description

As the title

### Test plan

CI

### Related issues

- Related to RET-1004

### Backwards compatibility

Y

### Network scalability

NA