### PR TITLE
feat(earn): prepare transactions on the collect screen and display gas

### DIFF
--- a/src/earn/EarnCollectScreen.test.tsx
+++ b/src/earn/EarnCollectScreen.test.tsx
@@ -298,10 +298,6 @@ describe('EarnCollectScreen', () => {
 
     expect(getByText('earnFlow.collect.title')).toBeTruthy()
     expect(getByText('earnFlow.collect.total')).toBeTruthy()
-    expect(getByTestId(`EarnCollect/${mockArbUsdcTokenId}/CryptoAmount`)).toHaveTextContent(
-      '10.75 USDC'
-    )
-    expect(getByTestId(`EarnCollect/${mockArbUsdcTokenId}/FiatAmount`)).toHaveTextContent('₱14.30')
     expect(getByTestId('EarnCollect/RewardsLoading')).toBeTruthy()
     expect(getByTestId('EarnCollect/ApyLoading')).toBeTruthy()
     expect(getByTestId('EarnCollect/GasLoading')).toBeTruthy()

--- a/src/earn/EarnCollectScreen.test.tsx
+++ b/src/earn/EarnCollectScreen.test.tsx
@@ -1,16 +1,21 @@
 import { render, waitFor } from '@testing-library/react-native'
+import BigNumber from 'bignumber.js'
 import React from 'react'
 import { Provider } from 'react-redux'
 import EarnCollectScreen from 'src/earn/EarnCollectScreen'
 import { fetchAavePoolInfo, fetchAaveRewards } from 'src/earn/poolInfo'
+import { prepareWithdrawAndClaimTransactions } from 'src/earn/prepareTransactions'
 import { NetworkId } from 'src/transactions/types'
+import { PreparedTransactionsPossible } from 'src/viem/prepareTransactions'
 import networkConfig from 'src/web3/networkConfig'
 import MockedNavigator from 'test/MockedNavigator'
-import { createMockStore } from 'test/utils'
+import { createMockStore, mockStoreBalancesToTokenBalances } from 'test/utils'
 import {
   mockAaveArbUsdcAddress,
+  mockAccount,
   mockArbArbTokenBalance,
   mockArbArbTokenId,
+  mockArbEthTokenId,
   mockArbUsdcTokenId,
   mockTokenBalances,
 } from 'test/values'
@@ -33,17 +38,49 @@ const store = createMockStore({
 })
 
 jest.mock('src/earn/poolInfo')
+jest.mock('src/earn/prepareTransactions')
+
+const mockPreparedTransaction: PreparedTransactionsPossible = {
+  type: 'possible' as const,
+  transactions: [
+    {
+      from: '0xfrom',
+      to: '0xto',
+      data: '0xdata',
+      gas: BigInt(5e16),
+      _baseFeePerGas: BigInt(1),
+      maxFeePerGas: BigInt(1),
+      maxPriorityFeePerGas: undefined,
+    },
+    {
+      from: '0xfrom',
+      to: '0xto',
+      data: '0xdata',
+      gas: BigInt(1e16),
+      _baseFeePerGas: BigInt(1),
+      maxFeePerGas: BigInt(1),
+      maxPriorityFeePerGas: undefined,
+    },
+  ],
+  feeCurrency: {
+    ...mockTokenBalances[mockArbEthTokenId],
+    balance: new BigNumber(10),
+    priceUsd: new BigNumber(1),
+    lastKnownPriceUsd: new BigNumber(1),
+  },
+}
+
+const mockRewards = [{ amount: '0.01', tokenInfo: mockArbArbTokenBalance }]
 
 describe('EarnCollectScreen', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     jest.mocked(fetchAavePoolInfo).mockResolvedValue({ apy: 0.03 })
-    jest
-      .mocked(fetchAaveRewards)
-      .mockResolvedValue([{ amount: '0.01', tokenInfo: mockArbArbTokenBalance }])
+    jest.mocked(fetchAaveRewards).mockResolvedValue(mockRewards)
+    jest.mocked(prepareWithdrawAndClaimTransactions).mockResolvedValue(mockPreparedTransaction)
   })
 
-  it('renders total balance, rewards and apy', async () => {
+  it('renders total balance, rewards, apy and gas after fetching rewards and preparing tx', async () => {
     const { getByText, getByTestId, queryByTestId } = render(
       <Provider store={store}>
         <MockedNavigator
@@ -64,6 +101,7 @@ describe('EarnCollectScreen', () => {
     expect(getByTestId(`EarnCollect/${mockArbUsdcTokenId}/FiatAmount`)).toHaveTextContent('₱14.30')
     expect(getByTestId('EarnCollect/RewardsLoading')).toBeTruthy()
     expect(getByTestId('EarnCollect/ApyLoading')).toBeTruthy()
+    expect(getByTestId('EarnCollect/GasLoading')).toBeTruthy()
     expect(getByTestId('EarnCollectScreen/CTA')).toBeDisabled()
 
     await waitFor(() => {
@@ -77,9 +115,22 @@ describe('EarnCollectScreen', () => {
       '0.01 ARB'
     )
     expect(getByTestId(`EarnCollect/${mockArbArbTokenId}/FiatAmount`)).toHaveTextContent('₱0.016')
-    expect(getByTestId('EarnCollectScreen/CTA')).toBeEnabled()
-
     expect(getByText('earnFlow.collect.apy, {"apy":"3.00"}')).toBeTruthy()
+
+    await waitFor(() => {
+      expect(queryByTestId('EarnCollect/GasLoading')).toBeFalsy()
+    })
+    expect(getByTestId('EarnCollect/GasFeeCryptoAmount')).toHaveTextContent('0.06 ETH')
+    expect(getByTestId('EarnCollect/GasFeeFiatAmount')).toHaveTextContent('₱119.70')
+    expect(getByTestId('EarnCollectScreen/CTA')).toBeEnabled()
+    expect(prepareWithdrawAndClaimTransactions).toHaveBeenCalledWith({
+      amount: '10.75',
+      feeCurrencies: mockStoreBalancesToTokenBalances([mockTokenBalances[mockArbEthTokenId]]),
+      poolTokenAddress: mockAaveArbUsdcAddress,
+      rewards: mockRewards,
+      token: mockStoreBalancesToTokenBalances([mockTokenBalances[mockArbUsdcTokenId]])[0],
+      walletAddress: mockAccount.toLowerCase(),
+    })
   })
 
   it('skips rewards section when no rewards', async () => {
@@ -112,6 +163,11 @@ describe('EarnCollectScreen', () => {
     expect(queryByTestId(`EarnCollect/${mockArbArbTokenId}/CryptoAmount`)).toBeFalsy()
     expect(queryByTestId(`EarnCollect/${mockArbArbTokenId}/FiatAmount`)).toBeFalsy()
     expect(getByTestId('EarnCollectScreen/CTA')).toBeEnabled()
+
+    await waitFor(() => {
+      expect(queryByTestId('EarnCollect/GasLoading')).toBeFalsy()
+    })
+    expect(getByTestId('EarnCollectScreen/CTA')).toBeEnabled()
   })
 
   it('shows error and keeps cta disabled if rewards loading fails', async () => {
@@ -132,6 +188,7 @@ describe('EarnCollectScreen', () => {
     expect(getByText('earnFlow.collect.total')).toBeTruthy()
     expect(getByTestId('EarnCollect/RewardsLoading')).toBeTruthy()
     expect(getByTestId('EarnCollect/ApyLoading')).toBeTruthy()
+    expect(getByTestId('EarnCollect/GasLoading')).toBeTruthy()
     expect(getByTestId('EarnCollectScreen/CTA')).toBeDisabled()
 
     await waitFor(() => {
@@ -140,8 +197,49 @@ describe('EarnCollectScreen', () => {
     await waitFor(() => {
       expect(queryByTestId('EarnCollect/ApyLoading')).toBeFalsy()
     })
+    await waitFor(() => {
+      expect(queryByTestId('EarnCollect/GasLoading')).toBeFalsy()
+    })
     expect(getByText('earnFlow.collect.errorTitle')).toBeTruthy()
     expect(queryByText('earnFlow.collect.plus')).toBeFalsy()
+    expect(getByTestId('EarnCollectScreen/CTA')).toBeDisabled()
+    expect(prepareWithdrawAndClaimTransactions).not.toHaveBeenCalled()
+  })
+
+  it('shows error and keeps cta disabled if prepare tx fails', async () => {
+    jest
+      .mocked(prepareWithdrawAndClaimTransactions)
+      .mockRejectedValue(new Error('Failed to prepare'))
+    const { getByText, getByTestId, queryByTestId } = render(
+      <Provider store={store}>
+        <MockedNavigator
+          component={EarnCollectScreen}
+          params={{
+            depositTokenId: mockArbUsdcTokenId,
+            poolTokenId: networkConfig.aaveArbUsdcTokenId,
+          }}
+        />
+      </Provider>
+    )
+
+    expect(getByText('earnFlow.collect.title')).toBeTruthy()
+    expect(getByText('earnFlow.collect.total')).toBeTruthy()
+    expect(getByTestId('EarnCollect/RewardsLoading')).toBeTruthy()
+    expect(getByTestId('EarnCollect/ApyLoading')).toBeTruthy()
+    expect(getByTestId('EarnCollect/GasLoading')).toBeTruthy()
+    expect(getByTestId('EarnCollectScreen/CTA')).toBeDisabled()
+
+    await waitFor(() => {
+      expect(queryByTestId('EarnCollect/RewardsLoading')).toBeFalsy()
+    })
+    await waitFor(() => {
+      expect(queryByTestId('EarnCollect/ApyLoading')).toBeFalsy()
+    })
+    await waitFor(() => {
+      expect(queryByTestId('EarnCollect/GasLoading')).toBeFalsy()
+    })
+    expect(getByText('earnFlow.collect.errorTitle')).toBeTruthy()
+    expect(getByTestId('EarnCollect/GasError')).toBeTruthy()
     expect(getByTestId('EarnCollectScreen/CTA')).toBeDisabled()
   })
 
@@ -163,6 +261,7 @@ describe('EarnCollectScreen', () => {
     expect(getByText('earnFlow.collect.total')).toBeTruthy()
     expect(getByTestId('EarnCollect/RewardsLoading')).toBeTruthy()
     expect(getByTestId('EarnCollect/ApyLoading')).toBeTruthy()
+    expect(getByTestId('EarnCollect/GasLoading')).toBeTruthy()
     expect(getByTestId('EarnCollectScreen/CTA')).toBeDisabled()
 
     await waitFor(() => {
@@ -171,9 +270,53 @@ describe('EarnCollectScreen', () => {
     await waitFor(() => {
       expect(queryByTestId('EarnCollect/ApyLoading')).toBeFalsy()
     })
+    await waitFor(() => {
+      expect(queryByTestId('EarnCollect/GasLoading')).toBeFalsy()
+    })
     expect(getByText('earnFlow.collect.apy, {"apy":"--"}')).toBeTruthy()
     expect(getByText('earnFlow.collect.plus')).toBeTruthy()
     expect(getByTestId('EarnCollectScreen/CTA')).toBeEnabled()
     expect(queryByText('earnFlow.collect.errorTitle')).toBeFalsy()
+  })
+
+  it('disables cta if not enough balance for gas', async () => {
+    jest.mocked(prepareWithdrawAndClaimTransactions).mockResolvedValue({
+      type: 'not-enough-balance-for-gas',
+      feeCurrencies: [mockPreparedTransaction.feeCurrency],
+    })
+    const { getByText, getByTestId, queryByTestId } = render(
+      <Provider store={store}>
+        <MockedNavigator
+          component={EarnCollectScreen}
+          params={{
+            depositTokenId: mockArbUsdcTokenId,
+            poolTokenId: networkConfig.aaveArbUsdcTokenId,
+          }}
+        />
+      </Provider>
+    )
+
+    expect(getByText('earnFlow.collect.title')).toBeTruthy()
+    expect(getByText('earnFlow.collect.total')).toBeTruthy()
+    expect(getByTestId(`EarnCollect/${mockArbUsdcTokenId}/CryptoAmount`)).toHaveTextContent(
+      '10.75 USDC'
+    )
+    expect(getByTestId(`EarnCollect/${mockArbUsdcTokenId}/FiatAmount`)).toHaveTextContent('₱14.30')
+    expect(getByTestId('EarnCollect/RewardsLoading')).toBeTruthy()
+    expect(getByTestId('EarnCollect/ApyLoading')).toBeTruthy()
+    expect(getByTestId('EarnCollect/GasLoading')).toBeTruthy()
+    expect(getByTestId('EarnCollectScreen/CTA')).toBeDisabled()
+
+    await waitFor(() => {
+      expect(queryByTestId('EarnCollect/RewardsLoading')).toBeFalsy()
+    })
+    await waitFor(() => {
+      expect(queryByTestId('EarnCollect/ApyLoading')).toBeFalsy()
+    })
+    await waitFor(() => {
+      expect(queryByTestId('EarnCollect/GasLoading')).toBeFalsy()
+    })
+    expect(getByTestId('EarnCollectScreen/CTA')).toBeDisabled()
+    expect(getByTestId('EarnCollect/GasError')).toBeTruthy()
   })
 })

--- a/src/earn/hooks.ts
+++ b/src/earn/hooks.ts
@@ -56,14 +56,12 @@ export function useAaveRewardsInfoAndPrepareTransactions({
 
   const asyncRewardsInfo = useAsync(
     async () => {
-      if (!poolTokenInfo || !poolTokenInfo.address) {
-        throw new Error(`Token with id ${networkConfig.aaveArbUsdcTokenId} not found`)
+      if (!poolTokenInfo) {
+        throw new Error(`Token with id ${poolTokenId} not found`)
       }
 
-      if (!isAddress(poolTokenInfo.address)) {
-        throw new Error(
-          `Token with id ${networkConfig.arbUsdcTokenId} does not contain a valid address`
-        )
+      if (!poolTokenInfo.address || !isAddress(poolTokenInfo.address)) {
+        throw new Error(`Token with id ${poolTokenId} does not contain a valid address`)
       }
 
       if (!walletAddress || !isAddress(walletAddress)) {
@@ -81,35 +79,43 @@ export function useAaveRewardsInfoAndPrepareTransactions({
     [],
     {
       onError: (error) => {
-        Logger.warn(`${TAG}/useAaveRewardsInfo`, error.message)
+        Logger.warn(`${TAG}/useAaveRewardsInfoAndPrepareTransactions`, error)
       },
     }
   )
 
-  const asyncPreparedTransactions = useAsync(async () => {
-    if (!asyncRewardsInfo.result) {
-      return
-    }
+  const asyncPreparedTransactions = useAsync(
+    async () => {
+      if (!asyncRewardsInfo.result) {
+        return
+      }
 
-    if (
-      !walletAddress ||
-      !isAddress(walletAddress) ||
-      !poolTokenInfo?.address ||
-      !isAddress(poolTokenInfo.address) ||
-      !depositTokenInfo
-    ) {
-      // should never happen
-      throw new Error('Invalid wallet or pool token address')
-    }
+      if (
+        !walletAddress ||
+        !isAddress(walletAddress) ||
+        !poolTokenInfo?.address ||
+        !isAddress(poolTokenInfo.address) ||
+        !depositTokenInfo
+      ) {
+        // should never happen
+        throw new Error('Invalid wallet or pool token address')
+      }
 
-    return prepareWithdrawAndClaimTransactions({
-      amount: poolTokenInfo.balance.toString(),
-      token: depositTokenInfo,
-      walletAddress,
-      feeCurrencies,
-      rewards: asyncRewardsInfo.result,
-      poolTokenAddress: poolTokenInfo.address,
-    })
-  }, [asyncRewardsInfo.result])
+      return prepareWithdrawAndClaimTransactions({
+        amount: poolTokenInfo.balance.toString(),
+        token: depositTokenInfo,
+        walletAddress,
+        feeCurrencies,
+        rewards: asyncRewardsInfo.result,
+        poolTokenAddress: poolTokenInfo.address,
+      })
+    },
+    [asyncRewardsInfo.result],
+    {
+      onError: (error) => {
+        Logger.warn(`${TAG}/useAaveRewardsInfoAndPrepareTransactions`, error)
+      },
+    }
+  )
   return { asyncRewardsInfo, asyncPreparedTransactions }
 }

--- a/src/send/SendEnterAmount.test.tsx
+++ b/src/send/SendEnterAmount.test.tsx
@@ -11,10 +11,9 @@ import { RecipientType } from 'src/recipients/recipient'
 import SendEnterAmount from 'src/send/SendEnterAmount'
 import { usePrepareSendTransactions } from 'src/send/usePrepareSendTransactions'
 import { getDynamicConfigParams } from 'src/statsig'
-import { StoredTokenBalance, TokenBalance } from 'src/tokens/slice'
 import { PreparedTransactionsPossible } from 'src/viem/prepareTransactions'
 import MockedNavigator from 'test/MockedNavigator'
-import { createMockStore } from 'test/utils'
+import { createMockStore, mockStoreBalancesToTokenBalances } from 'test/utils'
 import {
   mockAccount,
   mockCeloAddress,
@@ -55,16 +54,6 @@ const mockPrepareTransactionsResultPossible: PreparedTransactionsPossible = {
   feeCurrency: mockCeloTokenBalance,
 }
 
-const mockStoreBalancesToTokenBalances = (storeBalances: StoredTokenBalance[]): TokenBalance[] => {
-  return storeBalances.map(
-    (token): TokenBalance => ({
-      ...token,
-      balance: new BigNumber(token.balance ?? 0),
-      priceUsd: new BigNumber(token.priceUsd ?? 0),
-      lastKnownPriceUsd: token.priceUsd ? new BigNumber(token.priceUsd) : null,
-    })
-  )
-}
 const tokenBalances = {
   [mockCeloTokenId]: { ...mockTokenBalances[mockCeloTokenId], balance: '10' },
   [mockCusdTokenId]: { ...mockTokenBalances[mockCusdTokenId], balance: '10' },

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -6,6 +6,7 @@ import configureMockStore from 'redux-mock-store'
 import i18n from 'src/i18n'
 import { StackParamList } from 'src/navigator/types'
 import { RootState } from 'src/redux/reducers'
+import { StoredTokenBalance, TokenBalance } from 'src/tokens/slice'
 import { getLatestSchema } from 'test/schemas'
 import {
   mockAddressToE164Number,
@@ -155,4 +156,17 @@ export function getElementText(instance: ReactTestInstance | string): string {
       return getElementText(child)
     })
     .join('')
+}
+
+export const mockStoreBalancesToTokenBalances = (
+  storeBalances: StoredTokenBalance[]
+): TokenBalance[] => {
+  return storeBalances.map(
+    (token): TokenBalance => ({
+      ...token,
+      balance: new BigNumber(token.balance ?? 0),
+      priceUsd: new BigNumber(token.priceUsd ?? 0),
+      lastKnownPriceUsd: token.priceUsd ? new BigNumber(token.priceUsd) : null,
+    })
+  )
 }


### PR DESCRIPTION
### Description

Updates hook to prepare txs after rewards info is fetched and then use prepared txs to display gas fee on the collect screen

### Test plan

Unit tests, manual


https://github.com/valora-inc/wallet/assets/5062591/52291d53-72c4-4a46-a964-f273cfc7698d



### Related issues

- Part of ACT-1180

### Backwards compatibility

Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
