### PR TITLE
chore(points): add UI for no supported activities

### DIFF
--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -2261,6 +2261,10 @@
       "title": "How do I earn points?",
       "body": "It's easy! Earn points by simply using the app."
     },
+    "noActivities": {
+      "title": "Update to Unlock More Points 🔓",
+      "body": "Oops! It seems you're using an older version of {{appName}}. Update now to discover all the exciting new ways you can earn points"
+    },
     "activityCards": {
       "createWallet": {
         "title": "Create a {{appName}}  Wallet"

--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -2263,7 +2263,7 @@
     },
     "noActivities": {
       "title": "Update to Unlock More Points 🔓",
-      "body": "Oops! It seems you're using an older version of {{appName}}. Update now to discover all the exciting new ways you can earn points"
+      "body": "Oops! It seems you're using an older version of {{appName}}. Update now to discover all the exciting new ways you can earn points."
     },
     "activityCards": {
       "createWallet": {

--- a/src/points/PointsHome.test.tsx
+++ b/src/points/PointsHome.test.tsx
@@ -7,17 +7,23 @@ import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import PointsHome from 'src/points/PointsHome'
 import { getHistoryStarted, getPointsConfigRetry } from 'src/points/slice'
+import { PointsActivity } from 'src/points/types'
 import { createMockStore, getMockStackScreenProps } from 'test/utils'
 
 const mockScreenProps = () => getMockStackScreenProps(Screens.PointsHome)
 
 const renderPointsHome = (
-  pointsConfigStatus: 'idle' | 'loading' | 'error' | 'success' = 'success'
+  pointsConfigStatus: 'idle' | 'loading' | 'error' | 'success' = 'success',
+  activitiesById?: {
+    [activityId in PointsActivity]?: {
+      pointsAmount: number
+    }
+  }
 ) => {
   const store = createMockStore({
     points: {
       pointsConfig: {
-        activitiesById: {
+        activitiesById: activitiesById ?? {
           swap: {
             pointsAmount: 50,
           },
@@ -92,6 +98,20 @@ describe(PointsHome, () => {
     expect(getByTestId('PointsActivityCard-more-coming-20')).toBeTruthy()
     expect(getByTestId('PointsActivityCard-create-wallet-20')).toBeTruthy()
 
+    expect(queryByText('points.loading.title')).toBeFalsy()
+    expect(queryByText('points.error.title')).toBeFalsy()
+  })
+
+  it('renders only the balance if there are no supported activities', async () => {
+    const { getByTestId, getByText, queryByText } = renderPointsHome('success', {})
+
+    expect(getByText('points.title')).toBeTruthy()
+    expect(getByText('50')).toBeTruthy() // balance
+    expect(getByTestId('PointsActivityButton')).toBeTruthy()
+    expect(getByText('points.noActivities.title')).toBeTruthy()
+    expect(getByText('points.noActivities.body')).toBeTruthy()
+
+    expect(queryByText('points.infoCard.title')).toBeFalsy()
     expect(queryByText('points.loading.title')).toBeFalsy()
     expect(queryByText('points.error.title')).toBeFalsy()
   })

--- a/src/points/PointsHome.tsx
+++ b/src/points/PointsHome.tsx
@@ -9,6 +9,7 @@ import BackButton from 'src/components/BackButton'
 import BeatingHeartLoader from 'src/components/BeatingHeartLoader'
 import BottomSheet, { BottomSheetRefType } from 'src/components/BottomSheet'
 import Button, { BtnSizes, BtnTypes } from 'src/components/Button'
+import InLineNotification, { NotificationVariant } from 'src/components/InLineNotification'
 import CustomHeader from 'src/components/header/CustomHeader'
 import AttentionIcon from 'src/icons/Attention'
 import LogoHeart from 'src/icons/LogoHeart'
@@ -103,7 +104,7 @@ export default function PointsHome({ route, navigation }: Props) {
           </View>
         )}
 
-        {pointsConfigStatus === 'success' && pointsSections.length > 0 && (
+        {pointsConfigStatus === 'success' && (
           <>
             <View style={styles.titleRow}>
               <Text style={styles.title}>{t('points.title')}</Text>
@@ -121,11 +122,23 @@ export default function PointsHome({ route, navigation }: Props) {
               <Text style={styles.balance}>{pointsBalance}</Text>
               <LogoHeart size={28} />
             </View>
-            <View style={styles.infoCard}>
-              <Text style={styles.infoCardTitle}>{t('points.infoCard.title')}</Text>
-              <Text style={styles.infoCardBody}>{t('points.infoCard.body')}</Text>
-            </View>
-            <ActivityCardSection onCardPress={onCardPress} pointsSections={pointsSections} />
+
+            {pointsSections.length > 0 ? (
+              <>
+                <View style={styles.infoCard}>
+                  <Text style={styles.infoCardTitle}>{t('points.infoCard.title')}</Text>
+                  <Text style={styles.infoCardBody}>{t('points.infoCard.body')}</Text>
+                </View>
+                <ActivityCardSection onCardPress={onCardPress} pointsSections={pointsSections} />
+              </>
+            ) : (
+              <InLineNotification
+                variant={NotificationVariant.Info}
+                hideIcon={true}
+                title={t('points.noActivities.title')}
+                description={t('points.noActivities.body')}
+              />
+            )}
           </>
         )}
       </ScrollView>


### PR DESCRIPTION
### Description

As the title. [Context](https://valora-app.slack.com/archives/C0684TXDR3K/p1713471273331519?thread_ts=1713256160.962269&cid=C0684TXDR3K).

### Test plan

When the activities defined in the app version has no overlap with the live points config:
![Simulator Screenshot - iPhone 14 Pro - 2024-04-19 at 10 23 42](https://github.com/valora-inc/wallet/assets/20150449/a0d1b675-5c97-48e8-9444-8216228a2d10)


### Related issues

- Fixes RET-1044

### Backwards compatibility

Y

### Network scalability

Y
