### PR TITLE
fix(earn): ripple on android exceeds border

### DIFF
--- a/src/earn/EarnCta.tsx
+++ b/src/earn/EarnCta.tsx
@@ -12,35 +12,39 @@ import { Spacing } from 'src/styles/styles'
 export default function EarnCta() {
   const { t } = useTranslation()
   return (
-    <Touchable
-      borderRadius={8}
-      style={styles.touchable}
-      onPress={() => {
-        ValoraAnalytics.track(EarnEvents.earn_cta_press)
-      }}
-      testID="EarnCta"
-    >
-      <>
-        <Text style={styles.title}>{t('earnFlow.cta.title')}</Text>
-        <View style={styles.row}>
-          <EarnAave />
-          <View style={styles.subtitleContainer}>
-            <Text style={styles.subtitle}>{t('earnFlow.cta.subtitle')}</Text>
-            <Text style={styles.description}>{t('earnFlow.cta.description')}</Text>
+    <View style={styles.container}>
+      <Touchable
+        borderRadius={8}
+        style={styles.touchable}
+        onPress={() => {
+          ValoraAnalytics.track(EarnEvents.earn_cta_press)
+        }}
+        testID="EarnCta"
+      >
+        <>
+          <Text style={styles.title}>{t('earnFlow.cta.title')}</Text>
+          <View style={styles.row}>
+            <EarnAave />
+            <View style={styles.subtitleContainer}>
+              <Text style={styles.subtitle}>{t('earnFlow.cta.subtitle')}</Text>
+              <Text style={styles.description}>{t('earnFlow.cta.description')}</Text>
+            </View>
           </View>
-        </View>
-      </>
-    </Touchable>
+        </>
+      </Touchable>
+    </View>
   )
 }
 
 const styles = StyleSheet.create({
+  container: {
+    marginBottom: Spacing.Thick24,
+  },
   touchable: {
     padding: Spacing.Regular16,
     borderColor: Colors.gray2,
     borderWidth: 1,
     borderRadius: 8,
-    marginBottom: Spacing.Thick24,
   },
   title: {
     ...typeScale.labelSemiBoldMedium,


### PR DESCRIPTION
### Description

The marginBottom on touchable was causing the ripple to exceed only on the bottom. Wrapped in a View to apply margin

### Test plan

| Before | After |
|--------|--------|
| <video src="https://github.com/valora-inc/wallet/assets/5062591/6b69a921-ab8b-4a8a-8193-a86b228bfa6c" /> | <video src="https://github.com/valora-inc/wallet/assets/5062591/c04e4581-6bf0-484a-800c-97ca9be195f3" /> | 

### Related issues

- Part of ACT-1174

### Backwards compatibility

Yes

### Network scalability

N/A
