### PR TITLE
feat(earn): implement deposit submit saga

### DIFF
--- a/src/analytics/Events.tsx
+++ b/src/analytics/Events.tsx
@@ -682,5 +682,9 @@ export enum EarnEvents {
   earn_deposit_terms_and_conditions_press = 'earn_deposit_terms_and_conditions_press',
   earn_deposit_complete = 'earn_deposit_complete',
   earn_deposit_cancel = 'earn_deposit_cancel',
+  earn_deposit_submit_start = 'earn_deposit_submit_start',
+  earn_deposit_submit_success = 'earn_deposit_submit_success',
+  earn_deposit_submit_error = 'earn_deposit_submit_error',
+  earn_deposit_submit_cancel = 'earn_deposit_submit_cancel',
   earn_view_pools_press = 'earn_view_pools_press',
 }

--- a/src/analytics/Properties.tsx
+++ b/src/analytics/Properties.tsx
@@ -1573,6 +1573,13 @@ interface PointsEventsProperties {
   [PointsEvents.points_screen_activity_learn_more_press]: undefined
 }
 
+interface EarnDepositProperties {
+  tokenId: string
+  networkId: NetworkId
+  tokenAmount: string
+  providerId: string
+}
+
 interface EarnEventsProperties {
   [EarnEvents.earn_cta_press]: undefined
   [EarnEvents.earn_add_crypto_action_press]: {
@@ -1582,6 +1589,12 @@ interface EarnEventsProperties {
   [EarnEvents.earn_deposit_terms_and_conditions_press]: undefined
   [EarnEvents.earn_deposit_complete]: undefined
   [EarnEvents.earn_deposit_cancel]: undefined
+  [EarnEvents.earn_deposit_submit_start]: EarnDepositProperties
+  [EarnEvents.earn_deposit_submit_success]: EarnDepositProperties
+  [EarnEvents.earn_deposit_submit_error]: EarnDepositProperties & {
+    error: string
+  }
+  [EarnEvents.earn_deposit_submit_cancel]: EarnDepositProperties
   [EarnEvents.earn_view_pools_press]: undefined
 }
 

--- a/src/analytics/docs.ts
+++ b/src/analytics/docs.ts
@@ -597,6 +597,10 @@ export const eventDocs: Record<AnalyticsEventType, string> = {
   [EarnEvents.earn_deposit_terms_and_conditions_press]: `When a user taps on the terms and conditions link on the deposit bottom sheet`,
   [EarnEvents.earn_deposit_complete]: `When a user taps on the complete button on the deposit bottom sheet`,
   [EarnEvents.earn_deposit_cancel]: `When a user taps on the cancel button on the deposit bottom sheet`,
+  [EarnEvents.earn_deposit_submit_start]: `When the wallet is about to submit the deposit transaction to the network`,
+  [EarnEvents.earn_deposit_submit_success]: `When the deposit transaction succeeds`,
+  [EarnEvents.earn_deposit_submit_error]: `When the deposit transaction fails`,
+  [EarnEvents.earn_deposit_submit_cancel]: `When the user cancels the deposit after submitting by cancelling PIN input`,
   [EarnEvents.earn_view_pools_press]: `When the user taps on the view pools button from token details`,
 
   // Legacy event docs

--- a/src/earn/saga.test.ts
+++ b/src/earn/saga.test.ts
@@ -18,7 +18,13 @@ import { createMockStore } from 'test/utils'
 import { mockArbUsdcTokenId, mockTokenBalances, mockUSDCAddress } from 'test/values'
 import { Address, decodeFunctionData } from 'viem'
 
-jest.mock('viem')
+jest.mock('viem', () => ({
+  ...jest.requireActual('viem'),
+  decodeFunctionData: jest.fn(() => ({
+    functionName: 'approve',
+    args: ['0xspenderAddress', BigInt(1e8)],
+  })),
+}))
 
 jest.mock('src/transactions/types', () => {
   const originalModule = jest.requireActual('src/transactions/types')
@@ -139,9 +145,6 @@ describe('depositSubmitSaga', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
-    jest
-      .mocked(decodeFunctionData)
-      .mockReturnValue({ functionName: 'approve', args: ['0xspenderAddress', BigInt(1e8)] })
   })
 
   it('sends approve and deposit transactions, navigates home and dispatches the success action', async () => {

--- a/src/earn/saga.test.ts
+++ b/src/earn/saga.test.ts
@@ -1,16 +1,300 @@
 import { expectSaga } from 'redux-saga-test-plan'
+import * as matchers from 'redux-saga-test-plan/matchers'
+import { call } from 'redux-saga-test-plan/matchers'
+import { StaticProvider, dynamic, throwError } from 'redux-saga-test-plan/providers'
+import erc20 from 'src/abis/IERC20'
+import { EarnEvents } from 'src/analytics/Events'
+import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import { depositSubmitSaga } from 'src/earn/saga'
-import { depositStart, depositSuccess } from 'src/earn/slice'
+import { depositCancel, depositError, depositStart, depositSuccess } from 'src/earn/slice'
 import { navigateHome } from 'src/navigator/NavigationService'
+import { CANCELLED_PIN_INPUT } from 'src/pincode/authentication'
+import { Network, NetworkId, TokenTransactionTypeV2 } from 'src/transactions/types'
+import { publicClient } from 'src/viem'
+import { SerializableTransactionRequest } from 'src/viem/preparedTransactionSerialization'
+import { sendPreparedTransactions } from 'src/viem/saga'
+import networkConfig from 'src/web3/networkConfig'
+import { createMockStore } from 'test/utils'
+import { mockArbUsdcTokenId, mockTokenBalances, mockUSDCAddress } from 'test/values'
+import { Address, decodeFunctionData } from 'viem'
+
+jest.mock('src/transactions/types', () => {
+  const originalModule = jest.requireActual('src/transactions/types')
+
+  return {
+    ...originalModule,
+    newTransactionContext: jest.fn((tag, description) => ({
+      id: `id-${tag}-${description}`,
+      tag,
+      description,
+    })),
+  }
+})
 
 describe('depositSubmitSaga', () => {
-  it('navigates home', async () => {
+  const serializableApproveTx: SerializableTransactionRequest = {
+    from: '0xa',
+    to: mockUSDCAddress as Address,
+    value: '100',
+    data: '0x01',
+    gas: '20000',
+  }
+  const serializableDepositTx: SerializableTransactionRequest = {
+    from: '0xa',
+    to: '0xc',
+    value: '100',
+    data: '0x02',
+    gas: '50000',
+  }
+  const mockApproveTxReceipt = {
+    status: 'success',
+    blockNumber: BigInt(1234),
+    transactionHash: '0x1',
+    cumulativeGasUsed: BigInt(3_129_217),
+    effectiveGasPrice: BigInt(5_000_000_000),
+    gasUsed: BigInt(51_578),
+  }
+  const mockDepositTxReceipt = {
+    status: 'success',
+    blockNumber: BigInt(1234),
+    transactionHash: '0x2',
+    cumulativeGasUsed: BigInt(3_899_547),
+    effectiveGasPrice: BigInt(5_000_000_000),
+    gasUsed: BigInt(371_674),
+  }
+  const mockStandbyHandler = jest.fn()
+
+  const sagaProviders: StaticProvider[] = [
+    [
+      matchers.call.fn(decodeFunctionData),
+      { functionName: 'approve', args: ['0xspenderAddress', BigInt(1e8)] },
+    ],
+    [
+      matchers.call.fn(sendPreparedTransactions),
+      dynamic(({ args: [txs, _networkId, standbyHandlers] }) => {
+        if (txs.length === 1) {
+          mockStandbyHandler(standbyHandlers[0]('0x2'))
+          return ['0x2']
+        } else {
+          mockStandbyHandler(standbyHandlers[0]('0x1'))
+          mockStandbyHandler(standbyHandlers[1]('0x2'))
+          return ['0x1', '0x2']
+        }
+      }),
+    ],
+    [
+      call([publicClient[Network.Arbitrum], 'waitForTransactionReceipt'], { hash: '0x1' }),
+      mockApproveTxReceipt,
+    ],
+    [
+      call([publicClient[Network.Arbitrum], 'waitForTransactionReceipt'], { hash: '0x2' }),
+      mockDepositTxReceipt,
+    ],
+  ]
+
+  const expectedAnalyticsProps = {
+    tokenId: mockArbUsdcTokenId,
+    tokenAmount: '100',
+    networkId: NetworkId['arbitrum-sepolia'],
+    providerId: 'aave-v3',
+  }
+
+  const expectedApproveStandbyTx = {
+    __typename: 'TokenApproval',
+    context: {
+      id: 'id-earn/saga-Earn/Approve',
+      tag: 'earn/saga',
+      description: 'Earn/Approve',
+    },
+    networkId: NetworkId['arbitrum-sepolia'],
+    tokenId: mockArbUsdcTokenId,
+    transactionHash: '0x1',
+    type: TokenTransactionTypeV2.Approval,
+    approvedAmount: '100',
+    feeCurrencyId: undefined,
+  }
+
+  const expectedDepositStandbyTx = {
+    __typename: 'TokenExchangeV3',
+    context: {
+      id: 'id-earn/saga-Earn/Deposit',
+      tag: 'earn/saga',
+      description: 'Earn/Deposit',
+    },
+    networkId: NetworkId['arbitrum-sepolia'],
+    inAmount: {
+      value: '100',
+      tokenId: networkConfig.aaveArbUsdcTokenId,
+    },
+    outAmount: {
+      value: '100',
+      tokenId: mockArbUsdcTokenId,
+    },
+    transactionHash: '0x2',
+    type: TokenTransactionTypeV2.SwapTransaction,
+    feeCurrencyId: undefined,
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('sends approve and deposit transactions, navigates home and dispatches the success action', async () => {
     await expectSaga(depositSubmitSaga, {
       type: depositStart.type,
-      payload: { amount: '100', tokenId: 'tokenId', preparedTransactions: [] },
+      payload: {
+        amount: '100',
+        tokenId: mockArbUsdcTokenId,
+        preparedTransactions: [serializableApproveTx, serializableDepositTx],
+      },
     })
+      .withState(createMockStore({ tokens: { tokenBalances: mockTokenBalances } }).getState())
+      .provide(sagaProviders)
       .put(depositSuccess())
+      .call(decodeFunctionData, { abi: erc20.abi, data: '0x01' })
+      .call.like({ fn: sendPreparedTransactions })
+      .call([publicClient[Network.Arbitrum], 'waitForTransactionReceipt'], { hash: '0x1' })
+      .call([publicClient[Network.Arbitrum], 'waitForTransactionReceipt'], { hash: '0x2' })
       .run()
     expect(navigateHome).toHaveBeenCalled()
+    expect(mockStandbyHandler).toHaveBeenCalledTimes(2)
+    expect(mockStandbyHandler).toHaveBeenNthCalledWith(1, expectedApproveStandbyTx)
+    expect(mockStandbyHandler).toHaveBeenNthCalledWith(2, expectedDepositStandbyTx)
+    expect(ValoraAnalytics.track).toHaveBeenCalledWith(
+      EarnEvents.earn_deposit_submit_start,
+      expectedAnalyticsProps
+    )
+    expect(ValoraAnalytics.track).toHaveBeenCalledWith(
+      EarnEvents.earn_deposit_submit_success,
+      expectedAnalyticsProps
+    )
+  })
+
+  it('sends only deposit transaction, navigates home and dispatches the success action', async () => {
+    await expectSaga(depositSubmitSaga, {
+      type: depositStart.type,
+      payload: {
+        amount: '100',
+        tokenId: mockArbUsdcTokenId,
+        preparedTransactions: [serializableDepositTx],
+      },
+    })
+      .withState(createMockStore({ tokens: { tokenBalances: mockTokenBalances } }).getState())
+      .provide(sagaProviders)
+      .put(depositSuccess())
+      .not.call.like({ fn: decodeFunctionData })
+      .call.like({ fn: sendPreparedTransactions })
+      .call([publicClient[Network.Arbitrum], 'waitForTransactionReceipt'], { hash: '0x2' })
+      .run()
+    expect(navigateHome).toHaveBeenCalled()
+    expect(mockStandbyHandler).toHaveBeenCalledTimes(1)
+    expect(mockStandbyHandler).toHaveBeenCalledWith(expectedDepositStandbyTx)
+    expect(ValoraAnalytics.track).toHaveBeenCalledWith(
+      EarnEvents.earn_deposit_submit_start,
+      expectedAnalyticsProps
+    )
+    expect(ValoraAnalytics.track).toHaveBeenCalledWith(
+      EarnEvents.earn_deposit_submit_success,
+      expectedAnalyticsProps
+    )
+  })
+
+  it('dispatches cancel action if pin input is cancelled and does not navigate home', async () => {
+    await expectSaga(depositSubmitSaga, {
+      type: depositStart.type,
+      payload: {
+        amount: '100',
+        tokenId: mockArbUsdcTokenId,
+        preparedTransactions: [serializableDepositTx],
+      },
+    })
+      .withState(createMockStore({ tokens: { tokenBalances: mockTokenBalances } }).getState())
+      .provide([
+        [matchers.call.fn(sendPreparedTransactions), throwError(CANCELLED_PIN_INPUT as any)],
+        ...sagaProviders,
+      ])
+      .put(depositCancel())
+      .not.call.like({ fn: decodeFunctionData })
+      .call.like({ fn: sendPreparedTransactions })
+      .not.call([publicClient[Network.Arbitrum], 'waitForTransactionReceipt'])
+      .run()
+    expect(navigateHome).not.toHaveBeenCalled()
+    expect(mockStandbyHandler).not.toHaveBeenCalled()
+    expect(ValoraAnalytics.track).toHaveBeenCalledWith(
+      EarnEvents.earn_deposit_submit_start,
+      expectedAnalyticsProps
+    )
+    expect(ValoraAnalytics.track).toHaveBeenCalledWith(
+      EarnEvents.earn_deposit_submit_cancel,
+      expectedAnalyticsProps
+    )
+  })
+
+  it('dispatches error action if transaction submission fails and does not navigate home', async () => {
+    await expectSaga(depositSubmitSaga, {
+      type: depositStart.type,
+      payload: {
+        amount: '100',
+        tokenId: mockArbUsdcTokenId,
+        preparedTransactions: [serializableDepositTx],
+      },
+    })
+      .withState(createMockStore({ tokens: { tokenBalances: mockTokenBalances } }).getState())
+      .provide([
+        [matchers.call.fn(sendPreparedTransactions), throwError(new Error('Transaction failed'))],
+        ...sagaProviders,
+      ])
+      .put(depositError())
+      .not.call.like({ fn: decodeFunctionData })
+      .call.like({ fn: sendPreparedTransactions })
+      .not.call([publicClient[Network.Arbitrum], 'waitForTransactionReceipt'])
+      .run()
+    expect(navigateHome).not.toHaveBeenCalled()
+    expect(mockStandbyHandler).not.toHaveBeenCalled()
+    expect(ValoraAnalytics.track).toHaveBeenCalledWith(
+      EarnEvents.earn_deposit_submit_start,
+      expectedAnalyticsProps
+    )
+    expect(ValoraAnalytics.track).toHaveBeenCalledWith(EarnEvents.earn_deposit_submit_error, {
+      ...expectedAnalyticsProps,
+      error: 'Transaction failed',
+    })
+  })
+
+  it('dispatches error action and navigates home if deposit transaction status is reverted', async () => {
+    await expectSaga(depositSubmitSaga, {
+      type: depositStart.type,
+      payload: {
+        amount: '100',
+        tokenId: mockArbUsdcTokenId,
+        preparedTransactions: [serializableApproveTx, serializableDepositTx],
+      },
+    })
+      .withState(createMockStore({ tokens: { tokenBalances: mockTokenBalances } }).getState())
+      .provide([
+        [
+          call([publicClient[Network.Arbitrum], 'waitForTransactionReceipt'], { hash: '0x2' }),
+          { ...mockDepositTxReceipt, status: 'reverted' },
+        ],
+        ...sagaProviders,
+      ])
+      .put(depositError())
+      .call.like({ fn: decodeFunctionData })
+      .call.like({ fn: sendPreparedTransactions })
+      .call([publicClient[Network.Arbitrum], 'waitForTransactionReceipt'], { hash: '0x1' })
+      .call([publicClient[Network.Arbitrum], 'waitForTransactionReceipt'], { hash: '0x2' })
+      .run()
+    expect(navigateHome).toHaveBeenCalled()
+    expect(mockStandbyHandler).toHaveBeenCalledTimes(2)
+    expect(mockStandbyHandler).toHaveBeenNthCalledWith(1, expectedApproveStandbyTx)
+    expect(mockStandbyHandler).toHaveBeenNthCalledWith(2, expectedDepositStandbyTx)
+    expect(ValoraAnalytics.track).toHaveBeenCalledWith(
+      EarnEvents.earn_deposit_submit_start,
+      expectedAnalyticsProps
+    )
+    expect(ValoraAnalytics.track).toHaveBeenCalledWith(EarnEvents.earn_deposit_submit_error, {
+      ...expectedAnalyticsProps,
+      error: 'Deposit transaction reverted: 0x2',
+    })
   })
 })

--- a/src/earn/saga.ts
+++ b/src/earn/saga.ts
@@ -1,14 +1,177 @@
 import { PayloadAction } from '@reduxjs/toolkit'
-import { depositStart, depositSuccess } from 'src/earn/slice'
+import BigNumber from 'bignumber.js'
+import erc20 from 'src/abis/IERC20'
+import { EarnEvents } from 'src/analytics/Events'
+import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
+import { depositCancel, depositError, depositStart, depositSuccess } from 'src/earn/slice'
 import { DepositInfo } from 'src/earn/types'
 import { navigateHome } from 'src/navigator/NavigationService'
+import { CANCELLED_PIN_INPUT } from 'src/pincode/authentication'
+import { vibrateError } from 'src/styles/hapticFeedback'
+import { getTokenInfo } from 'src/tokens/saga'
+import { BaseStandbyTransaction } from 'src/transactions/actions'
+import { TokenTransactionTypeV2, newTransactionContext } from 'src/transactions/types'
+import Logger from 'src/utils/Logger'
+import { ensureError } from 'src/utils/ensureError'
 import { safely } from 'src/utils/safely'
-import { put, takeLeading } from 'typed-redux-saga'
+import { publicClient } from 'src/viem'
+import { getPreparedTransactions } from 'src/viem/preparedTransactionSerialization'
+import { sendPreparedTransactions } from 'src/viem/saga'
+import networkConfig, { networkIdToNetwork } from 'src/web3/networkConfig'
+import { all, call, put, takeLeading } from 'typed-redux-saga'
+import { decodeFunctionData } from 'viem'
+
+const TAG = 'earn/saga'
 
 export function* depositSubmitSaga(action: PayloadAction<DepositInfo>) {
-  // todo(act-1178): submit the tx
-  yield* put(depositSuccess())
-  navigateHome()
+  const { tokenId, preparedTransactions: serializablePreparedTransactions, amount } = action.payload
+
+  const preparedTransactions = getPreparedTransactions(serializablePreparedTransactions)
+
+  const tokenInfo = yield* call(getTokenInfo, tokenId)
+  if (!tokenInfo) {
+    Logger.error(`${TAG}/depositSubmitSaga`, 'Token info not found for token id', tokenId)
+    yield* put(depositError())
+    return
+  }
+
+  const networkId = tokenInfo.networkId
+  const trackedProperties = {
+    tokenId,
+    networkId,
+    tokenAmount: amount,
+    providerId: 'aave-v3',
+  }
+
+  let submitted = false
+
+  try {
+    Logger.debug(
+      `${TAG}/depositSubmitSaga`,
+      `Starting deposit for token ${tokenId}, total transactions: ${preparedTransactions.length}`
+    )
+
+    const createDepositStandbyTxHandlers = []
+
+    if (preparedTransactions.length > 1 && preparedTransactions[0].data) {
+      const { functionName, args } = yield* call(decodeFunctionData, {
+        abi: erc20.abi,
+        data: preparedTransactions[0].data,
+      })
+      if (functionName === 'approve' && preparedTransactions[0].to === tokenInfo.address && args) {
+        Logger.debug(`${TAG}/depositSubmitSaga`, 'First transaction is an approval transaction')
+        const approvedAmountInSmallestUnit = args[1] as bigint
+        const approvedAmount = new BigNumber(approvedAmountInSmallestUnit.toString())
+          .shiftedBy(-tokenInfo.decimals)
+          .toString()
+
+        const createApprovalStandbyTx = (
+          transactionHash: string,
+          feeCurrencyId?: string
+        ): BaseStandbyTransaction => {
+          return {
+            context: newTransactionContext(TAG, 'Earn/Approve'),
+            __typename: 'TokenApproval',
+            networkId,
+            type: TokenTransactionTypeV2.Approval,
+            transactionHash,
+            tokenId,
+            approvedAmount,
+            feeCurrencyId,
+          }
+        }
+        createDepositStandbyTxHandlers.push(createApprovalStandbyTx)
+      }
+    }
+
+    // this is a placeholder for now, should be updated to a "deposit" transaction type
+    const createDepositStandbyTx = (
+      transactionHash: string,
+      feeCurrencyId?: string
+    ): BaseStandbyTransaction => {
+      return {
+        context: newTransactionContext(TAG, 'Earn/Deposit'),
+        __typename: 'TokenExchangeV3',
+        networkId,
+        type: TokenTransactionTypeV2.SwapTransaction,
+        inAmount: {
+          value: amount,
+          tokenId: networkConfig.aaveArbUsdcTokenId,
+        },
+        outAmount: {
+          value: amount,
+          tokenId,
+        },
+        transactionHash,
+        feeCurrencyId,
+      }
+    }
+    createDepositStandbyTxHandlers.push(createDepositStandbyTx)
+
+    ValoraAnalytics.track(EarnEvents.earn_deposit_submit_start, trackedProperties)
+
+    const txHashes = yield* call(
+      sendPreparedTransactions,
+      serializablePreparedTransactions,
+      networkId,
+      createDepositStandbyTxHandlers
+    )
+
+    Logger.debug(
+      `${TAG}/depositSubmitSaga`,
+      'Successfully sent deposit transaction(s) to the network',
+      txHashes
+    )
+
+    navigateHome()
+    submitted = true
+
+    // wait for the tx receipts, so that we can track them
+    Logger.debug(`${TAG}/depositSubmitSaga`, 'Waiting for transaction receipts')
+    const txReceipts = yield* all(
+      txHashes.map((txHash) => {
+        return call([publicClient[networkIdToNetwork[networkId]], 'waitForTransactionReceipt'], {
+          hash: txHash,
+        })
+      })
+    )
+    txReceipts.forEach((receipt, index) => {
+      Logger.debug(
+        `${TAG}/depositSubmitSaga`,
+        `Received transaction receipt ${index + 1} of ${txReceipts.length}`,
+        receipt
+      )
+    })
+
+    const depositTxReceipt = txReceipts[txReceipts.length - 1]
+    if (depositTxReceipt.status !== 'success') {
+      throw new Error(`Deposit transaction reverted: ${depositTxReceipt?.transactionHash}`)
+    }
+
+    ValoraAnalytics.track(EarnEvents.earn_deposit_submit_success, trackedProperties)
+    yield* put(depositSuccess())
+  } catch (err) {
+    if (err === CANCELLED_PIN_INPUT) {
+      Logger.info(`${TAG}/depositSubmitSaga`, 'Transaction cancelled by user')
+      yield* put(depositCancel())
+      ValoraAnalytics.track(EarnEvents.earn_deposit_submit_cancel, trackedProperties)
+      return
+    }
+
+    const error = ensureError(err)
+    Logger.error(`${TAG}/depositSubmitSaga`, 'Error sending deposit transaction', error)
+    yield* put(depositError())
+    ValoraAnalytics.track(EarnEvents.earn_deposit_submit_error, {
+      ...trackedProperties,
+      error: error.message,
+    })
+
+    // Only vibrate if we haven't already submitted the transaction
+    // since the user may be doing something else on the app by now
+    if (!submitted) {
+      vibrateError()
+    }
+  }
 }
 
 export function* earnSaga() {

--- a/src/viem/saga.ts
+++ b/src/viem/saga.ts
@@ -1,5 +1,3 @@
-import { TAG } from 'src/send/saga'
-
 import { tokensByIdSelector } from 'src/tokens/selectors'
 import { BaseStandbyTransaction, addStandbyTransaction } from 'src/transactions/actions'
 import { NetworkId } from 'src/transactions/types'
@@ -16,6 +14,8 @@ import { getNetworkFromNetworkId } from 'src/web3/utils'
 import { call, put, select } from 'typed-redux-saga'
 import { Hash } from 'viem'
 import { getTransactionCount } from 'viem/actions'
+
+const TAG = 'viem/saga'
 
 /**
  * Sends prepared transactions and adds standby transactions to the store.

--- a/test/values.ts
+++ b/test/values.ts
@@ -139,6 +139,7 @@ export const mockEthTokenId = 'ethereum-sepolia:native'
 export const mockUSDCTokenId = `ethereum-sepolia:${mockUSDCAddress}`
 export const mockARBTokenId = `arbitrum-sepolia:native`
 export const mockOPTokenId = `op-sepolia:native`
+export const mockArbUsdcTokenId = `arbitrum-sepolia:${mockUSDCAddress}`
 
 export const mockQrCodeData2 = {
   address: mockAccount2Invite,
@@ -567,6 +568,19 @@ export const mockTokenBalances: Record<string, StoredTokenBalance> = {
     balance: '0',
     priceUsd: '1500',
     isNative: true,
+    priceFetchedAt: Date.now(),
+  },
+  [mockArbUsdcTokenId]: {
+    name: 'USD Coin',
+    networkId: NetworkId['arbitrum-sepolia'],
+    tokenId: mockArbUsdcTokenId,
+    address: mockUSDCAddress,
+    symbol: 'USDC',
+    decimals: 6,
+    imageUrl:
+      'https://raw.githubusercontent.com/valora-inc/address-metadata/main/assets/tokens/ETH.png',
+    balance: '0',
+    priceUsd: '1',
     priceFetchedAt: Date.now(),
   },
 }


### PR DESCRIPTION
### Description

Submits the deposit transactions, mostly based on the swap and jumpstart sagas

### Test plan

Unit tests, manually
- tx currently fails because of a gas limit issue, will make a follow up for this
- loading state is done in #5415 



Uploading earn-submit-tx.mp4…




### Related issues

- Part of ACT-1178

### Backwards compatibility

Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
