### PR TITLE
feat(send): allow entering amount in fiat

### DIFF
--- a/e2e/src/usecases/HandleDeepLinkSend.js
+++ b/e2e/src/usecases/HandleDeepLinkSend.js
@@ -71,8 +71,8 @@ export default HandleDeepLinkSend = () => {
       await launchDeepLink(PAY_URL)
       await waitForElementId('SendEnterAmount/TokenSelect', 10_000)
       await expect(element(by.text('cUSD')).atIndex(0)).toBeVisible()
-      await element(by.id('SendEnterAmount/Input')).replaceText('0.01')
-      await element(by.id('SendEnterAmount/Input')).tapReturnKey()
+      await element(by.id('SendEnterAmount/TokenAmountInput')).replaceText('0.01')
+      await element(by.id('SendEnterAmount/TokenAmountInput')).tapReturnKey()
       await waitForElementByIdAndTap('SendEnterAmount/ReviewButton', 30_000)
 
       await addComment(commentText)

--- a/e2e/src/usecases/SecureSend.js
+++ b/e2e/src/usecases/SecureSend.js
@@ -68,9 +68,9 @@ export default SecureSend = () => {
       await waitForElementByIdAndTap('cUSDSymbol', 30_000)
 
       // Enter the amount and review
-      await element(by.id('SendEnterAmount/Input')).tap()
-      await element(by.id('SendEnterAmount/Input')).replaceText(AMOUNT_TO_SEND)
-      await element(by.id('SendEnterAmount/Input')).tapReturnKey()
+      await element(by.id('SendEnterAmount/TokenAmountInput')).tap()
+      await element(by.id('SendEnterAmount/TokenAmountInput')).replaceText(AMOUNT_TO_SEND)
+      await element(by.id('SendEnterAmount/TokenAmountInput')).tapReturnKey()
       await element(by.id('SendEnterAmount/ReviewButton')).tap()
 
       // Write a comment.

--- a/e2e/src/usecases/Send.js
+++ b/e2e/src/usecases/Send.js
@@ -50,7 +50,7 @@ export default Send = () => {
 
     it('Then tapping send button should navigate to Send Enter Amount screen', async () => {
       await element(by.id('SendOrInviteButton')).tap()
-      await waitForElementId('SendEnterAmount/Input', 30_000)
+      await waitForElementId('SendEnterAmount/TokenAmountInput', 30_000)
     })
 
     it('Then should be able to change token', async () => {
@@ -66,9 +66,9 @@ export default Send = () => {
     })
 
     it('Then should be able to enter amount and navigate to review screen', async () => {
-      await waitForElementByIdAndTap('SendEnterAmount/Input', 30_000)
-      await element(by.id('SendEnterAmount/Input')).replaceText('0.01')
-      await element(by.id('SendEnterAmount/Input')).tapReturnKey()
+      await waitForElementByIdAndTap('SendEnterAmount/TokenAmountInput', 30_000)
+      await element(by.id('SendEnterAmount/TokenAmountInput')).replaceText('0.01')
+      await element(by.id('SendEnterAmount/TokenAmountInput')).tapReturnKey()
       await waitForElementByIdAndTap('SendEnterAmount/ReviewButton', 30_000)
       await isElementVisible('ConfirmButton')
     })
@@ -86,10 +86,10 @@ export default Send = () => {
     it('Then should be able to edit amount', async () => {
       await element(by.id('BackChevron')).tap()
       await isElementVisible('SendEnterAmount/ReviewButton')
-      await element(by.id('SendEnterAmount/Input')).tap()
-      await waitForElementByIdAndTap('SendEnterAmount/Input', 30_000)
-      await element(by.id('SendEnterAmount/Input')).replaceText('0.01')
-      await element(by.id('SendEnterAmount/Input')).tapReturnKey()
+      await element(by.id('SendEnterAmount/TokenAmountInput')).tap()
+      await waitForElementByIdAndTap('SendEnterAmount/TokenAmountInput', 30_000)
+      await element(by.id('SendEnterAmount/TokenAmountInput')).replaceText('0.01')
+      await element(by.id('SendEnterAmount/TokenAmountInput')).tapReturnKey()
       await waitForElementByIdAndTap('SendEnterAmount/ReviewButton', 30_000)
       let amount = await element(by.id('SendAmount')).getAttributes()
       jestExpect(amount.text).toEqual('0.01 cEUR')
@@ -128,7 +128,7 @@ export default Send = () => {
 
     it('Then should be able to click on recent recipient', async () => {
       await element(by.text('0xe5f5...8846')).atIndex(0).tap()
-      await waitForElementId('SendEnterAmount/Input', 30_000)
+      await waitForElementId('SendEnterAmount/TokenAmountInput', 30_000)
     })
 
     it('Then should be able to choose token', async () => {
@@ -138,9 +138,9 @@ export default Send = () => {
     })
 
     it('Then should be able to enter amount and navigate to review screen', async () => {
-      await waitForElementByIdAndTap('SendEnterAmount/Input', 30_000)
-      await element(by.id('SendEnterAmount/Input')).replaceText('0.01')
-      await element(by.id('SendEnterAmount/Input')).tapReturnKey()
+      await waitForElementByIdAndTap('SendEnterAmount/TokenAmountInput', 30_000)
+      await element(by.id('SendEnterAmount/TokenAmountInput')).replaceText('0.01')
+      await element(by.id('SendEnterAmount/TokenAmountInput')).tapReturnKey()
       await waitForElementByIdAndTap('SendEnterAmount/ReviewButton', 30_000)
       await isElementVisible('ConfirmButton')
     })
@@ -195,7 +195,7 @@ export default Send = () => {
 
     it('Then tapping send button should navigate to Send Enter Amount screen', async () => {
       await element(by.id('SendOrInviteButton')).tap()
-      await waitForElementId('SendEnterAmount/Input', 30_000)
+      await waitForElementId('SendEnterAmount/TokenAmountInput', 30_000)
     })
 
     it('Then should be able to select token', async () => {
@@ -205,9 +205,9 @@ export default Send = () => {
     })
 
     it('Then should be able to enter amount and navigate to review screen', async () => {
-      await waitForElementByIdAndTap('SendEnterAmount/Input', 30_000)
-      await element(by.id('SendEnterAmount/Input')).replaceText('0.01')
-      await element(by.id('SendEnterAmount/Input')).tapReturnKey()
+      await waitForElementByIdAndTap('SendEnterAmount/TokenAmountInput', 30_000)
+      await element(by.id('SendEnterAmount/TokenAmountInput')).replaceText('0.01')
+      await element(by.id('SendEnterAmount/TokenAmountInput')).tapReturnKey()
       await waitForElementByIdAndTap('SendEnterAmount/ReviewButton', 30_000)
       await isElementVisible('ConfirmButton')
     })

--- a/src/analytics/Properties.tsx
+++ b/src/analytics/Properties.tsx
@@ -69,11 +69,10 @@ import { NotificationReceiveState } from 'src/notifications/types'
 import { AdventureCardName } from 'src/onboarding/types'
 import { PointsActivity } from 'src/points/types'
 import { RecipientType } from 'src/recipients/recipient'
-import { QrCode } from 'src/send/types'
+import { AmountEnteredIn, QrCode } from 'src/send/types'
 import { Field } from 'src/swap/types'
 import { TokenDetailsActionName } from 'src/tokens/types'
 import { NetworkId, TokenTransactionTypeV2, TransactionStatus } from 'src/transactions/types'
-import { Currency } from 'src/utils/currencies'
 
 type Web3LibraryProps = { web3Library: 'contract-kit' | 'viem' }
 
@@ -539,30 +538,21 @@ interface SendEventsProperties {
   }
   [SendEvents.send_cancel]: undefined
   [SendEvents.send_amount_back]: undefined
-  [SendEvents.send_amount_continue]:
-    | {
-        origin: SendOrigin
-        isScan: boolean
-        localCurrencyExchangeRate?: string | null
-        localCurrency: LocalCurrencyCode
-        localCurrencyAmount: string | null
-        underlyingCurrency: Currency
-        underlyingAmount: string | null
-      }
-    | {
-        origin: SendOrigin
-        recipientType: RecipientType
-        isScan: boolean
-        localCurrencyExchangeRate?: string | null
-        localCurrency: LocalCurrencyCode
-        localCurrencyAmount: string | null
-        underlyingTokenAddress: string | null
-        underlyingTokenSymbol: string
-        underlyingAmount: string | null
-        amountInUsd: string | null
-        tokenId: string | null
-        networkId: string | null
-      }
+  [SendEvents.send_amount_continue]: {
+    origin: SendOrigin
+    recipientType: RecipientType
+    isScan: boolean
+    localCurrencyExchangeRate?: string | null
+    localCurrency: LocalCurrencyCode
+    localCurrencyAmount: string | null
+    underlyingTokenAddress: string | null
+    underlyingTokenSymbol: string
+    underlyingAmount: string | null
+    amountInUsd: string | null
+    amountEnteredIn: AmountEnteredIn
+    tokenId: string | null
+    networkId: string | null
+  }
   [SendEvents.send_confirm_back]: undefined
   [SendEvents.send_confirm_send]:
     | {
@@ -1528,7 +1518,9 @@ interface JumpstartEventsProperties {
   [JumpstartEvents.jumpstart_send_amount_exceeds_threshold]: JumpstartDepositProperties & {
     thresholdUsd: number
   }
-  [JumpstartEvents.jumpstart_send_amount_continue]: JumpstartSendProperties
+  [JumpstartEvents.jumpstart_send_amount_continue]: JumpstartSendProperties & {
+    amountEnteredIn: AmountEnteredIn
+  }
   [JumpstartEvents.jumpstart_send_confirm]: JumpstartSendProperties
   [JumpstartEvents.jumpstart_send_start]: JumpstartSendProperties
   [JumpstartEvents.jumpstart_send_succeeded]: JumpstartSendProperties

--- a/src/jumpstart/JumpstartEnterAmount.test.tsx
+++ b/src/jumpstart/JumpstartEnterAmount.test.tsx
@@ -192,6 +192,7 @@ describe('JumpstartEnterAmount', () => {
         tokenAmount: '0.25',
         tokenId: mockCeurTokenId,
         tokenSymbol: 'cEUR',
+        amountEnteredIn: 'token',
       }
     )
   })

--- a/src/jumpstart/JumpstartEnterAmount.test.tsx
+++ b/src/jumpstart/JumpstartEnterAmount.test.tsx
@@ -122,7 +122,7 @@ describe('JumpstartEnterAmount', () => {
       </Provider>
     )
 
-    fireEvent.changeText(getByTestId('SendEnterAmount/Input'), '.25')
+    fireEvent.changeText(getByTestId('SendEnterAmount/TokenAmountInput'), '.25')
 
     await waitFor(() => expect(executeSpy).toHaveBeenCalledTimes(1))
     expect(executeSpy).toHaveBeenCalledWith({
@@ -142,7 +142,7 @@ describe('JumpstartEnterAmount', () => {
     )
 
     // default selected token is cEUR, priceUsd: '1.16' so max send amount will be 50 / 1.16 = 43.10
-    fireEvent.changeText(getByTestId('SendEnterAmount/Input'), '43.5')
+    fireEvent.changeText(getByTestId('SendEnterAmount/TokenAmountInput'), '43.5')
 
     await waitFor(() => expect(executeSpy).toHaveBeenCalledTimes(1))
     expect(getByText('review')).toBeDisabled()
@@ -153,7 +153,7 @@ describe('JumpstartEnterAmount', () => {
     ).toBeTruthy()
     expect(getByText('jumpstartEnterAmountScreen.maxAmountWarning.description')).toBeTruthy()
 
-    fireEvent.changeText(getByTestId('SendEnterAmount/Input'), '43')
+    fireEvent.changeText(getByTestId('SendEnterAmount/TokenAmountInput'), '43')
 
     await waitFor(() => expect(getByText('review')).not.toBeDisabled())
     expect(queryByText('jumpstartEnterAmountScreen.maxAmountWarning.title')).toBeFalsy()
@@ -169,7 +169,7 @@ describe('JumpstartEnterAmount', () => {
       </Provider>
     )
 
-    fireEvent.changeText(getByTestId('SendEnterAmount/Input'), '.25')
+    fireEvent.changeText(getByTestId('SendEnterAmount/TokenAmountInput'), '.25')
 
     await waitFor(() => expect(executeSpy).toHaveBeenCalledTimes(1))
     fireEvent.press(getByText('review'))
@@ -205,7 +205,7 @@ describe('JumpstartEnterAmount', () => {
 
     expect(store.getActions()).toEqual([depositTransactionFlowStarted()])
 
-    fireEvent.changeText(getByTestId('SendEnterAmount/Input'), '.25')
+    fireEvent.changeText(getByTestId('SendEnterAmount/TokenAmountInput'), '.25')
     await waitFor(() => expect(executeSpy).toHaveBeenCalledTimes(1))
     expect(getByTestId('SendEnterAmount/ReviewButton')).toBeEnabled()
 
@@ -225,7 +225,7 @@ describe('JumpstartEnterAmount', () => {
 
     // depositTransactionFlowStarted should not be dispatched
     expect(updatedStore.getActions()).toEqual([])
-    fireEvent.changeText(getByTestId('SendEnterAmount/Input'), '.30')
+    fireEvent.changeText(getByTestId('SendEnterAmount/TokenAmountInput'), '.30')
     // prepare transaction for a second time on this screen
     await waitFor(() => expect(executeSpy).toHaveBeenCalledTimes(2))
     // review button should remain disabled

--- a/src/jumpstart/JumpstartEnterAmount.tsx
+++ b/src/jumpstart/JumpstartEnterAmount.tsx
@@ -17,6 +17,7 @@ import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import { useSelector } from 'src/redux/hooks'
 import EnterAmount, { ProceedArgs } from 'src/send/EnterAmount'
+import { AmountEnteredIn } from 'src/send/types'
 import { getDynamicConfigParams } from 'src/statsig'
 import { DynamicConfigs } from 'src/statsig/constants'
 import { StatsigDynamicConfigs } from 'src/statsig/types'
@@ -66,12 +67,13 @@ function JumpstartEnterAmount() {
   }, [jumpstartLink.privateKey])
 
   const handleProceed = useAsyncCallback(
-    async ({ tokenAmount, token }: ProceedArgs) => {
+    async ({ tokenAmount, token, amountEnteredIn }: ProceedArgs) => {
       const link = await createJumpstartLink(jumpstartLink.privateKey, token.networkId)
       return {
         link,
         parsedAmount: tokenAmount,
         token,
+        amountEnteredIn,
       }
     },
     {
@@ -79,10 +81,12 @@ function JumpstartEnterAmount() {
         link,
         parsedAmount,
         token,
+        amountEnteredIn,
       }: {
         link: string
         parsedAmount: BigNumber
         token: TokenBalance
+        amountEnteredIn: AmountEnteredIn
       }) => {
         if (prepareJumpstartTransactions.result?.type !== 'possible') {
           // should never happen
@@ -110,6 +114,7 @@ function JumpstartEnterAmount() {
           amountInUsd: parsedAmount.multipliedBy(token.priceUsd ?? 0).toFixed(2),
           tokenId: token.tokenId,
           networkId: token.networkId,
+          amountEnteredIn,
         })
       },
       onError: (error) => {

--- a/src/jumpstart/JumpstartEnterAmount.tsx
+++ b/src/jumpstart/JumpstartEnterAmount.tsx
@@ -16,7 +16,7 @@ import { getLocalCurrencyCode, usdToLocalCurrencyRateSelector } from 'src/localC
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import { useSelector } from 'src/redux/hooks'
-import EnterAmount from 'src/send/EnterAmount'
+import EnterAmount, { ProceedArgs } from 'src/send/EnterAmount'
 import { getDynamicConfigParams } from 'src/statsig'
 import { DynamicConfigs } from 'src/statsig/constants'
 import { StatsigDynamicConfigs } from 'src/statsig/types'
@@ -66,11 +66,11 @@ function JumpstartEnterAmount() {
   }, [jumpstartLink.privateKey])
 
   const handleProceed = useAsyncCallback(
-    async (parsedAmount: BigNumber, token: TokenBalance) => {
+    async ({ tokenAmount, token }: ProceedArgs) => {
       const link = await createJumpstartLink(jumpstartLink.privateKey, token.networkId)
       return {
         link,
-        parsedAmount,
+        parsedAmount: tokenAmount,
         token,
       }
     },

--- a/src/send/EnterAmount.test.tsx
+++ b/src/send/EnterAmount.test.tsx
@@ -356,6 +356,52 @@ describe('EnterAmount', () => {
     })
   })
 
+  it('selecting new token with token amount entered updates local amount', async () => {
+    const store = createMockStore(mockStore)
+
+    const { getByTestId, getByText } = render(
+      <Provider store={store}>
+        <EnterAmount {...defaultParams} />
+      </Provider>
+    )
+
+    expect(getByTestId('SendEnterAmount/TokenSelect')).toHaveTextContent('POOF')
+    fireEvent.changeText(getByTestId('SendEnterAmount/TokenAmountInput'), '1')
+    expect(getByTestId('SendEnterAmount/TokenAmountInput').props.value).toBe('1')
+    expect(getByTestId('SendEnterAmount/LocalAmountInput').props.value).toBe('₱0.13')
+    fireEvent.press(getByTestId('SendEnterAmount/TokenSelect'))
+    await waitFor(() => expect(getByText('Ether')).toBeTruthy())
+    fireEvent.press(getByText('Ether'))
+    expect(getByTestId('SendEnterAmount/TokenSelect')).toHaveTextContent('ETH')
+    expect(getByTestId('SendEnterAmount/TokenAmountInput').props.value).toBe('1')
+    expect(getByTestId('SendEnterAmount/LocalAmountInput').props.value).toBe('₱1,995.00')
+  })
+
+  it('selecting new token with local amount entered updates token amount', async () => {
+    const store = createMockStore(mockStore)
+
+    const { getByTestId, getByText } = render(
+      <Provider store={store}>
+        <EnterAmount {...defaultParams} />
+      </Provider>
+    )
+
+    expect(getByTestId('SendEnterAmount/TokenSelect')).toHaveTextContent('POOF')
+    fireEvent.changeText(getByTestId('SendEnterAmount/LocalAmountInput'), '1')
+    expect(getByTestId('SendEnterAmount/TokenAmountInput').props.value).toBe(
+      '7.5187969924812030075'
+    )
+    expect(getByTestId('SendEnterAmount/LocalAmountInput').props.value).toBe('₱1')
+    fireEvent.press(getByTestId('SendEnterAmount/TokenSelect'))
+    await waitFor(() => expect(getByText('Ether')).toBeTruthy())
+    fireEvent.press(getByText('Ether'))
+    expect(getByTestId('SendEnterAmount/TokenSelect')).toHaveTextContent('ETH')
+    expect(getByTestId('SendEnterAmount/TokenAmountInput').props.value).toBe(
+      '0.0005012531328320802'
+    )
+    expect(getByTestId('SendEnterAmount/LocalAmountInput').props.value).toBe('₱1')
+  })
+
   it('pressing max fills in max available amount', () => {
     const store = createMockStore(mockStore)
 

--- a/src/send/EnterAmount.test.tsx
+++ b/src/send/EnterAmount.test.tsx
@@ -155,8 +155,8 @@ describe('EnterAmount', () => {
       </Provider>
     )
 
-    expect(getByTestId('SendEnterAmount/Input')).toBeTruthy()
-    expect(getByTestId('SendEnterAmount/LocalAmount')).toHaveTextContent('₱0.00')
+    expect(getByTestId('SendEnterAmount/TokenAmountInput')).toBeTruthy()
+    expect(getByTestId('SendEnterAmount/LocalAmountInput')).toBeTruthy()
     expect(getByTestId('SendEnterAmount/Max')).toBeTruthy()
     expect(getByTestId('SendEnterAmount/TokenSelect')).toHaveTextContent('ETH')
     expect(

--- a/src/send/EnterAmount.test.tsx
+++ b/src/send/EnterAmount.test.tsx
@@ -290,6 +290,35 @@ describe('EnterAmount', () => {
     })
   })
 
+  it.each([
+    { testPrefix: 'clearing one amount', text: '', expectedTokenValue: '', expectedLocalValue: '' },
+    { testPrefix: 'entering 0', text: '0', expectedTokenValue: '0', expectedLocalValue: '₱0' },
+  ])('$testPrefix clears the other amount', ({ text, expectedTokenValue, expectedLocalValue }) => {
+    const store = createMockStore(mockStore)
+
+    const { getByTestId } = render(
+      <Provider store={store}>
+        <EnterAmount {...defaultParams} />
+      </Provider>
+    )
+
+    fireEvent.changeText(getByTestId('SendEnterAmount/TokenAmountInput'), '2')
+    expect(getByTestId('SendEnterAmount/TokenAmountInput').props.value).toBe('2')
+    expect(getByTestId('SendEnterAmount/LocalAmountInput').props.value).toBe('₱0.27')
+
+    fireEvent.changeText(getByTestId('SendEnterAmount/TokenAmountInput'), text)
+    expect(getByTestId('SendEnterAmount/TokenAmountInput').props.value).toBe(expectedTokenValue)
+    expect(getByTestId('SendEnterAmount/LocalAmountInput').props.value).toBe('')
+
+    fireEvent.changeText(getByTestId('SendEnterAmount/LocalAmountInput'), '1.33')
+    expect(getByTestId('SendEnterAmount/TokenAmountInput').props.value).toBe('10')
+    expect(getByTestId('SendEnterAmount/LocalAmountInput').props.value).toBe('₱1.33')
+
+    fireEvent.changeText(getByTestId('SendEnterAmount/LocalAmountInput'), text)
+    expect(getByTestId('SendEnterAmount/TokenAmountInput').props.value).toBe('')
+    expect(getByTestId('SendEnterAmount/LocalAmountInput').props.value).toBe(expectedLocalValue)
+  })
+
   it('selecting new token updates token and network info', async () => {
     const store = createMockStore(mockStore)
 

--- a/src/send/EnterAmount.tsx
+++ b/src/send/EnterAmount.tsx
@@ -35,6 +35,7 @@ import DownArrowIcon from 'src/icons/DownArrowIcon'
 import { LocalCurrencySymbol } from 'src/localCurrency/consts'
 import { getLocalCurrencySymbol } from 'src/localCurrency/selectors'
 import { useSelector } from 'src/redux/hooks'
+import { AmountEnteredIn } from 'src/send/types'
 import { NETWORK_NAMES } from 'src/shared/conts'
 import Colors from 'src/styles/colors'
 import { typeScale } from 'src/styles/fonts'
@@ -48,7 +49,7 @@ export interface ProceedArgs {
   tokenAmount: BigNumber
   localAmount: BigNumber | null
   token: TokenBalance
-  amountEnteredIn: 'local' | 'token'
+  amountEnteredIn: AmountEnteredIn
 }
 
 interface Props {
@@ -129,7 +130,7 @@ function EnterAmount({
   const [token, setToken] = useState<TokenBalance>(() => defaultToken ?? tokens[0])
   const [tokenAmountInput, setTokenAmountInput] = useState<string>('')
   const [localAmountInput, setLocalAmountInput] = useState<string>('')
-  const [enteredIn, setEnteredIn] = useState<'token' | 'local'>('token')
+  const [enteredIn, setEnteredIn] = useState<AmountEnteredIn>('token')
   // this should never be null, just adding a default to make TS happy
   const localCurrencySymbol = useSelector(getLocalCurrencySymbol) ?? LocalCurrencySymbol.USD
 
@@ -421,7 +422,6 @@ function EnterAmount({
   )
 }
 
-// TODO(satish): Reuse this with SwapAmountInput
 function AmountInput({
   inputValue,
   onInputChange,

--- a/src/send/EnterAmount.tsx
+++ b/src/send/EnterAmount.tsx
@@ -203,7 +203,7 @@ function EnterAmount({
         localAmount: parsedLocalAmount,
       }
     }
-  }, [tokenAmountInput, localAmountInput, enteredIn])
+  }, [tokenAmountInput, localAmountInput, enteredIn, token])
 
   const { maxFeeAmount, feeCurrency } = getFeeCurrencyAndAmounts(prepareTransactionsResult)
 

--- a/src/send/EnterAmount.tsx
+++ b/src/send/EnterAmount.tsx
@@ -2,7 +2,14 @@ import { parseInputAmount } from '@celo/utils/lib/parsing'
 import BigNumber from 'bignumber.js'
 import React, { useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Platform, TextInput as RNTextInput, StyleSheet, Text } from 'react-native'
+import {
+  Platform,
+  TextInput as RNTextInput,
+  StyleProp,
+  StyleSheet,
+  Text,
+  TextStyle,
+} from 'react-native'
 import { View } from 'react-native-animatable'
 import { getNumberFormatSettings } from 'react-native-localize'
 import { SafeAreaView } from 'react-native-safe-area-context'
@@ -25,11 +32,14 @@ import TokenIcon, { IconSize } from 'src/components/TokenIcon'
 import Touchable from 'src/components/Touchable'
 import CustomHeader from 'src/components/header/CustomHeader'
 import DownArrowIcon from 'src/icons/DownArrowIcon'
+import { LocalCurrencySymbol } from 'src/localCurrency/consts'
+import { getLocalCurrencySymbol } from 'src/localCurrency/selectors'
 import { useSelector } from 'src/redux/hooks'
 import { NETWORK_NAMES } from 'src/shared/conts'
 import Colors from 'src/styles/colors'
 import { typeScale } from 'src/styles/fonts'
 import { Spacing } from 'src/styles/styles'
+import { useLocalToTokenAmount, useTokenToLocalAmount } from 'src/tokens/hooks'
 import { feeCurrenciesSelector } from 'src/tokens/selectors'
 import { TokenBalance } from 'src/tokens/slice'
 import { PreparedTransactionsResult, getFeeCurrencyAndAmounts } from 'src/viem/prepareTransactions'
@@ -105,15 +115,16 @@ function EnterAmount({
 }: Props) {
   const { t } = useTranslation()
 
-  // the startPosition and textInputRef variables exist to ensure TextInput
-  // displays the start of the value for long values on Android
-  // https://github.com/facebook/react-native/issues/14845
-  const [startPosition, setStartPosition] = useState<number | undefined>(0)
-  const textInputRef = useRef<RNTextInput | null>(null)
+  const tokenAmountInputRef = useRef<RNTextInput>(null)
+  const fiatAmountInputRef = useRef<RNTextInput>(null)
   const tokenBottomSheetRef = useRef<BottomSheetRefType>(null)
 
   const [token, setToken] = useState<TokenBalance>(() => defaultToken ?? tokens[0])
-  const [amount, setAmount] = useState<string>('')
+  const [tokenInputAmount, setTokenInputAmount] = useState<string>('')
+  const [localInputAmount, setLocalInputAmount] = useState<string>('')
+  const [inputType, setInputType] = useState<'token' | 'local'>('token')
+  // this should never be null, just adding a default to make TS happy
+  const localCurrencySymbol = useSelector(getLocalCurrencySymbol) ?? LocalCurrencySymbol.USD
 
   const onTokenPickerSelect = () => {
     tokenBottomSheetRef.current?.snapToIndex(0)
@@ -134,8 +145,10 @@ function EnterAmount({
     // eventually we may want to do something smarter here, like subtracting gas fees from the max amount if
     // this is a gas-paying token. for now, we are just showing a warning to the user prompting them to lower the amount
     // if there is not enough for gas
-    setAmount(token.balance.toString())
-    textInputRef.current?.blur()
+    setTokenInputAmount(token.balance.toString())
+    setInputType('token')
+    tokenAmountInputRef.current?.blur()
+    fiatAmountInputRef.current?.blur()
     ValoraAnalytics.track(SendEvents.max_pressed, {
       tokenId: token.tokenId,
       tokenAddress: token.address,
@@ -143,14 +156,40 @@ function EnterAmount({
     })
   }
 
-  const handleSetStartPosition = (value?: number) => {
-    if (Platform.OS === 'android') {
-      setStartPosition(value)
-    }
-  }
+  const { decimalSeparator, groupingSeparator } = getNumberFormatSettings()
+  const parsedTokenAmount = useMemo(
+    () => parseInputAmount(tokenInputAmount, decimalSeparator),
+    [tokenInputAmount]
+  )
+  const parsedLocalAmount = useMemo(
+    () => parseInputAmount(localInputAmount.replace(/[^0-9.,]/g, ''), decimalSeparator),
+    [localInputAmount]
+  )
 
-  const { decimalSeparator } = getNumberFormatSettings()
-  const parsedAmount = useMemo(() => parseInputAmount(amount, decimalSeparator), [amount])
+  const tokenToLocal = useTokenToLocalAmount(parsedTokenAmount, token.tokenId)
+  const localToToken = useLocalToTokenAmount(parsedLocalAmount, token.tokenId)
+  const { tokenAmount, tokenAmountDisplay, localAmountDisplay } = useMemo(() => {
+    if (inputType === 'token') {
+      return {
+        tokenAmount: parsedTokenAmount,
+        localAmount: tokenToLocal,
+        tokenAmountDisplay: tokenInputAmount,
+        localAmountDisplay:
+          tokenToLocal && tokenToLocal.gt(0)
+            ? `${localCurrencySymbol}${tokenToLocal.toFormat(2)}` // automatically adds grouping separators
+            : '',
+      }
+    } else {
+      return {
+        tokenAmount: localToToken,
+        localAmount: parsedLocalAmount,
+        tokenAmountDisplay: localToToken && localToToken.gt(0) ? localToToken.toString() : '',
+        // add grouping separators manually, using toFormat would add decimal
+        // places, which we don't want when the user enters local amount
+        localAmountDisplay: localInputAmount.replace(/\B(?=(\d{3})+(?!\d))/g, groupingSeparator),
+      }
+    }
+  }, [tokenInputAmount, localInputAmount, inputType])
 
   const { maxFeeAmount, feeCurrency } = getFeeCurrencyAndAmounts(prepareTransactionsResult)
 
@@ -159,16 +198,20 @@ function EnterAmount({
   useEffect(() => {
     onClearPreparedTransactions()
 
-    if (parsedAmount.isLessThanOrEqualTo(0) || parsedAmount.isGreaterThan(token.balance)) {
+    if (
+      !tokenAmount ||
+      tokenAmount.isLessThanOrEqualTo(0) ||
+      tokenAmount.isGreaterThan(token.balance)
+    ) {
       return
     }
     const debouncedRefreshTransactions = setTimeout(() => {
-      return onRefreshPreparedTransactions(parsedAmount, token, feeCurrencies)
+      return onRefreshPreparedTransactions(tokenAmount, token, feeCurrencies)
     }, FETCH_UPDATED_TRANSACTIONS_DEBOUNCE_TIME)
     return () => clearTimeout(debouncedRefreshTransactions)
-  }, [parsedAmount, token])
+  }, [tokenAmount, token])
 
-  const showLowerAmountError = token.balance.lt(amount)
+  const showLowerAmountError = token.balance.lt(tokenAmount ?? 0)
   const showMaxAmountWarning =
     !showLowerAmountError &&
     prepareTransactionsResult &&
@@ -186,7 +229,7 @@ function EnterAmount({
   const { tokenId: feeTokenId, symbol: feeTokenSymbol } = feeCurrency ?? feeCurrencies[0]
   let feeAmountSection = <FeeLoading />
   if (
-    amount === '' ||
+    tokenAmountDisplay === '' ||
     showLowerAmountError ||
     (prepareTransactionsResult && !maxFeeAmount) ||
     prepareTransactionError
@@ -194,6 +237,41 @@ function EnterAmount({
     feeAmountSection = <FeePlaceholder feeTokenSymbol={feeTokenSymbol} />
   } else if (prepareTransactionsResult && maxFeeAmount) {
     feeAmountSection = <FeeAmount feeAmount={maxFeeAmount} feeTokenId={feeTokenId} />
+  }
+
+  const onTokenAmountInputChange = (value: string) => {
+    setInputType('token')
+    if (!value) {
+      setTokenInputAmount('')
+    } else {
+      if (value.startsWith(decimalSeparator)) {
+        value = `0${value}`
+      }
+      // only allow numbers and one decimal separator
+      setTokenInputAmount((prev) => value.match(/^(?:\d+[.,]?\d*|[.,]\d*|[.,])$/)?.join('') ?? prev)
+    }
+  }
+
+  const onLocalAmountInputChange = (value: string) => {
+    setInputType('local')
+    // remove leading currency symbol and grouping separators
+    if (value.startsWith(localCurrencySymbol)) {
+      value = value.slice(1)
+    }
+    value = value.replaceAll(groupingSeparator, '')
+    if (!value) {
+      setLocalInputAmount('')
+    } else {
+      if (value.startsWith(decimalSeparator)) {
+        value = `0${value}`
+      }
+      setLocalInputAmount((prev) =>
+        // only allow numbers, one decimal separator, and two decimal places
+        value.match(/^(\d+([.,])?\d{0,2}|[.,]\d{0,2}|[.,])$/)
+          ? `${localCurrencySymbol}${value}`
+          : prev
+      )
+    }
   }
 
   return (
@@ -204,53 +282,13 @@ function EnterAmount({
           <Text style={styles.title}>{t('sendEnterAmountScreen.title')}</Text>
           <View style={styles.inputBox}>
             <View style={styles.inputRow}>
-              <TextInput
-                forwardedRef={textInputRef}
-                onChangeText={(value) => {
-                  handleSetStartPosition(undefined)
-                  if (!value) {
-                    setAmount('')
-                  } else {
-                    if (value.startsWith(decimalSeparator)) {
-                      value = `0${value}`
-                    }
-                    setAmount(
-                      (prev) => value.match(/^(?:\d+[.,]?\d*|[.,]\d*|[.,])$/)?.join('') ?? prev
-                    )
-                  }
-                }}
-                value={amount}
-                placeholder="0"
-                // hide input when loading to prevent the UI height from jumping
-                style={styles.input}
-                keyboardType="decimal-pad"
-                // Work around for RN issue with Samsung keyboards
-                // https://github.com/facebook/react-native/issues/22005
-                autoCapitalize="words"
-                autoFocus={true}
-                // unset lineHeight to allow ellipsis on long inputs on iOS. For
-                // android, ellipses doesn't work and unsetting line height causes
-                // height changes when amount is entered
-                inputStyle={[
-                  styles.inputText,
-                  Platform.select({ ios: { lineHeight: undefined } }),
-                  showLowerAmountError && { color: Colors.error },
-                ]}
-                testID="SendEnterAmount/Input"
-                onBlur={() => {
-                  handleSetStartPosition(0)
-                }}
-                onFocus={() => {
-                  handleSetStartPosition(amount?.length ?? 0)
-                }}
-                onSelectionChange={() => {
-                  handleSetStartPosition(undefined)
-                }}
-                selection={
-                  Platform.OS === 'android' && typeof startPosition === 'number'
-                    ? { start: startPosition }
-                    : undefined
-                }
+              <AmountInput
+                inputRef={tokenAmountInputRef}
+                inputValue={tokenAmountDisplay}
+                onInputChange={onTokenAmountInputChange}
+                inputStyle={[styles.inputText, showLowerAmountError && { color: Colors.error }]}
+                autoFocus
+                placeholder={new BigNumber(0).toFixed(2)}
               />
               <Touchable
                 borderRadius={TOKEN_SELECTOR_BORDER_RADIUS}
@@ -272,11 +310,12 @@ function EnterAmount({
               </Text>
             )}
             <View style={styles.localAmountRow}>
-              <TokenDisplay
-                amount={parsedAmount}
-                tokenId={token.tokenId}
-                style={styles.localAmount}
-                testID="SendEnterAmount/LocalAmount"
+              <AmountInput
+                inputValue={localAmountDisplay}
+                onInputChange={onLocalAmountInputChange}
+                inputRef={fiatAmountInputRef}
+                inputStyle={styles.localAmount}
+                placeholder={`${localCurrencySymbol}${new BigNumber(0).toFormat(2)}`}
               />
               <Touchable
                 borderRadius={MAX_BORDER_RADIUS}
@@ -335,7 +374,7 @@ function EnterAmount({
         {children}
 
         <Button
-          onPress={() => onPressProceed(parsedAmount, token)}
+          onPress={() => tokenAmount && onPressProceed(tokenAmount, token)}
           text={t('review')}
           style={styles.reviewButton}
           size={BtnSizes.FULL}
@@ -356,6 +395,87 @@ function EnterAmount({
         titleStyle={styles.title}
       />
     </SafeAreaView>
+  )
+}
+
+function AmountInput({
+  inputValue,
+  onInputChange,
+  inputRef,
+  inputStyle,
+  autoFocus,
+  loading,
+  placeholder = '0',
+}: {
+  inputValue: string
+  onInputChange(value: string): void
+  inputRef: React.MutableRefObject<RNTextInput | null>
+  inputStyle?: StyleProp<TextStyle>
+  autoFocus?: boolean
+  loading?: boolean
+  placeholder?: string
+}) {
+  // the startPosition and inputRef variables exist to ensure TextInput
+  // displays the start of the value for long values on Android
+  // https://github.com/facebook/react-native/issues/14845
+  const [startPosition, setStartPosition] = useState<number | undefined>(0)
+
+  const handleSetStartPosition = (value?: number) => {
+    if (Platform.OS === 'android') {
+      setStartPosition(value)
+    }
+  }
+
+  return (
+    <View style={styles.input}>
+      <TextInput
+        forwardedRef={inputRef}
+        onChangeText={(value) => {
+          handleSetStartPosition(undefined)
+          onInputChange(value)
+        }}
+        value={inputValue || undefined}
+        placeholder={placeholder}
+        // hide input when loading so that the value is not visible under the loader
+        style={{ opacity: loading ? 0 : 1 }}
+        keyboardType="decimal-pad"
+        // Work around for RN issue with Samsung keyboards
+        // https://github.com/facebook/react-native/issues/22005
+        autoCapitalize="words"
+        autoFocus={autoFocus}
+        // unset lineHeight to allow ellipsis on long inputs on iOS. For
+        // android, ellipses doesn't work and unsetting line height causes
+        // height changes when amount is entered
+        inputStyle={[inputStyle, Platform.select({ ios: { lineHeight: undefined } })]}
+        testID="SendEnterAmount/Input"
+        onBlur={() => {
+          handleSetStartPosition(0)
+        }}
+        onFocus={() => {
+          handleSetStartPosition(inputValue?.length ?? 0)
+        }}
+        onSelectionChange={() => {
+          handleSetStartPosition(undefined)
+        }}
+        selection={
+          Platform.OS === 'android' && typeof startPosition === 'number'
+            ? { start: startPosition }
+            : undefined
+        }
+      />
+      {loading && (
+        <View style={[styles.loaderContainer, { paddingVertical: Spacing.Small12 }]}>
+          <SkeletonPlaceholder
+            borderRadius={100} // ensure rounded corners with font scaling
+            backgroundColor={Colors.gray2}
+            highlightColor={Colors.white}
+            testID="SwapAmountInput/Loader"
+          >
+            <View style={styles.amountLoader} />
+          </SkeletonPlaceholder>
+        </View>
+      )}
+    </View>
   )
 }
 
@@ -422,7 +542,6 @@ const styles = StyleSheet.create({
   },
   localAmount: {
     ...typeScale.labelMedium,
-    flex: 1,
   },
   maxTouchable: {
     paddingHorizontal: 12,
@@ -466,7 +585,7 @@ const styles = StyleSheet.create({
     borderRadius: 100,
   },
   lowerAmountError: {
-    color: Colors.error,
+    color: Colors.errorDark,
     ...typeScale.labelXSmall,
     paddingLeft: Spacing.Regular16,
   },
@@ -480,6 +599,17 @@ const styles = StyleSheet.create({
     marginBottom: Spacing.Regular16,
     paddingHorizontal: Spacing.Regular16,
     borderRadius: 16,
+  },
+  loaderContainer: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    width: '100%',
+    height: '100%',
+  },
+  amountLoader: {
+    height: '100%',
+    width: '40%',
   },
 })
 

--- a/src/send/SendEnterAmount.test.tsx
+++ b/src/send/SendEnterAmount.test.tsx
@@ -130,7 +130,7 @@ describe('SendEnterAmount', () => {
       </Provider>
     )
 
-    fireEvent.changeText(getByTestId('SendEnterAmount/Input'), '.25')
+    fireEvent.changeText(getByTestId('SendEnterAmount/TokenAmountInput'), '.25')
 
     await waitFor(() => expect(refreshPreparedTransactionsSpy).toHaveBeenCalledTimes(1))
     expect(refreshPreparedTransactionsSpy).toHaveBeenCalledWith({
@@ -159,17 +159,17 @@ describe('SendEnterAmount', () => {
       </Provider>
     )
 
-    fireEvent.changeText(getByTestId('SendEnterAmount/Input'), '8')
+    fireEvent.changeText(getByTestId('SendEnterAmount/TokenAmountInput'), '8')
 
     await waitFor(() => expect(getByText('review')).not.toBeDisabled())
     fireEvent.press(getByText('review'))
 
     await waitFor(() => expect(ValoraAnalytics.track).toHaveBeenCalledTimes(1))
     expect(ValoraAnalytics.track).toHaveBeenCalledWith(SendEvents.send_amount_continue, {
-      amountInUsd: null,
+      amountInUsd: '106.01',
       isScan: false,
       localCurrency: 'PHP',
-      localCurrencyAmount: '140.9891060477188235021376',
+      localCurrencyAmount: '140.99',
       localCurrencyExchangeRate: '1.33',
       networkId: 'celo-alfajores',
       origin: 'app_send_flow',

--- a/src/send/SendEnterAmount.test.tsx
+++ b/src/send/SendEnterAmount.test.tsx
@@ -178,6 +178,7 @@ describe('SendEnterAmount', () => {
       underlyingAmount: '8',
       underlyingTokenAddress: mockCeloAddress,
       underlyingTokenSymbol: 'CELO',
+      amountEnteredIn: 'token',
     })
     expect(navigate).toHaveBeenCalledWith(Screens.SendConfirmation, {
       origin: params.origin,

--- a/src/send/SendEnterAmount.tsx
+++ b/src/send/SendEnterAmount.tsx
@@ -71,6 +71,7 @@ function SendEnterAmount({ route }: Props) {
       underlyingTokenSymbol: token.symbol,
       underlyingAmount: tokenAmount.toString(),
       amountInUsd: tokenAmount.multipliedBy(token.priceUsd ?? 0).toFixed(2),
+      amountEnteredIn,
       tokenId: token.tokenId,
       networkId: token.networkId,
     })

--- a/src/send/SendEnterAmount.tsx
+++ b/src/send/SendEnterAmount.tsx
@@ -8,13 +8,13 @@ import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import { StackParamList } from 'src/navigator/types'
 import { useSelector } from 'src/redux/hooks'
-import EnterAmount from 'src/send/EnterAmount'
+import EnterAmount, { ProceedArgs } from 'src/send/EnterAmount'
 import { lastUsedTokenIdSelector } from 'src/send/selectors'
 import { usePrepareSendTransactions } from 'src/send/usePrepareSendTransactions'
 import { COMMENT_PLACEHOLDER_FOR_FEE_ESTIMATE } from 'src/send/utils'
 import { sortedTokensWithBalanceOrShowZeroBalanceSelector } from 'src/tokens/selectors'
 import { TokenBalance } from 'src/tokens/slice'
-import { convertTokenToLocalAmount, getSupportedNetworkIdsForSend } from 'src/tokens/utils'
+import { getSupportedNetworkIdsForSend } from 'src/tokens/utils'
 import Logger from 'src/utils/Logger'
 import { walletAddressSelector } from 'src/web3/selectors'
 
@@ -42,17 +42,11 @@ function SendEnterAmount({ route }: Props) {
   const localCurrencyCode = useSelector(getLocalCurrencyCode)
   const localCurrencyExchangeRate = useSelector(usdToLocalCurrencyRateSelector)
 
-  const handleReviewSend = (parsedAmount: BigNumber, token: TokenBalance) => {
+  const handleReviewSend = ({ tokenAmount, localAmount, token, amountEnteredIn }: ProceedArgs) => {
     if (!prepareTransactionsResult || prepareTransactionsResult.type !== 'possible') {
       // should never happen because button is disabled if send is not possible
       throw new Error('No prepared transactions found')
     }
-
-    const sendAmountInLocalCurrency = convertTokenToLocalAmount({
-      tokenAmount: parsedAmount,
-      tokenInfo: token,
-      usdToLocalRate: localCurrencyExchangeRate,
-    })
 
     navigate(Screens.SendConfirmation, {
       origin,
@@ -60,10 +54,10 @@ function SendEnterAmount({ route }: Props) {
       transactionData: {
         tokenId: token.tokenId,
         recipient,
-        inputAmount: parsedAmount,
+        inputAmount: tokenAmount,
         amountIsInLocalCurrency: false,
         tokenAddress: token.address!,
-        tokenAmount: parsedAmount,
+        tokenAmount,
       },
     })
     ValoraAnalytics.track(SendEvents.send_amount_continue, {
@@ -72,11 +66,11 @@ function SendEnterAmount({ route }: Props) {
       recipientType: recipient.recipientType,
       localCurrencyExchangeRate,
       localCurrency: localCurrencyCode,
-      localCurrencyAmount: sendAmountInLocalCurrency?.toString() ?? null,
+      localCurrencyAmount: localAmount?.toFixed(2) ?? null,
       underlyingTokenAddress: token.address,
       underlyingTokenSymbol: token.symbol,
-      underlyingAmount: parsedAmount.toString(),
-      amountInUsd: null,
+      underlyingAmount: tokenAmount.toString(),
+      amountInUsd: tokenAmount.multipliedBy(token.priceUsd ?? 0).toFixed(2),
       tokenId: token.tokenId,
       networkId: token.networkId,
     })

--- a/src/send/types.ts
+++ b/src/send/types.ts
@@ -21,3 +21,5 @@ export interface TransactionDataInput {
   tokenAmount: BigNumber
   comment?: string
 }
+
+export type AmountEnteredIn = 'local' | 'token'


### PR DESCRIPTION
### Description

Allows entering fiat amount with upto 2 decimal places. Automatically adds grouping separators to input

### Test plan

Unit tests. Tested manually on iOS and android with different separators


https://github.com/valora-inc/wallet/assets/5062591/e4f1f522-3572-4d80-83a5-b4683f17bbb6



### Related issues

- Fixes ACT-1142

### Backwards compatibility

Yes

### Network scalability

N/A