### PR TITLE
fix(points): prevent sagas spawning if points are disabled

### DIFF
--- a/src/points/saga.test.ts
+++ b/src/points/saga.test.ts
@@ -28,8 +28,6 @@ import pointsReducer, {
   trackPointsEvent,
 } from 'src/points/slice'
 import { ClaimHistory, GetHistoryResponse } from 'src/points/types'
-import { getFeatureGate } from 'src/statsig'
-import { StatsigFeatureGates } from 'src/statsig/types'
 import Logger from 'src/utils/Logger'
 import * as fetchWithTimeout from 'src/utils/fetchWithTimeout'
 import networkConfig from 'src/web3/networkConfig'
@@ -230,9 +228,6 @@ describe('getHistory', () => {
 describe('getPointsConfig', () => {
   beforeEach(() => {
     jest.clearAllMocks()
-    jest
-      .mocked(getFeatureGate)
-      .mockImplementation((gate) => gate === StatsigFeatureGates.SHOW_POINTS)
   })
 
   it('fetches and sets points config', async () => {
@@ -324,17 +319,6 @@ describe('getPointsConfig', () => {
       .put(getPointsConfigError())
       .not.put(getPointsConfigSucceeded(expect.anything()))
       .run()
-  })
-
-  it('does not fetch if points are not enabled', async () => {
-    jest.mocked(getFeatureGate).mockReturnValue(false)
-
-    await expectSaga(getPointsConfig)
-      .not.put(getPointsConfigStarted())
-      .not.put(getPointsConfigSucceeded(expect.anything()))
-      .run()
-
-    expect(mockFetch).not.toHaveBeenCalled()
   })
 })
 

--- a/src/points/saga.ts
+++ b/src/points/saga.ts
@@ -17,9 +17,9 @@ import {
 } from 'src/points/slice'
 import {
   GetHistoryResponse,
-  isPointsActivityId,
-  isClaimActivityId,
   PointsEvent,
+  isClaimActivityId,
+  isPointsActivityId,
 } from 'src/points/types'
 import { getFeatureGate } from 'src/statsig'
 import { StatsigFeatureGates } from 'src/statsig/types'
@@ -100,12 +100,6 @@ export function* getHistory({ payload: params }: ReturnType<typeof getHistorySta
 }
 
 export function* getPointsConfig() {
-  const showPoints = getFeatureGate(StatsigFeatureGates.SHOW_POINTS)
-  if (!showPoints) {
-    Logger.info(TAG, 'Points feature is disabled, not fetching points config')
-    return
-  }
-
   yield* put(getPointsConfigStarted())
 
   try {
@@ -215,6 +209,12 @@ export function* watchAppMounted() {
 }
 
 export function* pointsSaga() {
+  const showPoints = getFeatureGate(StatsigFeatureGates.SHOW_POINTS)
+  if (!showPoints) {
+    Logger.info(TAG, 'Points feature is disabled, not spawning points sagas')
+    return
+  }
+
   yield* spawn(watchGetHistory)
   yield* spawn(watchGetConfig)
   yield* spawn(watchTrackPointsEvent)


### PR DESCRIPTION
### Description

As the title. Rather than remembering to check the remote config in each saga, catch it all at the root level. We should not start talking to the points DB yet.

### Test plan

n/a

### Related issues

n/a

### Backwards compatibility

Y

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
