### PR TITLE
fix(qr-scanner): Allow data with network prefixes

### DIFF
--- a/src/qrcode/utils.test.tsx
+++ b/src/qrcode/utils.test.tsx
@@ -111,28 +111,31 @@ describe('handleQRCodeDefault', () => {
     })
     expect(ValoraAnalytics.track).toHaveBeenCalledWith(QrScreenEvents.qr_scanned, qrCode)
   })
-  it('navigates to the send amount screen with a qr code with address as the data', async () => {
-    const qrCode: QrCode = { type: QRCodeTypes.QR_CODE, data: mockAccount }
+  it.each([mockAccount, `ethereum:${mockAccount}`, `celo:${mockAccount}`])(
+    'navigates to the send amount screen with a qr code with address as the data',
+    async (data) => {
+      const qrCode: QrCode = { type: QRCodeTypes.QR_CODE, data }
 
-    await expectSaga(handleQRCodeDefault, handleQRCodeDetected(qrCode))
-      .withState(createMockStore({}).getState())
-      .provide([[select(recipientInfoSelector), mockRecipientInfo]])
-      .run()
-    expect(navigate).toHaveBeenCalledWith(Screens.SendEnterAmount, {
-      origin: SendOrigin.AppSendFlow,
-      isFromScan: true,
-      recipient: {
-        address: mockAccount.toLowerCase(),
-        name: mockName,
-        contactId: 'contactId',
-        displayNumber: '14155550000',
-        thumbnailPath: undefined,
-        recipientType: RecipientType.Address,
-      },
-      forceTokenId: false,
-    })
-    expect(ValoraAnalytics.track).toHaveBeenCalledWith(QrScreenEvents.qr_scanned, qrCode)
-  })
+      await expectSaga(handleQRCodeDefault, handleQRCodeDetected(qrCode))
+        .withState(createMockStore({}).getState())
+        .provide([[select(recipientInfoSelector), mockRecipientInfo]])
+        .run()
+      expect(navigate).toHaveBeenCalledWith(Screens.SendEnterAmount, {
+        origin: SendOrigin.AppSendFlow,
+        isFromScan: true,
+        recipient: {
+          address: mockAccount.toLowerCase(),
+          name: mockName,
+          contactId: 'contactId',
+          displayNumber: '14155550000',
+          thumbnailPath: undefined,
+          recipientType: RecipientType.Address,
+        },
+        forceTokenId: false,
+      })
+      expect(ValoraAnalytics.track).toHaveBeenCalledWith(QrScreenEvents.qr_scanned, qrCode)
+    }
+  )
   it('navigates to the send amount screen with a qr code with an empty display name', async () => {
     const qrCode: QrCode = {
       type: QRCodeTypes.QR_CODE,

--- a/src/qrcode/utils.test.tsx
+++ b/src/qrcode/utils.test.tsx
@@ -136,6 +136,14 @@ describe('handleQRCodeDefault', () => {
       expect(ValoraAnalytics.track).toHaveBeenCalledWith(QrScreenEvents.qr_scanned, qrCode)
     }
   )
+  it('throws an error when the QR code data is invalid', async () => {
+    const qrCode: QrCode = { type: QRCodeTypes.QR_CODE, data: mockAccount.replace('0x', '') }
+
+    await expectSaga(handleQRCodeDefault, handleQRCodeDetected(qrCode))
+      .withState(createMockStore({}).getState())
+      .put(showError(ErrorMessages.QR_FAILED_INVALID_ADDRESS))
+      .run()
+  })
   it('navigates to the send amount screen with a qr code with an empty display name', async () => {
     const qrCode: QrCode = {
       type: QRCodeTypes.QR_CODE,

--- a/src/qrcode/utils.ts
+++ b/src/qrcode/utils.ts
@@ -127,16 +127,10 @@ export function* handleSecureSend(
 }
 
 function* extractQRAddressData(qrCode: QrCode) {
-  // Check if the QR code is a valid address, does not perform checksum validation
-  if (isAddress(qrCode.data, { strict: false })) {
-    qrCode.data = `celo://wallet/pay?address=${qrCode.data}`
-  }
-  // Ignore network prefix and extract address
-  else if (
-    qrCode.data.split(':').length > 1 &&
-    isAddress(qrCode.data.split(':')[1], { strict: false })
-  ) {
-    qrCode.data = `celo://wallet/pay?address=${qrCode.data.split(':')[1]}`
+  // strip network prefix if present
+  const qrAddress = qrCode.data.replace(/^.*:/, '')
+  if (isAddress(qrAddress, { strict: false })) {
+    qrCode.data = `celo://wallet/pay?address=${qrAddress}`
   }
   let qrData: UriData | null
   try {

--- a/src/qrcode/utils.ts
+++ b/src/qrcode/utils.ts
@@ -128,7 +128,7 @@ export function* handleSecureSend(
 
 function* extractQRAddressData(qrCode: QrCode) {
   // strip network prefix if present
-  const qrAddress = qrCode.data.replace(/^.*:/, '')
+  const qrAddress = qrCode.data.split(':').at(-1) || qrCode.data
   if (isAddress(qrAddress, { strict: false })) {
     qrCode.data = `celo://wallet/pay?address=${qrAddress}`
   }


### PR DESCRIPTION
### Description

just ignores the network prefix and reads the address

I considered trying to read and validate the network, but some things stopped me:
1. lack of any kind of plumbing for a 'default network' in the send flow to action upon the prefix. If we want to use it, should probably be another ticket and have specific UX guidelines
2. Lack of consistency for how other wallets mark their data.

| Wallet              | Celo | Ethereum |
| :---------------- | :------: | ----: |
| Metamask        |   ethereum:0x   | ethereum:0x |
| Coinbase           |  celo:0x   | ethereum:0x |
| SafeWallet    |  celo:0x   | ethereum:0x |

Sometimes the wallets mark L2 chains as their own (celo, optimism, arbitrum) and sometimes just label it 'ethereum'. This inconsistency makes it difficult to action upon.

### Test plan

Unit tested with examples pulled from metamask and coinbase

### Related issues

- Fixes https://linear.app/valora/issue/ACT-1155/chain-prefix-support-for-qr-scanner
