### PR TITLE
ci: upload detox build to emerge on merge queue runs

### DIFF
--- a/.github/scripts/uploadE2eBuildToEmerge.ts
+++ b/.github/scripts/uploadE2eBuildToEmerge.ts
@@ -25,7 +25,10 @@ function getGitHubInfo() {
     if (!prNumber) {
       throw new Error('Could not get prNumber for a PR triggered build.')
     }
-  } else if (['push', 'merge_group'].includes(process.env.GITHUB_EVENT_NAME)) {
+  } else if (
+    process.env.GITHUB_EVENT_NAME === 'push' ||
+    process.env.GITHUB_EVENT_NAME === 'merge_queue'
+  ) {
     sha = process.env.GITHUB_SHA ?? ''
     // Get the SHA of the previous commit, which will be the baseSha in the case of a push event.
     baseSha = eventFileJson?.before ?? ''

--- a/.github/scripts/uploadE2eBuildToEmerge.ts
+++ b/.github/scripts/uploadE2eBuildToEmerge.ts
@@ -25,14 +25,15 @@ function getGitHubInfo() {
     if (!prNumber) {
       throw new Error('Could not get prNumber for a PR triggered build.')
     }
-  } else if (
-    process.env.GITHUB_EVENT_NAME === 'push' ||
-    process.env.GITHUB_EVENT_NAME === 'merge_group'
-  ) {
-    console.log('event file...', eventFileJson)
+  } else if (process.env.GITHUB_EVENT_NAME === 'push') {
     sha = process.env.GITHUB_SHA ?? ''
     // Get the SHA of the previous commit, which will be the baseSha in the case of a push event.
     baseSha = eventFileJson?.before ?? ''
+    branchName = process.env.GITHUB_REF_NAME ?? ''
+  } else if (process.env.GITHUB_EVENT_NAME === 'merge_group') {
+    sha = process.env.GITHUB_SHA ?? ''
+    // Get the SHA of the base commit, which will be the base_sha in the case of a merge_group event.
+    baseSha = eventFileJson?.merge_group?.base_sha ?? ''
     branchName = process.env.GITHUB_REF_NAME ?? ''
   } else {
     throw new Error(`Unsupported action trigger: ${process.env.GITHUB_EVENT_NAME}`)

--- a/.github/scripts/uploadE2eBuildToEmerge.ts
+++ b/.github/scripts/uploadE2eBuildToEmerge.ts
@@ -25,7 +25,7 @@ function getGitHubInfo() {
     if (!prNumber) {
       throw new Error('Could not get prNumber for a PR triggered build.')
     }
-  } else if (process.env.GITHUB_EVENT_NAME === 'push') {
+  } else if (['push', 'merge_group'].includes(process.env.GITHUB_EVENT_NAME)) {
     sha = process.env.GITHUB_SHA ?? ''
     // Get the SHA of the previous commit, which will be the baseSha in the case of a push event.
     baseSha = eventFileJson?.before ?? ''

--- a/.github/scripts/uploadE2eBuildToEmerge.ts
+++ b/.github/scripts/uploadE2eBuildToEmerge.ts
@@ -27,7 +27,7 @@ function getGitHubInfo() {
     }
   } else if (
     process.env.GITHUB_EVENT_NAME === 'push' ||
-    process.env.GITHUB_EVENT_NAME === 'merge_queue'
+    process.env.GITHUB_EVENT_NAME === 'merge_group'
   ) {
     sha = process.env.GITHUB_SHA ?? ''
     // Get the SHA of the previous commit, which will be the baseSha in the case of a push event.

--- a/.github/scripts/uploadE2eBuildToEmerge.ts
+++ b/.github/scripts/uploadE2eBuildToEmerge.ts
@@ -29,6 +29,7 @@ function getGitHubInfo() {
     process.env.GITHUB_EVENT_NAME === 'push' ||
     process.env.GITHUB_EVENT_NAME === 'merge_group'
   ) {
+    console.log('event file...', eventFileJson)
     sha = process.env.GITHUB_SHA ?? ''
     // Get the SHA of the previous commit, which will be the baseSha in the case of a push event.
     baseSha = eventFileJson?.before ?? ''

--- a/.github/workflows/e2e-ios.yml
+++ b/.github/workflows/e2e-ios.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Upload Detox Build to Emerge
         if: |
           env.SECRETS_AVAILABLE
-            && (github.event_name == 'pull_request' || github.event_name == 'push')
+            && (github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group')
         run: yarn ts-node .github/scripts/uploadE2eBuildToEmerge.ts
         env:
           EMERGE_API_TOKEN: ${{ steps.google-secrets.outputs.EMERGE_API_TOKEN }}


### PR DESCRIPTION
### Description

Some main runs fail to upload this because E2E-main runs are skipped if multiple PRs merge at the same time (or if some fail due to test flake). This ensures a commit on main always uploads a build to emerge.

More context here: https://valora-app.slack.com/archives/C02E2FE98P2/p1713968251987719

### Test plan

Watch CI run on merge queue

### Related issues

N/A

### Backwards compatibility

N/A

### Network scalability

N/A
