### PR TITLE
chore(renovate): increase concurrent PR limit

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -2,7 +2,7 @@
   extends: ['github>valora-inc/renovate-config:default.json5', ':disableDigestUpdates'],
 
   // Limit number of concurrent renovate branches/PRs, to avoid spamming the repo
-  prConcurrentLimit: 2,
+  prConcurrentLimit: 4,
 
   // timezone for automerge schedule
   timezone: 'America/Los_Angeles',


### PR DESCRIPTION
### Description

Now that we've a merge queue and faster CI, we can try getting more PRs merged

### Test plan

Watch PRs after merging

### Related issues

N/A

### Backwards compatibility

N/A

### Network scalability

N/A
