### PR TITLE
fix: ensure send flow does not crash when user has no balance

### DIFF
--- a/src/onboarding/ChooseYourAdventure.tsx
+++ b/src/onboarding/ChooseYourAdventure.tsx
@@ -128,7 +128,7 @@ function ChooseYourAdventure() {
         })
         goToNextScreen()
       }
-      return <AdventureCard text={text} onPress={onPress} index={index} icon={icon} />
+      return <AdventureCard key={name} text={text} onPress={onPress} index={index} icon={icon} />
     })
   }
 

--- a/src/onboarding/steps.ts
+++ b/src/onboarding/steps.ts
@@ -1,4 +1,5 @@
 import { BIOMETRY_TYPE } from 'react-native-keychain'
+import { createSelector } from 'reselect'
 import { initializeAccount } from 'src/account/actions'
 import {
   choseToRestoreAccountSelector,
@@ -14,7 +15,6 @@ import * as NavigationService from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import { StackParamList } from 'src/navigator/types'
 import { updateStatsigAndNavigate } from 'src/onboarding/actions'
-import { RootState } from 'src/redux/reducers'
 import { store } from 'src/redux/store'
 import { getExperimentParams, getFeatureGate } from 'src/statsig'
 import { ExperimentConfigs } from 'src/statsig/constants'
@@ -75,30 +75,40 @@ export function firstOnboardingScreen({
  * @param state
  * @returns OnboardingProps
  */
-export function onboardingPropsSelector(state: RootState): OnboardingProps {
-  const recoveringFromStoreWipe = recoveringFromStoreWipeSelector(state)
-  const choseToRestoreAccount = choseToRestoreAccountSelector(state)
-  const supportedBiometryType = supportedBiometryTypeSelector(state)
-  const skipVerification = skipVerificationSelector(state)
-  const numberAlreadyVerifiedCentrally = phoneNumberVerifiedSelector(state)
-  const { chooseAdventureEnabled, onboardingNameScreenEnabled } = getExperimentParams(
-    ExperimentConfigs[StatsigExperiments.CHOOSE_YOUR_ADVENTURE]
-  )
-  const showCloudAccountBackupRestore = getFeatureGate(
-    StatsigFeatureGates.SHOW_CLOUD_ACCOUNT_BACKUP_RESTORE
-  )
-
-  return {
+export const onboardingPropsSelector = createSelector(
+  [
+    recoveringFromStoreWipeSelector,
+    choseToRestoreAccountSelector,
+    supportedBiometryTypeSelector,
+    skipVerificationSelector,
+    phoneNumberVerifiedSelector,
+  ],
+  (
     recoveringFromStoreWipe,
     choseToRestoreAccount,
     supportedBiometryType,
     skipVerification,
-    numberAlreadyVerifiedCentrally,
-    chooseAdventureEnabled,
-    onboardingNameScreenEnabled,
-    showCloudAccountBackupRestore,
+    numberAlreadyVerifiedCentrally
+  ) => {
+    const { chooseAdventureEnabled, onboardingNameScreenEnabled } = getExperimentParams(
+      ExperimentConfigs[StatsigExperiments.CHOOSE_YOUR_ADVENTURE]
+    )
+    const showCloudAccountBackupRestore = getFeatureGate(
+      StatsigFeatureGates.SHOW_CLOUD_ACCOUNT_BACKUP_RESTORE
+    )
+
+    return {
+      recoveringFromStoreWipe,
+      choseToRestoreAccount,
+      supportedBiometryType,
+      skipVerification,
+      numberAlreadyVerifiedCentrally,
+      chooseAdventureEnabled,
+      onboardingNameScreenEnabled,
+      showCloudAccountBackupRestore,
+    }
   }
-}
+)
 
 /**
  * Traverses through the directed graph of onboarding navigate, navigateClearingStack, and navigateHome calls

--- a/src/send/SendEnterAmount.tsx
+++ b/src/send/SendEnterAmount.tsx
@@ -12,9 +12,9 @@ import EnterAmount from 'src/send/EnterAmount'
 import { lastUsedTokenIdSelector } from 'src/send/selectors'
 import { usePrepareSendTransactions } from 'src/send/usePrepareSendTransactions'
 import { COMMENT_PLACEHOLDER_FOR_FEE_ESTIMATE } from 'src/send/utils'
-import { useTokensForSend } from 'src/tokens/hooks'
+import { sortedTokensWithBalanceOrShowZeroBalanceSelector } from 'src/tokens/selectors'
 import { TokenBalance } from 'src/tokens/slice'
-import { convertTokenToLocalAmount } from 'src/tokens/utils'
+import { convertTokenToLocalAmount, getSupportedNetworkIdsForSend } from 'src/tokens/utils'
 import Logger from 'src/utils/Logger'
 import { walletAddressSelector } from 'src/web3/selectors'
 
@@ -24,7 +24,12 @@ const TAG = 'SendEnterAmount'
 
 function SendEnterAmount({ route }: Props) {
   const { defaultTokenIdOverride, origin, recipient, isFromScan, forceTokenId } = route.params
-  const tokens = useTokensForSend()
+  const supportedNetworkIds = getSupportedNetworkIdsForSend()
+  // explicitly allow zero state tokens to be shown for exploration purposes for
+  // new users with no balance
+  const tokens = useSelector((state) =>
+    sortedTokensWithBalanceOrShowZeroBalanceSelector(state, supportedNetworkIds)
+  )
   const lastUsedTokenId = useSelector(lastUsedTokenIdSelector)
 
   const defaultToken = useMemo(() => {

--- a/src/tokens/TokenDetails.tsx
+++ b/src/tokens/TokenDetails.tsx
@@ -47,8 +47,8 @@ import {
   useCashOutTokens,
   useSwappableTokens,
   useTokenInfo,
-  useTokensForSend,
 } from 'src/tokens/hooks'
+import { sortedTokensWithBalanceSelector } from 'src/tokens/selectors'
 import { TokenBalance } from 'src/tokens/slice'
 import { TokenDetailsAction, TokenDetailsActionName } from 'src/tokens/types'
 import {
@@ -177,14 +177,16 @@ function PriceInfo({ token }: { token: TokenBalance }) {
 
 export const useActions = (token: TokenBalance) => {
   const { t } = useTranslation()
-  const sendableTokens = useTokensForSend()
+  const supportedNetworkIdsForSend = getSupportedNetworkIdsForSend()
+  const sendableTokensWithBalance = useSelector((state) =>
+    sortedTokensWithBalanceSelector(state, supportedNetworkIdsForSend)
+  )
   const { swappableFromTokens } = useSwappableTokens()
   const cashInTokens = useCashInTokens()
   const cashOutTokens = useCashOutTokens()
   const isSwapEnabled = useSelector(isAppSwapsEnabledSelector)
   const showWithdraw = !!cashOutTokens.find((tokenInfo) => tokenInfo.tokenId === token.tokenId)
 
-  const supportedNetworkIdsForSend = getSupportedNetworkIdsForSend()
   return [
     {
       name: TokenDetailsActionName.Send,
@@ -199,7 +201,7 @@ export const useActions = (token: TokenBalance) => {
       onPress: () => {
         navigate(Screens.SendSelectRecipient, { defaultTokenIdOverride: token.tokenId })
       },
-      visible: !!sendableTokens.find((tokenInfo) => tokenInfo.tokenId === token.tokenId),
+      visible: !!sendableTokensWithBalance.find((tokenInfo) => tokenInfo.tokenId === token.tokenId),
     },
     {
       name: TokenDetailsActionName.Swap,

--- a/src/tokens/hooks.test.tsx
+++ b/src/tokens/hooks.test.tsx
@@ -13,7 +13,6 @@ import {
   useSwappableTokens,
   useTokenPricesAreStale,
   useTokenToLocalAmount,
-  useTokensForSend,
 } from 'src/tokens/hooks'
 import { TokenBalance } from 'src/tokens/slice'
 import { NetworkId } from 'src/transactions/types'
@@ -211,40 +210,6 @@ describe('token to fiat exchanges', () => {
 
     const pricesStale = getByTestId('pricesStale')
     expect(pricesStale.props.children).toEqual(true)
-  })
-})
-
-describe('useTokensForSend', () => {
-  it('returns tokens with balance', () => {
-    const { getByTestId } = render(
-      <Provider store={storeWithMultipleNetworkTokens()}>
-        <TokenHookTestComponent hook={useTokensForSend} />
-      </Provider>
-    )
-
-    expect(getByTestId('tokenIDs').props.children).toEqual([
-      mockCeloTokenId,
-      mockPoofTokenId,
-      mockCrealTokenId,
-    ])
-  })
-
-  it('returns tokens with balance for multiple networks', () => {
-    jest.mocked(getDynamicConfigParams).mockReturnValueOnce({
-      showSend: [NetworkId['celo-alfajores'], NetworkId['ethereum-sepolia']],
-    })
-    const { getByTestId } = render(
-      <Provider store={storeWithMultipleNetworkTokens()}>
-        <TokenHookTestComponent hook={useTokensForSend} />
-      </Provider>
-    )
-
-    expect(getByTestId('tokenIDs').props.children).toEqual([
-      ethTokenId,
-      mockCeloTokenId,
-      mockPoofTokenId,
-      mockCrealTokenId,
-    ])
   })
 })
 

--- a/src/tokens/hooks.ts
+++ b/src/tokens/hooks.ts
@@ -8,7 +8,6 @@ import { StatsigDynamicConfigs, StatsigFeatureGates } from 'src/statsig/types'
 import {
   cashInTokensByNetworkIdSelector,
   cashOutTokensByNetworkIdSelector,
-  sortedTokensWithBalanceSelector,
   spendTokensByNetworkIdSelector,
   swappableFromTokensByNetworkIdSelector,
   swappableToTokensByNetworkIdSelector,
@@ -25,7 +24,6 @@ import { TokenBalance } from 'src/tokens/slice'
 import {
   convertLocalToTokenAmount,
   convertTokenToLocalAmount,
-  getSupportedNetworkIdsForSend,
   getSupportedNetworkIdsForTokenBalances,
 } from 'src/tokens/utils'
 import { NetworkId } from 'src/transactions/types'
@@ -54,11 +52,6 @@ export function useTotalTokenBalance() {
 export function useTokensWithTokenBalance() {
   const supportedNetworkIds = getSupportedNetworkIdsForTokenBalances()
   return useSelector((state) => tokensWithTokenBalanceSelector(state, supportedNetworkIds))
-}
-
-export function useTokensForSend() {
-  const supportedNetworkIds = getSupportedNetworkIdsForSend()
-  return useSelector((state) => sortedTokensWithBalanceSelector(state, supportedNetworkIds))
 }
 
 export function useTokensInfoUnavailable(networkIds: NetworkId[]) {


### PR DESCRIPTION
### Description

Also snuck in some onboarding warning fixes - 
- `onboardingPropsSelector` was returning a new value each time, causing unnecessary rerenders
- the pesky "unique key" warning on the CYA screen

### Test plan

A wallet with no balance should be able to enter the send amount screen

### Related issues

n/a

### Backwards compatibility

Y

### Network scalability

Y
