### PR TITLE
fix(qr): land on send screen when scanning with 0 balance

### DIFF
--- a/src/qrcode/QRScanner.tsx
+++ b/src/qrcode/QRScanner.tsx
@@ -70,8 +70,14 @@ export default function QRScanner({ onQRCodeDetected }: QRScannerProps) {
 
   const submitModal = () => {
     Keyboard.dismiss()
-    onQRCodeDetected({ type: '', data: value })
     closeModal()
+    // add a delay to allow modal to close before calling onQRCodeDetected,
+    // otherwise nothing is clickable in the next screen this navigates to. A
+    // better solution is to use onModalHide prop of Modal, but this is an
+    // emulator only feature, so this is good enough.
+    setTimeout(() => {
+      onQRCodeDetected({ type: '', data: value })
+    }, 500)
   }
 
   const onModalTextChange = (text: string) => {

--- a/src/send/utils.test.ts
+++ b/src/send/utils.test.ts
@@ -1,11 +1,9 @@
 import BigNumber from 'bignumber.js'
 import { expectSaga } from 'redux-saga-test-plan'
 import * as matchers from 'redux-saga-test-plan/matchers'
-import { select } from 'redux-saga-test-plan/matchers'
 import { SendOrigin } from 'src/analytics/types'
 import { LocalCurrencyCode } from 'src/localCurrency/consts'
 import { fetchExchangeRate } from 'src/localCurrency/saga'
-import { usdToLocalCurrencyRateSelector } from 'src/localCurrency/selectors'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import { UriData, urlFromUriData } from 'src/qrcode/schema'
@@ -94,25 +92,6 @@ describe('send/utils', () => {
           forceTokenId: false,
         })
       )
-    })
-
-    it('should throw an error when no local currency exchange rate is available', async () => {
-      await expect(
-        expectSaga(handleSendPaymentData, mockData, false, undefined)
-          .withState(
-            createMockStore({
-              localCurrency: {
-                usdToLocalRate: null,
-              },
-            }).getState()
-          )
-          .provide([
-            [matchers.call.fn(fetchExchangeRate), '1'],
-            [select(usdToLocalCurrencyRateSelector), '1'],
-          ])
-          .run()
-      ).rejects.toThrow("Precondition failed: Can't send tokens from payment data")
-      expect(navigate).not.toHaveBeenCalled()
     })
 
     it('should navigate to SendConfirmation screen when amount and token are sent', async () => {

--- a/src/send/utils.ts
+++ b/src/send/utils.ts
@@ -13,7 +13,6 @@ import { Screens } from 'src/navigator/Screens'
 import { UriData, uriDataFromUrl } from 'src/qrcode/schema'
 import { AddressRecipient, Recipient, RecipientType } from 'src/recipients/recipient'
 import { updateValoraRecipientCache } from 'src/recipients/reducer'
-import { canSendTokensSelector } from 'src/send/selectors'
 import { TransactionDataInput } from 'src/send/types'
 import { tokensListSelector } from 'src/tokens/selectors'
 import { TokenBalance } from 'src/tokens/slice'
@@ -97,10 +96,6 @@ export function* handleSendPaymentData(
       origin: SendOrigin.AppSendFlow,
     })
   } else {
-    const canSendTokens: boolean = yield* select(canSendTokensSelector)
-    if (!canSendTokens) {
-      throw new Error("Precondition failed: Can't send tokens from payment data")
-    }
     navigate(Screens.SendEnterAmount, {
       recipient,
       isFromScan,


### PR DESCRIPTION
### Description

send navigation was blocked on a `canSendTokensSelector` which uses a deprecated tokens selector that only checks celo tokens and returns true if the at least one celo network token has a balance > 0 and a local currency exchange rate is available. The new send flow can handle both these scenarios, and we want to navigate to the zero state send screen, so this check is removed

### Test plan

| Before | After |
|--------|--------|
| <video src="https://github.com/valora-inc/wallet/assets/5062591/279b6b1e-e9ac-4974-832d-2b4c0612df69" /> | <video src="https://github.com/valora-inc/wallet/assets/5062591/625788c9-fd1b-48bc-9b30-e61afad1df40" /> | 


### Related issues

- Fixes ACT-1148

### Backwards compatibility

Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
