### PR TITLE
fix(earn): navigation to enter amount on deposit more tap

### DIFF
--- a/src/analytics/Events.tsx
+++ b/src/analytics/Events.tsx
@@ -693,6 +693,7 @@ export enum EarnEvents {
   earn_enter_amount_continue_press = 'earn_enter_amount_continue_press',
   earn_enter_amount_info_more_pools = 'earn_enter_amount_info_more_pools',
   earn_exit_pool_press = 'earn_exit_pool_press',
+  earn_deposit_more_press = 'earn_deposit_more_press',
   earn_deposit_add_gas_press = 'earn_deposit_add_gas_press',
   earn_feed_item_select = 'earn_feed_item_select',
   earn_collect_earnings_press = 'earn_collect_earnings_press',

--- a/src/analytics/Properties.tsx
+++ b/src/analytics/Properties.tsx
@@ -1625,9 +1625,7 @@ interface EarnEventsProperties {
     providerId: string
   }
   [EarnEvents.earn_deposit_more_press]: {
-    poolTokenId: string
-    networkId: NetworkId
-    tokenAmount: string
+    depositTokenId: string
     providerId: string
   }
   [EarnEvents.earn_deposit_add_gas_press]: { gasTokenId: string }

--- a/src/analytics/Properties.tsx
+++ b/src/analytics/Properties.tsx
@@ -1624,6 +1624,12 @@ interface EarnEventsProperties {
     tokenAmount: string
     providerId: string
   }
+  [EarnEvents.earn_deposit_more_press]: {
+    poolTokenId: string
+    networkId: NetworkId
+    tokenAmount: string
+    providerId: string
+  }
   [EarnEvents.earn_deposit_add_gas_press]: { gasTokenId: string }
   [EarnEvents.earn_feed_item_select]: {
     origin: 'EarnDeposit' | 'EarnWithdraw' | 'EarnClaimReward'

--- a/src/analytics/docs.ts
+++ b/src/analytics/docs.ts
@@ -608,6 +608,7 @@ export const eventDocs: Record<AnalyticsEventType, string> = {
   [EarnEvents.earn_enter_amount_continue_press]: `When a user taps continue on the earn enter amount`,
   [EarnEvents.earn_enter_amount_info_more_pools]: `When a user taps to see other Aave pools`,
   [EarnEvents.earn_exit_pool_press]: `When the user taps on the exit pool button from the earn card in discover tab`,
+  [EarnEvents.earn_deposit_more_press]: `When the user taps deposit more button from the earn card in discover tab`,
   [EarnEvents.earn_deposit_add_gas_press]: `When the user doesn't have enough for gas when trying to deposit and clicks on the button to add gas token`,
   [EarnEvents.earn_feed_item_select]: `When the users taps on an earn transaction feed item`,
   [EarnEvents.earn_collect_earnings_press]: `When the user taps on the collect earnings button in the collect screen`,

--- a/src/earn/EarnActivePool.test.tsx
+++ b/src/earn/EarnActivePool.test.tsx
@@ -114,9 +114,7 @@ describe('EarnActivePool', () => {
 
     fireEvent.press(getByText('earnFlow.activePools.depositMore'))
     expect(ValoraAnalytics.track).toHaveBeenCalledWith(EarnEvents.earn_deposit_more_press, {
-      poolTokenId: networkConfig.aaveArbUsdcTokenId,
-      networkId: NetworkId['arbitrum-sepolia'],
-      tokenAmount: '10.75',
+      depositTokenId: networkConfig.arbUsdcTokenId,
       providerId: 'aave-v3',
     })
     expect(navigate).toBeCalledWith(Screens.EarnEnterAmount, {

--- a/src/earn/EarnActivePool.test.tsx
+++ b/src/earn/EarnActivePool.test.tsx
@@ -100,4 +100,27 @@ describe('EarnActivePool', () => {
       poolTokenId: networkConfig.aaveArbUsdcTokenId,
     })
   })
+
+  it('should have correct analytics and navigation with deposit more cta tap', () => {
+    const { getByText } = render(
+      <Provider store={store}>
+        <EarnActivePool
+          cta="ExitAndDeposit"
+          depositTokenId={networkConfig.arbUsdcTokenId}
+          poolTokenId={networkConfig.aaveArbUsdcTokenId}
+        />
+      </Provider>
+    )
+
+    fireEvent.press(getByText('earnFlow.activePools.depositMore'))
+    expect(ValoraAnalytics.track).toHaveBeenCalledWith(EarnEvents.earn_deposit_more_press, {
+      poolTokenId: networkConfig.aaveArbUsdcTokenId,
+      networkId: NetworkId['arbitrum-sepolia'],
+      tokenAmount: '10.75',
+      providerId: 'aave-v3',
+    })
+    expect(navigate).toBeCalledWith(Screens.EarnEnterAmount, {
+      tokenId: networkConfig.arbUsdcTokenId,
+    })
+  })
 })

--- a/src/earn/EarnActivePool.tsx
+++ b/src/earn/EarnActivePool.tsx
@@ -107,9 +107,19 @@ export default function EarnActivePool({ depositTokenId, poolTokenId, cta }: Pro
             />
             <Button
               onPress={() => {
-                // TODO (act-1176) create earn enter amount screen
-                // Will navigate to this screen with appropriate props
-                // fire analytics
+                if (!poolToken) {
+                  Logger.warn(TAG, 'No pool token found')
+                  return
+                }
+
+                ValoraAnalytics.track(EarnEvents.earn_deposit_more_press, {
+                  poolTokenId,
+                  networkId: poolToken.networkId,
+                  tokenAmount: poolToken.balance.toString(),
+                  providerId: 'aave-v3',
+                })
+
+                navigate(Screens.EarnEnterAmount, { tokenId: depositTokenId })
               }}
               text={t('earnFlow.activePools.depositMore')}
               type={BtnTypes.PRIMARY}

--- a/src/earn/EarnActivePool.tsx
+++ b/src/earn/EarnActivePool.tsx
@@ -107,18 +107,10 @@ export default function EarnActivePool({ depositTokenId, poolTokenId, cta }: Pro
             />
             <Button
               onPress={() => {
-                if (!poolToken) {
-                  Logger.warn(TAG, 'No pool token found')
-                  return
-                }
-
                 ValoraAnalytics.track(EarnEvents.earn_deposit_more_press, {
-                  poolTokenId,
-                  networkId: poolToken.networkId,
-                  tokenAmount: poolToken.balance.toString(),
+                  depositTokenId,
                   providerId: 'aave-v3',
                 })
-
                 navigate(Screens.EarnEnterAmount, { tokenId: depositTokenId })
               }}
               text={t('earnFlow.activePools.depositMore')}


### PR DESCRIPTION
### Description

Hooks up the deposit more button on the Earn cta to navigation and analytics.

### Test plan

- [x] Tested locally on iOS
- [x] Unit tests added 

### Related issues

- Part of ACT-1176

### Backwards compatibility

Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
