### PR TITLE
test(e2e): update tests to run against tab navigator

### DIFF
--- a/e2e/src/AccountManagement.spec.js
+++ b/e2e/src/AccountManagement.spec.js
@@ -9,6 +9,9 @@ describe('Account', () => {
   })
 
   describe('Support', Support)
-  describe('Settings', Settings)
-  describe('Reset Account', ResetAccount)
+  describe.each([{ navType: 'drawer' }, { navType: 'tab' }])('Settings ($navType)', Settings)
+  describe.each([{ navType: 'drawer' }, { navType: 'tab' }])(
+    'Reset Account ($navType)',
+    ResetAccount
+  )
 })

--- a/e2e/src/Pin.spec.js
+++ b/e2e/src/Pin.spec.js
@@ -3,21 +3,25 @@ import PINRequire from './usecases/PINRequire'
 import { launchApp } from './utils/retries'
 import { quickOnboarding } from './utils/utils'
 
-describe('Given PIN', () => {
-  beforeEach(async () => {
-    await device.uninstallApp()
-    await device.installApp()
-    await launchApp({
-      newInstance: false,
-      permissions: { notifications: 'YES', contacts: 'YES' },
+describe.each([{ navType: 'drawer' }, { navType: 'tab' }])(
+  'Given PIN (Navigation type: $navType)',
+  ({ navType }) => {
+    beforeEach(async () => {
+      await device.uninstallApp()
+      await device.installApp()
+      await launchApp({
+        newInstance: false,
+        permissions: { notifications: 'YES', contacts: 'YES' },
+        launchArgs: { statsigGateOverrides: `use_tab_navigator=${navType === 'tab'}` },
+      })
+      await quickOnboarding()
     })
-    await quickOnboarding()
-  })
 
-  afterAll(async () => {
-    await device.uninstallApp()
-  })
+    afterAll(async () => {
+      await device.uninstallApp()
+    })
 
-  describe('When Requiring Pin', PINRequire)
-  describe('When Changing Pin', PINChange)
-})
+    describe('When Requiring Pin', PINRequire(navType))
+    describe('When Changing Pin', PINChange(navType))
+  }
+)

--- a/e2e/src/usecases/NewAccountPhoneVerification.js
+++ b/e2e/src/usecases/NewAccountPhoneVerification.js
@@ -12,6 +12,7 @@ import {
   sleep,
   waitForElementId,
   completeProtectWalletScreen,
+  navigateToSettings,
 } from '../utils/utils'
 
 import jestExpect from 'expect'
@@ -22,6 +23,7 @@ export default NewAccountPhoneVerification = () => {
     await launchApp({
       delete: true,
       permissions: { notifications: 'YES', contacts: 'YES' },
+      launchArgs: { statsigGateOverrides: `use_tab_navigator=true` },
     })
 
     // Create new account
@@ -181,11 +183,7 @@ export default NewAccountPhoneVerification = () => {
     await waitForElementId('HomeAction-Send')
 
     // Assert that 'Connect phone number' is present in settings
-    await waitForElementId('Hamburger')
-    await element(by.id('Hamburger')).tap()
-    await scrollIntoView('Settings', 'SettingsScrollView')
-    await waitForElementId('Settings')
-    await element(by.id('Settings')).tap()
+    await navigateToSettings('tab')
     await waitFor(element(by.text('Connect phone number')))
       .toBeVisible()
       .withTimeout(10 * 1000)

--- a/e2e/src/usecases/PINChange.js
+++ b/e2e/src/usecases/PINChange.js
@@ -1,16 +1,10 @@
 import { ALTERNATIVE_PIN, DEFAULT_PIN } from '../utils/consts'
 import { reloadReactNative } from '../utils/retries'
-import { enterPinUi, scrollIntoView, sleep, waitForElementId } from '../utils/utils'
+import { enterPinUi, navigateToSettings, sleep, waitForElementId } from '../utils/utils'
 
-export default ChangePIN = () => {
+export default ChangePIN = (navType) => () => {
   it('Then should be retain changed PIN', async () => {
-    await waitForElementId('Hamburger')
-    await element(by.id('Hamburger')).tap()
-    await scrollIntoView('Settings', 'SettingsScrollView')
-    await waitFor(element(by.id('Settings')))
-      .toBeVisible()
-      .withTimeout(30 * 1000)
-    await element(by.id('Settings')).tap()
+    await navigateToSettings(navType)
     await waitForElementId('ChangePIN')
     await element(by.id('ChangePIN')).tap()
     // Existing PIN is needed first
@@ -37,13 +31,7 @@ export default ChangePIN = () => {
 
     // Reload app and navigate to change pin
     await reloadReactNative()
-    await waitForElementId('Hamburger')
-    await element(by.id('Hamburger')).tap()
-    await scrollIntoView('Settings', 'SettingsScrollView')
-    await waitFor(element(by.id('Settings')))
-      .toBeVisible()
-      .withTimeout(30 * 1000)
-    await element(by.id('Settings')).tap()
+    await navigateToSettings(navType)
     await element(by.id('ChangePIN')).tap()
     // Now try to change it again and enter the old PIN
     await sleep(500)

--- a/e2e/src/usecases/PINRequire.js
+++ b/e2e/src/usecases/PINRequire.js
@@ -1,13 +1,9 @@
-import { scrollIntoView, waitForElementId } from '../utils/utils'
+import { navigateToSettings } from '../utils/utils'
 import { reloadReactNative } from '../utils/retries'
 
-export default RequirePIN = () => {
+export default RequirePIN = (navType) => () => {
   it('Then should be require PIN on app open', async () => {
-    await waitForElementId('Hamburger')
-    await element(by.id('Hamburger')).tap()
-    await scrollIntoView('Settings', 'SettingsScrollView')
-    await waitForElementId('Settings')
-    await element(by.id('Settings')).tap()
+    await navigateToSettings(navType)
     // Request Pin on App Open disabled by default
     await element(by.id('requirePinOnAppOpenToggle')).tap()
     await expect(element(by.id('requirePinOnAppOpenToggle'))).toHaveToggleValue(true)

--- a/e2e/src/usecases/ResetAccount.js
+++ b/e2e/src/usecases/ResetAccount.js
@@ -1,8 +1,18 @@
 import { SAMPLE_BACKUP_KEY } from '../utils/consts'
-import { reloadReactNative } from '../utils/retries'
-import { enterPinUiIfNecessary, waitForElementId } from '../utils/utils'
+import { reloadReactNative, launchApp } from '../utils/retries'
+import { enterPinUiIfNecessary, navigateToSettings, waitForElementId } from '../utils/utils'
 
-export default ResetAccount = () => {
+export default ResetAccount = ({ navType }) => {
+  // TODO(ACT-1133): remove this launchApp as it is only needed to update
+  // statsig gate overrides
+  beforeAll(async () => {
+    await launchApp({
+      newInstance: false,
+      permissions: { notifications: 'YES', contacts: 'YES' },
+      launchArgs: { statsigGateOverrides: `use_tab_navigator=${navType === 'tab'}` },
+    })
+  })
+
   beforeEach(async () => {
     await reloadReactNative()
   })
@@ -16,9 +26,7 @@ export default ResetAccount = () => {
     // }
 
     // Go to Settings
-    await waitForElementId('Hamburger')
-    await element(by.id('Hamburger')).tap()
-    await element(by.id('Settings')).tap()
+    await navigateToSettings(navType)
 
     // Scroll to bottom and start the reset process.
     // await waitForElementId('SettingsScrollView')

--- a/e2e/src/usecases/Settings.js
+++ b/e2e/src/usecases/Settings.js
@@ -1,18 +1,22 @@
 import { dismissBanners } from '../utils/banners'
-import { reloadReactNative } from '../utils/retries'
-import { scrollIntoView, sleep, waitForElementId } from '../utils/utils'
+import { reloadReactNative, launchApp } from '../utils/retries'
+import { navigateToSettings, scrollIntoView, sleep, waitForElementByIdAndTap } from '../utils/utils'
 const faker = require('@faker-js/faker')
 
-export default Settings = () => {
+export default Settings = ({ navType }) => {
+  // TODO(ACT-1133): remove this launchApp as it is only needed to update
+  // statsig gate overrides
+  beforeAll(async () => {
+    await launchApp({
+      newInstance: false,
+      permissions: { notifications: 'YES', contacts: 'YES' },
+      launchArgs: { statsigGateOverrides: `use_tab_navigator=${navType === 'tab'}` },
+    })
+  })
+
   beforeEach(async () => {
     await reloadReactNative()
-    await waitForElementId('Hamburger')
-    await element(by.id('Hamburger')).tap()
-    await scrollIntoView('Settings', 'SettingsScrollView')
-    await waitFor(element(by.id('Settings')))
-      .toBeVisible()
-      .withTimeout(30000)
-    await element(by.id('Settings')).tap()
+    await navigateToSettings(navType)
     await sleep(3000)
   })
 
@@ -28,8 +32,7 @@ export default Settings = () => {
       .toBeVisible()
       .withTimeout(1000 * 10)
     await dismissBanners()
-    await waitForElementId('Hamburger')
-    await element(by.id('Hamburger')).tap()
+    await waitForElementByIdAndTap(navType === 'tab' ? 'BackChevron' : 'Hamburger')
     // TODO replace this with an ID selector
     await expect(element(by.text(`${randomName}`))).toBeVisible()
   })

--- a/e2e/src/usecases/Support.js
+++ b/e2e/src/usecases/Support.js
@@ -1,5 +1,5 @@
-import { reloadReactNative } from '../utils/retries'
-import { scrollIntoView, waitForElementId } from '../utils/utils'
+import { reloadReactNative, launchApp } from '../utils/retries'
+import { scrollIntoView, waitForElementId, waitForElementByIdAndTap } from '../utils/utils'
 
 export default Support = () => {
   beforeEach(async () => {
@@ -32,7 +32,7 @@ export default Support = () => {
   }
 
   jest.retryTimes(2)
-  it('Send Message to Support', async () => {
+  it('Send Message to Support (drawer)', async () => {
     await waitForElementId('Hamburger')
     await element(by.id('Hamburger')).tap()
     await scrollIntoView('Help', 'SettingsScrollView')
@@ -40,6 +40,26 @@ export default Support = () => {
       .toExist()
       .withTimeout(10000)
     await element(by.id('Help')).tap()
+    await waitFor(element(by.id('SupportContactLink')))
+      .toBeVisible()
+      .withTimeout(10000)
+    await element(by.id('SupportContactLink')).tap()
+    await waitFor(element(by.id('MessageEntry')))
+      .toBeVisible()
+      .withTimeout(10000)
+    await element(by.id('MessageEntry')).tap()
+    await element(by.id('MessageEntry')).typeText('This is a test from Valora')
+    await expect(element(by.id('MessageEntry'))).toHaveText('This is a test from Valora')
+  })
+
+  it('Send Message to Support (tab)', async () => {
+    await launchApp({
+      newInstance: false,
+      permissions: { notifications: 'YES', contacts: 'YES' },
+      launchArgs: { statsigGateOverrides: `use_tab_navigator=true` },
+    })
+    await waitForElementByIdAndTap('WalletHome/AccountCircle')
+    await waitForElementByIdAndTap('ProfileMenu/Help')
     await waitFor(element(by.id('SupportContactLink')))
       .toBeVisible()
       .withTimeout(10000)

--- a/e2e/src/usecases/WalletConnectV2.js
+++ b/e2e/src/usecases/WalletConnectV2.js
@@ -12,7 +12,7 @@ import { hexToNumber } from 'viem'
 import { parseTransaction } from 'viem/celo'
 import { formatUri, utf8ToHex } from '../utils/encoding'
 import { launchApp } from '../utils/retries'
-import { enterPinUiIfNecessary, scrollIntoView, sleep, waitForElementId } from '../utils/utils'
+import { enterPinUiIfNecessary, navigateToSettings, sleep } from '../utils/utils'
 
 import jestExpect from 'expect'
 
@@ -360,12 +360,7 @@ export default WalletConnect = () => {
   })
 
   it('Then should be able to disconnect a session', async () => {
-    await waitForElementId('Hamburger')
-    await element(by.id('Hamburger')).tap()
-
-    await scrollIntoView('Settings', 'SettingsScrollView')
-    await waitForElementId('Settings')
-    await element(by.id('Settings')).tap()
+    await navigateToSettings('drawer')
     await element(by.id('ConnectedApplications')).tap()
     await element(by.text('Tap to Disconnect')).tap()
     await element(by.text('Disconnect')).tap()

--- a/e2e/src/utils/utils.js
+++ b/e2e/src/utils/utils.js
@@ -427,3 +427,16 @@ export async function fundWallet(senderPrivateKey, recipientAddress, stableToken
 export const createCommentText = () => {
   return `${new Date().getTime()}-${parseInt(Math.random() * 100_000)}`
 }
+
+export async function navigateToSettings(navType) {
+  if (navType === 'tab') {
+    await waitForElementByIdAndTap('WalletHome/AccountCircle')
+    await waitForElementByIdAndTap('ProfileMenu/Settings')
+  } else {
+    await waitForElementId('Hamburger')
+    await element(by.id('Hamburger')).tap()
+    await scrollIntoView('Settings', 'SettingsScrollView')
+    await waitForElementId('Settings')
+    await element(by.id('Settings')).tap()
+  }
+}


### PR DESCRIPTION
### Description

Updates the following tests

- AccountManagement.spec.js - updates to run against both variants
- Pin.spec.js - updates to run against both variants
- Verify.spec.js - updated to run against tab navigator (no need for drawer here since there's sufficient coverage against drawer settings)
- WalletConnect.spec.js - still runs agains the drawer (hard to override statsig gate since app launched from deeplink in some cases) but reuses the `navigateToSettings` helper so its easier to update when tab is rolled out

### Test plan

CI

### Related issues

- Part of ACT-1113

### Backwards compatibility

N/A

### Network scalability

N/A