### PR TITLE
feat: support deep link swap pairs and to tokenId

### DIFF
--- a/src/navigator/types.tsx
+++ b/src/navigator/types.tsx
@@ -283,7 +283,12 @@ export type StackParamList = {
         prefilledText: string
       }
     | undefined
-  [Screens.SwapScreenWithBack]: { fromTokenId: string } | undefined
+  [Screens.SwapScreenWithBack]:
+    | {
+        fromTokenId?: string
+        toTokenId?: string
+      }
+    | undefined
   [Screens.TabDiscover]: { isTabNavigator?: boolean } | undefined
   [Screens.TabHome]: { isTabNavigator?: boolean } | undefined
   [Screens.TabWallet]: { activeAssetTab?: AssetTabType; isWalletTab?: boolean } | undefined

--- a/src/swap/SwapScreen.tsx
+++ b/src/swap/SwapScreen.tsx
@@ -84,10 +84,10 @@ interface SwapState {
   switchedToNetworkId: NetworkId | null
 }
 
-function getInitialState(fromTokenId?: string): SwapState {
+function getInitialState(fromTokenId?: string, toTokenId?: string): SwapState {
   return {
     fromTokenId,
-    toTokenId: undefined,
+    toTokenId,
     inputSwapAmount: DEFAULT_INPUT_SWAP_AMOUNT,
     updatedField: Field.FROM,
     selectingField: null,
@@ -253,7 +253,11 @@ export function SwapScreen({ route }: Props) {
   )
 
   const initialFromTokenId = route.params?.fromTokenId
-  const [state, localDispatch] = useReducer(swapStateReducer, getInitialState(initialFromTokenId))
+  const initialToTokenId = route.params?.toTokenId
+  const [state, localDispatch] = useReducer(
+    swapStateReducer,
+    getInitialState(initialFromTokenId, initialToTokenId)
+  )
   const {
     fromTokenId,
     toTokenId,


### PR DESCRIPTION
### Description

Adds the route param toTokenId to the SwapScreenWithBack screen allowing the use of a deep link to set the to tokenId.
This enables the creation of deep link which contains a swap pair or a target to token. 

### Test plan

Prerequisites:
- Remove `isSecureOrigin` from https://github.com/valora-inc/wallet/blob/main/src/app/saga.ts#L348 for local testing.
- Use iOS mainnetDev with `yarn dev:ios -e mainnetdev`

Tests urls:
- Swap pair: `celo://wallet/openScreen?screen=SwapScreenWithBack&fromTokenId=celo-mainnet:native&toTokenId=celo-mainnet:0x765de816845861e75a25fca122bb6898b8b1282a`
- From token: `celo://wallet/openScreen?screen=SwapScreenWithBack&fromTokenId=celo-mainnet:native`
- To token: `celo://wallet/openScreen?screen=SwapScreenWithBack&toTokenId=celo-mainnet:native`
- No tokens: `celo://wallet/openScreen?screen=SwapScreenWithBack`

### Related issues

N/A

### Backwards compatibility

Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
