### PR TITLE
test(e2e): run assets tests against tab navigator

### DIFF
--- a/e2e/src/Assets.spec.js
+++ b/e2e/src/Assets.spec.js
@@ -1,3 +1,6 @@
 import Assets from './usecases/Assets'
+import AssetsDrawer from './usecases/AssetsDrawer'
 
 describe('Assets', Assets)
+
+describe('Assets drawer', AssetsDrawer)

--- a/e2e/src/usecases/Assets.js
+++ b/e2e/src/usecases/Assets.js
@@ -75,6 +75,9 @@ export default Assets = () => {
       await launchApp({
         newInstance: true,
         permissions: { notifications: 'YES', contacts: 'YES', camera: 'YES' },
+        launchArgs: {
+          statsigGateOverrides: `use_tab_navigator=true`,
+        },
       })
       let mnemonic = SAMPLE_BACKUP_KEY
       if (balance === 'zero') {
@@ -83,8 +86,8 @@ export default Assets = () => {
       await quickOnboarding(mnemonic)
     })
 
-    it('navigates to Assets screen from home', async () => {
-      await waitForElementByIdAndTap('ViewBalances')
+    it('navigates to wallet tab from home', async () => {
+      await waitForElementByIdAndTap('Tab/Wallet')
       await waitForElementId('Assets/TabBar')
     })
 

--- a/e2e/src/usecases/AssetsDrawer.js
+++ b/e2e/src/usecases/AssetsDrawer.js
@@ -1,0 +1,47 @@
+import { generateMnemonic } from '@celo/cryptographic-utils'
+import { DEFAULT_RECIPIENT_ADDRESS, SAMPLE_BACKUP_KEY } from '../utils/consts'
+import { launchApp } from '../utils/retries'
+import { quickOnboarding, waitForElementByIdAndTap, waitForElementId } from '../utils/utils'
+
+export default Assets = () => {
+  describe.each([
+    {
+      balance: 'non zero',
+    },
+    {
+      balance: 'zero',
+    },
+  ])('For wallet with $balance balance', ({ balance, tokens }) => {
+    beforeAll(async () => {
+      // uninstall and reinstall to start with either a new account or the usual
+      // e2e account
+      await device.uninstallApp()
+      await device.installApp()
+      await launchApp({
+        newInstance: true,
+        permissions: { notifications: 'YES', contacts: 'YES', camera: 'YES' },
+        launchArgs: {
+          statsigGateOverrides: `use_tab_navigator=false`,
+        },
+      })
+      let mnemonic = SAMPLE_BACKUP_KEY
+      if (balance === 'zero') {
+        mnemonic = await generateMnemonic()
+      }
+      await quickOnboarding(mnemonic)
+    })
+
+    it('navigates to Assets screen from home', async () => {
+      await waitForElementByIdAndTap('ViewBalances')
+      await waitForElementId('Assets/TabBar')
+    })
+
+    it('switching tabs displays corresponding assets', async () => {
+      await expect(element(by.id('TokenBalanceItem')).atIndex(0)).toBeVisible()
+      await element(by.id('Assets/TabBarItem')).atIndex(1).tap()
+      await waitForElementId('Assets/NoNfts')
+      await element(by.id('Assets/TabBarItem')).atIndex(0).tap()
+      await expect(element(by.id('TokenBalanceItem')).atIndex(0)).toBeVisible()
+    })
+  })
+}

--- a/src/navigator/TabNavigator.tsx
+++ b/src/navigator/TabNavigator.tsx
@@ -47,6 +47,7 @@ export default function TabNavigator({ route }: Props) {
         options={{
           tabBarLabel: t('bottomTabsNavigator.wallet.tabName') as string,
           tabBarIcon: Wallet,
+          tabBarTestID: 'Tab/Wallet',
         }}
         initialParams={{ isWalletTab: true }}
       />


### PR DESCRIPTION
### Description

Update assets test to run against the tab navigator. Retains a subset of tests on the drawer for any regression while we are in process of rolling this out.

### Test plan

CI

### Related issues

- Part of ACT-1113

### Backwards compatibility

Yes

### Network scalability

N/A
