### PR TITLE
test(e2e): ensure new instance whenever launch args are set

### DIFF
--- a/e2e/src/Pin.spec.js
+++ b/e2e/src/Pin.spec.js
@@ -10,7 +10,7 @@ describe.each([{ navType: 'drawer' }, { navType: 'tab' }])(
       await device.uninstallApp()
       await device.installApp()
       await launchApp({
-        newInstance: false,
+        newInstance: true,
         permissions: { notifications: 'YES', contacts: 'YES' },
         launchArgs: { statsigGateOverrides: `use_tab_navigator=${navType === 'tab'}` },
       })

--- a/e2e/src/usecases/ChooseYourAdventure.js
+++ b/e2e/src/usecases/ChooseYourAdventure.js
@@ -6,6 +6,7 @@ export default ChooseYourAdventure = () => {
     await device.uninstallApp()
     await device.installApp()
     await launchApp({
+      newInstance: true,
       launchArgs: {
         statsigGateOverrides: `use_tab_navigator=true,show_cloud_account_backup_setup=true,show_cloud_account_backup_restore=true`,
       },

--- a/e2e/src/usecases/NewAccountOnboarding.js
+++ b/e2e/src/usecases/NewAccountOnboarding.js
@@ -157,6 +157,7 @@ export default NewAccountOnboarding = () => {
     await device.uninstallApp()
     await device.installApp()
     await launchApp({
+      newInstance: true,
       launchArgs: {
         statsigGateOverrides: `use_tab_navigator=true,show_cloud_account_backup_setup=true,show_cloud_account_backup_restore=true`,
       },

--- a/e2e/src/usecases/ResetAccount.js
+++ b/e2e/src/usecases/ResetAccount.js
@@ -7,7 +7,7 @@ export default ResetAccount = ({ navType }) => {
   // statsig gate overrides
   beforeAll(async () => {
     await launchApp({
-      newInstance: false,
+      newInstance: true,
       permissions: { notifications: 'YES', contacts: 'YES' },
       launchArgs: { statsigGateOverrides: `use_tab_navigator=${navType === 'tab'}` },
     })

--- a/e2e/src/usecases/Settings.js
+++ b/e2e/src/usecases/Settings.js
@@ -8,7 +8,7 @@ export default Settings = ({ navType }) => {
   // statsig gate overrides
   beforeAll(async () => {
     await launchApp({
-      newInstance: false,
+      newInstance: true,
       permissions: { notifications: 'YES', contacts: 'YES' },
       launchArgs: { statsigGateOverrides: `use_tab_navigator=${navType === 'tab'}` },
     })

--- a/e2e/src/usecases/Support.js
+++ b/e2e/src/usecases/Support.js
@@ -54,7 +54,7 @@ export default Support = () => {
 
   it('Send Message to Support (tab)', async () => {
     await launchApp({
-      newInstance: false,
+      newInstance: true,
       permissions: { notifications: 'YES', contacts: 'YES' },
       launchArgs: { statsigGateOverrides: `use_tab_navigator=true` },
     })


### PR DESCRIPTION
### Description

Noticed some e2e failures where a drawer is rendered instead of tab nav for tab tests. Seems like launch args don't get passed through. Setting newInstance to true so this always gets picked up

### Test plan

CI

### Related issues

N/A

### Backwards compatibility

N/A

### Network scalability

N/A
