### PR TITLE
chore(jumpstart): add networkId to claim request

### DIFF
--- a/src/jumpstart/jumpstartLinkHandler.test.ts
+++ b/src/jumpstart/jumpstartLinkHandler.test.ts
@@ -53,7 +53,7 @@ describe('jumpstartLinkHandler', () => {
     expect(result).toEqual(['0xHASH'])
     expect(fetchWithTimeout).toHaveBeenCalledTimes(1)
     expect(fetchWithTimeout).toHaveBeenCalledWith(
-      `https://api.alfajores.valora.xyz/walletJumpstart?index=1&beneficiary=${mockAccount}&signature=0xweb3-signature&sendTo=${mockAccount2}&assetType=erc20`,
+      `https://api.alfajores.valora.xyz/walletJumpstart?index=1&beneficiary=${mockAccount}&signature=0xweb3-signature&sendTo=${mockAccount2}&assetType=erc20&networkId=celo-alfajores`,
       expect.any(Object),
       expect.any(Number)
     )

--- a/src/jumpstart/jumpstartLinkHandler.ts
+++ b/src/jumpstart/jumpstartLinkHandler.ts
@@ -31,8 +31,8 @@ export async function jumpstartLinkHandler(
 
   const transactionHashes = (
     await Promise.all([
-      executeClaims(kit, jumpstart, publicKey, userAddress, 'erc20', privateKey),
-      executeClaims(kit, jumpstart, publicKey, userAddress, 'erc721', privateKey),
+      executeClaims(kit, jumpstart, publicKey, userAddress, 'erc20', privateKey, networkId),
+      executeClaims(kit, jumpstart, publicKey, userAddress, 'erc721', privateKey, networkId),
     ])
   ).flat()
 
@@ -49,7 +49,8 @@ export async function executeClaims(
   beneficiary: string,
   userAddress: string,
   assetType: 'erc20' | 'erc721',
-  privateKey: string
+  privateKey: string,
+  networkId: NetworkId
 ): Promise<Hash[]> {
   let index = 0
   const transactionHashes: Hash[] = []
@@ -81,6 +82,7 @@ export async function executeClaims(
         signature,
         sendTo: userAddress,
         assetType,
+        networkId,
       })
 
       const transactionHash = response?.result?.transactionHash
@@ -113,6 +115,7 @@ export interface RewardInfo {
   signature: string
   sendTo: string
   assetType: 'erc20' | 'erc721'
+  networkId: NetworkId
 }
 
 export async function claimReward(rewardInfo: RewardInfo) {


### PR DESCRIPTION
### Description

As the title. Related to https://github.com/valora-inc/valora-rest-api/pull/921, to enable the claim backend to use dynamic config to get the contract address.

### Test plan

n/a

### Related issues

n/a

### Backwards compatibility

Y

### Network scalability

Y
