### PR TITLE
chore(dep): disable automatic updates to firebase dependencies

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -64,6 +64,8 @@
       // Group updates for @react-native-firebase packages
       matchPackagePatterns: ['^@react-native-firebase/'],
       groupName: 'react-native-firebase',
+      // TODO(ENG-105): enable once we have migrated away from react-native-sms-retriever
+      enabled: false,
     },
     {
       // Group updates for @segment packages


### PR DESCRIPTION
### Description

As the title - related to #5297. We can't update firebase deps further until we decide what to do with `react-native-sms-retriever`.

### Test plan

n/a

### Related issues

Related to RET-1058

### Backwards compatibility

Y

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
