### PR TITLE
fix: last item obscured when limited positions or tokens

### DIFF
--- a/src/tokens/AssetList.tsx
+++ b/src/tokens/AssetList.tsx
@@ -279,7 +279,7 @@ export default function AssetList({
   return (
     <AnimatedSectionList
       contentContainerStyle={[
-        { minHeight: variables.height + headerHeight },
+        { minHeight: variables.height + (isWalletTab ? 0 : headerHeight) },
         {
           paddingBottom: isWalletTab ? 0 : insets.bottom,
           opacity: listHeaderHeight > 0 ? 1 : 0,

--- a/src/tokens/AssetList.tsx
+++ b/src/tokens/AssetList.tsx
@@ -279,6 +279,8 @@ export default function AssetList({
   return (
     <AnimatedSectionList
       contentContainerStyle={[
+        // TODO (act-ACT-1133): remove conditional and headerHeight
+        // Only needed on Android with DrawerTopBar; headerHeight is 0 on iOS
         { minHeight: variables.height + (isWalletTab ? 0 : headerHeight) },
         {
           paddingBottom: isWalletTab ? 0 : insets.bottom,

--- a/src/tokens/AssetList.tsx
+++ b/src/tokens/AssetList.tsx
@@ -277,6 +277,7 @@ export default function AssetList({
   return (
     <AnimatedSectionList
       contentContainerStyle={[
+        styles.containerHeight,
         {
           paddingBottom: isWalletTab ? 0 : insets.bottom,
           opacity: listHeaderHeight > 0 ? 1 : 0,
@@ -383,5 +384,8 @@ const styles = StyleSheet.create({
   importTokenText: {
     ...typeScale.labelMedium,
     color: Colors.black,
+  },
+  containerHeight: {
+    minHeight: variables.height,
   },
 })

--- a/src/tokens/AssetList.tsx
+++ b/src/tokens/AssetList.tsx
@@ -1,3 +1,4 @@
+import { useHeaderHeight } from '@react-navigation/elements'
 import React, { useEffect, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import {
@@ -95,6 +96,7 @@ export default function AssetList({
   const dispatch = useDispatch()
   const { t } = useTranslation()
   const insets = useSafeAreaInsets()
+  const headerHeight = useHeaderHeight()
 
   const supportedNetworkIds = getSupportedNetworkIdsForTokenBalances()
   const tokens = useSelector((state) =>
@@ -277,7 +279,7 @@ export default function AssetList({
   return (
     <AnimatedSectionList
       contentContainerStyle={[
-        styles.containerHeight,
+        { minHeight: variables.height + headerHeight },
         {
           paddingBottom: isWalletTab ? 0 : insets.bottom,
           opacity: listHeaderHeight > 0 ? 1 : 0,
@@ -384,8 +386,5 @@ const styles = StyleSheet.create({
   importTokenText: {
     ...typeScale.labelMedium,
     color: Colors.black,
-  },
-  containerHeight: {
-    minHeight: variables.height,
   },
 })

--- a/src/tokens/AssetList.tsx
+++ b/src/tokens/AssetList.tsx
@@ -279,7 +279,7 @@ export default function AssetList({
   return (
     <AnimatedSectionList
       contentContainerStyle={[
-        // TODO (act-ACT-1133): remove conditional and headerHeight
+        // TODO (ACT-1133): remove conditional and headerHeight
         // Only needed on Android with DrawerTopBar; headerHeight is 0 on iOS
         { minHeight: variables.height + (isWalletTab ? 0 : headerHeight) },
         {


### PR DESCRIPTION
### Description

Adds a minimum height to the `AnimatedSectionList` container styles to prevent the last item from being obscured.

#### iOS Video (Tabs)

https://github.com/valora-inc/wallet/assets/26950305/3390a615-e367-4dad-9fc5-c516280930b9

#### iOS Video (Drawer)

https://github.com/valora-inc/wallet/assets/26950305/cdcf7694-6180-42ff-937a-838cdba41047

#### Android Video (Tabs)

https://github.com/valora-inc/wallet/assets/26950305/54d78cfd-27de-4577-9396-7198373f308f

#### Android Video (Drawer)

https://github.com/valora-inc/wallet/assets/26950305/f165e3dc-f8a5-47cc-b841-9e92a4b2814f





### Test plan

- Tested locally on iOS
- Tested locally on Android

### Related issues

- Fixes ACT-1116

### Backwards compatibility

Yes

### Network scalability

N/A