### PR TITLE
fix(jumpstart): fix jumpstart claim

### DIFF
--- a/src/jumpstart/jumpstartLinkHandler.test.ts
+++ b/src/jumpstart/jumpstartLinkHandler.test.ts
@@ -39,7 +39,7 @@ describe('jumpstartLinkHandler', () => {
   it('calls executeClaims with correct parameters', async () => {
     ;(fetchWithTimeout as jest.Mock).mockImplementation(() => ({
       ok: true,
-      json: async () => ({ transactionHash: '0xHASH' }),
+      json: async () => ({ result: { transactionHash: '0xHASH' } }),
     }))
     const contractAddress = '0xTEST'
 

--- a/src/jumpstart/jumpstartLinkHandler.ts
+++ b/src/jumpstart/jumpstartLinkHandler.ts
@@ -75,13 +75,15 @@ export async function executeClaims(
 
       const { signature } = await kit.web3.eth.accounts.sign(messageHash, privateKey)
 
-      const { transactionHash } = await claimReward({
+      const response = await claimReward({
         index: index.toString(),
         beneficiary,
         signature,
         sendTo: userAddress,
         assetType,
       })
+
+      const transactionHash = response?.result?.transactionHash
 
       if (transactionHash) {
         transactionHashes.push(transactionHash)

--- a/src/jumpstart/saga.test.ts
+++ b/src/jumpstart/saga.test.ts
@@ -259,7 +259,7 @@ describe('dispatchPendingERC20Transactions', () => {
     expect(Logger.warn).toHaveBeenCalledWith(
       'WalletJumpstart',
       'Claimed unknown tokenId',
-      'celo-alfajores:0xUNKNOWN'
+      'celo-alfajores:0xunknown'
     )
   })
 })
@@ -292,7 +292,7 @@ describe('dispatchPendingERC721Transactions', () => {
           nfts: [
             {
               tokenId: mockNftAllFields.tokenId,
-              contractAddress: mockNftAllFields.contractAddress,
+              contractAddress: mockNftAllFields.contractAddress.toLowerCase(),
               tokenUri,
               metadata,
               media: [{ raw: metadata.image, gateway: metadata.image }],

--- a/src/jumpstart/saga.ts
+++ b/src/jumpstart/saga.ts
@@ -103,7 +103,7 @@ export function* dispatchPendingERC20Transactions(
       address,
       args: { token: tokenAddress, amount },
     } of parsedLogs) {
-      const tokenId = getTokenId(networkId, tokenAddress)
+      const tokenId = getTokenId(networkId, tokenAddress.toLowerCase())
 
       const token = tokensById[tokenId]
       if (!token) {
@@ -179,7 +179,7 @@ export function* dispatchPendingERC721Transactions(
             nfts: [
               {
                 tokenId: tokenId.toString(),
-                contractAddress,
+                contractAddress: contractAddress.toLowerCase(),
                 tokenUri,
                 metadata,
                 media: [


### PR DESCRIPTION
### Description

Fix bugs causing error in claim status despite the claim itself succeeds:
* wrong assumption about `jumpstartClaim` cloud function result format
* use of non-lowercased addresses

### Test plan

* Tested manually
* Updated unit rests

### Related issues

- Related to [RET-1004](https://linear.app/valora/issue/RET-1004)

### Backwards compatibility

Y

### Network scalability

No. 

Jumpstart works only for Celo. See also RET-1019.
