### PR TITLE
feat(earn): Withdraw screen gas subsidy update

### DIFF
--- a/src/earn/EarnCollectScreen.test.tsx
+++ b/src/earn/EarnCollectScreen.test.tsx
@@ -10,6 +10,8 @@ import { prepareWithdrawAndClaimTransactions } from 'src/earn/prepareTransaction
 import { withdrawStart } from 'src/earn/slice'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
+import { getFeatureGate } from 'src/statsig'
+import { StatsigFeatureGates } from 'src/statsig/types'
 import { NetworkId } from 'src/transactions/types'
 import { PreparedTransactionsPossible } from 'src/viem/prepareTransactions'
 import { getSerializablePreparedTransactions } from 'src/viem/preparedTransactionSerialization'
@@ -44,6 +46,7 @@ const mockStoreTokens = {
 const store = createMockStore({ tokens: mockStoreTokens })
 
 jest.mock('src/earn/poolInfo')
+jest.mock('src/statsig')
 jest.mock('src/earn/prepareTransactions')
 
 const mockPreparedTransaction: PreparedTransactionsPossible = {
@@ -84,6 +87,7 @@ describe('EarnCollectScreen', () => {
     jest.mocked(fetchAavePoolInfo).mockResolvedValue({ apy: 0.03 })
     jest.mocked(fetchAaveRewards).mockResolvedValue(mockRewards)
     jest.mocked(prepareWithdrawAndClaimTransactions).mockResolvedValue(mockPreparedTransaction)
+    jest.mocked(getFeatureGate).mockReturnValue(false)
     store.clearActions()
   })
 
@@ -129,6 +133,7 @@ describe('EarnCollectScreen', () => {
     })
     expect(getByTestId('EarnCollect/GasFeeCryptoAmount')).toHaveTextContent('0.06 ETH')
     expect(getByTestId('EarnCollect/GasFeeFiatAmount')).toHaveTextContent('₱119.70')
+    expect(queryByTestId('EarnCollect/GasSubsidized')).toBeFalsy()
     expect(getByTestId('EarnCollectScreen/CTA')).toBeEnabled()
     expect(prepareWithdrawAndClaimTransactions).toHaveBeenCalledWith({
       amount: '10.75',
@@ -423,5 +428,26 @@ describe('EarnCollectScreen', () => {
     expect(ValoraAnalytics.track).toBeCalledWith(EarnEvents.earn_withdraw_add_gas_press, {
       gasTokenId: mockArbEthTokenId,
     })
+  })
+
+  it('shows gas subsidized copy when feature gate is true', async () => {
+    jest
+      .mocked(getFeatureGate)
+      .mockImplementation(
+        (featureGateName) =>
+          featureGateName === StatsigFeatureGates.SUBSIDIZE_STABLECOIN_EARN_GAS_FEES
+      )
+    const { getByTestId } = render(
+      <Provider store={store}>
+        <MockedNavigator
+          component={EarnCollectScreen}
+          params={{
+            depositTokenId: mockArbUsdcTokenId,
+            poolTokenId: networkConfig.aaveArbUsdcTokenId,
+          }}
+        />
+      </Provider>
+    )
+    expect(getByTestId('EarnCollect/GasSubsidized')).toBeTruthy()
   })
 })

--- a/src/earn/EarnCollectScreen.tsx
+++ b/src/earn/EarnCollectScreen.tsx
@@ -137,7 +137,7 @@ export default function EarnCollectScreen({ route }: Props) {
             <Text style={styles.rateText}>{t('earnFlow.collect.fee')}</Text>
             {feeSection}
             {isGasSubsidized && (
-              <Text style={styles.gasSubsidized} testID={'EarnDeposit/GasSubsidized'}>
+              <Text style={styles.gasSubsidized} testID={'EarnCollect/GasSubsidized'}>
                 {t('earnFlow.gasSubsidized')}
               </Text>
             )}

--- a/src/earn/EarnCollectScreen.tsx
+++ b/src/earn/EarnCollectScreen.tsx
@@ -400,5 +400,6 @@ const styles = StyleSheet.create({
   gasSubsidized: {
     ...typeScale.labelXSmall,
     color: Colors.primary,
+    marginTop: Spacing.Tiny4,
   },
 })

--- a/src/earn/EarnCollectScreen.tsx
+++ b/src/earn/EarnCollectScreen.tsx
@@ -20,6 +20,8 @@ import { Screens } from 'src/navigator/Screens'
 import { StackParamList } from 'src/navigator/types'
 import { useDispatch, useSelector } from 'src/redux/hooks'
 import { NETWORK_NAMES } from 'src/shared/conts'
+import { getFeatureGate } from 'src/statsig'
+import { StatsigFeatureGates } from 'src/statsig/types'
 import Colors from 'src/styles/colors'
 import { typeScale } from 'src/styles/fonts'
 import { Spacing } from 'src/styles/styles'
@@ -43,6 +45,8 @@ export default function EarnCollectScreen({ route }: Props) {
     // should never happen
     throw new Error('Deposit / pool token not found')
   }
+
+  const isGasSubsidized = getFeatureGate(StatsigFeatureGates.SUBSIDIZE_STABLECOIN_EARN_GAS_FEES)
 
   const feeCurrencies = useSelector((state) => feeCurrenciesSelector(state, depositToken.networkId))
   const { asyncRewardsInfo, asyncPreparedTransactions } = useAaveRewardsInfoAndPrepareTransactions({
@@ -93,7 +97,13 @@ export default function EarnCollectScreen({ route }: Props) {
   const { maxFeeAmount, feeCurrency } = getFeeCurrencyAndAmounts(asyncPreparedTransactions.result)
   let feeSection = <GasFeeLoading />
   if (maxFeeAmount && feeCurrency) {
-    feeSection = <GasFee maxFeeAmount={maxFeeAmount} feeCurrency={feeCurrency} />
+    feeSection = (
+      <GasFee
+        maxFeeAmount={maxFeeAmount}
+        feeCurrency={feeCurrency}
+        isGasSubsidized={isGasSubsidized}
+      />
+    )
   } else if (!asyncPreparedTransactions.loading) {
     feeSection = <GasFeeError />
   }
@@ -126,6 +136,11 @@ export default function EarnCollectScreen({ route }: Props) {
           <View>
             <Text style={styles.rateText}>{t('earnFlow.collect.fee')}</Text>
             {feeSection}
+            {isGasSubsidized && (
+              <Text style={styles.gasSubsidized} testID={'EarnDeposit/GasSubsidized'}>
+                {t('earnFlow.gasSubsidized')}
+              </Text>
+            )}
           </View>
         </View>
         {error && (
@@ -270,26 +285,30 @@ function GasFeeLoading() {
 function GasFee({
   maxFeeAmount,
   feeCurrency,
+  isGasSubsidized = false,
 }: {
   maxFeeAmount: BigNumber
   feeCurrency: TokenBalance
+  isGasSubsidized: Boolean
 }) {
   return (
     <>
       <TokenDisplay
-        style={styles.apyText}
+        style={[styles.apyText, isGasSubsidized && { textDecorationLine: 'line-through' }]}
         tokenId={feeCurrency.tokenId}
         amount={maxFeeAmount}
         showLocalAmount={false}
         testID="EarnCollect/GasFeeCryptoAmount"
       />
-      <TokenDisplay
-        style={styles.gasFeeFiat}
-        tokenId={feeCurrency.tokenId}
-        amount={maxFeeAmount}
-        showLocalAmount={true}
-        testID="EarnCollect/GasFeeFiatAmount"
-      />
+      {!isGasSubsidized && (
+        <TokenDisplay
+          style={styles.gasFeeFiat}
+          tokenId={feeCurrency.tokenId}
+          amount={maxFeeAmount}
+          showLocalAmount={true}
+          testID="EarnCollect/GasFeeFiatAmount"
+        />
+      )}
     </>
   )
 }
@@ -377,5 +396,9 @@ const styles = StyleSheet.create({
     width: 64,
     borderRadius: 100,
     ...typeScale.bodyXSmall,
+  },
+  gasSubsidized: {
+    ...typeScale.labelXSmall,
+    color: Colors.primary,
   },
 })


### PR DESCRIPTION
### Description

If feature flag set, strikethrough gas token amount, don't show gas fiat amount, show gas subsidized copy.

### Test plan

Unit tests updated/added.

Subsidize gas feature gate true:
![Simulator Screenshot - iPhone 14 Pro - 2024-05-22 at 12 31 52](https://github.com/valora-inc/wallet/assets/140328381/92d8c9bd-081a-44c7-8e8f-f1da274cfce5)

Subsidize gas feature gate false:
![collect-false](https://github.com/valora-inc/wallet/assets/140328381/8a98d885-1796-4d09-b75c-a8b3be2453ec)

### Related issues

- Fixes #ACT-1196

### Backwards compatibility

Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [X] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
