### PR TITLE
ci: cancel outdated merge queue requests, run test always on main

### DIFF
--- a/.github/workflows/check-translation-files-pr.yml
+++ b/.github/workflows/check-translation-files-pr.yml
@@ -5,11 +5,11 @@ on:
   pull_request:
   merge_group:
 
-# Cancel any non merge queue in progress run of the workflow for a given PR
+# Cancel any in progress run of the workflow for a given PR
 # This avoids building outdated code
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
-  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+  cancel-in-progress: true
 
 jobs:
   check-translation-files:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -9,12 +9,12 @@ on:
   schedule:
     - cron: '30 20 * * *'
 
-# Cancel any non merge queue in progress run of the workflow for a given PR
+# Cancel any in progress run of the workflow for a given PR
 # This avoids building outdated code
 concurrency:
   # Fallback used github.ref_name as it is always defined
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
-  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+  cancel-in-progress: true
 
 jobs:
   vulnerability:

--- a/.github/workflows/e2e-pr.yml
+++ b/.github/workflows/e2e-pr.yml
@@ -5,11 +5,11 @@ on:
       - main
   merge_group:
 
-# Cancel any non merge queue in progress run of the workflow for a given PR
+# Cancel any in progress run of the workflow for a given PR
 # This avoids building outdated code
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
-  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+  cancel-in-progress: true
 
 jobs:
   android:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,15 +1,19 @@
 name: Test
 
 on:
-  # ..any pull request and merge queue (covers main)
+  # Run on pushes to main..
+  push:
+    branches:
+      - main
+  # ..any pull request and merge queue
   pull_request:
   merge_group:
 
-# Cancel any non merge queue in progress run of the workflow for a given PR
+# Cancel any in progress run of the workflow for a given PR
 # This avoids building outdated code
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
-  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+  cancel-in-progress: true
 
 jobs:
   mobile:


### PR DESCRIPTION
### Description

Fixes a couple of things
1. Cancels in progress merge queue requests on outdated branches. We originally had this because we used only `head_ref` as the key, which is defined only for PR runs. But now we also have `ref_name`, which should be unique per merge queue PR
2. Run Test workflow on main. Sometimes we merge skipping the queue because of codecov/patch failures (or other reasons). In this case, subsequent PRs won't have a base to compare against because codecov never ran on the commit on main, leading to inconsistent results. 

### Test plan

CI

### Related issues

N/A

### Backwards compatibility

N/A

### Network scalability

N/A