### PR TITLE
refactor(tabs): rename tab screen components

### DIFF
--- a/src/dappsExplorer/TabDiscover.test.tsx
+++ b/src/dappsExplorer/TabDiscover.test.tsx
@@ -5,7 +5,7 @@ import { DappExplorerEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import { dappSelected, favoriteDapp, fetchDappsList, unfavoriteDapp } from 'src/dapps/slice'
 import { DappCategory, DappSection } from 'src/dapps/types'
-import DAppsExplorerScreenSearchFilter from 'src/dappsExplorer/DAppsExplorerScreenSearchFilter'
+import TabDiscover from 'src/dappsExplorer/TabDiscover'
 import MockedNavigator from 'test/MockedNavigator'
 import { createMockStore } from 'test/utils'
 import { mockDappListWithCategoryNames } from 'test/values'
@@ -40,7 +40,7 @@ const defaultStore = createMockStore({
   dapps: { dappListApiUrl: 'http://url.com', dappsList, dappsCategories },
 })
 
-describe('DAppsExplorerScreenSearchFilter', () => {
+describe('TabDiscover', () => {
   beforeEach(() => {
     defaultStore.clearActions()
     jest.clearAllMocks()
@@ -49,7 +49,7 @@ describe('DAppsExplorerScreenSearchFilter', () => {
   it('renders correctly and fires the correct actions on press dapp', () => {
     const { getByText, queryByText } = render(
       <Provider store={defaultStore}>
-        <MockedNavigator component={DAppsExplorerScreenSearchFilter} />
+        <MockedNavigator component={TabDiscover} />
       </Provider>
     )
 
@@ -69,7 +69,7 @@ describe('DAppsExplorerScreenSearchFilter', () => {
   it('renders correctly and fires the correct actions on press deep linked dapp', () => {
     const { getByText, queryByText } = render(
       <Provider store={defaultStore}>
-        <MockedNavigator component={DAppsExplorerScreenSearchFilter} />
+        <MockedNavigator component={TabDiscover} />
       </Provider>
     )
 
@@ -96,7 +96,7 @@ describe('DAppsExplorerScreenSearchFilter', () => {
     })
     const { getByText } = render(
       <Provider store={store}>
-        <MockedNavigator component={DAppsExplorerScreenSearchFilter} />
+        <MockedNavigator component={TabDiscover} />
       </Provider>
     )
 
@@ -122,7 +122,7 @@ describe('DAppsExplorerScreenSearchFilter', () => {
       })
       const { getByText, queryByText } = render(
         <Provider store={store}>
-          <MockedNavigator component={DAppsExplorerScreenSearchFilter} />
+          <MockedNavigator component={TabDiscover} />
         </Provider>
       )
 
@@ -143,7 +143,7 @@ describe('DAppsExplorerScreenSearchFilter', () => {
       })
       const { queryByText, getAllByTestId } = render(
         <Provider store={store}>
-          <MockedNavigator component={DAppsExplorerScreenSearchFilter} />
+          <MockedNavigator component={TabDiscover} />
         </Provider>
       )
 
@@ -167,7 +167,7 @@ describe('DAppsExplorerScreenSearchFilter', () => {
       })
       const { getByTestId, getByText } = render(
         <Provider store={store}>
-          <MockedNavigator component={DAppsExplorerScreenSearchFilter} />
+          <MockedNavigator component={TabDiscover} />
         </Provider>
       )
 
@@ -202,7 +202,7 @@ describe('DAppsExplorerScreenSearchFilter', () => {
       })
       const { getByTestId, getAllByTestId, queryByText } = render(
         <Provider store={store}>
-          <MockedNavigator component={DAppsExplorerScreenSearchFilter} />
+          <MockedNavigator component={TabDiscover} />
         </Provider>
       )
 
@@ -241,7 +241,7 @@ describe('DAppsExplorerScreenSearchFilter', () => {
 
       const { getByTestId, queryByTestId } = render(
         <Provider store={store}>
-          <MockedNavigator component={DAppsExplorerScreenSearchFilter} />
+          <MockedNavigator component={TabDiscover} />
         </Provider>
       )
 
@@ -264,7 +264,7 @@ describe('DAppsExplorerScreenSearchFilter', () => {
 
       const { getByTestId, queryByTestId, getAllByTestId } = render(
         <Provider store={store}>
-          <MockedNavigator component={DAppsExplorerScreenSearchFilter} />
+          <MockedNavigator component={TabDiscover} />
         </Provider>
       )
 
@@ -299,7 +299,7 @@ describe('DAppsExplorerScreenSearchFilter', () => {
 
       const { getByTestId, getAllByTestId } = render(
         <Provider store={store}>
-          <MockedNavigator component={DAppsExplorerScreenSearchFilter} />
+          <MockedNavigator component={TabDiscover} />
         </Provider>
       )
 
@@ -336,7 +336,7 @@ describe('DAppsExplorerScreenSearchFilter', () => {
       })
       const { getByText, queryByText, getAllByTestId } = render(
         <Provider store={store}>
-          <MockedNavigator component={DAppsExplorerScreenSearchFilter} />
+          <MockedNavigator component={TabDiscover} />
         </Provider>
       )
 
@@ -369,7 +369,7 @@ describe('DAppsExplorerScreenSearchFilter', () => {
       })
       const { getByTestId, getByText, queryByTestId, getAllByTestId } = render(
         <Provider store={store}>
-          <MockedNavigator component={DAppsExplorerScreenSearchFilter} />
+          <MockedNavigator component={TabDiscover} />
         </Provider>
       )
 
@@ -403,7 +403,7 @@ describe('DAppsExplorerScreenSearchFilter', () => {
       })
       const { getByText } = render(
         <Provider store={store}>
-          <MockedNavigator component={DAppsExplorerScreenSearchFilter} />
+          <MockedNavigator component={TabDiscover} />
         </Provider>
       )
 
@@ -431,7 +431,7 @@ describe('DAppsExplorerScreenSearchFilter', () => {
       })
       const { getByText } = render(
         <Provider store={store}>
-          <MockedNavigator component={DAppsExplorerScreenSearchFilter} />
+          <MockedNavigator component={TabDiscover} />
         </Provider>
       )
 
@@ -466,7 +466,7 @@ describe('DAppsExplorerScreenSearchFilter', () => {
       })
       const { getByTestId, getByText } = render(
         <Provider store={store}>
-          <MockedNavigator component={DAppsExplorerScreenSearchFilter} />
+          <MockedNavigator component={TabDiscover} />
         </Provider>
       )
 
@@ -502,7 +502,7 @@ describe('DAppsExplorerScreenSearchFilter', () => {
       })
       const { getByText, queryByTestId } = render(
         <Provider store={store}>
-          <MockedNavigator component={DAppsExplorerScreenSearchFilter} />
+          <MockedNavigator component={TabDiscover} />
         </Provider>
       )
 
@@ -537,7 +537,7 @@ describe('DAppsExplorerScreenSearchFilter', () => {
       })
       const { getByTestId, getAllByTestId } = render(
         <Provider store={store}>
-          <MockedNavigator component={DAppsExplorerScreenSearchFilter} />
+          <MockedNavigator component={TabDiscover} />
         </Provider>
       )
 
@@ -568,7 +568,7 @@ describe('DAppsExplorerScreenSearchFilter', () => {
       })
       const { getByTestId, getByText, getAllByTestId, queryByTestId } = render(
         <Provider store={store}>
-          <MockedNavigator component={DAppsExplorerScreenSearchFilter} />
+          <MockedNavigator component={TabDiscover} />
         </Provider>
       )
 
@@ -601,7 +601,7 @@ describe('DAppsExplorerScreenSearchFilter', () => {
       })
       const { getByTestId, getByText, queryByTestId } = render(
         <Provider store={store}>
-          <MockedNavigator component={DAppsExplorerScreenSearchFilter} />
+          <MockedNavigator component={TabDiscover} />
         </Provider>
       )
 
@@ -646,7 +646,7 @@ describe('DAppsExplorerScreenSearchFilter', () => {
       })
       const { getByText } = render(
         <Provider store={store}>
-          <MockedNavigator component={DAppsExplorerScreenSearchFilter} />
+          <MockedNavigator component={TabDiscover} />
         </Provider>
       )
 
@@ -667,7 +667,7 @@ describe('DAppsExplorerScreenSearchFilter', () => {
       })
       const { getByText } = render(
         <Provider store={store}>
-          <MockedNavigator component={DAppsExplorerScreenSearchFilter} />
+          <MockedNavigator component={TabDiscover} />
         </Provider>
       )
 
@@ -685,7 +685,7 @@ describe('DAppsExplorerScreenSearchFilter', () => {
       })
       const { getByText, getByTestId, getAllByTestId } = render(
         <Provider store={store}>
-          <MockedNavigator component={DAppsExplorerScreenSearchFilter} />
+          <MockedNavigator component={TabDiscover} />
         </Provider>
       )
 

--- a/src/dappsExplorer/TabDiscover.tsx
+++ b/src/dappsExplorer/TabDiscover.tsx
@@ -55,7 +55,7 @@ interface SectionData {
 
 type Props = NativeStackScreenProps<StackParamList, Screens.TabDiscover>
 
-export function DAppsExplorerScreenSearchFilter({ navigation }: Props) {
+function TabDiscover({ navigation }: Props) {
   const { t } = useTranslation()
 
   const insets = useSafeAreaInsets()
@@ -362,4 +362,4 @@ const styles = StyleSheet.create({
   },
 })
 
-export default DAppsExplorerScreenSearchFilter
+export default TabDiscover

--- a/src/home/TabHome.test.tsx
+++ b/src/home/TabHome.test.tsx
@@ -2,7 +2,7 @@ import { act, render } from '@testing-library/react-native'
 import { FetchMock } from 'jest-fetch-mock/types'
 import * as React from 'react'
 import { Provider } from 'react-redux'
-import WalletHome from 'src/home/WalletHome'
+import TabHome from 'src/home/TabHome'
 import { Actions as IdentityActions } from 'src/identity/actions'
 import { RootState } from 'src/redux/reducers'
 import { getFeatureGate } from 'src/statsig'
@@ -76,7 +76,7 @@ jest.mock('src/fiatExchanges/utils', () => ({
   fetchProviders: jest.fn(),
 }))
 
-describe('WalletHome', () => {
+describe('TabHome', () => {
   const mockFetch = fetch as FetchMock
 
   beforeEach(() => {
@@ -101,7 +101,7 @@ describe('WalletHome', () => {
 
     const tree = render(
       <Provider store={store}>
-        <MockedNavigator component={WalletHome} params={screenParams} />
+        <MockedNavigator component={TabHome} params={screenParams} />
       </Provider>
     )
 

--- a/src/home/TabHome.tsx
+++ b/src/home/TabHome.tsx
@@ -45,7 +45,7 @@ const AnimatedSectionList = Animated.createAnimatedComponent(SectionList)
 
 type Props = NativeStackScreenProps<StackParamList, Screens.TabHome>
 
-function WalletHome({ navigation }: Props) {
+function TabHome({ navigation }: Props) {
   const { t } = useTranslation()
 
   const appState = useSelector(appStateSelector)
@@ -216,4 +216,4 @@ const styles = StyleSheet.create({
   },
 })
 
-export default WalletHome
+export default TabHome

--- a/src/navigator/TabNavigator.tsx
+++ b/src/navigator/TabNavigator.tsx
@@ -3,8 +3,8 @@ import { NativeStackHeaderProps, NativeStackScreenProps } from '@react-navigatio
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 import { StyleSheet } from 'react-native'
-import DAppsExplorerScreenSearchFilter from 'src/dappsExplorer/DAppsExplorerScreenSearchFilter'
-import WalletHome from 'src/home/WalletHome'
+import TabDiscover from 'src/dappsExplorer/TabDiscover'
+import TabHome from 'src/home/TabHome'
 import Logo from 'src/icons/Logo'
 import Discover from 'src/icons/navigator/Discover'
 import Wallet from 'src/icons/navigator/Wallet'
@@ -15,7 +15,7 @@ import Colors from 'src/styles/colors'
 import { typeScale } from 'src/styles/fonts'
 import { Spacing } from 'src/styles/styles'
 import variables from 'src/styles/variables'
-import AssetsScreen from 'src/tokens/Assets'
+import TabWallet from 'src/tokens/TabWallet'
 
 const Tab = createBottomTabNavigator()
 
@@ -45,7 +45,7 @@ export default function TabNavigator({ route }: Props) {
     >
       <Tab.Screen
         name={Screens.TabWallet}
-        component={AssetsScreen}
+        component={TabWallet}
         options={{
           tabBarLabel: t('bottomTabsNavigator.wallet.tabName') as string,
           tabBarIcon: Wallet,
@@ -54,7 +54,7 @@ export default function TabNavigator({ route }: Props) {
       />
       <Tab.Screen
         name={Screens.TabHome}
-        component={WalletHome}
+        component={TabHome}
         options={{
           freezeOnBlur: false,
           lazy: false,
@@ -65,7 +65,7 @@ export default function TabNavigator({ route }: Props) {
       />
       <Tab.Screen
         name={Screens.TabDiscover}
-        component={DAppsExplorerScreenSearchFilter}
+        component={TabDiscover}
         options={{
           tabBarLabel: t('bottomTabsNavigator.discover.tabName') as string,
           tabBarIcon: Discover,

--- a/src/tokens/TabWallet.test.tsx
+++ b/src/tokens/TabWallet.test.tsx
@@ -5,7 +5,7 @@ import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import { getFeatureGate } from 'src/statsig'
 import { StatsigFeatureGates } from 'src/statsig/types'
-import AssetsScreen from 'src/tokens/Assets'
+import TabWallet from 'src/tokens/TabWallet'
 import { NetworkId } from 'src/transactions/types'
 import MockedNavigator from 'test/MockedNavigator'
 import { createMockStore } from 'test/utils'
@@ -99,7 +99,7 @@ const storeWithNfts = {
   },
 }
 
-describe('AssetsScreen', () => {
+describe('TabWallet', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     jest.mocked(getFeatureGate).mockRestore()
@@ -112,7 +112,7 @@ describe('AssetsScreen', () => {
     const { getByTestId, getAllByTestId, queryAllByTestId, getByText, queryByText, queryByTestId } =
       render(
         <Provider store={store}>
-          <MockedNavigator component={AssetsScreen} />
+          <MockedNavigator component={TabWallet} />
         </Provider>
       )
 
@@ -136,7 +136,7 @@ describe('AssetsScreen', () => {
 
     const { getByTestId, getAllByTestId, queryAllByTestId, getByText, queryByText } = render(
       <Provider store={store}>
-        <MockedNavigator component={AssetsScreen} />
+        <MockedNavigator component={TabWallet} />
       </Provider>
     )
 
@@ -161,7 +161,7 @@ describe('AssetsScreen', () => {
     const { getByTestId, getAllByTestId, queryAllByTestId, getByText, queryByTestId, queryByText } =
       render(
         <Provider store={store}>
-          <MockedNavigator component={AssetsScreen} />
+          <MockedNavigator component={TabWallet} />
         </Provider>
       )
 
@@ -184,7 +184,7 @@ describe('AssetsScreen', () => {
 
     const { getAllByTestId, queryAllByTestId, getByText } = render(
       <Provider store={store}>
-        <MockedNavigator component={AssetsScreen} />
+        <MockedNavigator component={TabWallet} />
       </Provider>
     )
 
@@ -205,7 +205,7 @@ describe('AssetsScreen', () => {
 
     const { getAllByTestId, queryAllByTestId, getByText } = render(
       <Provider store={store}>
-        <MockedNavigator component={AssetsScreen} />
+        <MockedNavigator component={TabWallet} />
       </Provider>
     )
 
@@ -231,7 +231,7 @@ describe('AssetsScreen', () => {
 
     const { queryByText } = render(
       <Provider store={store}>
-        <MockedNavigator component={AssetsScreen} />
+        <MockedNavigator component={TabWallet} />
       </Provider>
     )
 
@@ -244,7 +244,7 @@ describe('AssetsScreen', () => {
 
     const { queryByText } = render(
       <Provider store={store}>
-        <MockedNavigator component={AssetsScreen} />
+        <MockedNavigator component={TabWallet} />
       </Provider>
     )
 
@@ -257,7 +257,7 @@ describe('AssetsScreen', () => {
 
     const { getByText, queryByText } = render(
       <Provider store={store}>
-        <MockedNavigator component={AssetsScreen} />
+        <MockedNavigator component={TabWallet} />
       </Provider>
     )
 
@@ -276,7 +276,7 @@ describe('AssetsScreen', () => {
 
     const { getByText } = render(
       <Provider store={store}>
-        <MockedNavigator component={AssetsScreen} />
+        <MockedNavigator component={TabWallet} />
       </Provider>
     )
 

--- a/src/tokens/TabWallet.tsx
+++ b/src/tokens/TabWallet.tsx
@@ -12,7 +12,6 @@ import { AssetsEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import Button, { BtnSizes, BtnTypes } from 'src/components/Button'
 import { AssetsTokenBalance } from 'src/components/TokenBalance'
-import { headerWithBackButton } from 'src/navigator/Headers'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import useScrollAwareHeader from 'src/navigator/ScrollAwareHeader'
@@ -193,10 +192,6 @@ function TabWallet({ navigation, route }: Props) {
       )}
     </Animated.View>
   )
-}
-
-TabWallet.navigationOptions = {
-  ...headerWithBackButton,
 }
 
 const styles = StyleSheet.create({

--- a/src/tokens/TabWallet.tsx
+++ b/src/tokens/TabWallet.tsx
@@ -35,7 +35,7 @@ const HEADER_OPACITY_ANIMATION_START_OFFSET = 44
 // distance in points over which the screen header opacity animation is applied
 const HEADER_OPACITY_ANIMATION_DISTANCE = 20
 
-function AssetsScreen({ navigation, route }: Props) {
+function TabWallet({ navigation, route }: Props) {
   const { t } = useTranslation()
 
   const activeTab = route.params?.activeAssetTab ?? AssetTabType.Tokens
@@ -195,7 +195,7 @@ function AssetsScreen({ navigation, route }: Props) {
   )
 }
 
-AssetsScreen.navigationOptions = {
+TabWallet.navigationOptions = {
   ...headerWithBackButton,
 }
 
@@ -224,4 +224,4 @@ const styles = StyleSheet.create({
   },
 })
 
-export default AssetsScreen
+export default TabWallet


### PR DESCRIPTION
### Description

Renames:
- WalletHome -> TabHome
- Assets -> TabWallet
- DAppsExplorerScreenSearchFilter -> Discover

### Test plan

CI

### Related issues

- Part of ACT-1133

### Backwards compatibility

Yes

### Network scalability

N/A
