### PR TITLE
chore: remove trailing slash from base urls

### DIFF
--- a/src/web3/networkConfig.ts
+++ b/src/web3/networkConfig.ts
@@ -435,14 +435,14 @@ const ETHERSCAN_BASE_URL_MAINNET = 'https://etherscan.io'
 const ARBISCAN_BASE_URL_ONE = 'https://arbiscan.io'
 const ARBISCAN_BASE_URL_SEPOLIA = 'https://sepolia.arbiscan.io'
 
-const OP_MAINNET_EXPLORER_BASE_URL = 'https://optimistic.etherscan.io/'
-const OP_SEPOLIA_EXPLORER_BASE_URL = 'https://sepolia-optimism.etherscan.io/'
+const OP_MAINNET_EXPLORER_BASE_URL = 'https://optimistic.etherscan.io'
+const OP_SEPOLIA_EXPLORER_BASE_URL = 'https://sepolia-optimism.etherscan.io'
 
-const POLYGON_POS_BASE_URL_MUMBAI = 'https://mumbai.polygonscan.com/'
-const POLYGON_POS_BASE_URL_MAINNET = 'https://polygonscan.com/'
+const POLYGON_POS_BASE_URL_MUMBAI = 'https://mumbai.polygonscan.com'
+const POLYGON_POS_BASE_URL_MAINNET = 'https://polygonscan.com'
 
-const BASE_BASE_URL_SEPOLIA = 'https://sepolia.basescan.org/'
-const BASE_BASE_URL_MAINNET = 'https://basescan.org/'
+const BASE_BASE_URL_SEPOLIA = 'https://sepolia.basescan.org'
+const BASE_BASE_URL_MAINNET = 'https://basescan.org'
 
 export const blockExplorerUrls: BlockExplorerUrls = {
   [NetworkId['celo-mainnet']]: {


### PR DESCRIPTION
### Description

Small nit fix to baseUrls to avoid `//` in urls.

### Test plan

Tested locally on iOS

### Related issues

N/A

### Backwards compatibility

Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
