### PR TITLE
chore(viem): use TransactionRequestCIP64 type

### DIFF
--- a/src/viem/prepareTransactions.ts
+++ b/src/viem/prepareTransactions.ts
@@ -1,5 +1,4 @@
 import BigNumber from 'bignumber.js'
-import { TransactionRequestCIP42 } from 'node_modules/viem/_types/celo/types'
 import erc20 from 'src/abis/IERC20'
 import stableToken from 'src/abis/StableToken'
 import { STATIC_GAS_PADDING } from 'src/config'
@@ -27,11 +26,12 @@ import {
   encodeFunctionData,
 } from 'viem'
 import { estimateGas } from 'viem/actions'
+import { TransactionRequestCIP64 } from 'viem/chains'
 
 const TAG = 'viem/prepareTransactions'
 
 // Supported transaction types
-export type TransactionRequest = (TransactionRequestCIP42 | TransactionRequestEIP1559) & {
+export type TransactionRequest = (TransactionRequestCIP64 | TransactionRequestEIP1559) & {
   // Custom fields needed for showing the user the estimated gas fee
   // underscored to denote that they are not part of the TransactionRequest fields from viem
   // and only intended for internal use in Valora


### PR DESCRIPTION
### Description

We're actually already using CIP64 TXs, but the type we import still is CIP42.
And it's going away soon: https://github.com/wevm/viem/pull/2187

### Test plan

- Typecheck passes

### Related issues

N/A

### Backwards compatibility

Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
