### PR TITLE
feat(earn): redux setup for submitting deposit transaction

### DIFF
--- a/src/earn/EarnDepositBottomSheet.tsx
+++ b/src/earn/EarnDepositBottomSheet.tsx
@@ -3,12 +3,14 @@ import { Trans, useTranslation } from 'react-i18next'
 import { StyleSheet, Text, View } from 'react-native'
 import FastImage from 'react-native-fast-image'
 import { ResizeMode } from 'react-native-video'
+import { useDispatch } from 'react-redux'
 import { EarnEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import BottomSheet, { BottomSheetRefType } from 'src/components/BottomSheet'
 import Button, { BtnSizes, BtnTypes } from 'src/components/Button'
 import TokenDisplay from 'src/components/TokenDisplay'
 import Touchable from 'src/components/Touchable'
+import { depositStart } from 'src/earn/slice'
 import InfoIcon from 'src/icons/InfoIcon'
 import Logo from 'src/icons/Logo'
 import { navigate } from 'src/navigator/NavigationService'
@@ -24,6 +26,7 @@ import {
   PreparedTransactionsPossible,
   getFeeCurrencyAndAmounts,
 } from 'src/viem/prepareTransactions'
+import { getSerializablePreparedTransactions } from 'src/viem/preparedTransactionSerialization'
 
 const LOGO_SIZE = 24
 
@@ -39,6 +42,7 @@ export default function EarnDepositBottomSheet({
   tokenId: string
 }) {
   const { t } = useTranslation()
+  const dispatch = useDispatch()
 
   const { estimatedFeeAmount, feeCurrency } = getFeeCurrencyAndAmounts(preparedTransaction)
 
@@ -64,8 +68,14 @@ export default function EarnDepositBottomSheet({
   }
 
   const onPressComplete = () => {
+    dispatch(
+      depositStart({
+        amount,
+        tokenId,
+        preparedTransactions: getSerializablePreparedTransactions(preparedTransaction.transactions),
+      })
+    )
     ValoraAnalytics.track(EarnEvents.earn_deposit_complete)
-    // TODO(ACT-1178): submit tx
   }
 
   const onPressCancel = () => {

--- a/src/earn/saga.test.ts
+++ b/src/earn/saga.test.ts
@@ -1,0 +1,16 @@
+import { expectSaga } from 'redux-saga-test-plan'
+import { depositSubmitSaga } from 'src/earn/saga'
+import { depositStart, depositSuccess } from 'src/earn/slice'
+import { navigateHome } from 'src/navigator/NavigationService'
+
+describe('depositSubmitSaga', () => {
+  it('navigates home', async () => {
+    await expectSaga(depositSubmitSaga, {
+      type: depositStart.type,
+      payload: { amount: '100', tokenId: 'tokenId', preparedTransactions: [] },
+    })
+      .put(depositSuccess())
+      .run()
+    expect(navigateHome).toHaveBeenCalled()
+  })
+})

--- a/src/earn/saga.ts
+++ b/src/earn/saga.ts
@@ -1,0 +1,16 @@
+import { PayloadAction } from '@reduxjs/toolkit'
+import { depositStart, depositSuccess } from 'src/earn/slice'
+import { DepositInfo } from 'src/earn/types'
+import { navigateHome } from 'src/navigator/NavigationService'
+import { safely } from 'src/utils/safely'
+import { put, takeLeading } from 'typed-redux-saga'
+
+export function* depositSubmitSaga(action: PayloadAction<DepositInfo>) {
+  // todo(act-1178): submit the tx
+  yield* put(depositSuccess())
+  navigateHome()
+}
+
+export function* earnSaga() {
+  yield* takeLeading(depositStart.type, safely(depositSubmitSaga))
+}

--- a/src/earn/slice.test.ts
+++ b/src/earn/slice.test.ts
@@ -1,0 +1,30 @@
+import reducer, { depositCancel, depositError, depositStart, depositSuccess } from './slice'
+
+describe('Earn Slice', () => {
+  it('should handle deposit start', () => {
+    const updatedState = reducer(
+      undefined,
+      depositStart({ amount: '100', tokenId: 'tokenId', preparedTransactions: [] })
+    )
+
+    expect(updatedState).toHaveProperty('depositStatus', 'started')
+  })
+
+  it('should handle deposit success', () => {
+    const updatedState = reducer(undefined, depositSuccess())
+
+    expect(updatedState).toHaveProperty('depositStatus', 'success')
+  })
+
+  it('should handle deposit error', () => {
+    const updatedState = reducer(undefined, depositError())
+
+    expect(updatedState).toHaveProperty('depositStatus', 'error')
+  })
+
+  it('should handle deposit cancel', () => {
+    const updatedState = reducer(undefined, depositCancel())
+
+    expect(updatedState).toHaveProperty('depositStatus', 'idle')
+  })
+})

--- a/src/earn/slice.ts
+++ b/src/earn/slice.ts
@@ -3,7 +3,7 @@ import { REHYDRATE, RehydrateAction } from 'redux-persist'
 import { DepositInfo } from 'src/earn/types'
 import { getRehydratePayload } from 'src/redux/persist-helper'
 
-export interface State {
+interface State {
   depositStatus: 'idle' | 'started' | 'success' | 'error'
 }
 

--- a/src/earn/slice.ts
+++ b/src/earn/slice.ts
@@ -1,0 +1,42 @@
+import { PayloadAction, createSlice } from '@reduxjs/toolkit'
+import { REHYDRATE, RehydrateAction } from 'redux-persist'
+import { DepositInfo } from 'src/earn/types'
+import { getRehydratePayload } from 'src/redux/persist-helper'
+
+export interface State {
+  depositStatus: 'idle' | 'started' | 'success' | 'error'
+}
+
+const initialState: State = {
+  depositStatus: 'idle',
+}
+
+export const slice = createSlice({
+  name: 'earn',
+  initialState,
+  reducers: {
+    depositStart: (state, action: PayloadAction<DepositInfo>) => {
+      state.depositStatus = 'started'
+    },
+    depositSuccess: (state) => {
+      state.depositStatus = 'success'
+    },
+    depositError: (state) => {
+      state.depositStatus = 'error'
+    },
+    depositCancel: (state) => {
+      state.depositStatus = 'idle'
+    },
+  },
+  extraReducers: (builder) => {
+    builder.addCase(REHYDRATE, (state, action: RehydrateAction) => ({
+      ...state,
+      ...getRehydratePayload(action, 'earn'),
+      depositStatus: 'idle',
+    }))
+  },
+})
+
+export const { depositStart, depositSuccess, depositError, depositCancel } = slice.actions
+
+export default slice.reducer

--- a/src/earn/types.ts
+++ b/src/earn/types.ts
@@ -1,0 +1,5 @@
+export interface DepositInfo {
+  amount: string
+  tokenId: string
+  preparedTransactions: SerializableTransactionRequest[]
+}

--- a/src/earn/types.ts
+++ b/src/earn/types.ts
@@ -1,3 +1,5 @@
+import { SerializableTransactionRequest } from 'src/viem/preparedTransactionSerialization'
+
 export interface DepositInfo {
   amount: string
   tokenId: string

--- a/src/redux/migrations.ts
+++ b/src/redux/migrations.ts
@@ -1778,4 +1778,10 @@ export const migrations = {
     ...(_.omit(state, 'exchange') as any),
   }),
   212: (state: any) => state,
+  213: (state: any) => ({
+    ...state,
+    earn: {
+      depositStatus: 'idle',
+    },
+  }),
 }

--- a/src/redux/reducers.ts
+++ b/src/redux/reducers.ts
@@ -6,6 +6,7 @@ import { reducer as alert } from 'src/alert/reducer'
 import { appReducer as app } from 'src/app/reducers'
 import superchargeReducer from 'src/consumerIncentives/slice'
 import dappsReducer from 'src/dapps/slice'
+import earnReducer from 'src/earn/slice'
 import { escrowReducer as escrow } from 'src/escrow/reducer'
 import { reducer as fees } from 'src/fees/reducer'
 import { reducer as fiatExchanges } from 'src/fiatExchanges/reducer'
@@ -59,6 +60,7 @@ const appReducer = combineReducers({
   priceHistory: priceHistoryReducer,
   jumpstart: jumpstartReducer,
   points: pointsReducer,
+  earn: earnReducer,
 })
 
 const rootReducer = (state: RootState | undefined, action: Action): RootState => {

--- a/src/redux/sagas.ts
+++ b/src/redux/sagas.ts
@@ -17,6 +17,7 @@ import {
 import { superchargeSaga } from 'src/consumerIncentives/saga'
 import { dappKitSaga } from 'src/dappkit/dappkit'
 import { dappsSaga } from 'src/dapps/saga'
+import { earnSaga } from 'src/earn/saga'
 import { escrowSaga } from 'src/escrow/saga'
 import { feesSaga } from 'src/fees/saga'
 import { fiatExchangesSaga } from 'src/fiatExchanges/saga'
@@ -139,6 +140,7 @@ export function* rootSaga() {
     yield* spawn(nftsSaga)
     yield* spawn(priceHistorySaga)
     yield* spawn(pointsSaga)
+    yield* spawn(earnSaga)
   } catch (error) {
     Logger.error('@rootSaga', 'Error while initializing sagas', error)
     // Propagate so it's handled by Sentry

--- a/src/redux/store.test.ts
+++ b/src/redux/store.test.ts
@@ -98,7 +98,7 @@ describe('store state', () => {
       {
         "_persist": {
           "rehydrated": true,
-          "version": 212,
+          "version": 213,
         },
         "account": {
           "acceptedTerms": false,
@@ -186,6 +186,9 @@ describe('store state', () => {
           "maxNumRecentDapps": 0,
           "mostPopularDappIds": [],
           "recentDappIds": [],
+        },
+        "earn": {
+          "depositStatus": "idle",
         },
         "escrow": {
           "isReclaiming": false,

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -21,7 +21,7 @@ const persistConfig: PersistConfig<ReducersRootState> = {
   key: 'root',
   // default is -1, increment as we make migrations
   // See https://github.com/valora-inc/wallet/tree/main/WALLET.md#redux-state-migration
-  version: 212,
+  version: 213,
   keyPrefix: `reduxStore-`, // the redux-persist default is `persist:` which doesn't work with some file systems.
   storage: FSStorage(),
   blacklist: ['networkInfo', 'alert', 'imports', 'keylessBackup', 'jumpstart'],
@@ -141,6 +141,7 @@ export const setupStore = (initialState?: ReducersRootState, config = persistCon
           'nfts',
           'swap',
           'jumpstart',
+          'earn',
           // 'exchange',
           // 'tokens',
           // 'priceHistory',

--- a/test/RootStateSchema.json
+++ b/test/RootStateSchema.json
@@ -4382,6 +4382,24 @@
             ],
             "type": "object"
         },
+        "State_28": {
+            "additionalProperties": false,
+            "properties": {
+                "depositStatus": {
+                    "enum": [
+                        "error",
+                        "idle",
+                        "started",
+                        "success"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "depositStatus"
+            ],
+            "type": "object"
+        },
         "State_3": {
             "anyOf": [
                 {
@@ -6275,6 +6293,9 @@
         "dapps": {
             "$ref": "#/definitions/State_19"
         },
+        "earn": {
+            "$ref": "#/definitions/State_28"
+        },
         "escrow": {
             "$ref": "#/definitions/State_10"
         },
@@ -6377,6 +6398,7 @@
         "alert",
         "app",
         "dapps",
+        "earn",
         "escrow",
         "fees",
         "fiatConnect",

--- a/test/schemas.ts
+++ b/test/schemas.ts
@@ -3298,6 +3298,17 @@ export const v212Schema = {
   },
 }
 
+export const v213Schema = {
+  ...v212Schema,
+  _persist: {
+    ...v212Schema._persist,
+    version: 213,
+  },
+  earn: {
+    depositStatus: 'idle',
+  },
+}
+
 export function getLatestSchema(): Partial<RootState> {
-  return v212Schema as Partial<RootState>
+  return v213Schema as Partial<RootState>
 }


### PR DESCRIPTION
### Description

Sets up earn reducer and actions for submitting deposit transaction. The actual submitting of transaction will be in a follow up PR

### Test plan

Unit tests

### Related issues

- Part of ACT-1178

### Backwards compatibility

yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
