### PR TITLE
chore: add statsig stable id to debug screen

### DIFF
--- a/src/app/Debug.test.tsx
+++ b/src/app/Debug.test.tsx
@@ -5,6 +5,12 @@ import { Provider } from 'react-redux'
 import Debug from 'src/app/Debug'
 import { createMockStore } from 'test/utils'
 
+jest.mock('statsig-react-native', () => ({
+  Statsig: {
+    getStableID: () => 'stableId',
+  },
+}))
+
 describe('Debug', () => {
   it('renders correctly', () => {
     const tree = render(

--- a/src/app/Debug.tsx
+++ b/src/app/Debug.tsx
@@ -12,6 +12,7 @@ import { RootState } from 'src/redux/reducers'
 import Logger from 'src/utils/Logger'
 import { currentAccountSelector } from 'src/web3/selectors'
 import { getLatestBlock } from 'src/web3/utils'
+import { Statsig } from 'statsig-react-native'
 
 interface State {
   latestBlockNumber: number
@@ -55,6 +56,7 @@ export class Debug extends React.Component<RootState, State> {
     const buildNumber = DeviceInfo.getBuildNumber()
     const apiLevel = DeviceInfo.getApiLevelSync()
     const deviceId = DeviceInfo.getDeviceId()
+    const stableId = Statsig.getStableID()
 
     return (
       <SafeAreaView style={styles.container}>
@@ -71,6 +73,9 @@ export class Debug extends React.Component<RootState, State> {
           onPress={this.onClickText(address)}
           style={styles.singleLine}
         >{`Address: ${address}`}</Text>
+        <Text onPress={this.onClickText(stableId)} style={styles.singleLine}>
+          {`Statsig Stable ID: ${stableId}`}
+        </Text>
         <Text style={styles.singleLine}>{`Latest Block: ${latestBlockNumber}`}</Text>
         <Button
           onPress={this.onClickEmailLogs}

--- a/src/app/__snapshots__/Debug.test.tsx.snap
+++ b/src/app/__snapshots__/Debug.test.tsx.snap
@@ -63,6 +63,17 @@ exports[`Debug renders correctly 1`] = `
     Address: 0x0000000000000000000000000000000000007e57
   </Text>
   <Text
+    onPress={[Function]}
+    style={
+      {
+        "fontSize": 11,
+        "marginTop": 5,
+      }
+    }
+  >
+    Statsig Stable ID: stableId
+  </Text>
+  <Text
     style={
       {
         "fontSize": 11,


### PR DESCRIPTION
### Description

as the title, useful for overriding stable id based gates / experiments

### Test plan

Manually checked debug screen

### Related issues

N/A

### Backwards compatibility

N/A

### Network scalability

N/A