### PR TITLE
feat: setup skip phone verification experiment

### DIFF
--- a/src/app/reducers.ts
+++ b/src/app/reducers.ts
@@ -34,7 +34,6 @@ interface State {
   sentryTracesSampleRate: number
   sentryNetworkErrors: string[]
   supportedBiometryType: BIOMETRY_TYPE | null
-  skipVerification: boolean
   fiatConnectCashInEnabled: boolean
   fiatConnectCashOutEnabled: boolean
   coinbasePayEnabled: boolean
@@ -83,7 +82,6 @@ const initialState = {
   sentryTracesSampleRate: REMOTE_CONFIG_VALUES_DEFAULTS.sentryTracesSampleRate,
   sentryNetworkErrors: REMOTE_CONFIG_VALUES_DEFAULTS.sentryNetworkErrors.split(','),
   supportedBiometryType: null,
-  skipVerification: REMOTE_CONFIG_VALUES_DEFAULTS.skipVerification,
   fiatConnectCashInEnabled: REMOTE_CONFIG_VALUES_DEFAULTS.fiatConnectCashInEnabled,
   fiatConnectCashOutEnabled: REMOTE_CONFIG_VALUES_DEFAULTS.fiatConnectCashOutEnabled,
   coinbasePayEnabled: REMOTE_CONFIG_VALUES_DEFAULTS.coinbasePayEnabled,
@@ -204,7 +202,6 @@ export const appReducer = (
         pincodeUseExpandedBlocklist: action.configValues.pincodeUseExpandedBlocklist,
         sentryTracesSampleRate: action.configValues.sentryTracesSampleRate,
         sentryNetworkErrors: action.configValues.sentryNetworkErrors,
-        skipVerification: action.configValues.skipVerification,
         fiatConnectCashInEnabled: action.configValues.fiatConnectCashInEnabled,
         fiatConnectCashOutEnabled: action.configValues.fiatConnectCashOutEnabled,
         coinbasePayEnabled: action.configValues.coinbasePayEnabled,

--- a/src/app/saga.ts
+++ b/src/app/saga.ts
@@ -228,7 +228,6 @@ export interface RemoteConfigValues {
   sentryTracesSampleRate: number
   sentryNetworkErrors: string[]
   maxNumRecentDapps: number
-  skipVerification: boolean
   dappsWebViewEnabled: boolean
   fiatConnectCashInEnabled: boolean
   fiatConnectCashOutEnabled: boolean

--- a/src/app/selectors.ts
+++ b/src/app/selectors.ts
@@ -61,8 +61,6 @@ export const supportedBiometryTypeSelector = (state: RootState) => state.app.sup
 
 export const activeScreenSelector = (state: RootState) => state.app.activeScreen
 
-export const skipVerificationSelector = (state: RootState) => state.app.skipVerification
-
 export const fiatConnectCashInEnabledSelector = (state: RootState) =>
   state.app.fiatConnectCashInEnabled
 export const fiatConnectCashOutEnabledSelector = (state: RootState) =>

--- a/src/firebase/firebase.ts
+++ b/src/firebase/firebase.ts
@@ -328,7 +328,6 @@ export async function fetchRemoteConfigValues(): Promise<RemoteConfigValues | nu
     sentryTracesSampleRate: flags.sentryTracesSampleRate.asNumber(),
     sentryNetworkErrors: flags.sentryNetworkErrors.asString().split(','),
     maxNumRecentDapps: flags.maxNumRecentDapps.asNumber(),
-    skipVerification: flags.skipVerification.asBoolean(),
     dappsWebViewEnabled: flags.dappsWebViewEnabled.asBoolean(),
     fiatConnectCashInEnabled: flags.fiatConnectCashInEnabled.asBoolean(),
     fiatConnectCashOutEnabled: flags.fiatConnectCashOutEnabled.asBoolean(),

--- a/src/firebase/remoteConfigValuesDefaults.e2e.ts
+++ b/src/firebase/remoteConfigValuesDefaults.e2e.ts
@@ -34,7 +34,6 @@ export const REMOTE_CONFIG_VALUES_DEFAULTS: Omit<
   sentryNetworkErrors: '',
   dappListApiUrl: 'https://us-central1-celo-mobile-alfajores.cloudfunctions.net/dappList',
   maxNumRecentDapps: 4,
-  skipVerification: false,
   dappsWebViewEnabled: true,
   fiatConnectCashInEnabled: false,
   fiatConnectCashOutEnabled: true,

--- a/src/firebase/remoteConfigValuesDefaults.ts
+++ b/src/firebase/remoteConfigValuesDefaults.ts
@@ -35,7 +35,6 @@ export const REMOTE_CONFIG_VALUES_DEFAULTS: Omit<
   sentryTracesSampleRate: DEFAULT_SENTRY_TRACES_SAMPLE_RATE,
   sentryNetworkErrors: DEFAULT_SENTRY_NETWORK_ERRORS.join(','),
   maxNumRecentDapps: 0,
-  skipVerification: false,
   dappsWebViewEnabled: false,
   dappListApiUrl: '',
   fiatConnectCashInEnabled: false,

--- a/src/import/saga.test.ts
+++ b/src/import/saga.test.ts
@@ -6,7 +6,7 @@ import { initializeAccountSaga } from 'src/account/saga'
 import { recoveringFromStoreWipeSelector } from 'src/account/selectors'
 import { showError } from 'src/alert/actions'
 import { ErrorMessages } from 'src/app/ErrorMessages'
-import { phoneNumberVerifiedSelector, skipVerificationSelector } from 'src/app/selectors'
+import { phoneNumberVerifiedSelector } from 'src/app/selectors'
 import { storeMnemonic } from 'src/backup/utils'
 import { refreshAllBalances } from 'src/home/actions'
 import { currentLanguageSelector } from 'src/i18n/selectors'
@@ -125,7 +125,6 @@ describe('Import wallet saga', () => {
           [matchers.call.fn(assignAccountFromPrivateKey), walletAddress],
           [call(storeMnemonic, mockPhraseValid, walletAddress), true],
           [select(recoveringFromStoreWipeSelector), false],
-          [select(skipVerificationSelector), false],
           [call(initializeAccountSaga), undefined],
           [select(phoneNumberVerifiedSelector), false],
         ])

--- a/src/onboarding/registration/EnableBiometry.test.tsx
+++ b/src/onboarding/registration/EnableBiometry.test.tsx
@@ -85,7 +85,6 @@ describe('EnableBiometry', () => {
       app: {
         supportedBiometryType: BIOMETRY_TYPE.FACE_ID,
         activeScreen: Screens.EnableBiometry,
-        skipVerification: true,
       },
       account: {
         choseToRestoreAccount: false,

--- a/src/onboarding/steps.ts
+++ b/src/onboarding/steps.ts
@@ -5,19 +5,16 @@ import {
   choseToRestoreAccountSelector,
   recoveringFromStoreWipeSelector,
 } from 'src/account/selectors'
-import {
-  phoneNumberVerifiedSelector,
-  skipVerificationSelector,
-  supportedBiometryTypeSelector,
-} from 'src/app/selectors'
+import { phoneNumberVerifiedSelector, supportedBiometryTypeSelector } from 'src/app/selectors'
 import { setHasSeenVerificationNux } from 'src/identity/actions'
 import * as NavigationService from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import { StackParamList } from 'src/navigator/types'
 import { updateStatsigAndNavigate } from 'src/onboarding/actions'
 import { store } from 'src/redux/store'
-import { getFeatureGate } from 'src/statsig'
-import { StatsigFeatureGates } from 'src/statsig/types'
+import { getExperimentParams, getFeatureGate } from 'src/statsig'
+import { ExperimentConfigs } from 'src/statsig/constants'
+import { StatsigExperiments, StatsigFeatureGates } from 'src/statsig/types'
 
 export const END_OF_ONBOARDING_SCREENS = [Screens.TabHome, Screens.ChooseYourAdventure]
 
@@ -73,18 +70,20 @@ export const onboardingPropsSelector = createSelector(
     recoveringFromStoreWipeSelector,
     choseToRestoreAccountSelector,
     supportedBiometryTypeSelector,
-    skipVerificationSelector,
     phoneNumberVerifiedSelector,
   ],
   (
     recoveringFromStoreWipe,
     choseToRestoreAccount,
     supportedBiometryType,
-    skipVerification,
     numberAlreadyVerifiedCentrally
   ) => {
     const showCloudAccountBackupRestore = getFeatureGate(
       StatsigFeatureGates.SHOW_CLOUD_ACCOUNT_BACKUP_RESTORE
+    )
+
+    const { skipVerification } = getExperimentParams(
+      ExperimentConfigs[StatsigExperiments.ONBOARDING_PHONE_VERIFICATION]
     )
 
     return {

--- a/src/pincode/PincodeSet.tsx
+++ b/src/pincode/PincodeSet.tsx
@@ -12,7 +12,7 @@ import { initializeAccount, setPincodeSuccess } from 'src/account/actions'
 import { PincodeType } from 'src/account/reducer'
 import { OnboardingEvents, SettingsEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
-import { skipVerificationSelector, supportedBiometryTypeSelector } from 'src/app/selectors'
+import { supportedBiometryTypeSelector } from 'src/app/selectors'
 import DevSkipButton from 'src/components/DevSkipButton'
 import i18n, { withTranslation } from 'src/i18n'
 import { setHasSeenVerificationNux } from 'src/identity/actions'
@@ -50,7 +50,6 @@ interface StateProps {
   registrationStep: { step: number; totalSteps: number }
   onboardingProps: OnboardingProps
   supportedBiometryType: BIOMETRY_TYPE | null
-  skipVerification: boolean
 }
 
 interface DispatchProps {
@@ -80,7 +79,6 @@ function mapStateToProps(state: RootState): StateProps {
     useExpandedBlocklist: state.app.pincodeUseExpandedBlocklist,
     account: currentAccountSelector(state) ?? '',
     supportedBiometryType: supportedBiometryTypeSelector(state),
-    skipVerification: skipVerificationSelector(state),
   }
 }
 

--- a/src/redux/migrations.ts
+++ b/src/redux/migrations.ts
@@ -1732,4 +1732,8 @@ export const migrations = {
     }
   },
   205: (state: any) => state,
+  206: (state: any) => ({
+    ...state,
+    app: _.omit(state.app, 'skipVerification'),
+  }),
 }

--- a/src/redux/store.test.ts
+++ b/src/redux/store.test.ts
@@ -98,7 +98,7 @@ describe('store state', () => {
       {
         "_persist": {
           "rehydrated": true,
-          "version": 205,
+          "version": 206,
         },
         "account": {
           "acceptedTerms": false,

--- a/src/redux/store.test.ts
+++ b/src/redux/store.test.ts
@@ -169,7 +169,6 @@ describe('store state', () => {
           "sessionId": "",
           "showNotificationSpotlight": true,
           "showSwapMenuInDrawerMenu": false,
-          "skipVerification": false,
           "superchargeApy": 12,
           "superchargeTokenConfigByToken": {},
           "supportedBiometryType": null,

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -21,7 +21,7 @@ const persistConfig: PersistConfig<ReducersRootState> = {
   key: 'root',
   // default is -1, increment as we make migrations
   // See https://github.com/valora-inc/wallet/tree/main/WALLET.md#redux-state-migration
-  version: 205,
+  version: 206,
   keyPrefix: `reduxStore-`, // the redux-persist default is `persist:` which doesn't work with some file systems.
   storage: FSStorage(),
   blacklist: ['networkInfo', 'alert', 'imports', 'keylessBackup', 'jumpstart'],

--- a/src/statsig/constants.ts
+++ b/src/statsig/constants.ts
@@ -41,6 +41,12 @@ export const ExperimentConfigs = {
       swapBuyAmountEnabled: true,
     },
   },
+  [StatsigExperiments.ONBOARDING_PHONE_VERIFICATION]: {
+    experimentName: StatsigExperiments.ONBOARDING_PHONE_VERIFICATION,
+    defaultValues: {
+      skipVerification: false,
+    },
+  },
 }
 
 export const DynamicConfigs = {

--- a/src/statsig/types.ts
+++ b/src/statsig/types.ts
@@ -38,6 +38,7 @@ export enum StatsigExperiments {
   SWAPPING_NON_NATIVE_TOKENS = 'swapping_non_native_tokens',
   DAPP_RANKINGS = 'dapp_rankings',
   SWAP_BUY_AMOUNT = 'swap_buy_amount',
+  ONBOARDING_PHONE_VERIFICATION = 'onboarding_phone_verification',
 }
 
 export type StatsigParameter =

--- a/test/RootStateSchema.json
+++ b/test/RootStateSchema.json
@@ -3445,9 +3445,6 @@
                 "showSwapMenuInDrawerMenu": {
                     "type": "boolean"
                 },
-                "skipVerification": {
-                    "type": "boolean"
-                },
                 "superchargeApy": {
                     "type": "number"
                 },
@@ -3508,7 +3505,6 @@
                 "sessionId",
                 "showNotificationSpotlight",
                 "showSwapMenuInDrawerMenu",
-                "skipVerification",
                 "superchargeApy",
                 "superchargeTokenConfigByToken",
                 "supportedBiometryType",

--- a/test/schemas.ts
+++ b/test/schemas.ts
@@ -3227,6 +3227,15 @@ export const v205Schema = {
   },
 }
 
+export const v206Schema = {
+  ...v205Schema,
+  _persist: {
+    ...v205Schema._persist,
+    version: 206,
+  },
+  app: _.omit(v205Schema.app, 'skipVerification'),
+}
+
 export function getLatestSchema(): Partial<RootState> {
-  return v205Schema as Partial<RootState>
+  return v206Schema as Partial<RootState>
 }


### PR DESCRIPTION
### Description

Moves `skipVerification` previously stored in app state to a Statsig Experiment; it appears this was originally put into app state so that it could be a/b tested. Now we're just using a different hook, `getExperimentParams`, instead of a `useSelector`.

### Test plan

- Tested locally on iOS using a Stable ID in Statsig.
- E2E tests in CI.
- Unit tests in CI.

### Related issues

- Fixes ACT-1163

### Backwards compatibility

Yes

### Network scalability

N/A
