### PR TITLE
chore(jumpstart): support for reclaim from retired jumpstart contracts

### DIFF
--- a/src/statsig/constants.ts
+++ b/src/statsig/constants.ts
@@ -102,7 +102,11 @@ export const DynamicConfigs = {
     configName: StatsigDynamicConfigs.WALLET_JUMPSTART_CONFIG,
     defaultValues: {
       jumpstartContracts: {} as {
-        [key in NetworkId]?: { contractAddress?: string; depositERC20GasEstimate: string }
+        [key in NetworkId]?: {
+          contractAddress?: string
+          depositERC20GasEstimate: string
+          retiredContractAddresses?: string[]
+        }
       },
       maxAllowedSendAmountUsd: 100,
     },

--- a/src/transactions/feed/TransferFeedItem.test.tsx
+++ b/src/transactions/feed/TransferFeedItem.test.tsx
@@ -43,6 +43,7 @@ const MOCK_CONTACT = {
   contactId: 'contactId',
   address: MOCK_ADDRESS,
 }
+const mockRetiredJumpstartAdddress = '0xabc'
 
 jest.mock('src/statsig')
 
@@ -68,7 +69,10 @@ describe('TransferFeedItem', () => {
     jest.mocked(getFeatureGate).mockReturnValue(true)
     jest.mocked(getDynamicConfigParams).mockReturnValue({
       jumpstartContracts: {
-        [NetworkId['celo-alfajores']]: { contractAddress: mockJumpstartAdddress },
+        [NetworkId['celo-alfajores']]: {
+          contractAddress: mockJumpstartAdddress,
+          retiredContractAddresses: [mockRetiredJumpstartAdddress],
+        },
       },
     })
   })
@@ -654,10 +658,13 @@ describe('TransferFeedItem', () => {
     expect(queryByTestId('TransferFeedItem/tokenAmount')).toBeNull()
   })
 
-  it('renders correctly for jumpstart deposit', async () => {
+  it.each([
+    { address: mockJumpstartAdddress, addressType: 'current' },
+    { address: mockRetiredJumpstartAdddress, addressType: 'retired' },
+  ])('renders correctly for jumpstart deposit to $addressType contract', async ({ address }) => {
     const { getByTestId } = renderScreen({
       type: TokenTransactionTypeV2.Sent,
-      address: mockJumpstartAdddress,
+      address,
       amount: {
         tokenAddress: mockCusdAddress,
         tokenId: mockCusdTokenId,

--- a/src/transactions/feed/TransferFeedItem.tsx
+++ b/src/transactions/feed/TransferFeedItem.tsx
@@ -99,10 +99,15 @@ function TransferFeedItem({ transfer }: Props) {
 }
 
 function isJumpstartTransaction(tx: TokenTransfer) {
-  const jumpstartAddress = getDynamicConfigParams(
+  const jumpstartConfig = getDynamicConfigParams(
     DynamicConfigs[StatsigDynamicConfigs.WALLET_JUMPSTART_CONFIG]
-  ).jumpstartContracts[tx.networkId]?.contractAddress
-  return tx.address === jumpstartAddress
+  ).jumpstartContracts[tx.networkId]
+  const jumpstartAddresses = [
+    jumpstartConfig?.contractAddress,
+    ...(jumpstartConfig?.retiredContractAddresses ?? []),
+  ].filter((address): address is string => !!address)
+
+  return jumpstartAddresses.includes(tx.address)
 }
 
 const styles = StyleSheet.create({


### PR DESCRIPTION
### Description

This PR adds a `retiredContractAddresses` to the jumpstart dynamic config.

If we need to change the contract for whatever reason, we should still allow users to reclaim their funds that were sent to previous versions of the contract. The only place we need to do this is in the transaction classification stage - we should mark transactions to _any_ jumpstart contract appropriately, from there the jumpstart transaction details screen will allow reclaim from that contract directly.

Of course this logic relies on the abi of the jumpstart contracts staying the same, since a single abi is baked into the app. 

### Test plan

Unit tests

### Related issues

n/a

### Backwards compatibility

Y

### Network scalability

Y
