### PR TITLE
feat(feed): include network icon in tx feed items

### DIFF
--- a/src/components/IconWithNetworkBadge.tsx
+++ b/src/components/IconWithNetworkBadge.tsx
@@ -11,7 +11,7 @@ interface Props {
 }
 
 export default function IconWithNetworkBadge({ networkId, children }: Props) {
-  const networkIcons = useSelector((state) => networksIconSelector(state, [networkId]))
+  const networkIcons = useSelector(networksIconSelector)
   const networkImageUrl = networkIcons[networkId]
   return (
     <View>

--- a/src/components/IconWithNetworkBadge.tsx
+++ b/src/components/IconWithNetworkBadge.tsx
@@ -1,0 +1,40 @@
+import React from 'react'
+import { StyleSheet, View } from 'react-native'
+import FastImage from 'react-native-fast-image'
+import { useSelector } from 'src/redux/hooks'
+import { networksIconSelector } from 'src/tokens/selectors'
+import { NetworkId } from 'src/transactions/types'
+
+interface Props {
+  networkId: NetworkId
+  children: React.ReactNode
+}
+
+export default function IconWithNetworkBadge({ networkId, children }: Props) {
+  const networkIcons = useSelector((state) => networksIconSelector(state, [networkId]))
+  const networkImageUrl = networkIcons[networkId]
+  return (
+    <View>
+      {children}
+      {networkImageUrl && (
+        <FastImage
+          source={{
+            uri: networkImageUrl,
+          }}
+          style={styles.networkIconStyle}
+        />
+      )}
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  networkIconStyle: {
+    position: 'absolute',
+    width: 16,
+    height: 16,
+    borderRadius: 8,
+    top: 25,
+    left: 25,
+  },
+})

--- a/src/components/IconWithNetworkBadge.tsx
+++ b/src/components/IconWithNetworkBadge.tsx
@@ -10,6 +10,7 @@ interface Props {
   children: React.ReactNode
 }
 
+// TODO(ACT-1137): update TokenIcon to use this
 export default function IconWithNetworkBadge({ networkId, children }: Props) {
   const networkIcons = useSelector(networksIconSelector)
   const networkImageUrl = networkIcons[networkId]

--- a/src/transactions/feed/NftFeedItem.tsx
+++ b/src/transactions/feed/NftFeedItem.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { StyleSheet, Text, View } from 'react-native'
 import { HomeEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
+import IconWithNetworkBadge from 'src/components/IconWithNetworkBadge'
 import Touchable from 'src/components/Touchable'
 import ImageErrorIcon from 'src/icons/ImageErrorIcon'
 import NftReceivedIcon from 'src/icons/NftReceivedIcon'
@@ -33,27 +34,29 @@ function NftFeedItem({ transaction }: Props) {
   return (
     <Touchable testID={'NftFeedItem'} disabled={false} onPress={openNftTransactionDetails}>
       <View style={styles.container}>
-        {/* If enabled try to show the first image. Otherwise display the default icons */}
-        {nfts.length > 0 && nfts[0].metadata?.image ? (
-          <NftMedia
-            nft={nfts[0]}
-            ErrorComponent={
-              <View style={styles.errorCircleIcon}>
-                <ImageErrorIcon size={30} testID="NftFeedItem/NftErrorIcon" />
-              </View>
-            }
-            borderRadius={20}
-            width={40}
-            height={40}
-            testID="NftFeedItem/NftIcon"
-            origin={NftOrigin.TransactionFeed}
-            mediaType="image"
-          />
-        ) : transaction.type === TokenTransactionTypeV2.NftReceived ? (
-          <NftReceivedIcon />
-        ) : (
-          <NftSentIcon />
-        )}
+        {/* Try to show the first image. Otherwise display the default icons */}
+        <IconWithNetworkBadge networkId={transaction.networkId}>
+          {nfts.length > 0 && nfts[0].metadata?.image ? (
+            <NftMedia
+              nft={nfts[0]}
+              ErrorComponent={
+                <View style={styles.errorCircleIcon}>
+                  <ImageErrorIcon size={30} testID="NftFeedItem/NftErrorIcon" />
+                </View>
+              }
+              borderRadius={20}
+              width={40}
+              height={40}
+              testID="NftFeedItem/NftIcon"
+              origin={NftOrigin.TransactionFeed}
+              mediaType="image"
+            />
+          ) : transaction.type === TokenTransactionTypeV2.NftReceived ? (
+            <NftReceivedIcon />
+          ) : (
+            <NftSentIcon />
+          )}
+        </IconWithNetworkBadge>
         <Text style={styles.title}>
           {transaction.type === TokenTransactionTypeV2.NftReceived
             ? t('receivedNft')

--- a/src/transactions/feed/SwapFeedItem.tsx
+++ b/src/transactions/feed/SwapFeedItem.tsx
@@ -36,7 +36,11 @@ function SwapFeedItem({ exchange }: Props) {
   return (
     <Touchable testID="SwapFeedItem" onPress={handleTransferDetails}>
       <View style={styles.container}>
-        <TransactionFeedItemImage status={exchange.status} transactionType={exchange.__typename} />
+        <TransactionFeedItemImage
+          status={exchange.status}
+          transactionType={exchange.__typename}
+          networkId={exchange.networkId}
+        />
         <View style={styles.contentContainer}>
           <Text style={styles.title} testID={'SwapFeedItem/title'} numberOfLines={1}>
             {t('swapScreen.title')}

--- a/src/transactions/feed/TokenApprovalFeedItem.test.tsx
+++ b/src/transactions/feed/TokenApprovalFeedItem.test.tsx
@@ -1,9 +1,11 @@
 import { fireEvent, render } from '@testing-library/react-native'
 import React from 'react'
+import { Provider } from 'react-redux'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import { getDynamicConfigParams } from 'src/statsig'
 import TokenApprovalFeedItem from 'src/transactions/feed/TokenApprovalFeedItem'
+import { createMockStore } from 'test/utils'
 import { mockApprovalTransaction } from 'test/values'
 
 jest.mock('src/statsig')
@@ -17,7 +19,11 @@ describe('TokenApprovalFeedItem', () => {
   })
 
   it('should display the feed item title and open the details screen on press', () => {
-    const tree = render(<TokenApprovalFeedItem transaction={mockApprovalTransaction} />)
+    const tree = render(
+      <Provider store={createMockStore()}>
+        <TokenApprovalFeedItem transaction={mockApprovalTransaction} />
+      </Provider>
+    )
 
     expect(tree.getByText('transactionFeed.approvalTransactionTitle')).toBeTruthy()
     fireEvent.press(

--- a/src/transactions/feed/TokenApprovalFeedItem.tsx
+++ b/src/transactions/feed/TokenApprovalFeedItem.tsx
@@ -33,6 +33,7 @@ function TokenApprovalFeedItem({ transaction }: Props) {
         <TransactionFeedItemImage
           status={transaction.status}
           transactionType={transaction.__typename}
+          networkId={transaction.networkId}
         />
         <Text style={styles.title}>{t('transactionFeed.approvalTransactionTitle')}</Text>
       </View>

--- a/src/transactions/feed/TransactionFeedItemImage.tsx
+++ b/src/transactions/feed/TransactionFeedItemImage.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import ContactCircle from 'src/components/ContactCircle'
+import IconWithNetworkBadge from 'src/components/IconWithNetworkBadge'
 import Activity from 'src/icons/Activity'
 import AttentionIcon from 'src/icons/Attention'
 import CircledIcon from 'src/icons/CircledIcon'
@@ -8,28 +9,26 @@ import MagicWand from 'src/icons/MagicWand'
 import SwapIcon from 'src/icons/SwapIcon'
 import { Recipient } from 'src/recipients/recipient'
 import Colors from 'src/styles/colors'
-import { TransactionStatus } from 'src/transactions/types'
+import { NetworkId, TransactionStatus } from 'src/transactions/types'
 import Logger from 'src/utils/Logger'
 
 const AVATAR_SIZE = 40
 
-type Props =
+type Props = { networkId: NetworkId; status: TransactionStatus } & (
   | {
-      status: TransactionStatus
       transactionType: 'TokenExchangeV3'
     }
   | {
-      status: TransactionStatus
       transactionType: 'TokenTransferV3'
       recipient: Recipient
       isJumpstart: boolean
     }
   | {
-      status: TransactionStatus
       transactionType: 'TokenApproval'
     }
+)
 
-function TransactionFeedItemImage(props: Props) {
+function TransactionFeedItemBaseImage(props: Props) {
   const { status, transactionType } = props
 
   if (status === TransactionStatus.Failed) {
@@ -71,6 +70,14 @@ function TransactionFeedItemImage(props: Props) {
     `Could not render image for transaction for transaction type ${transactionType} and status ${status}`
   )
   return null
+}
+
+function TransactionFeedItemImage(props: Props) {
+  return (
+    <IconWithNetworkBadge networkId={props.networkId}>
+      <TransactionFeedItemBaseImage {...props} />
+    </IconWithNetworkBadge>
+  )
 }
 
 export default TransactionFeedItemImage

--- a/src/transactions/feed/TransferFeedItem.tsx
+++ b/src/transactions/feed/TransferFeedItem.tsx
@@ -49,6 +49,7 @@ function TransferFeedItem({ transfer }: Props) {
           status={transfer.status}
           transactionType={transfer.__typename}
           isJumpstart={isJumpstartTransaction(transfer)}
+          networkId={transfer.networkId}
         />
         <View style={styles.contentContainer}>
           <Text style={styles.title} testID={'TransferFeedItem/title'} numberOfLines={1}>


### PR DESCRIPTION
### Description

Made a reusable component to create an icon with a badge and used for all icons in the tx feed

### Test plan

Manually

| Pending, send/receive | Nfts and swaps |
|:--------:|:--------:|
| <img src="https://github.com/valora-inc/wallet/assets/5062591/756a7902-3169-4371-875c-51dad8659425" width="250" /> | <img src="https://github.com/valora-inc/wallet/assets/5062591/5a5c1aae-9b9e-48bb-8fee-8be64843d941" width="250" /> | 



### Related issues

- Fixes ACT-105

### Backwards compatibility

Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
