### PR TITLE
fix(jumpstart): prevent possibility of sending multiple transactions

### DIFF
--- a/src/jumpstart/JumpstartSendConfirmation.test.tsx
+++ b/src/jumpstart/JumpstartSendConfirmation.test.tsx
@@ -106,7 +106,7 @@ describe('JumpstartSendConfirmation', () => {
         depositStatus: 'idle',
       },
     })
-    const { rerender } = render(
+    const { rerender, getByTestId } = render(
       <Provider store={store}>
         <MockedNavigator component={JumpstartSendConfirmation} params={navParams} />
       </Provider>
@@ -123,6 +123,7 @@ describe('JumpstartSendConfirmation', () => {
       </Provider>
     )
     expect(navigate).not.toHaveBeenCalled()
+    expect(getByTestId('JumpstartSendConfirmation/ConfirmButton')).toBeDisabled()
 
     const updatedStoreCompleted = createMockStore({
       jumpstart: {

--- a/src/jumpstart/JumpstartSendConfirmation.tsx
+++ b/src/jumpstart/JumpstartSendConfirmation.tsx
@@ -110,6 +110,8 @@ function JumpstartSendConfirmation({ route }: Props) {
             size={BtnSizes.FULL}
             style={styles.button}
             showLoading={jumpstartSendStatus === 'loading'}
+            disabled={jumpstartSendStatus === 'loading' || jumpstartSendStatus === 'success'}
+            testID="JumpstartSendConfirmation/ConfirmButton"
           />
           <InLineNotification
             variant={NotificationVariant.Info}


### PR DESCRIPTION
### Description

As the title - prevent triggering the send action again while there is a transaction inflight by disabling the button while loading.

### Test plan

n/a

### Related issues

n/a

### Backwards compatibility

Y

### Network scalability

Y
