### PR TITLE
feat(earn): dispatch withdraw start on pressing collect

### DIFF
--- a/src/analytics/Events.tsx
+++ b/src/analytics/Events.tsx
@@ -691,4 +691,5 @@ export enum EarnEvents {
   earn_view_pools_press = 'earn_view_pools_press',
   earn_exit_pool_press = 'earn_exit_pool_press',
   earn_feed_item_select = 'earn_feed_item_select',
+  earn_collect_earnings_press = 'earn_collect_earnings_press',
 }

--- a/src/analytics/Properties.tsx
+++ b/src/analytics/Properties.tsx
@@ -60,6 +60,7 @@ import {
   RewardsScreenOrigin,
 } from 'src/consumerIncentives/analyticsEventsTracker'
 import { DappSection } from 'src/dapps/types'
+import { SerializableRewardsInfo } from 'src/earn/types'
 import { ProviderSelectionAnalyticsData } from 'src/fiatExchanges/types'
 import { CICOFlow, FiatExchangeFlow, PaymentMethod } from 'src/fiatExchanges/utils'
 import { HomeActionName, NotificationBannerCTATypes, NotificationType } from 'src/home/types'
@@ -1607,6 +1608,13 @@ interface EarnEventsProperties {
   }
   [EarnEvents.earn_feed_item_select]: {
     origin: 'EarnDeposit' | 'EarnWithdraw' | 'EarnClaimReward'
+  }
+  [EarnEvents.earn_collect_earnings_press]: {
+    tokenId: string
+    amount: string
+    networkId: NetworkId
+    providerId: string
+    rewards: SerializableRewardsInfo[]
   }
 }
 

--- a/src/analytics/docs.ts
+++ b/src/analytics/docs.ts
@@ -606,6 +606,7 @@ export const eventDocs: Record<AnalyticsEventType, string> = {
   [EarnEvents.earn_view_pools_press]: `When the user taps on the view pools button from token details`,
   [EarnEvents.earn_exit_pool_press]: `When the user taps on the exit pool button from the earn card in discover tab`,
   [EarnEvents.earn_feed_item_select]: `When the users taps on an earn transaction feed item`,
+  [EarnEvents.earn_collect_earnings_press]: `When the user taps on the collect earnings button in the collect screen`,
 
   // Legacy event docs
   //  The below events had docs, but are no longer produced by the latest app version.

--- a/src/earn/selectors.ts
+++ b/src/earn/selectors.ts
@@ -1,3 +1,5 @@
 import { RootState } from 'src/redux/store'
 
 export const depositStatusSelector = (state: RootState) => state.earn.depositStatus
+
+export const withdrawStatusSelector = (state: RootState) => state.earn.withdrawStatus

--- a/src/earn/types.ts
+++ b/src/earn/types.ts
@@ -12,12 +12,14 @@ export interface RewardsInfo {
   tokenInfo: TokenBalance
 }
 
+export interface SerializableRewardsInfo {
+  amount: string
+  tokenId: string
+}
+
 export interface WithdrawInfo {
   amount: string
   tokenId: string
   preparedTransactions: SerializableTransactionRequest[]
-  rewards: {
-    amount: string
-    tokenId: string
-  }[]
+  rewards: SerializableRewardsInfo[]
 }


### PR DESCRIPTION
### Description

Dispatches the redux action on pressing the collect earnings button and fires analytics event

### Test plan

Unit tests

### Related issues

- Part of ACT-1180

### Backwards compatibility

Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
