### PR TITLE
fix(earn): android header back button

### DIFF
--- a/src/earn/EarnEnterAmount.tsx
+++ b/src/earn/EarnEnterAmount.tsx
@@ -3,15 +3,9 @@ import { NativeStackScreenProps } from '@react-navigation/native-stack'
 import BigNumber from 'bignumber.js'
 import React, { useEffect, useMemo, useRef, useState } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
-import {
-  TextInput as RNTextInput,
-  SafeAreaView,
-  StyleSheet,
-  Text,
-  TouchableOpacity,
-  View,
-} from 'react-native'
+import { TextInput as RNTextInput, StyleSheet, Text, TouchableOpacity, View } from 'react-native'
 import { getNumberFormatSettings } from 'react-native-localize'
+import { SafeAreaView } from 'react-native-safe-area-context'
 import { EarnEvents, SendEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import BackButton from 'src/components/BackButton'


### PR DESCRIPTION
### Description

On Android the header back button was displayed in the status bar this should fix that issue.

#### Screenshots

| Android Before | Android After |
| ----- | ----- |
| ![](https://github.com/valora-inc/wallet/assets/26950305/b941cac5-6644-4a1e-8832-ee9474efe67a "Android Before") | ![](https://github.com/valora-inc/wallet/assets/26950305/810f81fd-e695-4149-a061-2ac94bc17e72 "Android After") |

### Test plan

- [x] Tested locally on Android.

### Related issues

N/A

### Backwards compatibility

Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
