### PR TITLE
feat(earn): add loading state for deposit when tx is submitted

### DIFF
--- a/src/earn/EarnDepositBottomSheet.test.tsx
+++ b/src/earn/EarnDepositBottomSheet.test.tsx
@@ -177,4 +177,25 @@ describe('EarnDepositBottomSheet', () => {
     )
     expect(navigate).toHaveBeenCalledWith('WebViewScreen', { uri: 'termsUrl' })
   })
+
+  it('shows loading state and buttons are disabled when deposit is submitted', () => {
+    const store = createMockStore({
+      tokens: { tokenBalances: mockTokenBalances },
+      earn: { depositStatus: 'started' },
+    })
+    const { getByTestId } = render(
+      <Provider store={store}>
+        <EarnDepositBottomSheet
+          forwardedRef={{ current: null }}
+          amount={'100'}
+          tokenId={mockARBTokenId}
+          preparedTransaction={mockPreparedTransaction}
+        />
+      </Provider>
+    )
+
+    expect(getByTestId('EarnDeposit/PrimaryCta')).toBeDisabled()
+    expect(getByTestId('EarnDeposit/SecondaryCta')).toBeDisabled()
+    expect(getByTestId('EarnDeposit/PrimaryCta')).toContainElement(getByTestId('Button/Loading'))
+  })
 })

--- a/src/earn/EarnDepositBottomSheet.tsx
+++ b/src/earn/EarnDepositBottomSheet.tsx
@@ -10,11 +10,13 @@ import BottomSheet, { BottomSheetRefType } from 'src/components/BottomSheet'
 import Button, { BtnSizes, BtnTypes } from 'src/components/Button'
 import TokenDisplay from 'src/components/TokenDisplay'
 import Touchable from 'src/components/Touchable'
+import { depositStatusSelector } from 'src/earn/selectors'
 import { depositStart } from 'src/earn/slice'
 import InfoIcon from 'src/icons/InfoIcon'
 import Logo from 'src/icons/Logo'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
+import { useSelector } from 'src/redux/hooks'
 import { NETWORK_NAMES } from 'src/shared/conts'
 import { getDynamicConfigParams } from 'src/statsig'
 import { DynamicConfigs } from 'src/statsig/constants'
@@ -43,6 +45,8 @@ export default function EarnDepositBottomSheet({
 }) {
   const { t } = useTranslation()
   const dispatch = useDispatch()
+  const depositStatus = useSelector(depositStatusSelector)
+  const transactionSubmitted = depositStatus === 'started'
 
   const { estimatedFeeAmount, feeCurrency } = getFeeCurrencyAndAmounts(preparedTransaction)
 
@@ -141,6 +145,7 @@ export default function EarnDepositBottomSheet({
             type={BtnTypes.GRAY_WITH_BORDER}
             style={styles.cta}
             onPress={onPressCancel}
+            disabled={transactionSubmitted}
           />
           <Button
             testID="EarnDeposit/PrimaryCta"
@@ -148,6 +153,8 @@ export default function EarnDepositBottomSheet({
             text={t('earnFlow.depositBottomSheet.primaryCta')}
             style={styles.cta}
             onPress={onPressComplete}
+            disabled={transactionSubmitted}
+            showLoading={transactionSubmitted}
           />
         </View>
       </View>

--- a/src/earn/selectors.ts
+++ b/src/earn/selectors.ts
@@ -1,0 +1,3 @@
+import { RootState } from 'src/redux/store'
+
+export const depositStatusSelector = (state: RootState) => state.earn.depositStatus


### PR DESCRIPTION
### Description

As the title

### Test plan

<img src="https://github.com/valora-inc/wallet/assets/5062591/94068934-579a-4748-8310-5d82b73c73b5" width="250" />


### Related issues

- Part of ACT-1178

### Backwards compatibility

Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
