### PR TITLE
fix(profile-menu): use 16 for horizontal margin

### DIFF
--- a/src/navigator/ProfileMenu.tsx
+++ b/src/navigator/ProfileMenu.tsx
@@ -109,8 +109,7 @@ ProfileMenu.navigationOptions = () => ({
 const styles = StyleSheet.create({
   top: {
     alignItems: 'flex-start',
-    marginLeft: Spacing.Thick24,
-    marginRight: Spacing.Regular16,
+    marginHorizontal: Spacing.Regular16,
     marginTop: Spacing.Thick24,
   },
   nameLabel: {
@@ -122,14 +121,14 @@ const styles = StyleSheet.create({
   },
   topBorder: {
     marginVertical: Spacing.Thick24,
-    marginLeft: Spacing.Thick24,
+    marginLeft: Spacing.Regular16,
     height: 1,
     backgroundColor: colors.gray2,
     alignSelf: 'stretch',
   },
   bottomBorder: {
     marginTop: Spacing.Thick24,
-    marginLeft: Spacing.Thick24,
+    marginLeft: Spacing.Regular16,
     height: 1,
     backgroundColor: colors.gray2,
     alignSelf: 'stretch',
@@ -152,7 +151,7 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     marginVertical: Spacing.Smallest8,
-    marginLeft: Spacing.Thick24,
+    marginLeft: Spacing.Regular16,
     gap: Spacing.Small12,
   },
   actionLabel: {


### PR DESCRIPTION
### Description

[Figma](https://www.figma.com/file/EkJ8MVKoc6QVrrdKYFBARw/Navigation-Strategy?type=design&node-id=2722-7691&mode=design&t=bcpx3QA2KQAsxWsG-0)

### Test plan


| Before | After |
|--------|--------|
| <img src="https://github.com/valora-inc/wallet/assets/5062591/91ebccf5-e63e-49f5-b934-2d6ba6085ec6" width="250" /> | <img src="https://github.com/valora-inc/wallet/assets/5062591/0512e887-4283-4dd4-9163-725623121a16" width="250" /> |


### Related issues

N/A

### Backwards compatibility

Yes

### Network scalability

N/A