### PR TITLE
chore(deps): remove react-native-fs custom fork resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -331,7 +331,6 @@
     "simple-plist": "^1.3.1",
     "moment": "^2.30.1",
     "async": "^3.2.5",
-    "react-native-fs": "git+https://github.com/celo-org/react-native-fs#aa6db0f",
     "json-schema": "^0.4.0",
     "shell-quote": "^1.8.1",
     "hermes-engine": "^0.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15309,14 +15309,7 @@ react-native-flipper@^0.127.0:
   resolved "https://registry.yarnpkg.com/react-native-flipper/-/react-native-flipper-0.127.0.tgz#4d4040c0d0a45136b9bbabdc801d3e32d385de73"
   integrity sha512-qloUyUOs9MoMVncIDDWeOxAPbomWJ3e4y0SgyCgq8joJEOXC7RvPWeEfUXp0EPyNhHGQV9a4RwzF6BWKFCR3Kg==
 
-react-native-fs@*, react-native-fs@^2.14.1, "react-native-fs@git+https://github.com/celo-org/react-native-fs#aa6db0f":
-  version "2.16.6"
-  resolved "git+https://github.com/celo-org/react-native-fs#aa6db0f1d9b82bfdf58ebf72450c28311414f45f"
-  dependencies:
-    base-64 "^0.1.0"
-    utf8 "^3.0.0"
-
-react-native-fs@^2.20.0:
+react-native-fs@*, react-native-fs@^2.14.1, react-native-fs@^2.20.0:
   version "2.20.0"
   resolved "https://registry.yarnpkg.com/react-native-fs/-/react-native-fs-2.20.0.tgz#05a9362b473bfc0910772c0acbb73a78dbc810f6"
   integrity sha512-VkTBzs7fIDUiy/XajOSNk0XazFE9l+QlMAce7lGuebZcag5CnjszB+u4BdqzwaQOdcYb5wsJIsqq4kxInIRpJQ==


### PR DESCRIPTION
### Description

This is no longer needed. The custom fork only contained [2 commits](https://github.com/valora-inc/react-native-fs/commits/master/) by our team, both changes are now included in the latest version of `react-native-fs` (which we already have in the package.json).

### Test plan

n/a

### Related issues

- Related to RET-1058

### Backwards compatibility

Y

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
