### PR TITLE
chore: simplify the NumberTicker interface

### DIFF
--- a/src/components/NumberTicker.tsx
+++ b/src/components/NumberTicker.tsx
@@ -2,36 +2,33 @@ import * as React from 'react'
 import { Animated, StyleProp, StyleSheet, Text, TextStyle, View } from 'react-native'
 import { typeScale } from 'src/styles/fonts'
 
-interface CommonProps {
-  textHeight: number
-  textStyles?: StyleProp<TextStyle>
-  animationDuration?: number
-}
-interface Props extends CommonProps {
+interface Props {
   finalValue: string
+  typeScaleName?: keyof typeof typeScale
+  animationDuration?: number
   testID?: string
 }
 
-interface TickProps extends CommonProps {
-  startValue: number
-  endValue: number
+interface TickTextProps {
+  textStyles: StyleProp<TextStyle>
+  value: string
 }
 
-interface TickTextProps extends CommonProps {
-  value: string
+interface TickProps {
+  startValue: number
+  endValue: number
+  animationDuration: number
+  textHeight: number
+  textStyles: StyleProp<TextStyle>
 }
 
 const numberRange = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']
 
-function TickText({ value, textHeight, textStyles }: TickTextProps) {
-  return (
-    <View style={[styles.tickText, { height: textHeight }]}>
-      <Text style={[styles.text, textStyles]}>{value}</Text>
-    </View>
-  )
+function TickText({ value, textStyles }: TickTextProps) {
+  return <Text style={[styles.tickerText, textStyles]}>{value}</Text>
 }
 
-function Tick({ startValue, endValue, textHeight, textStyles, animationDuration }: TickProps) {
+function Tick({ startValue, endValue, textStyles, textHeight, animationDuration }: TickProps) {
   const animatedValue = new Animated.Value(startValue * textHeight * -1)
   const transformStyle = { transform: [{ translateY: animatedValue }] }
   const duration = animationDuration ?? 1300
@@ -43,11 +40,9 @@ function Tick({ startValue, endValue, textHeight, textStyles, animationDuration 
   }).start()
 
   return (
-    <Animated.View style={[transformStyle]}>
+    <Animated.View style={transformStyle}>
       {numberRange.map((number, index) => {
-        return (
-          <TickText key={index} textHeight={textHeight} textStyles={textStyles} value={number} />
-        )
+        return <TickText key={index} textStyles={textStyles} value={number} />
       })}
     </Animated.View>
   )
@@ -55,11 +50,12 @@ function Tick({ startValue, endValue, textHeight, textStyles, animationDuration 
 
 export default function NumberTicker({
   finalValue,
-  textStyles,
-  textHeight,
-  animationDuration,
+  typeScaleName = 'displaySmall',
+  animationDuration = 1300,
   testID,
 }: Props) {
+  const textStyles = typeScale[typeScaleName]
+  const textHeight = textStyles.lineHeight
   const finalValueArray = finalValue.toString().split('')
 
   // For the startValueArray, map over each character in the finalValueArray to
@@ -74,9 +70,7 @@ export default function NumberTicker({
       {finalValueArray.map((value, index) => {
         // If the character is not a digit, render it as a static text element
         if (!value.match(/\d/)) {
-          return (
-            <TickText key={index} textHeight={textHeight} textStyles={textStyles} value={value} />
-          )
+          return <TickText key={index} textStyles={textStyles} value={value} />
         }
 
         const endValue = parseInt(value, 10)
@@ -104,11 +98,7 @@ const styles = StyleSheet.create({
     // otherwise they feel unnatural and far apart
     gap: -2,
   },
-  tickText: {
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  text: {
-    ...typeScale.displaySmall,
+  tickerText: {
+    textAlign: 'center',
   },
 })

--- a/src/points/PointsHome.tsx
+++ b/src/points/PointsHome.tsx
@@ -122,12 +122,7 @@ export default function PointsHome({ route, navigation }: Props) {
               />
             </View>
             <View style={styles.balanceRow}>
-              <NumberTicker
-                testID="PointsBalance"
-                textStyles={styles.balance}
-                textHeight={48}
-                finalValue={pointsBalance.toString()}
-              />
+              <NumberTicker testID="PointsBalance" finalValue={pointsBalance.toString()} />
               <LogoHeart size={28} />
             </View>
 
@@ -240,9 +235,6 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     gap: Spacing.Tiny4,
-  },
-  balance: {
-    ...typeScale.displaySmall,
   },
   infoCard: {
     backgroundColor: Colors.successLight,


### PR DESCRIPTION
### Description

As the title, this addresses some discussions we had in #5345 about possible misuse of the props. This PR makes it harder to screw up the styles.

### Test plan

No visual changes

https://github.com/valora-inc/wallet/assets/20150449/2b203175-13a2-4dc3-bbd5-e53923e82d5a


### Related issues

- Fixes RET-1072

### Backwards compatibility

Y
### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [ ] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
