### PR TITLE
feat(earn): add gas related analytics properties

### DIFF
--- a/src/analytics/Properties.tsx
+++ b/src/analytics/Properties.tsx
@@ -1602,7 +1602,7 @@ type DepositTxReceiptProperties = PrefixedTxReceiptProperties<'deposit'>
 export type EarnDepositTxsReceiptProperties = Partial<ApproveTxReceiptProperties> &
   Partial<DepositTxReceiptProperties> &
   Partial<{
-    gasUsed: number // Gas used by the swap (approve + deposit)
+    gasUsed: number // Gas used by the deposit (approve + deposit)
     gasFee: number | undefined // Actual gas fee of the deposit (approve + deposit) in feeCurrency (decimal value)
     gasFeeUsd: number | undefined // Actual gas fee of the deposit (approve + deposit) in USD
   }>

--- a/src/analytics/Properties.tsx
+++ b/src/analytics/Properties.tsx
@@ -1596,6 +1596,17 @@ interface EarnWithdrawProperties {
   rewards: SerializableRewardsInfo[]
 }
 
+// Adds `deposit` prefix to all properties of TxReceiptProperties
+type DepositTxReceiptProperties = PrefixedTxReceiptProperties<'deposit'>
+
+export type EarnDepositTxsReceiptProperties = Partial<ApproveTxReceiptProperties> &
+  Partial<DepositTxReceiptProperties> &
+  Partial<{
+    gasUsed: number // Gas used by the swap (approve + deposit)
+    gasFee: number | undefined // Actual gas fee of the deposit (approve + deposit) in feeCurrency (decimal value)
+    gasFeeUsd: number | undefined // Actual gas fee of the deposit (approve + deposit) in USD
+  }>
+
 interface EarnEventsProperties {
   [EarnEvents.earn_cta_press]: undefined
   [EarnEvents.earn_add_crypto_action_press]: {
@@ -1606,10 +1617,11 @@ interface EarnEventsProperties {
   [EarnEvents.earn_deposit_complete]: undefined
   [EarnEvents.earn_deposit_cancel]: undefined
   [EarnEvents.earn_deposit_submit_start]: EarnDepositProperties
-  [EarnEvents.earn_deposit_submit_success]: EarnDepositProperties
-  [EarnEvents.earn_deposit_submit_error]: EarnDepositProperties & {
-    error: string
-  }
+  [EarnEvents.earn_deposit_submit_success]: EarnDepositProperties & EarnDepositTxsReceiptProperties
+  [EarnEvents.earn_deposit_submit_error]: EarnDepositProperties &
+    EarnDepositTxsReceiptProperties & {
+      error: string
+    }
   [EarnEvents.earn_deposit_submit_cancel]: EarnDepositProperties
   [EarnEvents.earn_view_pools_press]: undefined
   [EarnEvents.earn_enter_amount_info_press]: undefined

--- a/src/swap/saga.ts
+++ b/src/swap/saga.ts
@@ -3,12 +3,7 @@ import { PayloadAction } from '@reduxjs/toolkit'
 import BigNumber from 'bignumber.js'
 import erc20 from 'src/abis/IERC20'
 import { SwapEvents } from 'src/analytics/Events'
-import {
-  PrefixedTxReceiptProperties,
-  SwapTimeMetrics,
-  SwapTxsReceiptProperties,
-  TxReceiptProperties,
-} from 'src/analytics/Properties'
+import { SwapTimeMetrics, SwapTxsReceiptProperties } from 'src/analytics/Properties'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import { navigateHome } from 'src/navigator/NavigationService'
 import { CANCELLED_PIN_INPUT } from 'src/pincode/authentication'
@@ -21,26 +16,27 @@ import { tokensByIdSelector } from 'src/tokens/selectors'
 import { TokenBalance, TokenBalances } from 'src/tokens/slice'
 import { getSupportedNetworkIdsForSwap } from 'src/tokens/utils'
 import { BaseStandbyTransaction } from 'src/transactions/actions'
-import { NetworkId, TokenTransactionTypeV2, newTransactionContext } from 'src/transactions/types'
+import {
+  NetworkId,
+  TokenTransactionTypeV2,
+  TrackedTx,
+  newTransactionContext,
+} from 'src/transactions/types'
+import {
+  getPrefixedTxAnalyticsProperties,
+  getTxReceiptAnalyticsProperties,
+} from 'src/transactions/utils'
 import Logger from 'src/utils/Logger'
 import { ensureError } from 'src/utils/ensureError'
 import { safely } from 'src/utils/safely'
 import { publicClient } from 'src/viem'
-import {
-  TransactionRequest,
-  getEstimatedGasFee,
-  getFeeCurrency,
-  getFeeCurrencyToken,
-  getFeeDecimals,
-  getMaxGasFee,
-} from 'src/viem/prepareTransactions'
 import { getPreparedTransactions } from 'src/viem/preparedTransactionSerialization'
 import { sendPreparedTransactions } from 'src/viem/saga'
 import { getViemWallet } from 'src/web3/contracts'
 import networkConfig from 'src/web3/networkConfig'
 import { getNetworkFromNetworkId } from 'src/web3/utils'
 import { call, put, select, takeEvery } from 'typed-redux-saga'
-import { Hash, TransactionReceipt, decodeFunctionData } from 'viem'
+import { decodeFunctionData } from 'viem'
 
 const TAG = 'swap/saga'
 
@@ -56,75 +52,6 @@ function calculateEstimatedUsdValue({
   }
 
   return valueToBigNumber(tokenAmount).times(tokenInfo.priceUsd).toNumber()
-}
-
-interface TrackedTx {
-  tx: TransactionRequest | undefined
-  txHash: Hash | undefined
-  txReceipt: TransactionReceipt | undefined
-}
-
-function getTxReceiptAnalyticsProperties(
-  { tx, txHash, txReceipt }: TrackedTx,
-  networkId: NetworkId,
-  tokensById: TokenBalances
-): Partial<TxReceiptProperties> {
-  const feeCurrencyToken = tx && getFeeCurrencyToken([tx], networkId, tokensById)
-  const feeDecimals = tx && feeCurrencyToken ? getFeeDecimals([tx], feeCurrencyToken) : undefined
-
-  const txMaxGasFee = tx && feeDecimals ? getMaxGasFee([tx]).shiftedBy(-feeDecimals) : undefined
-  const txMaxGasFeeUsd =
-    feeCurrencyToken && txMaxGasFee && feeCurrencyToken.priceUsd
-      ? txMaxGasFee.times(feeCurrencyToken.priceUsd)
-      : undefined
-  const txEstimatedGasFee =
-    tx && feeDecimals ? getEstimatedGasFee([tx]).shiftedBy(-feeDecimals) : undefined
-  const txEstimatedGasFeeUsd =
-    feeCurrencyToken && txEstimatedGasFee && feeCurrencyToken.priceUsd
-      ? txEstimatedGasFee.times(feeCurrencyToken.priceUsd)
-      : undefined
-
-  const txGasFee =
-    txReceipt?.gasUsed && txReceipt?.effectiveGasPrice && feeDecimals
-      ? new BigNumber((txReceipt.gasUsed * txReceipt.effectiveGasPrice).toString()).shiftedBy(
-          -feeDecimals
-        )
-      : undefined
-  const txGasFeeUsd =
-    feeCurrencyToken && txGasFee && feeCurrencyToken.priceUsd
-      ? txGasFee.times(feeCurrencyToken.priceUsd)
-      : undefined
-
-  return {
-    txCumulativeGasUsed: txReceipt?.cumulativeGasUsed
-      ? Number(txReceipt.cumulativeGasUsed)
-      : undefined,
-    txEffectiveGasPrice: txReceipt?.effectiveGasPrice
-      ? Number(txReceipt.effectiveGasPrice)
-      : undefined,
-    txGas: tx?.gas ? Number(tx.gas) : undefined,
-    txMaxGasFee: txMaxGasFee?.toNumber(),
-    txMaxGasFeeUsd: txMaxGasFeeUsd?.toNumber(),
-    txEstimatedGasFee: txEstimatedGasFee?.toNumber(),
-    txEstimatedGasFeeUsd: txEstimatedGasFeeUsd?.toNumber(),
-    txGasUsed: txReceipt?.gasUsed ? Number(txReceipt.gasUsed) : undefined,
-    txGasFee: txGasFee?.toNumber(),
-    txGasFeeUsd: txGasFeeUsd?.toNumber(),
-    txHash,
-    txFeeCurrency: tx && getFeeCurrency(tx),
-    txFeeCurrencySymbol: feeCurrencyToken?.symbol,
-  }
-}
-
-function getPrefixedTxAnalyticsProperties<Prefix extends string>(
-  receiptProperties: Partial<TxReceiptProperties>,
-  prefix: Prefix
-): Partial<PrefixedTxReceiptProperties<Prefix>> {
-  const prefixedProperties: Record<string, any> = {}
-  for (const [key, value] of Object.entries(receiptProperties)) {
-    prefixedProperties[`${prefix}${key[0].toUpperCase()}${key.slice(1)}`] = value
-  }
-  return prefixedProperties as Partial<PrefixedTxReceiptProperties<Prefix>>
 }
 
 function getSwapTxsReceiptAnalyticsProperties(

--- a/src/transactions/types.ts
+++ b/src/transactions/types.ts
@@ -1,6 +1,8 @@
 import BigNumber from 'bignumber.js'
 import { Nft } from 'src/nfts/types'
+import { TransactionRequest } from 'src/viem/prepareTransactions'
 import { v4 as uuidv4 } from 'uuid'
+import { Hash, TransactionReceipt } from 'viem'
 
 export enum Network {
   Celo = 'celo',
@@ -245,4 +247,10 @@ export interface EarnClaimReward {
   fees: Fee[]
   providerId: string
   status: TransactionStatus
+}
+
+export interface TrackedTx {
+  tx: TransactionRequest | undefined
+  txHash: Hash | undefined
+  txReceipt: TransactionReceipt | undefined
 }

--- a/src/transactions/utils.ts
+++ b/src/transactions/utils.ts
@@ -1,5 +1,16 @@
+import BigNumber from 'bignumber.js'
+import { PrefixedTxReceiptProperties, TxReceiptProperties } from 'src/analytics/Properties'
 import i18n from 'src/i18n'
+import { TokenBalances } from 'src/tokens/slice'
+import { NetworkId, TrackedTx } from 'src/transactions/types'
 import { formatFeedSectionTitle, timeDeltaInDays } from 'src/utils/time'
+import {
+  getEstimatedGasFee,
+  getFeeCurrency,
+  getFeeCurrencyToken,
+  getFeeDecimals,
+  getMaxGasFee,
+} from 'src/viem/prepareTransactions'
 
 // Groupings:
 // Recent -> Last 7 days (pending transactions always at the top, followed by recent confirmed transactions).
@@ -45,4 +56,67 @@ export function groupFeedItemsInSections<T extends { timestamp: number }>(
       title: key,
       data: value.data,
     }))
+}
+
+export function getTxReceiptAnalyticsProperties(
+  { tx, txHash, txReceipt }: TrackedTx,
+  networkId: NetworkId,
+  tokensById: TokenBalances
+): Partial<TxReceiptProperties> {
+  const feeCurrencyToken = tx && getFeeCurrencyToken([tx], networkId, tokensById)
+  const feeDecimals = tx && feeCurrencyToken ? getFeeDecimals([tx], feeCurrencyToken) : undefined
+
+  const txMaxGasFee = tx && feeDecimals ? getMaxGasFee([tx]).shiftedBy(-feeDecimals) : undefined
+  const txMaxGasFeeUsd =
+    feeCurrencyToken && txMaxGasFee && feeCurrencyToken.priceUsd
+      ? txMaxGasFee.times(feeCurrencyToken.priceUsd)
+      : undefined
+  const txEstimatedGasFee =
+    tx && feeDecimals ? getEstimatedGasFee([tx]).shiftedBy(-feeDecimals) : undefined
+  const txEstimatedGasFeeUsd =
+    feeCurrencyToken && txEstimatedGasFee && feeCurrencyToken.priceUsd
+      ? txEstimatedGasFee.times(feeCurrencyToken.priceUsd)
+      : undefined
+
+  const txGasFee =
+    txReceipt?.gasUsed && txReceipt?.effectiveGasPrice && feeDecimals
+      ? new BigNumber((txReceipt.gasUsed * txReceipt.effectiveGasPrice).toString()).shiftedBy(
+          -feeDecimals
+        )
+      : undefined
+  const txGasFeeUsd =
+    feeCurrencyToken && txGasFee && feeCurrencyToken.priceUsd
+      ? txGasFee.times(feeCurrencyToken.priceUsd)
+      : undefined
+
+  return {
+    txCumulativeGasUsed: txReceipt?.cumulativeGasUsed
+      ? Number(txReceipt.cumulativeGasUsed)
+      : undefined,
+    txEffectiveGasPrice: txReceipt?.effectiveGasPrice
+      ? Number(txReceipt.effectiveGasPrice)
+      : undefined,
+    txGas: tx?.gas ? Number(tx.gas) : undefined,
+    txMaxGasFee: txMaxGasFee?.toNumber(),
+    txMaxGasFeeUsd: txMaxGasFeeUsd?.toNumber(),
+    txEstimatedGasFee: txEstimatedGasFee?.toNumber(),
+    txEstimatedGasFeeUsd: txEstimatedGasFeeUsd?.toNumber(),
+    txGasUsed: txReceipt?.gasUsed ? Number(txReceipt.gasUsed) : undefined,
+    txGasFee: txGasFee?.toNumber(),
+    txGasFeeUsd: txGasFeeUsd?.toNumber(),
+    txHash,
+    txFeeCurrency: tx && getFeeCurrency(tx),
+    txFeeCurrencySymbol: feeCurrencyToken?.symbol,
+  }
+}
+
+export function getPrefixedTxAnalyticsProperties<Prefix extends string>(
+  receiptProperties: Partial<TxReceiptProperties>,
+  prefix: Prefix
+): Partial<PrefixedTxReceiptProperties<Prefix>> {
+  const prefixedProperties: Record<string, any> = {}
+  for (const [key, value] of Object.entries(receiptProperties)) {
+    prefixedProperties[`${prefix}${key[0].toUpperCase()}${key.slice(1)}`] = value
+  }
+  return prefixedProperties as Partial<PrefixedTxReceiptProperties<Prefix>>
 }


### PR DESCRIPTION
### Description

Adding gas fields to analytics properties similar to swaps for the earn deposit transaction

### Test plan

Unit tests

### Related issues

N/A

### Backwards compatibility

Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
