### PR TITLE
test(e2e): enable more tests on android with getAttribute changes

### DIFF
--- a/e2e/src/HomeFeed.spec.js
+++ b/e2e/src/HomeFeed.spec.js
@@ -6,8 +6,7 @@ beforeAll(async () => {
   await quickOnboarding()
 })
 
-// iOS only as getAttributes on multiple elements is not supported on Android
-describe(':ios: Home Feed', () => {
+describe('Home Feed', () => {
   it('should show correct information on tap of feed item', async () => {
     // Load Wallet Home
     await waitForElementId('WalletHome')
@@ -33,8 +32,10 @@ describe(':ios: Home Feed', () => {
     await waitForElementId('WalletHome')
     const startingItems = await element(by.id('TransferFeedItem')).getAttributes()
 
-    // Scroll to bottom
-    await element(by.id('WalletHome/SectionList')).scrollTo('bottom')
+    // Scroll to bottom - Android will scroll forever so we set a static value
+    device.getPlatform() === 'ios'
+      ? await element(by.id('WalletHome/SectionList')).scrollTo('bottom')
+      : await element(by.id('WalletHome/SectionList')).scroll(2000, 'down')
     await sleep(5000)
 
     // Compare initial number of items to new number of items after scroll

--- a/e2e/src/utils/utils.js
+++ b/e2e/src/utils/utils.js
@@ -344,12 +344,9 @@ export async function confirmTransaction(commentText) {
       .toBeVisible()
       .withTimeout(60 * 1000)
 
-    // getAttributes() for multiple elements only supported on iOS for Detox < 20.12.0
-    if (device.getPlatform() === 'ios') {
-      // Comment should be present in the feed
-      const { elements } = await element(by.id('TransferFeedItem/subtitle')).getAttributes()
-      jestExpect(elements.some((element) => element.text === commentText)).toBeTruthy()
-    }
+    // Comment should be present in the feed
+    const { elements } = await element(by.id('TransferFeedItem/subtitle')).getAttributes()
+    jestExpect(elements.some((element) => element.text === commentText)).toBeTruthy()
 
     // Scroll to transaction
     await waitFor(element(by.text(commentText)))


### PR DESCRIPTION
### Description

With the recent upgrade to Detox in #5375 [`getAttributes()`](https://wix.github.io/Detox/docs/api/actions#getattributes) now works with multiple elements on Android. With this change more tests that previously only ran on iOS can now be run on Android.

### Test plan

- [x] Tested locally on Android
- [x] Tested in CI

### Related issues

N/A

### Backwards compatibility

Yes

### Network scalability

N/A