### PR TITLE
feat(send): better regex handling of amount inputs

### DIFF
--- a/src/send/EnterAmount.tsx
+++ b/src/send/EnterAmount.tsx
@@ -271,7 +271,6 @@ function EnterAmount({
       if (value.startsWith(decimalSeparator)) {
         value = `0${value}`
       }
-      // only allow numbers and one decimal separator
       if (value.match(tokenAmountRegex)) {
         setTokenAmountInput(value)
         setEnteredIn('token')
@@ -292,8 +291,8 @@ function EnterAmount({
       if (value.startsWith(decimalSeparator)) {
         value = `0${value}`
       }
-
       if (value.match(localAmountRegex)) {
+        // add back currency symbol and grouping separators
         setLocalAmountInput(
           `${localCurrencySymbol}${value}`.replace(/\B(?=(\d{3})+(?!\d))/g, groupingSeparator)
         )

--- a/src/send/EnterAmount.tsx
+++ b/src/send/EnterAmount.tsx
@@ -165,6 +165,14 @@ function EnterAmount({
   }
 
   const { decimalSeparator, groupingSeparator } = getNumberFormatSettings()
+  // only allow numbers, one decimal separator, and two decimal places
+  const localAmountRegex = new RegExp(
+    `^(\\d+([${decimalSeparator}])?\\d{0,2}|[${decimalSeparator}]\\d{0,2}|[${decimalSeparator}])$`
+  )
+  // only allow numbers, one decimal separator
+  const tokenAmountRegex = new RegExp(
+    `^(?:\\d+[${decimalSeparator}]?\\d*|[${decimalSeparator}]\\d*|[${decimalSeparator}])$`
+  )
   const parsedTokenAmount = useMemo(
     () => parseInputAmount(tokenAmountInput, decimalSeparator),
     [tokenAmountInput]
@@ -194,8 +202,10 @@ function EnterAmount({
     } else {
       setTokenAmountInput(
         localToToken && localToToken.gt(0)
-          ? // no group separator for token amount
-            localToToken.toFormat({ decimalSeparator })
+          ? // no group separator for token amount, round to token.decimals and strip trailing zeros
+            localToToken
+              .toFormat(token.decimals, { decimalSeparator })
+              .replace(new RegExp(`[${decimalSeparator}]?0+$`), '')
           : ''
       )
       return {
@@ -262,7 +272,7 @@ function EnterAmount({
         value = `0${value}`
       }
       // only allow numbers and one decimal separator
-      if (value.match(/^(?:\d+[.,]?\d*|[.,]\d*|[.,])$/)) {
+      if (value.match(tokenAmountRegex)) {
         setTokenAmountInput(value)
         setEnteredIn('token')
       }
@@ -283,8 +293,7 @@ function EnterAmount({
         value = `0${value}`
       }
 
-      // only allow numbers, one decimal separator, and two decimal places
-      if (value.match(/^(\d+([.,])?\d{0,2}|[.,]\d{0,2}|[.,])$/)) {
+      if (value.match(localAmountRegex)) {
         setLocalAmountInput(
           `${localCurrencySymbol}${value}`.replace(/\B(?=(\d{3})+(?!\d))/g, groupingSeparator)
         )

--- a/test/values.ts
+++ b/test/values.ts
@@ -534,10 +534,11 @@ export const mockTokenBalances: Record<string, StoredTokenBalance> = {
     tokenId: mockUSDCTokenId,
     address: mockUSDCAddress,
     symbol: 'USDC',
-    decimals: 18,
+    decimals: 6,
     imageUrl: '',
     balance: '0',
     priceUsd: '1',
+    priceFetchedAt: Date.now(),
   },
   [mockARBTokenId]: {
     name: 'Ethereum',


### PR DESCRIPTION
### Description

- Only allow decimal separator for inputs, instead of both `,` and `.`
- Round token amount to decimals when converting from local amount

### Test plan

Unit tests, manual

### Related issues

- Fixes ACT-1142

### Backwards compatibility

Yes

### Network scalability

N/A