### PR TITLE
fix(discover): fix a crash when dapp list is empty

### DIFF
--- a/src/dappsExplorer/TabDiscover.test.tsx
+++ b/src/dappsExplorer/TabDiscover.test.tsx
@@ -110,6 +110,27 @@ describe('TabDiscover', () => {
     ])
   })
 
+  it('renders error message when fetching dapps fails', () => {
+    const store = createMockStore({
+      dapps: {
+        dappListApiUrl: 'http://url.com',
+        dappsList: [],
+        dappsCategories: [],
+        dappsListError: 'Error fetching dapps',
+      },
+    })
+    const { getByText, getByTestId } = render(
+      <Provider store={store}>
+        <MockedNavigator component={TabDiscover} />
+      </Provider>
+    )
+
+    expect(getByText('dappsScreen.errorMessage')).toBeTruthy()
+    // asserts whether categories.length (0) isn't rendered, which causes a
+    // crash in the app
+    expect(getByTestId('DAppsExplorerScreen')).not.toHaveTextContent('0')
+  })
+
   describe('favorite dapps', () => {
     it('renders correctly when there are no favorite dapps', () => {
       const store = createMockStore({

--- a/src/dappsExplorer/TabDiscover.tsx
+++ b/src/dappsExplorer/TabDiscover.tsx
@@ -209,7 +209,7 @@ function TabDiscover({ navigation }: Props) {
             <Text style={fontStyles.regular}>{t('dappsScreen.errorMessage')}</Text>
           </View>
         )}
-        {categories.length && (
+        {!!categories.length && (
           <AnimatedSectionList
             refreshControl={
               <RefreshControl


### PR DESCRIPTION
### Description

Fixes an edge case where if dapps don't load the first time (or comes back as an empty list), navigating to the discover tab crashes the app. This is because we render the dapps section using a boolean condition (`categories.length && <SectionList />`) and if the array length is 0, it attempts to render `0`, which is outside of a Text component

### Test plan

Manually by setting dapps list to empty list and ensuring the app no longer crashes

### Related issues

N/A

### Backwards compatibility

Yes

### Network scalability

N/A