### PR TITLE
fix(points): enable some activities to only be tracked once

### DIFF
--- a/src/home/TabHome.test.tsx
+++ b/src/home/TabHome.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, waitFor } from '@testing-library/react-native'
+import { act, render } from '@testing-library/react-native'
 import { FetchMock } from 'jest-fetch-mock/types'
 import * as React from 'react'
 import { Provider } from 'react-redux'
@@ -139,22 +139,6 @@ describe('TabHome', () => {
         'IDENTITY/IMPORT_CONTACTS',
         'points/trackPointsEvent',
       ])
-    )
-  })
-
-  it("doesn't track the create-wallet event if it has been tracked before", async () => {
-    const { store } = renderScreen({
-      points: {
-        trackOnceActivities: {
-          'create-wallet': true,
-        },
-      },
-    })
-
-    await waitFor(() =>
-      expect(store.getActions().map((action) => action.type)).not.toContain(
-        'points/trackPointsEvent'
-      )
     )
   })
 

--- a/src/home/TabHome.test.tsx
+++ b/src/home/TabHome.test.tsx
@@ -1,4 +1,4 @@
-import { act, render } from '@testing-library/react-native'
+import { act, render, waitFor } from '@testing-library/react-native'
 import { FetchMock } from 'jest-fetch-mock/types'
 import * as React from 'react'
 import { Provider } from 'react-redux'
@@ -127,8 +127,8 @@ describe('TabHome', () => {
     })
 
     // Multiple elements use this text with the scroll aware header
-    expect(tree.queryAllByText('bottomTabsNavigator.home.title')).toBeTruthy()
-    expect(tree.queryByTestId('HomeActionsCarousel')).toBeTruthy()
+    expect(tree.getAllByText('bottomTabsNavigator.home.title')).toBeTruthy()
+    expect(tree.getByTestId('HomeActionsCarousel')).toBeTruthy()
     expect(tree.queryByText('notificationCenterSpotlight.message')).toBeFalsy()
     expect(tree.queryByTestId('HomeTokenBalance')).toBeFalsy()
     expect(tree.queryByTestId('cashInBtn')).toBeFalsy()
@@ -137,7 +137,24 @@ describe('TabHome', () => {
         'HOME/VISIT_HOME',
         'HOME/REFRESH_BALANCES',
         'IDENTITY/IMPORT_CONTACTS',
+        'points/trackPointsEvent',
       ])
+    )
+  })
+
+  it("doesn't track the create-wallet event if it has been tracked before", async () => {
+    const { store } = renderScreen({
+      points: {
+        trackOnceActivities: {
+          'create-wallet': true,
+        },
+      },
+    })
+
+    await waitFor(() =>
+      expect(store.getActions().map((action) => action.type)).not.toContain(
+        'points/trackPointsEvent'
+      )
     )
   })
 

--- a/src/home/TabHome.tsx
+++ b/src/home/TabHome.tsx
@@ -125,13 +125,7 @@ function TabHome({ navigation }: Props) {
     // rest of feed to load unencumbered
     setTimeout(tryImportContacts, 500)
 
-    // stale reference to trackOnceActivities is intentional here to avoid
-    // queuing up multiple events with different id's in the case of track
-    // create-wallet failure + successful tracking of another activity in
-    // trackOnceActivities in the same app session
-    if (!trackOnceActivities['create-wallet']) {
-      dispatch(trackPointsEvent({ activityId: 'create-wallet' }))
-    }
+    dispatch(trackPointsEvent({ activityId: 'create-wallet' }))
   }, [])
 
   useEffect(() => {

--- a/src/home/TabHome.tsx
+++ b/src/home/TabHome.tsx
@@ -125,6 +125,10 @@ function TabHome({ navigation }: Props) {
     // rest of feed to load unencumbered
     setTimeout(tryImportContacts, 500)
 
+    // stale reference to trackOnceActivities is intentional here to avoid
+    // queuing up multiple events with different id's in the case of track
+    // create-wallet failure + successful tracking of another activity in
+    // trackOnceActivities in the same app session
     if (!trackOnceActivities['create-wallet']) {
       dispatch(trackPointsEvent({ activityId: 'create-wallet' }))
     }

--- a/src/home/TabHome.tsx
+++ b/src/home/TabHome.tsx
@@ -31,7 +31,6 @@ import { importContacts } from 'src/identity/actions'
 import { Screens } from 'src/navigator/Screens'
 import useScrollAwareHeader from 'src/navigator/ScrollAwareHeader'
 import { StackParamList } from 'src/navigator/types'
-import { trackOnceActivitiesSelector } from 'src/points/selectors'
 import { trackPointsEvent } from 'src/points/slice'
 import { phoneRecipientCacheSelector } from 'src/recipients/reducer'
 import { useDispatch, useSelector } from 'src/redux/hooks'
@@ -54,7 +53,6 @@ function TabHome({ navigation }: Props) {
   const recipientCache = useSelector(phoneRecipientCacheSelector)
   const isNumberVerified = useSelector(phoneNumberVerifiedSelector)
   const showNotificationSpotlight = useSelector(showNotificationSpotlightSelector)
-  const trackOnceActivities = useSelector(trackOnceActivitiesSelector)
 
   const insets = useSafeAreaInsets()
 

--- a/src/home/TabHome.tsx
+++ b/src/home/TabHome.tsx
@@ -31,6 +31,7 @@ import { importContacts } from 'src/identity/actions'
 import { Screens } from 'src/navigator/Screens'
 import useScrollAwareHeader from 'src/navigator/ScrollAwareHeader'
 import { StackParamList } from 'src/navigator/types'
+import { trackOnceActivitiesSelector } from 'src/points/selectors'
 import { trackPointsEvent } from 'src/points/slice'
 import { phoneRecipientCacheSelector } from 'src/recipients/reducer'
 import { useDispatch, useSelector } from 'src/redux/hooks'
@@ -53,6 +54,7 @@ function TabHome({ navigation }: Props) {
   const recipientCache = useSelector(phoneRecipientCacheSelector)
   const isNumberVerified = useSelector(phoneNumberVerifiedSelector)
   const showNotificationSpotlight = useSelector(showNotificationSpotlightSelector)
+  const trackOnceActivities = useSelector(trackOnceActivitiesSelector)
 
   const insets = useSafeAreaInsets()
 
@@ -123,7 +125,9 @@ function TabHome({ navigation }: Props) {
     // rest of feed to load unencumbered
     setTimeout(tryImportContacts, 500)
 
-    dispatch(trackPointsEvent({ activityId: 'create-wallet' }))
+    if (!trackOnceActivities['create-wallet']) {
+      dispatch(trackPointsEvent({ activityId: 'create-wallet' }))
+    }
   }, [])
 
   useEffect(() => {

--- a/src/points/selectors.ts
+++ b/src/points/selectors.ts
@@ -78,3 +78,7 @@ export const pointsBalanceSelector = (state: RootState) => {
 export const pointsBalanceStatusSelector = (state: RootState) => {
   return state.points.pointsBalanceStatus
 }
+
+export const trackOnceActivitiesSelector = (state: RootState) => {
+  return state.points.trackOnceActivities
+}

--- a/src/points/slice.test.ts
+++ b/src/points/slice.test.ts
@@ -1,5 +1,5 @@
 import { PointsEvent } from 'src/points/types'
-import reducer, { State, pointsEventProcessed, sendPointsEventStarted } from './slice'
+import reducer, { initialState, pointsEventProcessed, sendPointsEventStarted } from './slice'
 
 describe('pending points events', () => {
   it('should add a pending points event', () => {
@@ -8,9 +8,10 @@ describe('pending points events', () => {
     const event: PointsEvent = { activityId: 'create-wallet' }
     const pendingPointsEvent = { id, timestamp, event }
 
-    const initialState = { pendingPointsEvents: [] } as unknown as State
-
-    const newState = reducer(initialState, sendPointsEventStarted(pendingPointsEvent))
+    const newState = reducer(
+      { ...initialState, pendingPointsEvents: [] },
+      sendPointsEventStarted(pendingPointsEvent)
+    )
 
     expect(newState.pendingPointsEvents).toEqual([pendingPointsEvent])
   })
@@ -25,12 +26,20 @@ describe('pending points events', () => {
     const pendingPointsEvent1 = { id: id1, timestamp: timestamp1, event: event1 }
     const pendingPointsEvent2 = { id: id2, timestamp: timestamp2, event: event2 }
 
-    const initialState = {
-      pendingPointsEvents: [pendingPointsEvent1, pendingPointsEvent2],
-    } as unknown as State
-
-    const newState = reducer(initialState, pointsEventProcessed({ id: id1 }))
+    const newState = reducer(
+      {
+        ...initialState,
+        pendingPointsEvents: [pendingPointsEvent1, pendingPointsEvent2],
+        trackOnceActivities: {
+          'create-wallet': false,
+        },
+      },
+      pointsEventProcessed(pendingPointsEvent1)
+    )
 
     expect(newState.pendingPointsEvents).toEqual([pendingPointsEvent2])
+    expect(newState.trackOnceActivities).toEqual({
+      'create-wallet': true,
+    })
   })
 })

--- a/src/points/slice.test.ts
+++ b/src/points/slice.test.ts
@@ -1,45 +1,62 @@
-import { PointsEvent } from 'src/points/types'
-import reducer, { initialState, pointsEventProcessed, sendPointsEventStarted } from './slice'
+import reducer, {
+  PendingPointsEvent,
+  initialState,
+  pointsEventProcessed,
+  sendPointsEventStarted,
+} from './slice'
+
+const pendingCreateWalletEvent: PendingPointsEvent = {
+  id: 'test-id-1',
+  timestamp: '2024-04-22T11:00:00.000Z',
+  event: { activityId: 'create-wallet' },
+}
+const pendingSwapEvent: PendingPointsEvent = {
+  id: 'test-id-2',
+  timestamp: '2024-04-22T12:00:00.000Z',
+  event: { activityId: 'swap', transactionHash: '0xTEST' },
+}
 
 describe('pending points events', () => {
-  it('should add a pending points event', () => {
-    const id = 'test-id'
-    const timestamp = '2024-04-22T11:00:00.000Z'
-    const event: PointsEvent = { activityId: 'create-wallet' }
-    const pendingPointsEvent = { id, timestamp, event }
-
-    const newState = reducer(
-      { ...initialState, pendingPointsEvents: [] },
-      sendPointsEventStarted(pendingPointsEvent)
-    )
-
-    expect(newState.pendingPointsEvents).toEqual([pendingPointsEvent])
-  })
-
-  it('should remove a pending points event by id', () => {
-    const id1 = 'test-id-1'
-    const id2 = 'test-id-2'
-    const timestamp1 = '2024-04-22T11:00:00.000Z'
-    const timestamp2 = '2024-04-22T12:00:00.000Z'
-    const event1: PointsEvent = { activityId: 'create-wallet' }
-    const event2: PointsEvent = { activityId: 'swap', transactionHash: '0xTEST' }
-    const pendingPointsEvent1 = { id: id1, timestamp: timestamp1, event: event1 }
-    const pendingPointsEvent2 = { id: id2, timestamp: timestamp2, event: event2 }
-
-    const newState = reducer(
+  it('should add pending points events', () => {
+    const stateAfterSwapEvent = reducer(
       {
         ...initialState,
-        pendingPointsEvents: [pendingPointsEvent1, pendingPointsEvent2],
+        pendingPointsEvents: [],
         trackOnceActivities: {
           'create-wallet': false,
         },
       },
-      pointsEventProcessed(pendingPointsEvent1)
+      sendPointsEventStarted(pendingSwapEvent)
     )
 
-    expect(newState.pendingPointsEvents).toEqual([pendingPointsEvent2])
-    expect(newState.trackOnceActivities).toEqual({
+    expect(stateAfterSwapEvent.pendingPointsEvents).toEqual([pendingSwapEvent])
+    expect(stateAfterSwapEvent.trackOnceActivities).toEqual({
+      'create-wallet': false,
+    })
+
+    const stateAfterCreateWalletEvent = reducer(
+      stateAfterSwapEvent,
+      sendPointsEventStarted(pendingCreateWalletEvent)
+    )
+
+    expect(stateAfterCreateWalletEvent.pendingPointsEvents).toEqual([
+      pendingSwapEvent,
+      pendingCreateWalletEvent,
+    ])
+    expect(stateAfterCreateWalletEvent.trackOnceActivities).toEqual({
       'create-wallet': true,
     })
+  })
+
+  it('should remove a pending points event by id', () => {
+    const newState = reducer(
+      {
+        ...initialState,
+        pendingPointsEvents: [pendingCreateWalletEvent, pendingSwapEvent],
+      },
+      pointsEventProcessed(pendingCreateWalletEvent)
+    )
+
+    expect(newState.pendingPointsEvents).toEqual([pendingSwapEvent])
   })
 })

--- a/src/points/slice.ts
+++ b/src/points/slice.ts
@@ -30,7 +30,7 @@ export interface PendingPointsEvent {
   event: PointsEvent
 }
 
-export interface State {
+interface State {
   pointsHistory: ClaimHistory[]
   nextPageUrl: string | null
   getHistoryStatus: 'idle' | 'loading' | 'errorFirstPage' | 'errorNextPage'

--- a/src/points/slice.ts
+++ b/src/points/slice.ts
@@ -94,18 +94,18 @@ const slice = createSlice({
     getPointsConfigRetry: (state) => ({
       ...state,
     }),
-    sendPointsEventStarted: (state, action: PayloadAction<PendingPointsEvent>) => ({
-      ...state,
-      pendingPointsEvents: [...state.pendingPointsEvents, action.payload],
-    }),
-    pointsEventProcessed: (state, action: PayloadAction<PendingPointsEvent>) => {
-      state.pendingPointsEvents = state.pendingPointsEvents.filter(
-        (event) => event.id !== action.payload.id
-      )
+    sendPointsEventStarted: (state, action: PayloadAction<PendingPointsEvent>) => {
+      state.pendingPointsEvents = [...state.pendingPointsEvents, action.payload]
       if (action.payload.event.activityId in state.trackOnceActivities) {
         state.trackOnceActivities[action.payload.event.activityId] = true
       }
     },
+    pointsEventProcessed: (state, action: PayloadAction<Pick<PendingPointsEvent, 'id'>>) => ({
+      ...state,
+      pendingPointsEvents: state.pendingPointsEvents.filter(
+        (event) => event.id !== action.payload.id
+      ),
+    }),
     getPointsBalanceStarted: (state) => ({
       ...state,
       pointsBalanceStatus: 'loading',

--- a/src/points/slice.ts
+++ b/src/points/slice.ts
@@ -39,9 +39,12 @@ export interface State {
   pendingPointsEvents: PendingPointsEvent[]
   pointsBalanceStatus: 'idle' | 'loading' | 'error' | 'success'
   pointsBalance: string
+  trackOnceActivities: {
+    [key in PointsActivityId]?: boolean
+  }
 }
 
-const initialState: State = {
+export const initialState: State = {
   pointsHistory: [],
   nextPageUrl: null,
   getHistoryStatus: 'idle',
@@ -50,6 +53,9 @@ const initialState: State = {
   pendingPointsEvents: [],
   pointsBalanceStatus: 'idle',
   pointsBalance: '0',
+  trackOnceActivities: {
+    'create-wallet': false,
+  },
 }
 
 const slice = createSlice({
@@ -92,12 +98,14 @@ const slice = createSlice({
       ...state,
       pendingPointsEvents: [...state.pendingPointsEvents, action.payload],
     }),
-    pointsEventProcessed: (state, action: PayloadAction<Pick<PendingPointsEvent, 'id'>>) => ({
-      ...state,
-      pendingPointsEvents: state.pendingPointsEvents.filter(
+    pointsEventProcessed: (state, action: PayloadAction<PendingPointsEvent>) => {
+      state.pendingPointsEvents = state.pendingPointsEvents.filter(
         (event) => event.id !== action.payload.id
-      ),
-    }),
+      )
+      if (action.payload.event.activityId in state.trackOnceActivities) {
+        state.trackOnceActivities[action.payload.event.activityId] = true
+      }
+    },
     getPointsBalanceStarted: (state) => ({
       ...state,
       pointsBalanceStatus: 'loading',

--- a/src/redux/migrations.ts
+++ b/src/redux/migrations.ts
@@ -1784,4 +1784,5 @@ export const migrations = {
       depositStatus: 'idle',
     },
   }),
+  214: (state: any) => state,
 }

--- a/src/redux/store.test.ts
+++ b/src/redux/store.test.ts
@@ -98,7 +98,7 @@ describe('store state', () => {
       {
         "_persist": {
           "rehydrated": true,
-          "version": 213,
+          "version": 214,
         },
         "account": {
           "acceptedTerms": false,
@@ -298,6 +298,9 @@ describe('store state', () => {
           },
           "pointsConfigStatus": "idle",
           "pointsHistory": [],
+          "trackOnceActivities": {
+            "create-wallet": false,
+          },
         },
         "positions": {
           "positions": [],

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -21,7 +21,7 @@ const persistConfig: PersistConfig<ReducersRootState> = {
   key: 'root',
   // default is -1, increment as we make migrations
   // See https://github.com/valora-inc/wallet/tree/main/WALLET.md#redux-state-migration
-  version: 213,
+  version: 214,
   keyPrefix: `reduxStore-`, // the redux-persist default is `persist:` which doesn't work with some file systems.
   storage: FSStorage(),
   blacklist: ['networkInfo', 'alert', 'imports', 'keylessBackup', 'jumpstart'],

--- a/test/RootStateSchema.json
+++ b/test/RootStateSchema.json
@@ -4369,6 +4369,9 @@
                         "$ref": "#/definitions/ClaimHistory"
                     },
                     "type": "array"
+                },
+                "trackOnceActivities": {
+                    "$ref": "#/definitions/{swap?:boolean|undefined;\"create-wallet\"?:boolean|undefined;\"more-coming\"?:boolean|undefined;}"
                 }
             },
             "required": [
@@ -4379,7 +4382,8 @@
                 "pointsBalanceStatus",
                 "pointsConfig",
                 "pointsConfigStatus",
-                "pointsHistory"
+                "pointsHistory",
+                "trackOnceActivities"
             ],
             "type": "object"
         },
@@ -6231,6 +6235,21 @@
                 },
                 "swap": {
                     "$ref": "#/definitions/FeeEstimateState"
+                }
+            },
+            "type": "object"
+        },
+        "{swap?:boolean|undefined;\"create-wallet\"?:boolean|undefined;\"more-coming\"?:boolean|undefined;}": {
+            "additionalProperties": false,
+            "properties": {
+                "create-wallet": {
+                    "type": "boolean"
+                },
+                "more-coming": {
+                    "type": "boolean"
+                },
+                "swap": {
+                    "type": "boolean"
                 }
             },
             "type": "object"

--- a/test/schemas.ts
+++ b/test/schemas.ts
@@ -3309,6 +3309,20 @@ export const v213Schema = {
   },
 }
 
+export const v214Schema = {
+  ...v213Schema,
+  _persist: {
+    ...v213Schema._persist,
+    version: 214,
+  },
+  points: {
+    ...v213Schema.points,
+    trackOnceActivities: {
+      'create-wallet': false,
+    },
+  },
+}
+
 export function getLatestSchema(): Partial<RootState> {
-  return v213Schema as Partial<RootState>
+  return v214Schema as Partial<RootState>
 }


### PR DESCRIPTION
### Description

As the title, this PR:
1. adds a redux property that tracks the status of "track once" activities, which is updated after a points event is processed
2. ensure the track event for create-wallet is not fired again after successfully being processed
3. update tests and migrations

I opted not to hook up the create-wallet activity card status with redux because it'd be very confusing for the user in case of tracking failure.

### Test plan

n/a

### Related issues

- Fixes RET-1069

### Backwards compatibility

Y

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
