### PR TITLE
feat(bottom-tabs): navigate gold education completion to home

### DIFF
--- a/src/account/GoldEducation.tsx
+++ b/src/account/GoldEducation.tsx
@@ -9,9 +9,11 @@ import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import { BtnTypes } from 'src/components/Button'
 import { celoEducation1, celoEducation2, celoEducation3, celoEducation4 } from 'src/images/Images'
 import { noHeader } from 'src/navigator/Headers'
-import { navigate, navigateBack } from 'src/navigator/NavigationService'
+import { navigateBack, navigateClearingStack, navigateHome } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import { useDispatch, useSelector } from 'src/redux/hooks'
+import { getFeatureGate } from 'src/statsig'
+import { StatsigFeatureGates } from 'src/statsig/types'
 
 export default function GoldEducation() {
   const { t } = useTranslation()
@@ -26,7 +28,11 @@ export default function GoldEducation() {
     if (isCeloEducationComplete) {
       navigateBack()
     } else {
-      navigate(Screens.ExchangeHomeScreen)
+      getFeatureGate(StatsigFeatureGates.USE_TAB_NAVIGATOR)
+        ? navigateHome()
+        : navigateClearingStack(Screens.DrawerNavigator, {
+            initialScreen: Screens.ExchangeHomeScreen,
+          })
       dispatch(setGoldEducationCompleted())
     }
   }

--- a/src/navigator/NavigationService.ts
+++ b/src/navigator/NavigationService.ts
@@ -177,14 +177,6 @@ export async function ensurePincode(): Promise<boolean> {
   }
 }
 
-export function navigateToExchangeHome() {
-  if (store.getState().account.celoEducationCompleted) {
-    navigate(Screens.ExchangeHomeScreen)
-  } else {
-    navigate(Screens.GoldEducation)
-  }
-}
-
 export function navigateBack() {
   ensureNavigator()
     .then(() => {


### PR DESCRIPTION
### Description

Navigate to home instead of the drawer celo screen from the gold education screen when using tab navigator

### Test plan

Manual

With gate off:


https://github.com/valora-inc/wallet/assets/5062591/6ae3892d-6445-4eed-ad22-44bc71f085b2


With gate on:


https://github.com/valora-inc/wallet/assets/5062591/d98c32a0-d785-4ccd-b112-60faaf34175f



### Related issues

- Part of ACT-1110

### Backwards compatibility

Yes

### Network scalability

N/A
