### PR TITLE
fix(points): only fetch config if points are enabled

### DIFF
--- a/src/points/saga.test.ts
+++ b/src/points/saga.test.ts
@@ -13,9 +13,13 @@ import pointsReducer, {
   getPointsConfigSucceeded,
 } from 'src/points/slice'
 import { ClaimHistory, GetHistoryResponse } from 'src/points/types'
+import { getFeatureGate } from 'src/statsig'
+import { StatsigFeatureGates } from 'src/statsig/types'
 import * as fetchWithTimeout from 'src/utils/fetchWithTimeout'
 import networkConfig from 'src/web3/networkConfig'
 import { createMockStore } from 'test/utils'
+
+jest.mock('src/statsig')
 
 const MOCK_HISTORY_RESPONSE: GetHistoryResponse = {
   data: [
@@ -174,6 +178,9 @@ describe('getHistory', () => {
 describe('getPointsConfig', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    jest
+      .mocked(getFeatureGate)
+      .mockImplementation((gate) => gate === StatsigFeatureGates.SHOW_POINTS)
   })
 
   it('fetches and sets points config', async () => {
@@ -265,5 +272,16 @@ describe('getPointsConfig', () => {
       .put(getPointsConfigError())
       .not.put(getPointsConfigSucceeded(expect.anything()))
       .run()
+  })
+
+  it('does not fetch if points are not enabled', async () => {
+    jest.mocked(getFeatureGate).mockReturnValue(false)
+
+    await expectSaga(getPointsConfig)
+      .not.put(getPointsConfigStarted())
+      .not.put(getPointsConfigSucceeded(expect.anything()))
+      .run()
+
+    expect(mockFetch).not.toHaveBeenCalled()
   })
 })

--- a/src/points/saga.ts
+++ b/src/points/saga.ts
@@ -11,6 +11,8 @@ import {
   getPointsConfigSucceeded,
 } from 'src/points/slice'
 import { GetHistoryResponse, isPointsActivity } from 'src/points/types'
+import { getFeatureGate } from 'src/statsig'
+import { StatsigFeatureGates } from 'src/statsig/types'
 import Logger from 'src/utils/Logger'
 import { fetchWithTimeout } from 'src/utils/fetchWithTimeout'
 import { safely } from 'src/utils/safely'
@@ -77,6 +79,12 @@ export function* getHistory({ payload: params }: ReturnType<typeof getHistorySta
 }
 
 export function* getPointsConfig() {
+  const showPoints = getFeatureGate(StatsigFeatureGates.SHOW_POINTS)
+  if (!showPoints) {
+    Logger.info(TAG, 'Points feature is disabled, not fetching points config')
+    return
+  }
+
   yield* put(getPointsConfigStarted())
 
   try {


### PR DESCRIPTION
### Description

As the title.

### Test plan

n/a
### Related issues

- Related to RET-1044

### Backwards compatibility

Y

### Network scalability

Y