### PR TITLE
fix(earn): hide pools with less than .001

### DIFF
--- a/src/earn/EarnCard.tsx
+++ b/src/earn/EarnCard.tsx
@@ -8,6 +8,8 @@ import { StatsigFeatureGates } from 'src/statsig/types'
 import { Spacing } from 'src/styles/styles'
 import { useTokenInfo } from 'src/tokens/hooks'
 
+const MIN_POOL_BALANCE = 0.001
+
 interface Props {
   depositTokenId: string
   poolTokenId: string
@@ -18,7 +20,7 @@ export function EarnCardDiscover({ depositTokenId, poolTokenId }: Props) {
   const poolToken = useTokenInfo(poolTokenId)
 
   if (showStablecoinEarn) {
-    return poolToken && poolToken.balance.gt(0) ? (
+    return poolToken && poolToken.balance.gt(MIN_POOL_BALANCE) ? (
       <EarnActivePool
         cta="ExitAndDeposit"
         depositTokenId={depositTokenId}
@@ -35,7 +37,7 @@ export function EarnCardTokenDetails({ depositTokenId, poolTokenId }: Props) {
   const showStablecoinEarn = getFeatureGate(StatsigFeatureGates.SHOW_STABLECOIN_EARN)
   const poolToken = useTokenInfo(poolTokenId)
 
-  return showStablecoinEarn && poolToken && poolToken.balance.gt(0) ? (
+  return showStablecoinEarn && poolToken && poolToken.balance.gt(MIN_POOL_BALANCE) ? (
     <>
       <ItemSeparator />
       <View style={{ margin: Spacing.Regular16 }}>


### PR DESCRIPTION
### Description

Hides pools with a token balances below `0.001.`

#### Screenshots

| iOS Before | iOS After |
| ----- | ----- | 
| ![](https://github.com/valora-inc/wallet/assets/26950305/d243f2fd-6cae-4a8f-ae49-604a4f3eb51e "iOS Before") | ![](https://github.com/valora-inc/wallet/assets/26950305/43345771-e707-4904-9789-fbf1cf6e50c2 "iOS After" ) |

### Test plan

- [x] Tested locally on iOS

### Related issues

N/A

### Backwards compatibility

Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
