### PR TITLE
feat(earn): get gas padding from dynamic config

### DIFF
--- a/src/earn/prepareTransactions.ts
+++ b/src/earn/prepareTransactions.ts
@@ -1,6 +1,9 @@
 import BigNumber from 'bignumber.js'
 import aavePool from 'src/abis/AavePoolV3'
 import erc20 from 'src/abis/IERC20'
+import { getDynamicConfigParams } from 'src/statsig'
+import { DynamicConfigs } from 'src/statsig/constants'
+import { StatsigDynamicConfigs } from 'src/statsig/types'
 import { TokenBalance } from 'src/tokens/slice'
 import { fetchWithTimeout } from 'src/utils/fetchWithTimeout'
 import { publicClient } from 'src/viem'
@@ -112,7 +115,13 @@ export async function prepareSupplyTransactions({
     )
   }
 
-  baseTransactions[baseTransactions.length - 1].gas = BigInt(supplySimulatedTx.gasNeeded)
+  const { depositGasPadding } = getDynamicConfigParams(
+    DynamicConfigs[StatsigDynamicConfigs.EARN_STABLECOIN_CONFIG]
+  )
+
+  baseTransactions[baseTransactions.length - 1].gas = BigInt(
+    supplySimulatedTx.gasNeeded + depositGasPadding
+  )
   baseTransactions[baseTransactions.length - 1]._estimatedGasUse = BigInt(supplySimulatedTx.gasUsed)
 
   return prepareTransactions({

--- a/src/statsig/constants.ts
+++ b/src/statsig/constants.ts
@@ -141,6 +141,7 @@ export const DynamicConfigs = {
       providerName: 'Aave',
       providerLogoUrl: '',
       providerTermsAndConditionsUrl: '',
+      depositGasPadding: 0,
     },
   },
 } satisfies {


### PR DESCRIPTION
### Description

As the title

### Test plan

Unit tests, manual
Successful tx: https://sepolia.arbiscan.io/tx/0xe681a97041ad016ecfae008111285db3b14a60a5054abd5912109af2987245d0
https://arbiscan.io/tx/0x3a72d7edf302f4d88ae86dc42bbffd87b95d47ee9b4a1a0723ddee13cd30954f

https://github.com/valora-inc/wallet/assets/5062591/86a99157-d2c8-4c21-9196-640784d1ce9a


### Related issues

- Part of ACT-1178

### Backwards compatibility

Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
