### PR TITLE
feat(swap): enable app fee via remote config

### DIFF
--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -1824,7 +1824,7 @@
       "networkFeeInfoDismissButton": "Got it",
       "exchangeRate": "Exchange Rate",
       "exchangeRateInfo": "Exchange Rate\n\nWe've found the best exchange rate for you. Your trade will be completed at a price within {{slippagePercentage}}% of the estimate or the transaction will be cancelled & funds returned to your wallet.",
-      "exchangeRateInfo_withValoraFee": "Exchange Rate\n\nWe've found the best exchange rate for you. Your trade will be completed at a price within {{slippagePercentage}}% of the estimate or the transaction will be cancelled & funds returned to your wallet.\n\nThe estimated rate includes a {{appName}} fee of {{valoraFeePercentage}}%.",
+      "exchangeRateInfo_withAppFee": "Exchange Rate\n\nWe've found the best exchange rate for you. Your trade will be completed at a price within {{slippagePercentage}}% of the estimate or the transaction will be cancelled & funds returned to your wallet.\n\nThe estimated rate includes a {{appName}} fee of {{appFeePercentage}}%.",
       "exchangeRateInfoDismissButton": "Got it",
       "estimatedValue": "Estimated Value"
     },

--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -1823,6 +1823,9 @@
       "slippageToleranceInfo": "Slippage tolerance\n\nYour swap will execute within the slippage tolerance percentage. If the price changes more than the slippage tolerance, {{appName}} protects you by preventing the trade from executing.",
       "networkFeeInfoDismissButton": "Got it",
       "exchangeRate": "Exchange Rate",
+      "exchangeRateInfo": "Exchange Rate\n\nWe've found the best exchange rate for you. Your trade will be completed at a price within {{slippagePercentage}}% of the estimate or the transaction will be cancelled & funds returned to your wallet.",
+      "exchangeRateInfo_withValoraFee": "Exchange Rate\n\nWe've found the best exchange rate for you. Your trade will be completed at a price within {{slippagePercentage}}% of the estimate or the transaction will be cancelled & funds returned to your wallet.\n\nThe estimated rate includes a {{appName}} fee of {{valoraFeePercentage}}%.",
+      "exchangeRateInfoDismissButton": "Got it",
       "estimatedValue": "Estimated Value"
     },
     "fundYourWalletBottomSheet": {

--- a/src/analytics/Properties.tsx
+++ b/src/analytics/Properties.tsx
@@ -1251,6 +1251,7 @@ export enum SwapShowInfoType {
   MAX_NETWORK_FEE,
   ESTIMATED_NETWORK_FEE,
   SLIPPAGE,
+  EXCHANGE_RATE,
 }
 interface SwapEventsProperties {
   [SwapEvents.swap_screen_open]: undefined

--- a/src/statsig/constants.ts
+++ b/src/statsig/constants.ts
@@ -103,7 +103,7 @@ export const DynamicConfigs = {
     configName: StatsigDynamicConfigs.SWAP_CONFIG,
     defaultValues: {
       maxSlippagePercentage: '0.3',
-      enableValoraFee: false,
+      enableAppFee: false,
       popularTokenIds: [] as string[],
     },
   },

--- a/src/statsig/constants.ts
+++ b/src/statsig/constants.ts
@@ -103,6 +103,7 @@ export const DynamicConfigs = {
     configName: StatsigDynamicConfigs.SWAP_CONFIG,
     defaultValues: {
       maxSlippagePercentage: '0.3',
+      enableValoraFee: false,
       popularTokenIds: [] as string[],
     },
   },

--- a/src/swap/SwapScreen.test.tsx
+++ b/src/swap/SwapScreen.test.tsx
@@ -1808,9 +1808,9 @@ describe('SwapScreen', () => {
     })
   })
 
-  describe('valora fee', () => {
+  describe('app fee', () => {
     describe('when disabled', () => {
-      it('should show the free valora fee line item and exchange rate without fees when tapping the exchange rate info button', async () => {
+      it('should show the free swap fee line item and exchange rate without fees when tapping the exchange rate info button', async () => {
         mockFetch.mockResponse(defaultQuoteResponse)
         const { swapScreen, swapFromContainer, getByText, getByTestId } = renderScreen({})
 
@@ -1853,14 +1853,14 @@ describe('SwapScreen', () => {
       beforeEach(() => {
         jest.mocked(getDynamicConfigParams).mockReturnValue({
           maxSlippagePercentage: '0.3',
-          enableValoraFee: true,
+          enableAppFee: true,
           showSwap: ['celo-alfajores', 'ethereum-sepolia'],
           showBalances: ['celo-alfajores', 'ethereum-sepolia'],
           popularTokenIds: [],
         })
       })
 
-      it('should hide the free valora fee line item and show the exchange rate without the valora fee when tapping the exchange rate info button, when the quote does not include a positive valora fee', async () => {
+      it('should hide the free swap fee line item and show the exchange rate without the app fee when tapping the exchange rate info button, when the quote does not include a positive app fee', async () => {
         mockFetch.mockResponse(defaultQuoteResponse)
         const { swapScreen, swapFromContainer, getByText, getByTestId, queryByText } = renderScreen(
           {}
@@ -1884,7 +1884,7 @@ describe('SwapScreen', () => {
             NetworkId['celo-alfajores']
           }&sellToken=${mockCeloAddress}&sellIsNative=true&sellNetworkId=${
             NetworkId['celo-alfajores']
-          }&sellAmount=1234000000000000000&userAddress=${mockAccount.toLowerCase()}&slippagePercentage=0.3&enableValoraFee=true`
+          }&sellAmount=1234000000000000000&userAddress=${mockAccount.toLowerCase()}&slippagePercentage=0.3&enableAppFee=true`
         )
 
         expect(getByTestId('SwapTransactionDetails/ExchangeRate')).toHaveTextContent(
@@ -1900,13 +1900,13 @@ describe('SwapScreen', () => {
         expect(getByText(exchangeRateInfo)).toBeTruthy()
       })
 
-      it('should hide the free valora fee line item and show the exchange rate with the valora fee when tapping the exchange rate info button, when the quote includes a positive valora fee', async () => {
+      it('should hide the free swap fee line item and show the exchange rate with the app fee when tapping the exchange rate info button, when the quote includes a positive app fee', async () => {
         mockFetch.mockResponse(
           JSON.stringify({
             ...defaultQuote,
             unvalidatedSwapTransaction: {
               ...defaultQuote.unvalidatedSwapTransaction,
-              valoraFeePercentageIncludedInPrice: '2',
+              appFeePercentageIncludedInPrice: '2',
             },
           })
         )
@@ -1932,7 +1932,7 @@ describe('SwapScreen', () => {
             NetworkId['celo-alfajores']
           }&sellToken=${mockCeloAddress}&sellIsNative=true&sellNetworkId=${
             NetworkId['celo-alfajores']
-          }&sellAmount=1234000000000000000&userAddress=${mockAccount.toLowerCase()}&slippagePercentage=0.3&enableValoraFee=true`
+          }&sellAmount=1234000000000000000&userAddress=${mockAccount.toLowerCase()}&slippagePercentage=0.3&enableAppFee=true`
         )
 
         expect(getByTestId('SwapTransactionDetails/ExchangeRate')).toHaveTextContent(
@@ -1945,7 +1945,7 @@ describe('SwapScreen', () => {
 
         expect(
           getByText(
-            'swapScreen.transactionDetails.exchangeRateInfo, {"context":"withValoraFee","networkName":"Celo Alfajores","slippagePercentage":"0.3","valoraFeePercentage":"2"}'
+            'swapScreen.transactionDetails.exchangeRateInfo, {"context":"withAppFee","networkName":"Celo Alfajores","slippagePercentage":"0.3","appFeePercentage":"2"}'
           )
         ).toBeTruthy()
       })

--- a/src/swap/SwapScreen.test.tsx
+++ b/src/swap/SwapScreen.test.tsx
@@ -290,6 +290,7 @@ describe('SwapScreen', () => {
       },
     })
 
+    jest.mocked(getFeatureGate).mockReset()
     jest.mocked(getExperimentParams).mockReturnValue({
       swapBuyAmountEnabled: true,
     })
@@ -1803,6 +1804,150 @@ describe('SwapScreen', () => {
       })
       expectedEthTokens.forEach((token) => {
         expect(within(tokenBottomSheet).getByText(token.name)).toBeTruthy()
+      })
+    })
+  })
+
+  describe('valora fee', () => {
+    describe('when disabled', () => {
+      it('should show the free valora fee line item and exchange rate without fees when tapping the exchange rate info button', async () => {
+        mockFetch.mockResponse(defaultQuoteResponse)
+        const { swapScreen, swapFromContainer, getByText, getByTestId } = renderScreen({})
+
+        selectSwapTokens('CELO', 'cUSD', swapScreen)
+        fireEvent.changeText(
+          within(swapFromContainer).getByTestId('SwapAmountInput/Input'),
+          '1.234'
+        )
+
+        await act(() => {
+          jest.runOnlyPendingTimers()
+        })
+
+        expect(mockFetch.mock.calls.length).toEqual(1)
+        expect(mockFetch.mock.calls[0][0]).toEqual(
+          `${
+            networkConfig.getSwapQuoteUrl
+          }?buyToken=${mockCusdAddress}&buyIsNative=false&buyNetworkId=${
+            NetworkId['celo-alfajores']
+          }&sellToken=${mockCeloAddress}&sellIsNative=true&sellNetworkId=${
+            NetworkId['celo-alfajores']
+          }&sellAmount=1234000000000000000&userAddress=${mockAccount.toLowerCase()}&slippagePercentage=0.3`
+        )
+
+        expect(getByTestId('SwapTransactionDetails/ExchangeRate')).toHaveTextContent(
+          '1 CELO ≈ 1.23456 cUSD'
+        )
+        expect(getByText('swapScreen.transactionDetails.swapFee')).toBeTruthy()
+        expect(getByText('swapScreen.transactionDetails.swapFeeWaived')).toBeTruthy()
+
+        fireEvent.press(getByText('swapScreen.transactionDetails.exchangeRate'))
+
+        const exchangeRateInfo =
+          'swapScreen.transactionDetails.exchangeRateInfo, {"context":"","networkName":"Celo Alfajores","slippagePercentage":"0.3"}'
+        expect(getByText(exchangeRateInfo)).toBeTruthy()
+      })
+    })
+
+    describe('when enabled', () => {
+      beforeEach(() => {
+        jest.mocked(getDynamicConfigParams).mockReturnValue({
+          maxSlippagePercentage: '0.3',
+          enableValoraFee: true,
+          showSwap: ['celo-alfajores', 'ethereum-sepolia'],
+          showBalances: ['celo-alfajores', 'ethereum-sepolia'],
+          popularTokenIds: [],
+        })
+      })
+
+      it('should hide the free valora fee line item and show the exchange rate without the valora fee when tapping the exchange rate info button, when the quote does not include a positive valora fee', async () => {
+        mockFetch.mockResponse(defaultQuoteResponse)
+        const { swapScreen, swapFromContainer, getByText, getByTestId, queryByText } = renderScreen(
+          {}
+        )
+
+        selectSwapTokens('CELO', 'cUSD', swapScreen)
+        fireEvent.changeText(
+          within(swapFromContainer).getByTestId('SwapAmountInput/Input'),
+          '1.234'
+        )
+
+        await act(() => {
+          jest.runOnlyPendingTimers()
+        })
+
+        expect(mockFetch.mock.calls.length).toEqual(1)
+        expect(mockFetch.mock.calls[0][0]).toEqual(
+          `${
+            networkConfig.getSwapQuoteUrl
+          }?buyToken=${mockCusdAddress}&buyIsNative=false&buyNetworkId=${
+            NetworkId['celo-alfajores']
+          }&sellToken=${mockCeloAddress}&sellIsNative=true&sellNetworkId=${
+            NetworkId['celo-alfajores']
+          }&sellAmount=1234000000000000000&userAddress=${mockAccount.toLowerCase()}&slippagePercentage=0.3&enableValoraFee=true`
+        )
+
+        expect(getByTestId('SwapTransactionDetails/ExchangeRate')).toHaveTextContent(
+          '1 CELO ≈ 1.23456 cUSD'
+        )
+        expect(queryByText('swapScreen.transactionDetails.swapFee')).toBeFalsy()
+        expect(queryByText('swapScreen.transactionDetails.swapFeeWaived')).toBeFalsy()
+
+        fireEvent.press(getByText('swapScreen.transactionDetails.exchangeRate'))
+
+        const exchangeRateInfo =
+          'swapScreen.transactionDetails.exchangeRateInfo, {"context":"","networkName":"Celo Alfajores","slippagePercentage":"0.3"}'
+        expect(getByText(exchangeRateInfo)).toBeTruthy()
+      })
+
+      it('should hide the free valora fee line item and show the exchange rate with the valora fee when tapping the exchange rate info button, when the quote includes a positive valora fee', async () => {
+        mockFetch.mockResponse(
+          JSON.stringify({
+            ...defaultQuote,
+            unvalidatedSwapTransaction: {
+              ...defaultQuote.unvalidatedSwapTransaction,
+              valoraFeePercentageIncludedInPrice: '2',
+            },
+          })
+        )
+        const { swapScreen, swapFromContainer, getByText, getByTestId, queryByText } = renderScreen(
+          {}
+        )
+
+        selectSwapTokens('CELO', 'cUSD', swapScreen)
+        fireEvent.changeText(
+          within(swapFromContainer).getByTestId('SwapAmountInput/Input'),
+          '1.234'
+        )
+
+        await act(() => {
+          jest.runOnlyPendingTimers()
+        })
+
+        expect(mockFetch.mock.calls.length).toEqual(1)
+        expect(mockFetch.mock.calls[0][0]).toEqual(
+          `${
+            networkConfig.getSwapQuoteUrl
+          }?buyToken=${mockCusdAddress}&buyIsNative=false&buyNetworkId=${
+            NetworkId['celo-alfajores']
+          }&sellToken=${mockCeloAddress}&sellIsNative=true&sellNetworkId=${
+            NetworkId['celo-alfajores']
+          }&sellAmount=1234000000000000000&userAddress=${mockAccount.toLowerCase()}&slippagePercentage=0.3&enableValoraFee=true`
+        )
+
+        expect(getByTestId('SwapTransactionDetails/ExchangeRate')).toHaveTextContent(
+          '1 CELO ≈ 1.23456 cUSD'
+        )
+        expect(queryByText('swapScreen.transactionDetails.swapFee')).toBeFalsy()
+        expect(queryByText('swapScreen.transactionDetails.swapFeeWaived')).toBeFalsy()
+
+        fireEvent.press(getByText('swapScreen.transactionDetails.exchangeRate'))
+
+        expect(
+          getByText(
+            'swapScreen.transactionDetails.exchangeRateInfo, {"context":"withValoraFee","networkName":"Celo Alfajores","slippagePercentage":"0.3","valoraFeePercentage":"2"}'
+          )
+        ).toBeTruthy()
       })
     })
   })

--- a/src/swap/SwapScreen.tsx
+++ b/src/swap/SwapScreen.tsx
@@ -240,7 +240,7 @@ export function SwapScreen({ route }: Props) {
   const { swapBuyAmountEnabled } = getExperimentParams(
     ExperimentConfigs[StatsigExperiments.SWAP_BUY_AMOUNT]
   )
-  const { maxSlippagePercentage, enableValoraFee } = getDynamicConfigParams(
+  const { maxSlippagePercentage, enableAppFee } = getDynamicConfigParams(
     DynamicConfigs[StatsigDynamicConfigs.SWAP_CONFIG]
   )
   const parsedSlippagePercentage = new BigNumber(maxSlippagePercentage).toFormat()
@@ -296,7 +296,7 @@ export function SwapScreen({ route }: Props) {
   const { quote, refreshQuote, fetchSwapQuoteError, fetchingSwapQuote, clearQuote } = useSwapQuote({
     networkId: fromToken?.networkId || networkConfig.defaultNetworkId,
     slippagePercentage: maxSlippagePercentage,
-    enableValoraFee,
+    enableAppFee: enableAppFee,
   })
 
   // Parsed swap amounts (BigNumber)
@@ -632,8 +632,8 @@ export function SwapScreen({ route }: Props) {
     return getNetworkFee(quote, fromToken?.networkId)
   }, [fromToken, quote])
 
-  const valoraFeePercentage = quote?.valoraFeePercentageIncludedInPrice
-    ? new BigNumber(quote.valoraFeePercentageIncludedInPrice)
+  const appFeePercentage = quote?.appFeePercentageIncludedInPrice
+    ? new BigNumber(quote.appFeePercentageIncludedInPrice)
     : undefined
 
   useEffect(() => {
@@ -735,7 +735,7 @@ export function SwapScreen({ route }: Props) {
             exchangeRatePrice={quote?.price}
             swapAmount={parsedSwapAmount[Field.FROM]}
             fetchingSwapQuote={quoteUpdatePending}
-            enableValoraFee={enableValoraFee}
+            enableAppFee={enableAppFee}
             exchangeRateInfoBottomSheetRef={exchangeRateInfoBottomSheetRef}
           />
           {showSwitchedToNetworkWarning && (
@@ -852,10 +852,10 @@ export function SwapScreen({ route }: Props) {
       <BottomSheet
         forwardedRef={exchangeRateInfoBottomSheetRef}
         description={t('swapScreen.transactionDetails.exchangeRateInfo', {
-          context: valoraFeePercentage?.isGreaterThan(0) ? 'withValoraFee' : '',
+          context: appFeePercentage?.isGreaterThan(0) ? 'withAppFee' : '',
           networkName: NETWORK_NAMES[fromToken?.networkId || networkConfig.defaultNetworkId],
           slippagePercentage: parsedSlippagePercentage,
-          valoraFeePercentage: valoraFeePercentage?.toFormat(),
+          appFeePercentage: appFeePercentage?.toFormat(),
         })}
         testId="ExchangeRateInfoBottomSheet"
       >

--- a/src/swap/SwapTransactionDetails.test.tsx
+++ b/src/swap/SwapTransactionDetails.test.tsx
@@ -20,7 +20,9 @@ describe('SwapTransactionDetails', () => {
           estimatedNetworkFee={new BigNumber(0.00005)}
           networkFeeInfoBottomSheetRef={{ current: null }}
           slippageInfoBottomSheetRef={{ current: null }}
+          exchangeRateInfoBottomSheetRef={{ current: null }}
           feeTokenId={'someId'}
+          enableValoraFee={false}
           slippagePercentage={'0.5'}
           fetchingSwapQuote={false}
           fromToken={{
@@ -40,6 +42,8 @@ describe('SwapTransactionDetails', () => {
     expect(getByTestId('SwapTransactionDetails/ExchangeRate')).toHaveTextContent(
       '1 cUSD ≈ 0.58370 CELO'
     )
+    expect(getByTestId('SwapTransactionDetails/ExchangeRate/MoreInfo/Icon')).toBeTruthy()
+    expect(getByTestId('SwapTransactionDetails/ExchangeRate/MoreInfo')).not.toBeDisabled()
   })
 
   it('should render correctly without the fromToken and fees', () => {
@@ -48,7 +52,9 @@ describe('SwapTransactionDetails', () => {
         <SwapTransactionDetails
           networkFeeInfoBottomSheetRef={{ current: null }}
           slippageInfoBottomSheetRef={{ current: null }}
+          exchangeRateInfoBottomSheetRef={{ current: null }}
           feeTokenId={'someId'}
+          enableValoraFee={false}
           slippagePercentage={'0.5'}
           fetchingSwapQuote={false}
         />
@@ -72,7 +78,9 @@ describe('SwapTransactionDetails', () => {
           estimatedNetworkFee={new BigNumber(0.00005)}
           networkFeeInfoBottomSheetRef={{ current: null }}
           slippageInfoBottomSheetRef={{ current: null }}
+          exchangeRateInfoBottomSheetRef={{ current: null }}
           feeTokenId={mockCeloTokenId}
+          enableValoraFee={false}
           slippagePercentage={'0.5'}
           fromToken={mockCeloTokenBalance}
           fetchingSwapQuote={false}
@@ -101,6 +109,8 @@ describe('SwapTransactionDetails', () => {
           estimatedNetworkFee={new BigNumber(0.00005)}
           networkFeeInfoBottomSheetRef={{ current: null }}
           slippageInfoBottomSheetRef={{ current: null }}
+          exchangeRateInfoBottomSheetRef={{ current: null }}
+          enableValoraFee={false}
           feeTokenId={mockCeloTokenId}
           slippagePercentage={'0.5'}
           fromToken={mockCeloTokenBalance}
@@ -113,5 +123,29 @@ describe('SwapTransactionDetails', () => {
     expect(getByTestId('SwapTransactionDetails/Slippage')).toHaveTextContent('0.5%')
     expect(getByTestId('SwapTransactionDetails/Slippage/MoreInfo/Icon')).toBeTruthy()
     expect(getByTestId('SwapTransactionDetails/Slippage/MoreInfo')).not.toBeDisabled()
+  })
+
+  it('should render correctly when valora fee is enabled', () => {
+    const { queryByText } = render(
+      <Provider store={createMockStore()}>
+        <SwapTransactionDetails
+          maxNetworkFee={new BigNumber(0.0001)}
+          estimatedNetworkFee={new BigNumber(0.00005)}
+          networkFeeInfoBottomSheetRef={{ current: null }}
+          slippageInfoBottomSheetRef={{ current: null }}
+          exchangeRateInfoBottomSheetRef={{ current: null }}
+          enableValoraFee={true}
+          feeTokenId={mockCeloTokenId}
+          slippagePercentage={'0.5'}
+          fromToken={mockCeloTokenBalance}
+          fetchingSwapQuote={false}
+        />
+      </Provider>
+    )
+
+    // When Valora fee is enabled, the free swap fee should not be displayed
+    // it's part of the exchange rate
+    expect(queryByText('swapScreen.transactionDetails.swapFee')).toBeFalsy()
+    expect(queryByText('swapScreen.transactionDetails.swapFeeWaived')).toBeFalsy()
   })
 })

--- a/src/swap/SwapTransactionDetails.test.tsx
+++ b/src/swap/SwapTransactionDetails.test.tsx
@@ -22,7 +22,7 @@ describe('SwapTransactionDetails', () => {
           slippageInfoBottomSheetRef={{ current: null }}
           exchangeRateInfoBottomSheetRef={{ current: null }}
           feeTokenId={'someId'}
-          enableValoraFee={false}
+          enableAppFee={false}
           slippagePercentage={'0.5'}
           fetchingSwapQuote={false}
           fromToken={{
@@ -54,7 +54,7 @@ describe('SwapTransactionDetails', () => {
           slippageInfoBottomSheetRef={{ current: null }}
           exchangeRateInfoBottomSheetRef={{ current: null }}
           feeTokenId={'someId'}
-          enableValoraFee={false}
+          enableAppFee={false}
           slippagePercentage={'0.5'}
           fetchingSwapQuote={false}
         />
@@ -80,7 +80,7 @@ describe('SwapTransactionDetails', () => {
           slippageInfoBottomSheetRef={{ current: null }}
           exchangeRateInfoBottomSheetRef={{ current: null }}
           feeTokenId={mockCeloTokenId}
-          enableValoraFee={false}
+          enableAppFee={false}
           slippagePercentage={'0.5'}
           fromToken={mockCeloTokenBalance}
           fetchingSwapQuote={false}
@@ -110,7 +110,7 @@ describe('SwapTransactionDetails', () => {
           networkFeeInfoBottomSheetRef={{ current: null }}
           slippageInfoBottomSheetRef={{ current: null }}
           exchangeRateInfoBottomSheetRef={{ current: null }}
-          enableValoraFee={false}
+          enableAppFee={false}
           feeTokenId={mockCeloTokenId}
           slippagePercentage={'0.5'}
           fromToken={mockCeloTokenBalance}
@@ -125,7 +125,7 @@ describe('SwapTransactionDetails', () => {
     expect(getByTestId('SwapTransactionDetails/Slippage/MoreInfo')).not.toBeDisabled()
   })
 
-  it('should render correctly when valora fee is enabled', () => {
+  it('should render correctly when app fee is enabled', () => {
     const { queryByText } = render(
       <Provider store={createMockStore()}>
         <SwapTransactionDetails
@@ -134,7 +134,7 @@ describe('SwapTransactionDetails', () => {
           networkFeeInfoBottomSheetRef={{ current: null }}
           slippageInfoBottomSheetRef={{ current: null }}
           exchangeRateInfoBottomSheetRef={{ current: null }}
-          enableValoraFee={true}
+          enableAppFee={true}
           feeTokenId={mockCeloTokenId}
           slippagePercentage={'0.5'}
           fromToken={mockCeloTokenBalance}
@@ -143,7 +143,7 @@ describe('SwapTransactionDetails', () => {
       </Provider>
     )
 
-    // When Valora fee is enabled, the free swap fee should not be displayed
+    // When app fee is enabled, the free swap fee should not be displayed
     // it's part of the exchange rate
     expect(queryByText('swapScreen.transactionDetails.swapFee')).toBeFalsy()
     expect(queryByText('swapScreen.transactionDetails.swapFeeWaived')).toBeFalsy()

--- a/src/swap/SwapTransactionDetails.tsx
+++ b/src/swap/SwapTransactionDetails.tsx
@@ -145,7 +145,7 @@ export function SwapTransactionDetails({
         <LabelWithInfo
           onPress={() => {
             ValoraAnalytics.track(SwapEvents.swap_show_info, {
-              type: SwapShowInfoType.SLIPPAGE,
+              type: SwapShowInfoType.EXCHANGE_RATE,
             })
             exchangeRateInfoBottomSheetRef.current?.snapToIndex(0)
           }}

--- a/src/swap/SwapTransactionDetails.tsx
+++ b/src/swap/SwapTransactionDetails.tsx
@@ -26,6 +26,8 @@ interface Props {
   exchangeRatePrice?: string
   swapAmount?: BigNumber
   fetchingSwapQuote: boolean
+  enableValoraFee: boolean
+  exchangeRateInfoBottomSheetRef: React.RefObject<BottomSheetRefType>
 }
 
 function LabelWithInfo({
@@ -131,6 +133,8 @@ export function SwapTransactionDetails({
   exchangeRatePrice,
   swapAmount,
   fetchingSwapQuote,
+  enableValoraFee,
+  exchangeRateInfoBottomSheetRef,
 }: Props) {
   const { t } = useTranslation()
 
@@ -138,7 +142,16 @@ export function SwapTransactionDetails({
   return (
     <View style={styles.container} testID="SwapTransactionDetails">
       <View style={styles.row} testID="SwapTransactionDetails/ExchangeRate">
-        <Text style={styles.label}>{t('swapScreen.transactionDetails.exchangeRate')}</Text>
+        <LabelWithInfo
+          onPress={() => {
+            ValoraAnalytics.track(SwapEvents.swap_show_info, {
+              type: SwapShowInfoType.SLIPPAGE,
+            })
+            exchangeRateInfoBottomSheetRef.current?.snapToIndex(0)
+          }}
+          label={t('swapScreen.transactionDetails.exchangeRate')}
+          testID="SwapTransactionDetails/ExchangeRate/MoreInfo"
+        />
         <Text style={styles.value}>
           {!fetchingSwapQuote && fromToken && toToken && exchangeRatePrice ? (
             <>
@@ -181,12 +194,15 @@ export function SwapTransactionDetails({
         placeholder={placeholder}
         testID={`SwapTransactionDetails/MaxNetworkFee`}
       />
-      <View style={styles.row}>
-        <Text style={styles.label}>{t('swapScreen.transactionDetails.swapFee')}</Text>
-        <Text testID={'SwapFee'} style={styles.value}>
-          {t('swapScreen.transactionDetails.swapFeeWaived')}
-        </Text>
-      </View>
+      {/* When enabled, it's the fee is part of the exchange rate */}
+      {!enableValoraFee && (
+        <View style={styles.row}>
+          <Text style={styles.label}>{t('swapScreen.transactionDetails.swapFee')}</Text>
+          <Text testID={'SwapFee'} style={styles.value}>
+            {t('swapScreen.transactionDetails.swapFeeWaived')}
+          </Text>
+        </View>
+      )}
       <View style={styles.row} testID="SwapTransactionDetails/Slippage">
         <LabelWithInfo
           onPress={() => {

--- a/src/swap/SwapTransactionDetails.tsx
+++ b/src/swap/SwapTransactionDetails.tsx
@@ -26,7 +26,7 @@ interface Props {
   exchangeRatePrice?: string
   swapAmount?: BigNumber
   fetchingSwapQuote: boolean
-  enableValoraFee: boolean
+  enableAppFee: boolean
   exchangeRateInfoBottomSheetRef: React.RefObject<BottomSheetRefType>
 }
 
@@ -133,7 +133,7 @@ export function SwapTransactionDetails({
   exchangeRatePrice,
   swapAmount,
   fetchingSwapQuote,
-  enableValoraFee,
+  enableAppFee,
   exchangeRateInfoBottomSheetRef,
 }: Props) {
   const { t } = useTranslation()
@@ -194,8 +194,8 @@ export function SwapTransactionDetails({
         placeholder={placeholder}
         testID={`SwapTransactionDetails/MaxNetworkFee`}
       />
-      {/* When enabled, it's the fee is part of the exchange rate */}
-      {!enableValoraFee && (
+      {/* When enabled, the fee is part of the exchange rate */}
+      {!enableAppFee && (
         <View style={styles.row}>
           <Text style={styles.label}>{t('swapScreen.transactionDetails.swapFee')}</Text>
           <Text testID={'SwapFee'} style={styles.value}>

--- a/src/swap/types.ts
+++ b/src/swap/types.ts
@@ -32,6 +32,7 @@ export interface SwapTransaction {
   // be careful -- price means different things when using sellAmount vs buyAmount
   price: string
   guaranteedPrice: string
+  valoraFeePercentageIncludedInPrice: string | undefined
   /**
    * In percentage, between 0 and 100
    */

--- a/src/swap/types.ts
+++ b/src/swap/types.ts
@@ -32,7 +32,7 @@ export interface SwapTransaction {
   // be careful -- price means different things when using sellAmount vs buyAmount
   price: string
   guaranteedPrice: string
-  valoraFeePercentageIncludedInPrice: string | undefined
+  appFeePercentageIncludedInPrice: string | undefined
   /**
    * In percentage, between 0 and 100
    */

--- a/src/swap/useSwapQuote.ts
+++ b/src/swap/useSwapQuote.ts
@@ -28,6 +28,7 @@ export interface QuoteResult {
   fromTokenId: string
   swapAmount: BigNumber
   price: string
+  valoraFeePercentageIncludedInPrice: string | undefined
   provider: string
   estimatedPriceImpact: string | null
   allowanceTarget: string
@@ -136,7 +137,15 @@ async function prepareSwapTransactions(
   })
 }
 
-function useSwapQuote(networkId: NetworkId, slippagePercentage: string) {
+function useSwapQuote({
+  networkId,
+  slippagePercentage,
+  enableValoraFee,
+}: {
+  networkId: NetworkId
+  slippagePercentage: string
+  enableValoraFee: boolean
+}) {
   const walletAddress = useSelector(walletAddressSelector)
   const feeCurrencies = useSelector((state) => feeCurrenciesSelector(state, networkId))
 
@@ -174,6 +183,7 @@ function useSwapQuote(networkId: NetworkId, slippagePercentage: string) {
         [swapAmountParam]: swapAmountInWei.toFixed(0, BigNumber.ROUND_DOWN),
         userAddress: walletAddress ?? '',
         slippagePercentage,
+        ...(enableValoraFee === true && { enableValoraFee: enableValoraFee.toString() }),
       }
       const queryParams = new URLSearchParams({ ...params }).toString()
       const requestUrl = `${networkConfig.getSwapQuoteUrl}?${queryParams}`
@@ -207,6 +217,8 @@ function useSwapQuote(networkId: NetworkId, slippagePercentage: string) {
         fromTokenId: fromToken.tokenId,
         swapAmount: swapAmount[updatedField],
         price,
+        valoraFeePercentageIncludedInPrice:
+          quote.unvalidatedSwapTransaction.valoraFeePercentageIncludedInPrice,
         provider: quote.details.swapProvider,
         estimatedPriceImpact,
         allowanceTarget: quote.unvalidatedSwapTransaction.allowanceTarget,

--- a/src/swap/useSwapQuote.ts
+++ b/src/swap/useSwapQuote.ts
@@ -28,7 +28,7 @@ export interface QuoteResult {
   fromTokenId: string
   swapAmount: BigNumber
   price: string
-  valoraFeePercentageIncludedInPrice: string | undefined
+  appFeePercentageIncludedInPrice: string | undefined
   provider: string
   estimatedPriceImpact: string | null
   allowanceTarget: string
@@ -140,11 +140,11 @@ async function prepareSwapTransactions(
 function useSwapQuote({
   networkId,
   slippagePercentage,
-  enableValoraFee,
+  enableAppFee,
 }: {
   networkId: NetworkId
   slippagePercentage: string
-  enableValoraFee: boolean
+  enableAppFee: boolean
 }) {
   const walletAddress = useSelector(walletAddressSelector)
   const feeCurrencies = useSelector((state) => feeCurrenciesSelector(state, networkId))
@@ -183,7 +183,7 @@ function useSwapQuote({
         [swapAmountParam]: swapAmountInWei.toFixed(0, BigNumber.ROUND_DOWN),
         userAddress: walletAddress ?? '',
         slippagePercentage,
-        ...(enableValoraFee === true && { enableValoraFee: enableValoraFee.toString() }),
+        ...(enableAppFee === true && { enableAppFee: enableAppFee.toString() }),
       }
       const queryParams = new URLSearchParams({ ...params }).toString()
       const requestUrl = `${networkConfig.getSwapQuoteUrl}?${queryParams}`
@@ -217,8 +217,8 @@ function useSwapQuote({
         fromTokenId: fromToken.tokenId,
         swapAmount: swapAmount[updatedField],
         price,
-        valoraFeePercentageIncludedInPrice:
-          quote.unvalidatedSwapTransaction.valoraFeePercentageIncludedInPrice,
+        appFeePercentageIncludedInPrice:
+          quote.unvalidatedSwapTransaction.appFeePercentageIncludedInPrice,
         provider: quote.details.swapProvider,
         estimatedPriceImpact,
         allowanceTarget: quote.unvalidatedSwapTransaction.allowanceTarget,


### PR DESCRIPTION
### Description

This PR allows enabling the swap fee via the remote config.

When enabled, the free Valora swap fee line item is hidden.
The details of the Valora fee are then displayed when hitting the info button of the exchange rate line item.

### Test plan

- Updated tests

| Valora fee disabled | Valora fee enabled (0 fee from API) | Valora fee enabled (positive fee from API) |
|----------|----------|----------|
| ![image](https://github.com/valora-inc/wallet/assets/57791/6cded654-86bd-46eb-ab8d-da35076588bd)  | ![image](https://github.com/valora-inc/wallet/assets/57791/038fb3b4-d2cf-4d49-8325-40b6824038a8)   | ![image](https://github.com/valora-inc/wallet/assets/57791/576fcf93-b99a-4269-a387-fa009e10dedb)   |
| ![image](https://github.com/valora-inc/wallet/assets/57791/37ac4758-4d25-46a7-852a-c6b21ea44047) | ![image](https://github.com/valora-inc/wallet/assets/57791/49cd7a09-775e-4b47-91b4-ecf0a022b4c6)   | ![image](https://github.com/valora-inc/wallet/assets/57791/dd66d5d3-0bd3-4c89-a5cd-4b4b1c34d442)   |

Notes: 
- copies are not final
- the "Valora fee disabled" case is same as today except it also shows the info icon next to the exchange rate.

### Related issues

- Fixes RET-1061

### Backwards compatibility

Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
