### PR TITLE
fix(cico): fix crash on bottom sheet when token list is empty

### DIFF
--- a/src/fiatExchanges/FiatExchangeCurrencyBottomSheet.test.tsx
+++ b/src/fiatExchanges/FiatExchangeCurrencyBottomSheet.test.tsx
@@ -282,4 +282,20 @@ describe(FiatExchangeCurrencyBottomSheet, () => {
     expect(getAllByTestId('TokenBalanceItem')[3]).toHaveTextContent('CELO')
     expect(getAllByTestId('TokenBalanceItem')[4]).toHaveTextContent('ETH')
   })
+  it('renders correctly if token list is empty', () => {
+    const { queryByTestId, getByTestId } = render(
+      <Provider store={createMockStore({ tokens: { tokenBalances: {} } })}>
+        <MockedNavigator
+          component={FiatExchangeCurrencyBottomSheet}
+          params={{
+            flow: FiatExchangeFlow.CashIn,
+          }}
+        />
+      </Provider>
+    )
+    expect(queryByTestId('TokenBalanceItem')).toBeFalsy()
+    // asserts whether tokenList.length (0) isn't rendered, which causes a
+    // crash in the app
+    expect(getByTestId('FiatExchangeCurrencyBottomSheet')).not.toHaveTextContent('0')
+  })
 })

--- a/src/fiatExchanges/FiatExchangeCurrencyBottomSheet.tsx
+++ b/src/fiatExchanges/FiatExchangeCurrencyBottomSheet.tsx
@@ -65,7 +65,7 @@ function FiatExchangeCurrencyBottomSheet({ route }: Props) {
     >
       {/* padding undefined to prevent android ripple bug */}
       <Text style={styles.selectDigitalCurrency}>{t('sendEnterAmountScreen.selectToken')}</Text>
-      {tokenList.length &&
+      {!!tokenList.length &&
         tokenList.map((tokenInfo) => {
           return (
             <React.Fragment key={`token-${tokenInfo.tokenId}`}>


### PR DESCRIPTION
### Description

Crashes when token list is empty, which attempts to render a 0 outside of a `<Text>` component

### Test plan

Unit tests, manually by emptying token list

### Related issues

N/A

### Backwards compatibility

Yes

### Network scalability

N/A