### PR TITLE
fix(keychain): fix private key missing error

### DIFF
--- a/src/identity/actions.ts
+++ b/src/identity/actions.ts
@@ -33,6 +33,7 @@ export enum Actions {
   FETCH_ADDRESS_VERIFICATION_STATUS = 'IDENTITY/FETCH_ADDRESS_VERIFICATION_STATUS',
   ADDRESS_VERIFICATION_STATUS_RECEIVED = 'IDENTITY/ADDRESS_VERIFICATION_STATUS_RECEIVED',
   CONTACTS_SAVED = 'IDENTITY/CONTACTS_SAVED',
+  STORED_PASSWORD_REFRESHED = 'IDENTITY/STORED_PASSWORD_REFRESHED',
 }
 
 export interface SetHasSeenVerificationNux {
@@ -149,6 +150,10 @@ interface ContactsSavedAction {
   hash: string
 }
 
+interface StoredPasswordRefreshedAction {
+  type: Actions.STORED_PASSWORD_REFRESHED
+}
+
 export type ActionTypes =
   | SetHasSeenVerificationNux
   | UpdateE164PhoneNumberAddressesAction
@@ -170,6 +175,7 @@ export type ActionTypes =
   | FetchAddressVerificationAction
   | AddressVerificationStatusReceivedAction
   | ContactsSavedAction
+  | StoredPasswordRefreshedAction
 
 export const setHasSeenVerificationNux = (status: boolean): SetHasSeenVerificationNux => ({
   type: Actions.SET_SEEN_VERIFICATION_NUX,
@@ -332,4 +338,8 @@ export const updateAddressDekMap = (
 export const contactsSaved = (hash: string): ContactsSavedAction => ({
   type: Actions.CONTACTS_SAVED,
   hash,
+})
+
+export const storedPasswordRefreshed = (): StoredPasswordRefreshedAction => ({
+  type: Actions.STORED_PASSWORD_REFRESHED,
 })

--- a/src/identity/reducer.ts
+++ b/src/identity/reducer.ts
@@ -90,6 +90,7 @@ interface State {
   // Mapping of address to verification status; undefined entries represent a loading state
   addressToVerificationStatus: AddressToVerificationStatus
   lastSavedContactsHash: string | null
+  shouldRefreshStoredPasswordHash: boolean
 }
 
 const initialState: State = {
@@ -109,6 +110,7 @@ const initialState: State = {
   secureSendPhoneNumberMapping: {},
   addressToVerificationStatus: {},
   lastSavedContactsHash: null,
+  shouldRefreshStoredPasswordHash: false,
 }
 
 export const reducer = (
@@ -288,6 +290,11 @@ export const reducer = (
       return {
         ...state,
         lastSavedContactsHash: action.hash,
+      }
+    case Actions.STORED_PASSWORD_REFRESHED:
+      return {
+        ...state,
+        shouldRefreshStoredPasswordHash: false,
       }
     default:
       return state

--- a/src/identity/selectors.ts
+++ b/src/identity/selectors.ts
@@ -36,3 +36,6 @@ export const identifierToE164NumberSelector = createSelector(
 
 export const lastSavedContactsHashSelector = (state: RootState) =>
   state.identity.lastSavedContactsHash
+
+export const shouldRefreshStoredPasswordHashSelector = (state: RootState) =>
+  state.identity.shouldRefreshStoredPasswordHash

--- a/src/redux/migrations.ts
+++ b/src/redux/migrations.ts
@@ -1744,4 +1744,11 @@ export const migrations = {
       pointsConfigStatus: 'idle',
     },
   }),
+  208: (state: any) => ({
+    ...state,
+    identity: {
+      ...state.identity,
+      shouldRefreshStoredPasswordHash: true,
+    },
+  }),
 }

--- a/src/redux/store.test.ts
+++ b/src/redux/store.test.ts
@@ -98,7 +98,7 @@ describe('store state', () => {
       {
         "_persist": {
           "rehydrated": true,
-          "version": 207,
+          "version": 208,
         },
         "account": {
           "acceptedTerms": false,
@@ -253,6 +253,7 @@ describe('store state', () => {
           },
           "lastSavedContactsHash": null,
           "secureSendPhoneNumberMapping": {},
+          "shouldRefreshStoredPasswordHash": true,
           "walletToAccountAddress": {},
         },
         "imports": {

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -21,7 +21,7 @@ const persistConfig: PersistConfig<ReducersRootState> = {
   key: 'root',
   // default is -1, increment as we make migrations
   // See https://github.com/valora-inc/wallet/tree/main/WALLET.md#redux-state-migration
-  version: 207,
+  version: 208,
   keyPrefix: `reduxStore-`, // the redux-persist default is `persist:` which doesn't work with some file systems.
   storage: FSStorage(),
   blacklist: ['networkInfo', 'alert', 'imports', 'keylessBackup', 'jumpstart'],

--- a/src/web3/contracts.test.ts
+++ b/src/web3/contracts.test.ts
@@ -44,7 +44,7 @@ describe('getViemWallet', () => {
         .provide([
           [select(walletAddressSelector), '0x123'],
           [call(listStoredAccounts), [{ address: '0x123', createdAt: date }]],
-          [call(getPasswordSaga, '0x123', false, true), 'password'],
+          [call(getPasswordSaga, '0x123', true, false), 'password'],
           [
             call(getStoredPrivateKey, { address: '0x123', createdAt: new Date() }, 'password'),
             null,
@@ -61,7 +61,7 @@ describe('getViemWallet', () => {
       .provide([
         [select(walletAddressSelector), '0x123'],
         [call(listStoredAccounts), [{ address: '0x123', createdAt: date }]],
-        [call(getPasswordSaga, '0x123', false, true), 'password'],
+        [call(getPasswordSaga, '0x123', true, false), 'password'],
         [
           call(getStoredPrivateKey, { address: '0x123', createdAt: new Date() }, 'password'),
           'password',

--- a/src/web3/contracts.ts
+++ b/src/web3/contracts.ts
@@ -135,7 +135,7 @@ export function* getViemWallet(chain: Chain) {
   if (!account) {
     throw new Error(`Account ${walletAddress} not found in Keychain`)
   }
-  const password = yield* call(getPasswordSaga, walletAddress, false, true)
+  const password = yield* call(getPasswordSaga, walletAddress, true, false)
   const privateKey = yield* call(getStoredPrivateKey, account, password)
   if (!privateKey) {
     throw new Error(`Private key not found for account ${walletAddress}`)

--- a/test/RootStateSchema.json
+++ b/test/RootStateSchema.json
@@ -4716,6 +4716,9 @@
                 "secureSendPhoneNumberMapping": {
                     "$ref": "#/definitions/SecureSendPhoneNumberMapping"
                 },
+                "shouldRefreshStoredPasswordHash": {
+                    "type": "boolean"
+                },
                 "walletToAccountAddress": {
                     "$ref": "#/definitions/WalletToAccountAddressType"
                 }
@@ -4732,6 +4735,7 @@
                 "importContactsProgress",
                 "lastSavedContactsHash",
                 "secureSendPhoneNumberMapping",
+                "shouldRefreshStoredPasswordHash",
                 "walletToAccountAddress"
             ],
             "type": "object"

--- a/test/schemas.ts
+++ b/test/schemas.ts
@@ -3249,6 +3249,18 @@ export const v207Schema = {
   },
 }
 
+export const v208Schema = {
+  ...v207Schema,
+  _persist: {
+    ...v207Schema._persist,
+    version: 208,
+  },
+  identity: {
+    ...v207Schema.identity,
+    shouldRefreshStoredPasswordHash: true,
+  },
+}
+
 export function getLatestSchema(): Partial<RootState> {
-  return v207Schema as Partial<RootState>
+  return v208Schema as Partial<RootState>
 }


### PR DESCRIPTION
### Description

As the title. I've done a detailed writeup [here](https://linear.app/valora/issue/RET-1067/error-while-swapping-private-key-not-found#comment-3729279a).

### Test plan

As a user who knows their pincode, I should always be able to perform a transaction and see my recovery phrase.

### Related issues

- Fixes RET-1067

### Backwards compatibility

Y

### Network scalability

Y
