### PR TITLE
feat(earn): implement withdraw saga

### DIFF
--- a/src/analytics/Events.tsx
+++ b/src/analytics/Events.tsx
@@ -692,4 +692,8 @@ export enum EarnEvents {
   earn_exit_pool_press = 'earn_exit_pool_press',
   earn_feed_item_select = 'earn_feed_item_select',
   earn_collect_earnings_press = 'earn_collect_earnings_press',
+  earn_withdraw_submit_start = 'earn_withdraw_submit_start',
+  earn_withdraw_submit_success = 'earn_withdraw_submit_success',
+  earn_withdraw_submit_error = 'earn_withdraw_submit_error',
+  earn_withdraw_submit_cancel = 'earn_withdraw_submit_cancel',
 }

--- a/src/analytics/Properties.tsx
+++ b/src/analytics/Properties.tsx
@@ -1584,6 +1584,14 @@ interface EarnDepositProperties {
   providerId: string
 }
 
+interface EarnWithdrawProperties {
+  tokenId: string
+  tokenAmount: string
+  networkId: NetworkId
+  providerId: string
+  rewards: SerializableRewardsInfo[]
+}
+
 interface EarnEventsProperties {
   [EarnEvents.earn_cta_press]: undefined
   [EarnEvents.earn_add_crypto_action_press]: {
@@ -1609,13 +1617,13 @@ interface EarnEventsProperties {
   [EarnEvents.earn_feed_item_select]: {
     origin: 'EarnDeposit' | 'EarnWithdraw' | 'EarnClaimReward'
   }
-  [EarnEvents.earn_collect_earnings_press]: {
-    tokenId: string
-    amount: string
-    networkId: NetworkId
-    providerId: string
-    rewards: SerializableRewardsInfo[]
+  [EarnEvents.earn_collect_earnings_press]: EarnWithdrawProperties
+  [EarnEvents.earn_withdraw_submit_start]: EarnWithdrawProperties
+  [EarnEvents.earn_withdraw_submit_success]: EarnWithdrawProperties
+  [EarnEvents.earn_withdraw_submit_error]: EarnWithdrawProperties & {
+    error: string
   }
+  [EarnEvents.earn_withdraw_submit_cancel]: EarnWithdrawProperties
 }
 
 export type AnalyticsPropertiesList = AppEventsProperties &

--- a/src/analytics/docs.ts
+++ b/src/analytics/docs.ts
@@ -607,6 +607,10 @@ export const eventDocs: Record<AnalyticsEventType, string> = {
   [EarnEvents.earn_exit_pool_press]: `When the user taps on the exit pool button from the earn card in discover tab`,
   [EarnEvents.earn_feed_item_select]: `When the users taps on an earn transaction feed item`,
   [EarnEvents.earn_collect_earnings_press]: `When the user taps on the collect earnings button in the collect screen`,
+  [EarnEvents.earn_withdraw_submit_start]: `When the wallet is about to submit the withdraw and claim transactions to the network`,
+  [EarnEvents.earn_withdraw_submit_success]: `When the withdraw and claim transactions succeed`,
+  [EarnEvents.earn_withdraw_submit_error]: `When the withdraw and claim transactions fail`,
+  [EarnEvents.earn_withdraw_submit_cancel]: `When the user cancels the withdraw and claim transactions after submitting by cancelling PIN input`,
 
   // Legacy event docs
   //  The below events had docs, but are no longer produced by the latest app version.

--- a/src/earn/EarnCollectScreen.test.tsx
+++ b/src/earn/EarnCollectScreen.test.tsx
@@ -356,7 +356,7 @@ describe('EarnCollectScreen', () => {
 
     expect(ValoraAnalytics.track).toHaveBeenCalledWith(EarnEvents.earn_collect_earnings_press, {
       tokenId: mockArbUsdcTokenId,
-      amount: '10.75',
+      tokenAmount: '10.75',
       networkId: NetworkId['arbitrum-sepolia'],
       providerId: 'aave-v3',
       rewards: [{ amount: '0.01', tokenId: mockArbArbTokenId }],

--- a/src/earn/EarnCollectScreen.tsx
+++ b/src/earn/EarnCollectScreen.tsx
@@ -70,7 +70,7 @@ export default function EarnCollectScreen({ route }: Props) {
 
     ValoraAnalytics.track(EarnEvents.earn_collect_earnings_press, {
       tokenId: depositTokenId,
-      amount: poolToken.balance.toString(),
+      tokenAmount: poolToken.balance.toString(),
       networkId: depositToken.networkId,
       providerId: 'aave-v3',
       rewards: serializedRewards,

--- a/src/earn/saga.test.ts
+++ b/src/earn/saga.test.ts
@@ -11,6 +11,8 @@ import {
   depositError,
   depositStart,
   depositSuccess,
+  withdrawCancel,
+  withdrawError,
   withdrawStart,
   withdrawSuccess,
 } from 'src/earn/slice'
@@ -22,7 +24,12 @@ import { SerializableTransactionRequest } from 'src/viem/preparedTransactionSeri
 import { sendPreparedTransactions } from 'src/viem/saga'
 import networkConfig from 'src/web3/networkConfig'
 import { createMockStore } from 'test/utils'
-import { mockArbUsdcTokenId, mockTokenBalances, mockUSDCAddress } from 'test/values'
+import {
+  mockArbArbTokenId,
+  mockArbUsdcTokenId,
+  mockTokenBalances,
+  mockUSDCAddress,
+} from 'test/values'
 import { Address, decodeFunctionData } from 'viem'
 
 jest.mock('viem', () => ({
@@ -46,6 +53,23 @@ jest.mock('src/transactions/types', () => {
   }
 })
 
+const mockTxReceipt1 = {
+  status: 'success',
+  blockNumber: BigInt(1234),
+  transactionHash: '0x1',
+  cumulativeGasUsed: BigInt(3_129_217),
+  effectiveGasPrice: BigInt(5_000_000_000),
+  gasUsed: BigInt(51_578),
+}
+const mockTxReceipt2 = {
+  status: 'success',
+  blockNumber: BigInt(1234),
+  transactionHash: '0x2',
+  cumulativeGasUsed: BigInt(3_899_547),
+  effectiveGasPrice: BigInt(5_000_000_000),
+  gasUsed: BigInt(371_674),
+}
+
 describe('depositSubmitSaga', () => {
   const serializableApproveTx: SerializableTransactionRequest = {
     from: '0xa',
@@ -61,22 +85,7 @@ describe('depositSubmitSaga', () => {
     data: '0x02',
     gas: '50000',
   }
-  const mockApproveTxReceipt = {
-    status: 'success',
-    blockNumber: BigInt(1234),
-    transactionHash: '0x1',
-    cumulativeGasUsed: BigInt(3_129_217),
-    effectiveGasPrice: BigInt(5_000_000_000),
-    gasUsed: BigInt(51_578),
-  }
-  const mockDepositTxReceipt = {
-    status: 'success',
-    blockNumber: BigInt(1234),
-    transactionHash: '0x2',
-    cumulativeGasUsed: BigInt(3_899_547),
-    effectiveGasPrice: BigInt(5_000_000_000),
-    gasUsed: BigInt(371_674),
-  }
+
   const mockStandbyHandler = jest.fn()
 
   const sagaProviders: StaticProvider[] = [
@@ -99,11 +108,11 @@ describe('depositSubmitSaga', () => {
     ],
     [
       call([publicClient[Network.Arbitrum], 'waitForTransactionReceipt'], { hash: '0x1' }),
-      mockApproveTxReceipt,
+      mockTxReceipt1,
     ],
     [
       call([publicClient[Network.Arbitrum], 'waitForTransactionReceipt'], { hash: '0x2' }),
-      mockDepositTxReceipt,
+      mockTxReceipt2,
     ],
   ]
 
@@ -293,7 +302,7 @@ describe('depositSubmitSaga', () => {
       .provide([
         [
           call([publicClient[Network.Arbitrum], 'waitForTransactionReceipt'], { hash: '0x2' }),
-          { ...mockDepositTxReceipt, status: 'reverted' },
+          { ...mockTxReceipt2, status: 'reverted' },
         ],
         ...sagaProviders,
       ])
@@ -322,19 +331,272 @@ describe('depositSubmitSaga', () => {
 })
 
 describe('withdrawSubmitSaga', () => {
-  it('navigates home and fires success event', async () => {
+  const mockRewards = [{ tokenId: mockArbArbTokenId, amount: '1' }]
+  const serializableWithdrawTx: SerializableTransactionRequest = {
+    from: '0xa',
+    to: '0xb',
+    value: '100',
+    data: '0x02',
+    gas: '20000',
+  }
+  const serializableClaimRewardTx: SerializableTransactionRequest = {
+    from: '0xa',
+    to: '0xc',
+    value: '100',
+    data: '0x01',
+    gas: '50000',
+  }
+
+  const mockStandbyHandler = jest.fn()
+
+  const sagaProviders: StaticProvider[] = [
+    [
+      matchers.call.fn(sendPreparedTransactions),
+      dynamic(({ args: [txs, _networkId, standbyHandlers] }) => {
+        if (txs.length === 1) {
+          mockStandbyHandler(standbyHandlers[0]('0x1'))
+          return ['0x1']
+        } else {
+          mockStandbyHandler(standbyHandlers[0]('0x1'))
+          mockStandbyHandler(standbyHandlers[1]('0x2'))
+          return ['0x1', '0x2']
+        }
+      }),
+    ],
+    [
+      call([publicClient[Network.Arbitrum], 'waitForTransactionReceipt'], { hash: '0x1' }),
+      mockTxReceipt1,
+    ],
+    [
+      call([publicClient[Network.Arbitrum], 'waitForTransactionReceipt'], { hash: '0x2' }),
+      mockTxReceipt2,
+    ],
+  ]
+
+  const expectedAnalyticsPropsWithRewards = {
+    tokenId: mockArbUsdcTokenId,
+    tokenAmount: '100',
+    networkId: NetworkId['arbitrum-sepolia'],
+    providerId: 'aave-v3',
+    rewards: mockRewards,
+  }
+
+  const expectedAnalyticsPropsNoRewards = {
+    ...expectedAnalyticsPropsWithRewards,
+    rewards: [],
+  }
+
+  // TODO: replace with EarnWithdraw type
+  const expectedWithdrawStandbyTx = {
+    __typename: 'TokenExchangeV3',
+    context: {
+      id: 'id-earn/saga-Earn/Withdraw',
+      tag: 'earn/saga',
+      description: 'Earn/Withdraw',
+    },
+    networkId: NetworkId['arbitrum-sepolia'],
+    inAmount: {
+      value: '100',
+      tokenId: mockArbUsdcTokenId,
+    },
+    outAmount: {
+      value: '100',
+      tokenId: networkConfig.aaveArbUsdcTokenId,
+    },
+    transactionHash: '0x1',
+    type: TokenTransactionTypeV2.SwapTransaction,
+    feeCurrencyId: undefined,
+  }
+
+  // TODO: replace with EarnClaimReward type
+  const expectedClaimRewardTx = {
+    __typename: 'TokenTransferV3',
+    context: {
+      id: 'id-earn/saga-Earn/ClaimReward-1',
+      tag: 'earn/saga',
+      description: 'Earn/ClaimReward-1',
+    },
+    networkId: NetworkId['arbitrum-sepolia'],
+    amount: {
+      value: '1',
+      tokenId: mockArbArbTokenId,
+    },
+    transactionHash: '0x2',
+    type: TokenTransactionTypeV2.Received,
+    feeCurrencyId: undefined,
+    address: '',
+    metadata: {},
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('sends withdraw and claim transactions, navigates home and dispatches the success action', async () => {
     await expectSaga(withdrawSubmitSaga, {
       type: withdrawStart.type,
       payload: {
         amount: '100',
         tokenId: mockArbUsdcTokenId,
-        preparedTransactions: [],
-        rewards: [],
+        preparedTransactions: [serializableWithdrawTx, serializableClaimRewardTx],
+        rewards: mockRewards,
       },
     })
+      .withState(createMockStore({ tokens: { tokenBalances: mockTokenBalances } }).getState())
+      .provide(sagaProviders)
       .put(withdrawSuccess())
+      .call.like({ fn: sendPreparedTransactions })
+      .call([publicClient[Network.Arbitrum], 'waitForTransactionReceipt'], { hash: '0x1' })
+      .call([publicClient[Network.Arbitrum], 'waitForTransactionReceipt'], { hash: '0x2' })
       .run()
 
     expect(navigateHome).toHaveBeenCalled()
+    expect(mockStandbyHandler).toHaveBeenCalledTimes(2)
+    expect(mockStandbyHandler).toHaveBeenNthCalledWith(1, expectedWithdrawStandbyTx)
+    expect(mockStandbyHandler).toHaveBeenNthCalledWith(2, expectedClaimRewardTx)
+    expect(ValoraAnalytics.track).toHaveBeenCalledWith(
+      EarnEvents.earn_withdraw_submit_start,
+      expectedAnalyticsPropsWithRewards
+    )
+    expect(ValoraAnalytics.track).toHaveBeenCalledWith(
+      EarnEvents.earn_withdraw_submit_success,
+      expectedAnalyticsPropsWithRewards
+    )
   })
+
+  it('sends only withdraw if there are no rewards', async () => {
+    await expectSaga(withdrawSubmitSaga, {
+      type: withdrawStart.type,
+      payload: {
+        amount: '100',
+        tokenId: mockArbUsdcTokenId,
+        preparedTransactions: [serializableWithdrawTx],
+        rewards: [],
+      },
+    })
+      .withState(createMockStore({ tokens: { tokenBalances: mockTokenBalances } }).getState())
+      .provide(sagaProviders)
+      .put(withdrawSuccess())
+      .call.like({ fn: sendPreparedTransactions })
+      .call([publicClient[Network.Arbitrum], 'waitForTransactionReceipt'], { hash: '0x1' })
+      .run()
+
+    expect(navigateHome).toHaveBeenCalled()
+    expect(mockStandbyHandler).toHaveBeenCalledTimes(1)
+    expect(mockStandbyHandler).toHaveBeenNthCalledWith(1, expectedWithdrawStandbyTx)
+    expect(ValoraAnalytics.track).toHaveBeenCalledWith(
+      EarnEvents.earn_withdraw_submit_start,
+      expectedAnalyticsPropsNoRewards
+    )
+    expect(ValoraAnalytics.track).toHaveBeenCalledWith(
+      EarnEvents.earn_withdraw_submit_success,
+      expectedAnalyticsPropsNoRewards
+    )
+  })
+
+  it('dispatches cancel action if pin input is cancelled and does not navigate home', async () => {
+    await expectSaga(withdrawSubmitSaga, {
+      type: withdrawStart.type,
+      payload: {
+        amount: '100',
+        tokenId: mockArbUsdcTokenId,
+        preparedTransactions: [serializableWithdrawTx],
+        rewards: [],
+      },
+    })
+      .withState(createMockStore({ tokens: { tokenBalances: mockTokenBalances } }).getState())
+      .provide([
+        [matchers.call.fn(sendPreparedTransactions), throwError(CANCELLED_PIN_INPUT as any)],
+        ...sagaProviders,
+      ])
+      .put(withdrawCancel())
+      .call.like({ fn: sendPreparedTransactions })
+      .not.call([publicClient[Network.Arbitrum], 'waitForTransactionReceipt'])
+      .run()
+    expect(navigateHome).not.toHaveBeenCalled()
+    expect(mockStandbyHandler).not.toHaveBeenCalled()
+    expect(ValoraAnalytics.track).toHaveBeenCalledWith(
+      EarnEvents.earn_withdraw_submit_start,
+      expectedAnalyticsPropsNoRewards
+    )
+    expect(ValoraAnalytics.track).toHaveBeenCalledWith(
+      EarnEvents.earn_withdraw_submit_cancel,
+      expectedAnalyticsPropsNoRewards
+    )
+  })
+
+  it('dispatches error action if transaction submission fails and does not navigate home', async () => {
+    await expectSaga(withdrawSubmitSaga, {
+      type: withdrawStart.type,
+      payload: {
+        amount: '100',
+        tokenId: mockArbUsdcTokenId,
+        preparedTransactions: [serializableWithdrawTx, serializableClaimRewardTx],
+        rewards: mockRewards,
+      },
+    })
+      .withState(createMockStore({ tokens: { tokenBalances: mockTokenBalances } }).getState())
+      .provide([
+        [matchers.call.fn(sendPreparedTransactions), throwError(new Error('Transaction failed'))],
+        ...sagaProviders,
+      ])
+      .put(withdrawError())
+      .call.like({ fn: sendPreparedTransactions })
+      .not.call([publicClient[Network.Arbitrum], 'waitForTransactionReceipt'])
+      .run()
+    expect(navigateHome).not.toHaveBeenCalled()
+    expect(decodeFunctionData).not.toHaveBeenCalled()
+    expect(mockStandbyHandler).not.toHaveBeenCalled()
+    expect(ValoraAnalytics.track).toHaveBeenCalledWith(
+      EarnEvents.earn_withdraw_submit_start,
+      expectedAnalyticsPropsWithRewards
+    )
+    expect(ValoraAnalytics.track).toHaveBeenCalledWith(EarnEvents.earn_withdraw_submit_error, {
+      ...expectedAnalyticsPropsWithRewards,
+      error: 'Transaction failed',
+    })
+  })
+
+  it.each([
+    { txType: 'withdraw', receipt: mockTxReceipt1, hash: '0x1', num: 1 },
+    { txType: 'claim reward', receipt: mockTxReceipt2, hash: '0x2', num: 2 },
+  ])(
+    'dispatches error action and navigates home if $txType transaction status is reverted',
+    async ({ receipt, hash, num }) => {
+      await expectSaga(withdrawSubmitSaga, {
+        type: withdrawStart.type,
+        payload: {
+          amount: '100',
+          tokenId: mockArbUsdcTokenId,
+          preparedTransactions: [serializableWithdrawTx, serializableClaimRewardTx],
+          rewards: mockRewards,
+        },
+      })
+        .withState(createMockStore({ tokens: { tokenBalances: mockTokenBalances } }).getState())
+        .provide([
+          [
+            call([publicClient[Network.Arbitrum], 'waitForTransactionReceipt'], { hash }),
+            { ...receipt, status: 'reverted' },
+          ],
+          ...sagaProviders,
+        ])
+        .put(withdrawError())
+        .call.like({ fn: sendPreparedTransactions })
+        .call([publicClient[Network.Arbitrum], 'waitForTransactionReceipt'], { hash: '0x1' })
+        .call([publicClient[Network.Arbitrum], 'waitForTransactionReceipt'], { hash: '0x2' })
+        .run()
+      expect(navigateHome).toHaveBeenCalled()
+      expect(mockStandbyHandler).toHaveBeenCalledTimes(2)
+      expect(mockStandbyHandler).toHaveBeenNthCalledWith(1, expectedWithdrawStandbyTx)
+      expect(mockStandbyHandler).toHaveBeenNthCalledWith(2, expectedClaimRewardTx)
+      expect(ValoraAnalytics.track).toHaveBeenCalledWith(
+        EarnEvents.earn_withdraw_submit_start,
+        expectedAnalyticsPropsWithRewards
+      )
+      expect(ValoraAnalytics.track).toHaveBeenCalledWith(EarnEvents.earn_withdraw_submit_error, {
+        ...expectedAnalyticsPropsWithRewards,
+        error: `Transaction ${num} reverted: ${hash}`,
+      })
+    }
+  )
 })

--- a/src/earn/saga.ts
+++ b/src/earn/saga.ts
@@ -8,6 +8,8 @@ import {
   depositError,
   depositStart,
   depositSuccess,
+  withdrawCancel,
+  withdrawError,
   withdrawStart,
   withdrawSuccess,
 } from 'src/earn/slice'
@@ -182,9 +184,154 @@ export function* depositSubmitSaga(action: PayloadAction<DepositInfo>) {
 }
 
 export function* withdrawSubmitSaga(action: PayloadAction<WithdrawInfo>) {
-  // TODO: submit the tx
-  navigateHome()
-  yield* put(withdrawSuccess())
+  const {
+    tokenId,
+    preparedTransactions: serializablePreparedTransactions,
+    amount,
+    rewards,
+  } = action.payload
+
+  const preparedTransactions = getPreparedTransactions(serializablePreparedTransactions)
+
+  const tokenInfo = yield* call(getTokenInfo, tokenId)
+
+  if (!tokenInfo) {
+    Logger.error(`${TAG}/withdrawSubmitSaga`, 'Token info not found for token id', tokenId)
+    yield* put(withdrawError())
+    return
+  }
+
+  const networkId = tokenInfo.networkId
+  let submitted = false
+  const commonAnalyticsProps = {
+    tokenId,
+    networkId,
+    tokenAmount: amount,
+    providerId: 'aave-v3',
+    rewards,
+  }
+
+  try {
+    Logger.debug(
+      `${TAG}/withdrawSubmitSaga`,
+      `Starting withdraw for token ${tokenId}, total transactions: ${preparedTransactions.length}`
+    )
+
+    const createWithdrawStandbyTxHandlers = []
+
+    // Assumes the first tx is withdraw and the rest are claim rewards
+    const createWithdrawStandbyTxHandler = (
+      transactionHash: string,
+      feeCurrencyId?: string
+    ): BaseStandbyTransaction => {
+      return {
+        // TODO: replace with withdraw pending tx
+        context: newTransactionContext(TAG, 'Earn/Withdraw'),
+        __typename: 'TokenExchangeV3',
+        networkId,
+        type: TokenTransactionTypeV2.SwapTransaction,
+        inAmount: {
+          value: amount,
+          tokenId,
+        },
+        outAmount: {
+          value: amount,
+          tokenId: networkConfig.aaveArbUsdcTokenId,
+        },
+        transactionHash,
+        feeCurrencyId,
+      }
+    }
+
+    createWithdrawStandbyTxHandlers.push(createWithdrawStandbyTxHandler)
+
+    rewards.forEach(({ amount, tokenId }, index) => {
+      const createClaimRewardStandbyTx = (
+        transactionHash: string,
+        feeCurrencyId?: string
+      ): BaseStandbyTransaction => {
+        return {
+          // TODO: replace with claim reward pending tx
+          context: newTransactionContext(TAG, `Earn/ClaimReward-${index + 1}`),
+          __typename: 'TokenTransferV3',
+          networkId,
+          amount: {
+            value: amount,
+            tokenId,
+          },
+          type: TokenTransactionTypeV2.Received,
+          transactionHash,
+          feeCurrencyId,
+          address: '',
+          metadata: {},
+        }
+      }
+      createWithdrawStandbyTxHandlers.push(createClaimRewardStandbyTx)
+    })
+
+    ValoraAnalytics.track(EarnEvents.earn_withdraw_submit_start, commonAnalyticsProps)
+
+    const txHashes = yield* call(
+      sendPreparedTransactions,
+      serializablePreparedTransactions,
+      networkId,
+      createWithdrawStandbyTxHandlers
+    )
+
+    Logger.debug(
+      `${TAG}/withd`,
+      'Successfully sent withdraw transaction(s) to the network',
+      txHashes
+    )
+
+    navigateHome()
+    submitted = true
+
+    // wait for the tx receipts, so that we can track them
+    Logger.debug(`${TAG}/withdrawSubmitSaga`, 'Waiting for transaction receipts')
+    const txReceipts = yield* all(
+      txHashes.map((txHash) => {
+        return call([publicClient[networkIdToNetwork[networkId]], 'waitForTransactionReceipt'], {
+          hash: txHash,
+        })
+      })
+    )
+    txReceipts.forEach((receipt, index) => {
+      Logger.debug(
+        `${TAG}/withdrawSubmitSaga`,
+        `Received transaction receipt ${index + 1} of ${txReceipts.length}`,
+        receipt
+      )
+    })
+
+    txReceipts.forEach((receipt, index) => {
+      if (receipt.status !== 'success') {
+        throw new Error(`Transaction ${index + 1} reverted: ${receipt?.transactionHash}`)
+      }
+    })
+
+    yield* put(withdrawSuccess())
+    ValoraAnalytics.track(EarnEvents.earn_withdraw_submit_success, commonAnalyticsProps)
+  } catch (err) {
+    if (err === CANCELLED_PIN_INPUT) {
+      Logger.info(`${TAG}/withdrawSubmitSaga`, 'Transaction cancelled by user')
+      yield* put(withdrawCancel())
+      ValoraAnalytics.track(EarnEvents.earn_withdraw_submit_cancel, commonAnalyticsProps)
+      return
+    }
+
+    const error = ensureError(err)
+    Logger.error(`${TAG}/withdrawSubmitSaga`, 'Error sending withdraw transaction', error)
+    yield* put(withdrawError())
+    ValoraAnalytics.track(EarnEvents.earn_withdraw_submit_error, {
+      ...commonAnalyticsProps,
+      error: error.message,
+    })
+
+    if (!submitted) {
+      vibrateError()
+    }
+  }
 }
 
 export function* earnSaga() {


### PR DESCRIPTION
### Description

Submits the withdraw and claim tx. Uses swap and transfer as types for the pending tx, which will be updated in a followup 

### Test plan

Unit tests, manual

Successful withdraw tx: https://arbiscan.io/tx/0x1a478de2f1c87c47af5e1a86c8eef82b34c2f8563c9a4cdd1cc5c4022c3c436c
Successful reward tx: https://arbiscan.io/tx/0x57294a12d68d58378b6e4fa07209dfa2ccfa94dd0d60279fbcb8a9ef6e123883

### Related issues

- Fixes ACT-1180

### Backwards compatibility

Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
