### PR TITLE
chore: add fees to send confirmation

### DIFF
--- a/src/components/LineItemRow.tsx
+++ b/src/components/LineItemRow.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { ActivityIndicator, StyleSheet, Text, TextStyle, View, ViewStyle } from 'react-native'
 import colors from 'src/styles/colors'
-import fontStyles from 'src/styles/fonts'
+import { typeScale } from 'src/styles/fonts'
 
 interface LineItemProps {
   style?: ViewStyle
@@ -66,7 +66,7 @@ const styles = StyleSheet.create({
     marginRight: 5,
   },
   text: {
-    ...fontStyles.regular,
+    ...typeScale.labelMedium,
     color: colors.black,
   },
   loadingContainer: {

--- a/src/components/TokenTotalLineItem.tsx
+++ b/src/components/TokenTotalLineItem.tsx
@@ -6,7 +6,7 @@ import LineItemRow from 'src/components/LineItemRow'
 import TokenDisplay, { formatValueToDisplay } from 'src/components/TokenDisplay'
 import { LocalCurrencyCode, LocalCurrencySymbol } from 'src/localCurrency/consts'
 import colors from 'src/styles/colors'
-import fontStyles from 'src/styles/fonts'
+import { typeScale } from 'src/styles/fonts'
 import { useTokenInfo } from 'src/tokens/hooks'
 import { LocalAmount } from 'src/transactions/types'
 
@@ -42,7 +42,7 @@ export default function TokenTotalLineItem({
     <>
       <LineItemRow
         title={title ?? t('total')}
-        textStyle={fontStyles.regular600}
+        textStyle={typeScale.labelSemiBoldMedium}
         amount={
           <TokenDisplay
             amount={tokenAmount.plus(feeInToken ?? 0)}
@@ -93,11 +93,11 @@ const styles = StyleSheet.create({
     marginVertical: 0,
   },
   subtotalText: {
-    ...fontStyles.small,
+    ...typeScale.labelSmall,
     color: colors.gray4,
   },
   exchangeRate: {
-    ...fontStyles.small,
+    ...typeScale.labelSmall,
     color: colors.gray4,
   },
 })

--- a/src/escrow/__snapshots__/ReclaimPaymentConfirmationCard.test.tsx.snap
+++ b/src/escrow/__snapshots__/ReclaimPaymentConfirmationCard.test.tsx.snap
@@ -168,9 +168,9 @@ exports[`ReclaimPaymentConfirmationCard renders correctly for send payment confi
           [
             {
               "color": "#2E3338",
-              "fontFamily": "Inter-Regular",
+              "fontFamily": "Inter-Medium",
               "fontSize": 16,
-              "lineHeight": 22,
+              "lineHeight": 24,
             },
             undefined,
           ]
@@ -185,9 +185,9 @@ exports[`ReclaimPaymentConfirmationCard renders correctly for send payment confi
         [
           {
             "color": "#2E3338",
-            "fontFamily": "Inter-Regular",
+            "fontFamily": "Inter-Medium",
             "fontSize": 16,
-            "lineHeight": 22,
+            "lineHeight": 24,
           },
           undefined,
         ]
@@ -227,9 +227,9 @@ exports[`ReclaimPaymentConfirmationCard renders correctly for send payment confi
           [
             {
               "color": "#2E3338",
-              "fontFamily": "Inter-Regular",
+              "fontFamily": "Inter-Medium",
               "fontSize": 16,
-              "lineHeight": 22,
+              "lineHeight": 24,
             },
             undefined,
           ]
@@ -341,9 +341,9 @@ exports[`ReclaimPaymentConfirmationCard renders correctly for send payment confi
         [
           {
             "color": "#2E3338",
-            "fontFamily": "Inter-Regular",
+            "fontFamily": "Inter-Medium",
             "fontSize": 16,
-            "lineHeight": 22,
+            "lineHeight": 24,
           },
           undefined,
         ]
@@ -397,15 +397,14 @@ exports[`ReclaimPaymentConfirmationCard renders correctly for send payment confi
           [
             {
               "color": "#2E3338",
-              "fontFamily": "Inter-Regular",
+              "fontFamily": "Inter-Medium",
               "fontSize": 16,
-              "lineHeight": 22,
+              "lineHeight": 24,
             },
             {
-              "color": "#2E3338",
               "fontFamily": "Inter-SemiBold",
               "fontSize": 16,
-              "lineHeight": 22,
+              "lineHeight": 24,
             },
           ]
         }
@@ -419,15 +418,14 @@ exports[`ReclaimPaymentConfirmationCard renders correctly for send payment confi
         [
           {
             "color": "#2E3338",
-            "fontFamily": "Inter-Regular",
+            "fontFamily": "Inter-Medium",
             "fontSize": 16,
-            "lineHeight": 22,
+            "lineHeight": 24,
           },
           {
-            "color": "#2E3338",
             "fontFamily": "Inter-SemiBold",
             "fontSize": 16,
-            "lineHeight": 22,
+            "lineHeight": 24,
           },
         ]
       }
@@ -470,15 +468,15 @@ exports[`ReclaimPaymentConfirmationCard renders correctly for send payment confi
           [
             {
               "color": "#2E3338",
-              "fontFamily": "Inter-Regular",
+              "fontFamily": "Inter-Medium",
               "fontSize": 16,
-              "lineHeight": 22,
+              "lineHeight": 24,
             },
             {
               "color": "#666666",
-              "fontFamily": "Inter-Regular",
+              "fontFamily": "Inter-Medium",
               "fontSize": 14,
-              "lineHeight": 18,
+              "lineHeight": 20,
             },
           ]
         }
@@ -488,9 +486,9 @@ exports[`ReclaimPaymentConfirmationCard renders correctly for send payment confi
           style={
             {
               "color": "#666666",
-              "fontFamily": "Inter-Regular",
+              "fontFamily": "Inter-Medium",
               "fontSize": 14,
-              "lineHeight": 18,
+              "lineHeight": 20,
             }
           }
           testID="TotalLineItem/ExchangeRate"
@@ -508,15 +506,15 @@ exports[`ReclaimPaymentConfirmationCard renders correctly for send payment confi
         [
           {
             "color": "#2E3338",
-            "fontFamily": "Inter-Regular",
+            "fontFamily": "Inter-Medium",
             "fontSize": 16,
-            "lineHeight": 22,
+            "lineHeight": 24,
           },
           {
             "color": "#666666",
-            "fontFamily": "Inter-Regular",
+            "fontFamily": "Inter-Medium",
             "fontSize": 14,
-            "lineHeight": 18,
+            "lineHeight": 20,
           },
         ]
       }

--- a/src/send/SendConfirmation.tsx
+++ b/src/send/SendConfirmation.tsx
@@ -149,38 +149,36 @@ function SendConfirmation(props: Props) {
   const FeeContainer = () => {
     return (
       <View style={styles.feeContainer}>
-        <>
-          <LineItemRow
-            testID="SendConfirmation/fee"
-            title={t('feeEstimate')}
-            amount={
-              maxFeeAmount && (
-                <TokenDisplay
-                  amount={maxFeeAmount}
-                  tokenId={feeTokenInfo?.tokenId}
-                  showLocalAmount={false}
-                />
-              )
-            }
-            isLoading={!maxFeeAmount}
-          />
-          <LineItemRow
-            testID="SendConfirmation/localFee"
-            title=""
-            textStyle={{ ...fontStyles.small }}
-            style={{ marginVertical: 0 }}
-            amount={
-              maxFeeAmount && (
-                <TokenDisplay
-                  amount={maxFeeAmount}
-                  tokenId={feeTokenInfo?.tokenId}
-                  showLocalAmount={true}
-                />
-              )
-            }
-            isLoading={!maxFeeAmount}
-          />
-        </>
+        <LineItemRow
+          testID="SendConfirmation/fee"
+          title={t('feeEstimate')}
+          textStyle={{ ...typeScale.bodyMedium }}
+          amount={
+            maxFeeAmount && (
+              <TokenDisplay
+                amount={maxFeeAmount}
+                tokenId={feeTokenInfo?.tokenId}
+                showLocalAmount={false}
+              />
+            )
+          }
+          isLoading={!maxFeeAmount}
+        />
+        <LineItemRow
+          testID="SendConfirmation/localFee"
+          title=""
+          style={styles.subHeading}
+          textStyle={styles.subHeadingText}
+          amount={
+            maxFeeAmount && (
+              <TokenDisplay
+                amount={maxFeeAmount}
+                tokenId={feeTokenInfo?.tokenId}
+                showLocalAmount={true}
+              />
+            )
+          }
+        />
         <TokenTotalLineItem
           tokenAmount={tokenAmount}
           tokenId={tokenId}
@@ -343,7 +341,6 @@ const styles = StyleSheet.create({
   feeContainer: {
     padding: 16,
     paddingBottom: 8,
-    gap: 8,
   },
   transferContainer: {
     alignItems: 'flex-start',
@@ -390,6 +387,13 @@ const styles = StyleSheet.create({
     ...fontStyles.regular,
     color: colors.infoDark,
     paddingRight: 8,
+  },
+  subHeading: {
+    marginVertical: 0,
+  },
+  subHeadingText: {
+    ...fontStyles.small,
+    color: colors.gray4,
   },
 })
 

--- a/src/send/SendConfirmation.tsx
+++ b/src/send/SendConfirmation.tsx
@@ -149,21 +149,38 @@ function SendConfirmation(props: Props) {
   const FeeContainer = () => {
     return (
       <View style={styles.feeContainer}>
-        <LineItemRow
-          testID="SendConfirmation/fee"
-          title={t('feeEstimate')}
-          amount={
-            maxFeeAmount && (
-              <TokenDisplay
-                amount={maxFeeAmount}
-                tokenId={feeTokenInfo?.tokenId}
-                showLocalAmount={false}
-              />
-            )
-          }
-          isLoading={!maxFeeAmount}
-        />
-
+        <>
+          <LineItemRow
+            testID="SendConfirmation/fee"
+            title={t('feeEstimate')}
+            amount={
+              maxFeeAmount && (
+                <TokenDisplay
+                  amount={maxFeeAmount}
+                  tokenId={feeTokenInfo?.tokenId}
+                  showLocalAmount={false}
+                />
+              )
+            }
+            isLoading={!maxFeeAmount}
+          />
+          <LineItemRow
+            testID="SendConfirmation/localFee"
+            title=""
+            textStyle={{ ...fontStyles.small }}
+            style={{ marginVertical: 0 }}
+            amount={
+              maxFeeAmount && (
+                <TokenDisplay
+                  amount={maxFeeAmount}
+                  tokenId={feeTokenInfo?.tokenId}
+                  showLocalAmount={true}
+                />
+              )
+            }
+            isLoading={!maxFeeAmount}
+          />
+        </>
         <TokenTotalLineItem
           tokenAmount={tokenAmount}
           tokenId={tokenId}
@@ -326,6 +343,7 @@ const styles = StyleSheet.create({
   feeContainer: {
     padding: 16,
     paddingBottom: 8,
+    gap: 8,
   },
   transferContainer: {
     alignItems: 'flex-start',

--- a/src/send/SendConfirmation.tsx
+++ b/src/send/SendConfirmation.tsx
@@ -38,7 +38,7 @@ import {
 import { usePrepareSendTransactions } from 'src/send/usePrepareSendTransactions'
 import DisconnectBanner from 'src/shared/DisconnectBanner'
 import colors from 'src/styles/colors'
-import fontStyles, { typeScale } from 'src/styles/fonts'
+import { typeScale } from 'src/styles/fonts'
 import { iconHitslop } from 'src/styles/variables'
 import { useAmountAsUsd, useTokenInfo, useTokenToLocalAmount } from 'src/tokens/hooks'
 import { feeCurrenciesSelector } from 'src/tokens/selectors'
@@ -152,7 +152,7 @@ function SendConfirmation(props: Props) {
         <LineItemRow
           testID="SendConfirmation/fee"
           title={t('feeEstimate')}
-          textStyle={{ ...typeScale.bodyMedium }}
+          textStyle={typeScale.bodyMedium}
           amount={
             maxFeeAmount && (
               <TokenDisplay
@@ -354,23 +354,25 @@ const styles = StyleSheet.create({
     paddingLeft: 8,
   },
   headerText: {
-    ...fontStyles.regular,
+    ...typeScale.labelMedium,
     color: colors.gray4,
   },
   displayName: {
-    ...fontStyles.regular500,
+    ...typeScale.labelMedium,
+    color: colors.black,
   },
   addressContainer: {
     flexDirection: 'row',
   },
   address: {
-    ...fontStyles.small,
+    ...typeScale.labelSmall,
     color: colors.gray5,
     paddingRight: 4,
   },
   amount: {
+    ...typeScale.titleLarge,
     paddingVertical: 8,
-    ...fontStyles.largeNumber,
+    color: colors.black,
   },
   amountSubscript: {
     ...typeScale.bodyMedium,
@@ -384,7 +386,7 @@ const styles = StyleSheet.create({
     marginVertical: 16,
   },
   encryptionWarningLabel: {
-    ...fontStyles.regular,
+    ...typeScale.labelMedium,
     color: colors.infoDark,
     paddingRight: 8,
   },
@@ -392,7 +394,7 @@ const styles = StyleSheet.create({
     marginVertical: 0,
   },
   subHeadingText: {
-    ...fontStyles.small,
+    ...typeScale.labelSmall,
     color: colors.gray4,
   },
 })

--- a/src/send/__snapshots__/SendConfirmation.test.tsx.snap
+++ b/src/send/__snapshots__/SendConfirmation.test.tsx.snap
@@ -225,9 +225,9 @@ exports[`SendConfirmation renders correctly 1`] = `
                   style={
                     {
                       "color": "#666666",
-                      "fontFamily": "Inter-Regular",
+                      "fontFamily": "Inter-Medium",
                       "fontSize": 16,
-                      "lineHeight": 22,
+                      "lineHeight": 24,
                     }
                   }
                   testID="HeaderText"
@@ -240,7 +240,7 @@ exports[`SendConfirmation renders correctly 1`] = `
                       "color": "#2E3338",
                       "fontFamily": "Inter-Medium",
                       "fontSize": 16,
-                      "lineHeight": 22,
+                      "lineHeight": 24,
                     }
                   }
                   testID="DisplayName"
@@ -253,8 +253,9 @@ exports[`SendConfirmation renders correctly 1`] = `
               style={
                 {
                   "color": "#2E3338",
-                  "fontFamily": "Inter-SemiBold",
+                  "fontFamily": "Inter-Bold",
                   "fontSize": 32,
+                  "letterSpacing": -0.32,
                   "lineHeight": 40,
                   "paddingVertical": 8,
                 }
@@ -371,9 +372,9 @@ exports[`SendConfirmation renders correctly 1`] = `
               [
                 {
                   "color": "#2E3338",
-                  "fontFamily": "Inter-Regular",
+                  "fontFamily": "Inter-Medium",
                   "fontSize": 16,
-                  "lineHeight": 22,
+                  "lineHeight": 24,
                 },
                 {
                   "fontFamily": "Inter-Regular",
@@ -392,9 +393,9 @@ exports[`SendConfirmation renders correctly 1`] = `
             [
               {
                 "color": "#2E3338",
-                "fontFamily": "Inter-Regular",
+                "fontFamily": "Inter-Medium",
                 "fontSize": 16,
-                "lineHeight": 22,
+                "lineHeight": 24,
               },
               {
                 "fontFamily": "Inter-Regular",
@@ -440,15 +441,15 @@ exports[`SendConfirmation renders correctly 1`] = `
               [
                 {
                   "color": "#2E3338",
-                  "fontFamily": "Inter-Regular",
+                  "fontFamily": "Inter-Medium",
                   "fontSize": 16,
-                  "lineHeight": 22,
+                  "lineHeight": 24,
                 },
                 {
                   "color": "#666666",
-                  "fontFamily": "Inter-Regular",
+                  "fontFamily": "Inter-Medium",
                   "fontSize": 14,
-                  "lineHeight": 18,
+                  "lineHeight": 20,
                 },
               ]
             }
@@ -460,15 +461,15 @@ exports[`SendConfirmation renders correctly 1`] = `
             [
               {
                 "color": "#2E3338",
-                "fontFamily": "Inter-Regular",
+                "fontFamily": "Inter-Medium",
                 "fontSize": 16,
-                "lineHeight": 22,
+                "lineHeight": 24,
               },
               {
                 "color": "#666666",
-                "fontFamily": "Inter-Regular",
+                "fontFamily": "Inter-Medium",
                 "fontSize": 14,
-                "lineHeight": 18,
+                "lineHeight": 20,
               },
             ]
           }
@@ -507,15 +508,14 @@ exports[`SendConfirmation renders correctly 1`] = `
               [
                 {
                   "color": "#2E3338",
-                  "fontFamily": "Inter-Regular",
+                  "fontFamily": "Inter-Medium",
                   "fontSize": 16,
-                  "lineHeight": 22,
+                  "lineHeight": 24,
                 },
                 {
-                  "color": "#2E3338",
                   "fontFamily": "Inter-SemiBold",
                   "fontSize": 16,
-                  "lineHeight": 22,
+                  "lineHeight": 24,
                 },
               ]
             }
@@ -529,15 +529,14 @@ exports[`SendConfirmation renders correctly 1`] = `
             [
               {
                 "color": "#2E3338",
-                "fontFamily": "Inter-Regular",
+                "fontFamily": "Inter-Medium",
                 "fontSize": 16,
-                "lineHeight": 22,
+                "lineHeight": 24,
               },
               {
-                "color": "#2E3338",
                 "fontFamily": "Inter-SemiBold",
                 "fontSize": 16,
-                "lineHeight": 22,
+                "lineHeight": 24,
               },
             ]
           }
@@ -581,15 +580,15 @@ exports[`SendConfirmation renders correctly 1`] = `
               [
                 {
                   "color": "#2E3338",
-                  "fontFamily": "Inter-Regular",
+                  "fontFamily": "Inter-Medium",
                   "fontSize": 16,
-                  "lineHeight": 22,
+                  "lineHeight": 24,
                 },
                 {
                   "color": "#666666",
-                  "fontFamily": "Inter-Regular",
+                  "fontFamily": "Inter-Medium",
                   "fontSize": 14,
-                  "lineHeight": 18,
+                  "lineHeight": 20,
                 },
               ]
             }
@@ -599,9 +598,9 @@ exports[`SendConfirmation renders correctly 1`] = `
               style={
                 {
                   "color": "#666666",
-                  "fontFamily": "Inter-Regular",
+                  "fontFamily": "Inter-Medium",
                   "fontSize": 14,
-                  "lineHeight": 18,
+                  "lineHeight": 20,
                 }
               }
               testID="TotalLineItem/ExchangeRate"
@@ -619,15 +618,15 @@ exports[`SendConfirmation renders correctly 1`] = `
             [
               {
                 "color": "#2E3338",
-                "fontFamily": "Inter-Regular",
+                "fontFamily": "Inter-Medium",
                 "fontSize": 16,
-                "lineHeight": 22,
+                "lineHeight": 24,
               },
               {
                 "color": "#666666",
-                "fontFamily": "Inter-Regular",
+                "fontFamily": "Inter-Medium",
                 "fontSize": 14,
-                "lineHeight": 18,
+                "lineHeight": 20,
               },
             ]
           }

--- a/src/send/__snapshots__/SendConfirmation.test.tsx.snap
+++ b/src/send/__snapshots__/SendConfirmation.test.tsx.snap
@@ -375,7 +375,11 @@ exports[`SendConfirmation renders correctly 1`] = `
                   "fontSize": 16,
                   "lineHeight": 22,
                 },
-                undefined,
+                {
+                  "fontFamily": "Inter-Regular",
+                  "fontSize": 16,
+                  "lineHeight": 24,
+                },
               ]
             }
             testID="LineItemRowTitle/SendConfirmation/fee"
@@ -392,7 +396,11 @@ exports[`SendConfirmation renders correctly 1`] = `
                 "fontSize": 16,
                 "lineHeight": 22,
               },
-              undefined,
+              {
+                "fontFamily": "Inter-Regular",
+                "fontSize": 16,
+                "lineHeight": 24,
+              },
             ]
           }
           testID="LineItemRow/SendConfirmation/fee"
@@ -400,6 +408,75 @@ exports[`SendConfirmation renders correctly 1`] = `
           <Text>
             0.01
              CELO
+          </Text>
+        </Text>
+      </View>
+      <View
+        style={
+          [
+            {
+              "flexDirection": "row",
+              "flexWrap": "wrap",
+              "justifyContent": "space-between",
+              "marginVertical": 5,
+            },
+            {
+              "marginVertical": 0,
+            },
+          ]
+        }
+      >
+        <View
+          style={
+            {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "marginRight": 5,
+            }
+          }
+        >
+          <Text
+            style={
+              [
+                {
+                  "color": "#2E3338",
+                  "fontFamily": "Inter-Regular",
+                  "fontSize": 16,
+                  "lineHeight": 22,
+                },
+                {
+                  "color": "#666666",
+                  "fontFamily": "Inter-Regular",
+                  "fontSize": 14,
+                  "lineHeight": 18,
+                },
+              ]
+            }
+            testID="LineItemRowTitle/SendConfirmation/localFee"
+          />
+        </View>
+        <Text
+          style={
+            [
+              {
+                "color": "#2E3338",
+                "fontFamily": "Inter-Regular",
+                "fontSize": 16,
+                "lineHeight": 22,
+              },
+              {
+                "color": "#666666",
+                "fontFamily": "Inter-Regular",
+                "fontSize": 14,
+                "lineHeight": 18,
+              },
+            ]
+          }
+          testID="LineItemRow/SendConfirmation/localFee"
+        >
+          <Text>
+            ₱
+            0.067
           </Text>
         </Text>
       </View>


### PR DESCRIPTION
### Description

Adds the line item for local amount display of fees on the send confirmation screen.

| Before iOS stCelo | Before iOS ETH | After iOS stCELO | After iOS ETH |
| ---- | ---- | ---- | ---- |
| ![](https://github.com/valora-inc/wallet/assets/26950305/c53116f4-bd42-4ac9-8f97-03df7dfa2701 "iOS stCelo") | ![](https://github.com/valora-inc/wallet/assets/26950305/da1bcf00-05ab-4840-b1ff-215998feeec7 "iOS ETH") | ![](https://github.com/valora-inc/wallet/assets/26950305/efa83b76-c6ef-4e1d-946f-be232048b5fa "iOS stCelo Fees") | ![](https://github.com/valora-inc/wallet/assets/26950305/365d2fba-1388-4806-be15-541e49b66b4c "iOS ETH Fees") |

### Test plan

- Tested locally on iOS
- Tested locally on Android
- Unit test snapshot updated

### Related issues

- Fixes ACT-1135

### Backwards compatibility

Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
