### PR TITLE
feat(earn): fetch rewards on collect screen

### DIFF
--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -2393,9 +2393,11 @@
       "total": "TOTAL",
       "plus": "PLUS",
       "rate": "Rate (est.)",
-      "apy": "~{{apy}}% APY",
+      "apy": "{{apy}}% APY",
       "fee": "Gas Fee",
-      "cta": "Collect Earnings"
+      "cta": "Collect Earnings",
+      "errorTitle": "Something went wrong",
+      "errorDescription": "Unable to fetch deposit details. Please try again."
     }
   }
 }

--- a/src/analytics/Events.tsx
+++ b/src/analytics/Events.tsx
@@ -689,4 +689,5 @@ export enum EarnEvents {
   earn_deposit_submit_error = 'earn_deposit_submit_error',
   earn_deposit_submit_cancel = 'earn_deposit_submit_cancel',
   earn_view_pools_press = 'earn_view_pools_press',
+  earn_exit_pool_press = 'earn_exit_pool_press',
 }

--- a/src/analytics/Properties.tsx
+++ b/src/analytics/Properties.tsx
@@ -1599,6 +1599,12 @@ interface EarnEventsProperties {
   }
   [EarnEvents.earn_deposit_submit_cancel]: EarnDepositProperties
   [EarnEvents.earn_view_pools_press]: undefined
+  [EarnEvents.earn_exit_pool_press]: {
+    poolTokenId: string
+    networkId: NetworkId
+    tokenAmount: string
+    providerId: string
+  }
 }
 
 export type AnalyticsPropertiesList = AppEventsProperties &

--- a/src/analytics/docs.ts
+++ b/src/analytics/docs.ts
@@ -604,6 +604,7 @@ export const eventDocs: Record<AnalyticsEventType, string> = {
   [EarnEvents.earn_deposit_submit_error]: `When the deposit transaction fails`,
   [EarnEvents.earn_deposit_submit_cancel]: `When the user cancels the deposit after submitting by cancelling PIN input`,
   [EarnEvents.earn_view_pools_press]: `When the user taps on the view pools button from token details`,
+  [EarnEvents.earn_exit_pool_press]: `When the user taps on the exit pool button from the earn card in discover tab`,
 
   // Legacy event docs
   //  The below events had docs, but are no longer produced by the latest app version.

--- a/src/earn/EarnActivePool.test.tsx
+++ b/src/earn/EarnActivePool.test.tsx
@@ -95,6 +95,9 @@ describe('EarnActivePool', () => {
       tokenAmount: '10.75',
       providerId: 'aave-v3',
     })
-    expect(navigate).toBeCalledWith(Screens.EarnCollectScreen)
+    expect(navigate).toBeCalledWith(Screens.EarnCollectScreen, {
+      depositTokenId: networkConfig.arbUsdcTokenId,
+      poolTokenId: networkConfig.aaveArbUsdcTokenId,
+    })
   })
 })

--- a/src/earn/EarnActivePool.test.tsx
+++ b/src/earn/EarnActivePool.test.tsx
@@ -76,4 +76,25 @@ describe('EarnActivePool', () => {
     expect(ValoraAnalytics.track).toHaveBeenCalledWith(EarnEvents.earn_view_pools_press)
     expect(navigate).toBeCalledWith(Screens.TabDiscover)
   })
+
+  it('should have correct analytics and navigation with exit pool cta', () => {
+    const { getByText } = render(
+      <Provider store={store}>
+        <EarnActivePool
+          cta="ExitAndDeposit"
+          depositTokenId={networkConfig.arbUsdcTokenId}
+          poolTokenId={networkConfig.aaveArbUsdcTokenId}
+        />
+      </Provider>
+    )
+
+    fireEvent.press(getByText('earnFlow.activePools.exitPool'))
+    expect(ValoraAnalytics.track).toHaveBeenCalledWith(EarnEvents.earn_exit_pool_press, {
+      poolTokenId: networkConfig.aaveArbUsdcTokenId,
+      networkId: NetworkId['arbitrum-sepolia'],
+      tokenAmount: '10.75',
+      providerId: 'aave-v3',
+    })
+    expect(navigate).toBeCalledWith(Screens.EarnCollectScreen)
+  })
 })

--- a/src/earn/EarnCollectScreen.test.tsx
+++ b/src/earn/EarnCollectScreen.test.tsx
@@ -147,7 +147,7 @@ describe('EarnCollectScreen', () => {
 
   it('skips error and enables cta if only apy loading fails', async () => {
     jest.mocked(fetchAavePoolInfo).mockRejectedValue(new Error('Failed to fetch apy'))
-    const { getByText, getByTestId, queryByTestId } = render(
+    const { getByText, getByTestId, queryByTestId, queryByText } = render(
       <Provider store={store}>
         <MockedNavigator
           component={EarnCollectScreen}
@@ -168,8 +168,12 @@ describe('EarnCollectScreen', () => {
     await waitFor(() => {
       expect(queryByTestId('EarnCollect/RewardsLoading')).toBeFalsy()
     })
+    await waitFor(() => {
+      expect(queryByTestId('EarnCollect/ApyLoading')).toBeFalsy()
+    })
     expect(getByText('earnFlow.collect.apy, {"apy":"--"}')).toBeTruthy()
     expect(getByText('earnFlow.collect.plus')).toBeTruthy()
     expect(getByTestId('EarnCollectScreen/CTA')).toBeEnabled()
+    expect(queryByText('earnFlow.collect.errorTitle')).toBeFalsy()
   })
 })

--- a/src/earn/EarnCollectScreen.test.tsx
+++ b/src/earn/EarnCollectScreen.test.tsx
@@ -1,0 +1,178 @@
+import { render, waitFor } from '@testing-library/react-native'
+import React from 'react'
+import { Provider } from 'react-redux'
+import EarnCollectScreen from 'src/earn/EarnCollectScreen'
+import { fetchAavePoolInfo, fetchAaveRewards } from 'src/earn/poolInfo'
+import { NetworkId } from 'src/transactions/types'
+import networkConfig from 'src/web3/networkConfig'
+import MockedNavigator from 'test/MockedNavigator'
+import { createMockStore } from 'test/utils'
+import {
+  mockAaveArbUsdcAddress,
+  mockArbArbTokenBalance,
+  mockArbArbTokenId,
+  mockArbUsdcTokenId,
+  mockTokenBalances,
+} from 'test/values'
+
+const store = createMockStore({
+  tokens: {
+    tokenBalances: {
+      ...mockTokenBalances,
+      [networkConfig.aaveArbUsdcTokenId]: {
+        networkId: NetworkId['arbitrum-sepolia'],
+        address: mockAaveArbUsdcAddress,
+        tokenId: networkConfig.aaveArbUsdcTokenId,
+        symbol: 'aArbSepUSDC',
+        priceUsd: '1',
+        balance: '10.75',
+        priceFetchedAt: Date.now(),
+      },
+    },
+  },
+})
+
+jest.mock('src/earn/poolInfo')
+
+describe('EarnCollectScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.mocked(fetchAavePoolInfo).mockResolvedValue({ apy: 0.03 })
+    jest
+      .mocked(fetchAaveRewards)
+      .mockResolvedValue([{ amount: '0.01', tokenInfo: mockArbArbTokenBalance }])
+  })
+
+  it('renders total balance, rewards and apy', async () => {
+    const { getByText, getByTestId, queryByTestId } = render(
+      <Provider store={store}>
+        <MockedNavigator
+          component={EarnCollectScreen}
+          params={{
+            depositTokenId: mockArbUsdcTokenId,
+            poolTokenId: networkConfig.aaveArbUsdcTokenId,
+          }}
+        />
+      </Provider>
+    )
+
+    expect(getByText('earnFlow.collect.title')).toBeTruthy()
+    expect(getByText('earnFlow.collect.total')).toBeTruthy()
+    expect(getByTestId(`EarnCollect/${mockArbUsdcTokenId}/CryptoAmount`)).toHaveTextContent(
+      '10.75 USDC'
+    )
+    expect(getByTestId(`EarnCollect/${mockArbUsdcTokenId}/FiatAmount`)).toHaveTextContent('₱14.30')
+    expect(getByTestId('EarnCollect/RewardsLoading')).toBeTruthy()
+    expect(getByTestId('EarnCollect/ApyLoading')).toBeTruthy()
+    expect(getByTestId('EarnCollectScreen/CTA')).toBeDisabled()
+
+    await waitFor(() => {
+      expect(queryByTestId('EarnCollect/RewardsLoading')).toBeFalsy()
+    })
+    await waitFor(() => {
+      expect(queryByTestId('EarnCollect/ApyLoading')).toBeFalsy()
+    })
+    expect(getByText('earnFlow.collect.plus')).toBeTruthy()
+    expect(getByTestId(`EarnCollect/${mockArbArbTokenId}/CryptoAmount`)).toHaveTextContent(
+      '0.01 ARB'
+    )
+    expect(getByTestId(`EarnCollect/${mockArbArbTokenId}/FiatAmount`)).toHaveTextContent('₱0.016')
+    expect(getByTestId('EarnCollectScreen/CTA')).toBeEnabled()
+
+    expect(getByText('earnFlow.collect.apy, {"apy":"3.00"}')).toBeTruthy()
+  })
+
+  it('skips rewards section when no rewards', async () => {
+    jest.mocked(fetchAaveRewards).mockResolvedValue([])
+    const { getByText, getByTestId, queryByTestId, queryByText } = render(
+      <Provider store={store}>
+        <MockedNavigator
+          component={EarnCollectScreen}
+          params={{
+            depositTokenId: mockArbUsdcTokenId,
+            poolTokenId: networkConfig.aaveArbUsdcTokenId,
+          }}
+        />
+      </Provider>
+    )
+
+    expect(getByText('earnFlow.collect.title')).toBeTruthy()
+    expect(getByText('earnFlow.collect.total')).toBeTruthy()
+    expect(getByTestId(`EarnCollect/${mockArbUsdcTokenId}/CryptoAmount`)).toHaveTextContent(
+      '10.75 USDC'
+    )
+    expect(getByTestId(`EarnCollect/${mockArbUsdcTokenId}/FiatAmount`)).toHaveTextContent('₱14.30')
+    expect(getByTestId('EarnCollect/RewardsLoading')).toBeTruthy()
+    expect(getByTestId('EarnCollectScreen/CTA')).toBeDisabled()
+
+    await waitFor(() => {
+      expect(queryByTestId('EarnCollect/RewardsLoading')).toBeFalsy()
+    })
+    expect(queryByText('earnFlow.collect.plus')).toBeFalsy()
+    expect(queryByTestId(`EarnCollect/${mockArbArbTokenId}/CryptoAmount`)).toBeFalsy()
+    expect(queryByTestId(`EarnCollect/${mockArbArbTokenId}/FiatAmount`)).toBeFalsy()
+    expect(getByTestId('EarnCollectScreen/CTA')).toBeEnabled()
+  })
+
+  it('shows error and keeps cta disabled if rewards loading fails', async () => {
+    jest.mocked(fetchAaveRewards).mockRejectedValue(new Error('Failed to fetch rewards'))
+    const { getByText, getByTestId, queryByText, queryByTestId } = render(
+      <Provider store={store}>
+        <MockedNavigator
+          component={EarnCollectScreen}
+          params={{
+            depositTokenId: mockArbUsdcTokenId,
+            poolTokenId: networkConfig.aaveArbUsdcTokenId,
+          }}
+        />
+      </Provider>
+    )
+
+    expect(getByText('earnFlow.collect.title')).toBeTruthy()
+    expect(getByText('earnFlow.collect.total')).toBeTruthy()
+    expect(getByTestId('EarnCollect/RewardsLoading')).toBeTruthy()
+    expect(getByTestId('EarnCollect/ApyLoading')).toBeTruthy()
+    expect(getByTestId('EarnCollectScreen/CTA')).toBeDisabled()
+
+    await waitFor(() => {
+      expect(queryByTestId('EarnCollect/RewardsLoading')).toBeFalsy()
+    })
+    await waitFor(() => {
+      expect(queryByTestId('EarnCollect/ApyLoading')).toBeFalsy()
+    })
+    expect(getByText('earnFlow.collect.errorTitle')).toBeTruthy()
+    expect(queryByText('earnFlow.collect.plus')).toBeFalsy()
+    expect(getByTestId('EarnCollectScreen/CTA')).toBeDisabled()
+  })
+
+  it('skips error and enables cta if only apy loading fails', async () => {
+    jest.mocked(fetchAavePoolInfo).mockRejectedValue(new Error('Failed to fetch apy'))
+    const { getByText, getByTestId, queryByTestId } = render(
+      <Provider store={store}>
+        <MockedNavigator
+          component={EarnCollectScreen}
+          params={{
+            depositTokenId: mockArbUsdcTokenId,
+            poolTokenId: networkConfig.aaveArbUsdcTokenId,
+          }}
+        />
+      </Provider>
+    )
+
+    expect(getByText('earnFlow.collect.title')).toBeTruthy()
+    expect(getByText('earnFlow.collect.total')).toBeTruthy()
+    expect(getByTestId('EarnCollect/RewardsLoading')).toBeTruthy()
+    expect(getByTestId('EarnCollect/ApyLoading')).toBeTruthy()
+    expect(getByTestId('EarnCollectScreen/CTA')).toBeDisabled()
+
+    await waitFor(() => {
+      expect(queryByTestId('EarnCollect/ApyLoading')).toBeFalsy()
+    })
+    await waitFor(() => {
+      expect(queryByTestId('EarnCollect/RewardsLoading')).toBeFalsy()
+    })
+    expect(getByText('earnFlow.collect.apy, {"apy":"--"}')).toBeTruthy()
+    expect(getByText('earnFlow.collect.plus')).toBeTruthy()
+    expect(getByTestId('EarnCollectScreen/CTA')).toBeEnabled()
+  })
+})

--- a/src/earn/EarnCollectScreen.test.tsx
+++ b/src/earn/EarnCollectScreen.test.tsx
@@ -166,7 +166,7 @@ describe('EarnCollectScreen', () => {
     expect(getByTestId('EarnCollectScreen/CTA')).toBeDisabled()
 
     await waitFor(() => {
-      expect(queryByTestId('EarnCollect/ApyLoading')).toBeFalsy()
+      expect(queryByTestId('EarnCollect/RewardsLoading')).toBeFalsy()
     })
     expect(getByText('earnFlow.collect.apy, {"apy":"--"}')).toBeTruthy()
     expect(getByText('earnFlow.collect.plus')).toBeTruthy()

--- a/src/earn/EarnCollectScreen.test.tsx
+++ b/src/earn/EarnCollectScreen.test.tsx
@@ -168,9 +168,6 @@ describe('EarnCollectScreen', () => {
     await waitFor(() => {
       expect(queryByTestId('EarnCollect/ApyLoading')).toBeFalsy()
     })
-    await waitFor(() => {
-      expect(queryByTestId('EarnCollect/RewardsLoading')).toBeFalsy()
-    })
     expect(getByText('earnFlow.collect.apy, {"apy":"--"}')).toBeTruthy()
     expect(getByText('earnFlow.collect.plus')).toBeTruthy()
     expect(getByTestId('EarnCollectScreen/CTA')).toBeEnabled()

--- a/src/earn/hooks.ts
+++ b/src/earn/hooks.ts
@@ -1,0 +1,77 @@
+import { useAsync } from 'react-async-hook'
+import { fetchAavePoolInfo, fetchAaveRewards } from 'src/earn/poolInfo'
+import { useSelector } from 'src/redux/hooks'
+import { useTokenInfo, useTokensList } from 'src/tokens/hooks'
+import Logger from 'src/utils/Logger'
+import networkConfig, { networkIdToNetwork } from 'src/web3/networkConfig'
+import { walletAddressSelector } from 'src/web3/selectors'
+import { isAddress } from 'viem'
+
+const TAG = 'earn/hooks'
+
+export function useAavePoolInfo({ depositTokenId }: { depositTokenId: string }) {
+  const depositToken = useTokenInfo(depositTokenId)
+  const asyncPoolInfo = useAsync(
+    async () => {
+      if (!depositToken || !depositToken.address) {
+        throw new Error(`Token with id ${depositTokenId} not found`)
+      }
+
+      if (!isAddress(depositToken.address)) {
+        throw new Error(`Token with id ${depositTokenId} does not contain a valid address`)
+      }
+
+      return fetchAavePoolInfo({
+        assetAddress: depositToken.address,
+        contractAddress: networkConfig.arbAavePoolV3ContractAddress,
+        network: networkIdToNetwork[depositToken.networkId],
+      })
+    },
+    [],
+    {
+      onError: (error) => {
+        Logger.warn(`${TAG}/useAavePoolInfo`, error.message)
+      },
+    }
+  )
+
+  return asyncPoolInfo
+}
+
+export function useAaveRewardsInfo({ poolTokenId }: { poolTokenId: string }) {
+  const poolTokenInfo = useTokenInfo(poolTokenId)
+  const walletAddress = useSelector(walletAddressSelector)
+  const allTokens = useTokensList()
+
+  return useAsync(
+    async () => {
+      if (!poolTokenInfo || !poolTokenInfo.address) {
+        throw new Error(`Token with id ${networkConfig.aaveArbUsdcTokenId} not found`)
+      }
+
+      if (!isAddress(poolTokenInfo.address)) {
+        throw new Error(
+          `Token with id ${networkConfig.arbUsdcTokenId} does not contain a valid address`
+        )
+      }
+
+      if (!walletAddress || !isAddress(walletAddress)) {
+        throw new Error(`Invalid wallet address: ${walletAddress}`)
+      }
+
+      return fetchAaveRewards({
+        walletAddress,
+        assetAddress: poolTokenInfo.address,
+        contractAddress: networkConfig.arbAaveIncentivesV3ContractAddress,
+        networkId: poolTokenInfo.networkId,
+        allTokens,
+      })
+    },
+    [],
+    {
+      onError: (error) => {
+        Logger.warn(`${TAG}/useAaveRewardsInfo`, error.message)
+      },
+    }
+  )
+}

--- a/src/navigator/types.tsx
+++ b/src/navigator/types.tsx
@@ -81,7 +81,10 @@ export type StackParamList = {
     rewardId: string
   }
   [Screens.Debug]: undefined
-  [Screens.EarnCollectScreen]: undefined
+  [Screens.EarnCollectScreen]: {
+    depositTokenId: string
+    poolTokenId: string
+  }
   [Screens.ErrorScreen]: {
     errorMessage?: string
   }


### PR DESCRIPTION
### Description

Fetches and displays rewards on collect screen. Also hooks up the screen to the Exit Pool button on discover tab.

### Test plan

Unit tests, manual

Loading -> display rewards (intentionally slowed down to show loading state)

https://github.com/valora-inc/wallet/assets/5062591/0d4442e0-7648-4aad-9a84-c8917a99fd23


Error state:
<img src="https://github.com/valora-inc/wallet/assets/5062591/c9fd1f4c-d636-43ef-91ee-4d9736f9099d" width="250" />


### Related issues

- Part of ACT-1180

### Backwards compatibility

Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
