### PR TITLE
feat(earn): add function for preparing withdraw transactions

### DIFF
--- a/src/earn/prepareTransactions.test.ts
+++ b/src/earn/prepareTransactions.test.ts
@@ -336,13 +336,13 @@ describe('prepareTransactions', () => {
       })
       expect(encodeFunctionData).toHaveBeenCalledWith({
         abi: aaveIncentivesV3Abi,
-        functionName: 'claimRewards',
-        args: [['0x5678'], BigInt(2e15), '0x1234', mockArbArbAddress],
+        functionName: 'claimRewardsToSelf',
+        args: [['0x5678'], BigInt(2e15), mockArbArbAddress],
       })
       expect(encodeFunctionData).toHaveBeenCalledWith({
         abi: aaveIncentivesV3Abi,
-        functionName: 'claimRewards',
-        args: [['0x5678'], BigInt(3000), '0x1234', mockTokenAddress],
+        functionName: 'claimRewardsToSelf',
+        args: [['0x5678'], BigInt(3000), mockTokenAddress],
       })
       expect(prepareTransactions).toHaveBeenCalledWith({
         baseTransactions: expectedTransactions,

--- a/src/earn/prepareTransactions.test.ts
+++ b/src/earn/prepareTransactions.test.ts
@@ -1,14 +1,20 @@
 import BigNumber from 'bignumber.js'
 import { FetchMock } from 'jest-fetch-mock/types'
+import aaveIncentivesV3Abi from 'src/abis/AaveIncentivesV3'
 import aavePool from 'src/abis/AavePoolV3'
 import erc20 from 'src/abis/IERC20'
-import { prepareSupplyTransactions } from 'src/earn/prepareTransactions'
+import {
+  prepareSupplyTransactions,
+  prepareWithdrawAndClaimTransactions,
+} from 'src/earn/prepareTransactions'
 import { getDynamicConfigParams } from 'src/statsig'
 import { StatsigDynamicConfigs } from 'src/statsig/types'
 import { TokenBalance } from 'src/tokens/slice'
 import { Network, NetworkId } from 'src/transactions/types'
 import { publicClient } from 'src/viem'
 import { prepareTransactions } from 'src/viem/prepareTransactions'
+import networkConfig from 'src/web3/networkConfig'
+import { mockArbArbAddress, mockArbArbTokenBalance } from 'test/values'
 import { Address, encodeFunctionData } from 'viem'
 
 const mockFeeCurrency: TokenBalance = {
@@ -276,6 +282,106 @@ describe('prepareTransactions', () => {
           poolContractAddress: '0x5678',
         })
       ).rejects.toThrow('Expected 2 simulated transactions, got 1')
+    })
+  })
+
+  describe('prepareWithdrawAndClaimTransactions', () => {
+    it('prepares withdraw and claim transactions', async () => {
+      const rewards = [
+        {
+          amount: '0.002',
+          tokenInfo: mockArbArbTokenBalance,
+        },
+        {
+          amount: '0.003',
+          tokenInfo: mockToken,
+        },
+      ]
+      const result = await prepareWithdrawAndClaimTransactions({
+        amount: '5',
+        token: mockToken,
+        walletAddress: '0x1234',
+        feeCurrencies: [mockFeeCurrency],
+        rewards,
+        poolTokenAddress: '0x5678',
+      })
+
+      const expectedTransactions = [
+        {
+          from: '0x1234',
+          to: networkConfig.arbAavePoolV3ContractAddress,
+          data: '0xencodedData',
+        },
+        {
+          from: '0x1234',
+          to: networkConfig.arbAaveIncentivesV3ContractAddress,
+          data: '0xencodedData',
+        },
+        {
+          from: '0x1234',
+          to: networkConfig.arbAaveIncentivesV3ContractAddress,
+          data: '0xencodedData',
+        },
+      ]
+      expect(result).toEqual({
+        type: 'possible',
+        feeCurrency: mockFeeCurrency,
+        transactions: expectedTransactions,
+      })
+      expect(encodeFunctionData).toHaveBeenCalledTimes(3)
+      expect(encodeFunctionData).toHaveBeenCalledWith({
+        abi: aavePool,
+        functionName: 'withdraw',
+        args: [mockTokenAddress, BigInt(5e6), '0x1234'],
+      })
+      expect(encodeFunctionData).toHaveBeenCalledWith({
+        abi: aaveIncentivesV3Abi,
+        functionName: 'claimRewards',
+        args: [['0x5678'], BigInt(2e15), '0x1234', mockArbArbAddress],
+      })
+      expect(encodeFunctionData).toHaveBeenCalledWith({
+        abi: aaveIncentivesV3Abi,
+        functionName: 'claimRewards',
+        args: [['0x5678'], BigInt(3000), '0x1234', mockTokenAddress],
+      })
+      expect(prepareTransactions).toHaveBeenCalledWith({
+        baseTransactions: expectedTransactions,
+        feeCurrencies: [mockFeeCurrency],
+      })
+    })
+
+    it('prepares only withdraw transaction if no rewards', async () => {
+      const result = await prepareWithdrawAndClaimTransactions({
+        amount: '5',
+        token: mockToken,
+        walletAddress: '0x1234',
+        feeCurrencies: [mockFeeCurrency],
+        rewards: [],
+        poolTokenAddress: '0x5678',
+      })
+
+      const expectedTransactions = [
+        {
+          from: '0x1234',
+          to: networkConfig.arbAavePoolV3ContractAddress,
+          data: '0xencodedData',
+        },
+      ]
+      expect(result).toEqual({
+        type: 'possible',
+        feeCurrency: mockFeeCurrency,
+        transactions: expectedTransactions,
+      })
+      expect(encodeFunctionData).toHaveBeenCalledTimes(1)
+      expect(encodeFunctionData).toHaveBeenCalledWith({
+        abi: aavePool,
+        functionName: 'withdraw',
+        args: [mockTokenAddress, BigInt(5e6), '0x1234'],
+      })
+      expect(prepareTransactions).toHaveBeenCalledWith({
+        baseTransactions: expectedTransactions,
+        feeCurrencies: [mockFeeCurrency],
+      })
     })
   })
 })

--- a/src/earn/prepareTransactions.ts
+++ b/src/earn/prepareTransactions.ts
@@ -181,8 +181,8 @@ export async function prepareWithdrawAndClaimTransactions({
       to: networkConfig.arbAaveIncentivesV3ContractAddress,
       data: encodeFunctionData({
         abi: aaveIncentivesV3Abi,
-        functionName: 'claimRewards',
-        args: [[poolTokenAddress], amountToClaim, walletAddress, tokenInfo.address],
+        functionName: 'claimRewardsToSelf',
+        args: [[poolTokenAddress], amountToClaim, tokenInfo.address],
       }),
     })
   })


### PR DESCRIPTION
### Description

As the title

### Test plan

Unit tests, manually by invoking this function

### Related issues

- Part of ACT-1180

### Backwards compatibility

Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
