### PR TITLE
feat(earn): add earn info screen

### DIFF
--- a/branding/celo/src/brandingConfig.ts
+++ b/branding/celo/src/brandingConfig.ts
@@ -20,3 +20,4 @@ export const INVITE_REWARDS_NFTS_LEARN_MORE =
   'https://valoraapp.com/support/invite-rewards-nfts-learn-more'
 export const INVITE_REWARDS_STABLETOKEN_LEARN_MORE =
   'https://valoraapp.com/support/invite-rewards-stabletoken-learn-more'
+export const EARN_STABLECOINS_LEARN_MORE = 'https://valoraapp.com/support/Earn-on-your-stablecoins'

--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -2374,6 +2374,29 @@
       "subtitle": "Deposit today and earn returns",
       "description": "See how much you can earn when supplying a lending pool"
     },
+    "earnInfo": {
+      "titleWithApy": "Earn {{apy}}% on your\n{{tokenSymbol}}",
+      "titleWithoutApy": "Earn on your\n{{tokenSymbol}}",
+      "details": {
+        "earn": {
+          "title": "Maximize Earnings without Gas Fees*",
+          "subtitle": "Earn on {{tokenSymbol}} and get rewards when you supply an {{providerName}} Pool.",
+          "footnote": "*Gas fees are temporarily covered by Valora"
+        },
+        "manage": {
+          "title": "Manage Directly from Valora",
+          "subtitle": "We’ll take care of the setup so you can manage your {{providerName}} position directly from Valora."
+        },
+        "access": {
+          "title": "Easily Access your Funds",
+          "subtitle": "Collect your funds effortlessly with a single tap. Enjoy the same instant access as you would through {{providerName}}."
+        }
+      },
+      "action": {
+        "learn": "Learn More",
+        "earn": "Start Earning"
+      }
+    },
     "enterAmount": {
       "earnUpToLabel": "You could earn up to:",
       "rateLabel": "Rate (est.)",

--- a/src/earn/EarnInfoScreen.tsx
+++ b/src/earn/EarnInfoScreen.tsx
@@ -1,0 +1,173 @@
+import { useHeaderHeight } from '@react-navigation/elements'
+import { NativeStackScreenProps } from '@react-navigation/native-stack'
+import React, { ReactElement } from 'react'
+import { useTranslation } from 'react-i18next'
+import { ScrollView, StyleSheet, Text, View } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
+import { EARN_STABLECOINS_LEARN_MORE } from 'src/brandingConfig'
+import Button, { BtnSizes, BtnTypes } from 'src/components/Button'
+import { useAavePoolInfo } from 'src/earn/hooks'
+import ArrowDown from 'src/icons/ArrowDown'
+import CircledIcon from 'src/icons/CircledIcon'
+import Logo from 'src/icons/Logo'
+import UpwardGraph from 'src/icons/UpwardGraph'
+import { headerWithCloseButton } from 'src/navigator/Headers'
+import { navigate } from 'src/navigator/NavigationService'
+import { Screens } from 'src/navigator/Screens'
+import { StackParamList } from 'src/navigator/types'
+import { getDynamicConfigParams, getFeatureGate } from 'src/statsig'
+import { DynamicConfigs } from 'src/statsig/constants'
+import { StatsigDynamicConfigs, StatsigFeatureGates } from 'src/statsig/types'
+import Colors from 'src/styles/colors'
+import { typeScale } from 'src/styles/fonts'
+import { Spacing } from 'src/styles/styles'
+import { useTokenInfo } from 'src/tokens/hooks'
+
+const ICON_SIZE = 24
+const ICON_BACKGROUND_CIRCLE_SIZE = 36
+
+function DetailsItem({
+  icon,
+  title,
+  subtitle,
+  footnote,
+}: {
+  icon: ReactElement
+  title: string
+  subtitle: string
+  footnote?: string
+}) {
+  return (
+    <View style={styles.detailsItemContainer}>
+      <CircledIcon backgroundColor={Colors.white} radius={ICON_BACKGROUND_CIRCLE_SIZE}>
+        {icon}
+      </CircledIcon>
+      <View style={{ flex: 1 }}>
+        <Text style={styles.detailsItemTitle}>{title}</Text>
+        <Text style={styles.detailsItemSubtitle}>{subtitle}</Text>
+        {!!footnote && <Text style={styles.detailsItemFootnote}>{footnote}</Text>}
+      </View>
+    </View>
+  )
+}
+
+type Props = NativeStackScreenProps<StackParamList, Screens.EarnInfoScreen>
+
+export default function EarnInfoScreen({ route }: Props) {
+  const { t } = useTranslation()
+  const { depositTokenId } = route.params
+  const headerHeight = useHeaderHeight()
+
+  const tokenInfo = useTokenInfo(depositTokenId)
+  const tokenSymbol = tokenInfo?.symbol
+
+  const asyncPoolInfo = useAavePoolInfo({ depositTokenId })
+  const apy = asyncPoolInfo?.result?.apy
+
+  const isGasSubsidized = getFeatureGate(StatsigFeatureGates.SUBSIDIZE_STABLECOIN_EARN_GAS_FEES)
+  const { providerName } = getDynamicConfigParams(
+    DynamicConfigs[StatsigDynamicConfigs.EARN_STABLECOIN_CONFIG]
+  )
+
+  return (
+    <SafeAreaView
+      style={[styles.safeAreaContainer, { paddingTop: headerHeight }]}
+      edges={['bottom']}
+    >
+      <ScrollView>
+        {apy ? (
+          <Text style={styles.title}>
+            {t('earnFlow.earnInfo.titleWithApy', { apy: (apy * 100).toFixed(2), tokenSymbol })}
+          </Text>
+        ) : (
+          <Text style={styles.title}>
+            {t('earnFlow.earnInfo.titleWithoutApy', { tokenSymbol })}
+          </Text>
+        )}
+        <View style={styles.detailsContainer}>
+          <DetailsItem
+            icon={<UpwardGraph size={ICON_SIZE} color={Colors.black} />}
+            title={t('earnFlow.earnInfo.details.earn.title')}
+            subtitle={t('earnFlow.earnInfo.details.earn.subtitle', { tokenSymbol, providerName })}
+            footnote={isGasSubsidized ? t('earnFlow.earnInfo.details.earn.footnote') : undefined}
+          />
+          <DetailsItem
+            icon={<Logo size={ICON_SIZE} color={Colors.black} />}
+            title={t('earnFlow.earnInfo.details.manage.title')}
+            subtitle={t('earnFlow.earnInfo.details.manage.subtitle', { providerName })}
+          />
+          <DetailsItem
+            icon={<ArrowDown size={ICON_SIZE} color={Colors.black} />}
+            title={t('earnFlow.earnInfo.details.access.title')}
+            subtitle={t('earnFlow.earnInfo.details.access.subtitle', { providerName })}
+          />
+        </View>
+      </ScrollView>
+      <View style={styles.buttonContainer}>
+        <Button
+          onPress={() => {
+            navigate(Screens.WebViewScreen, { uri: EARN_STABLECOINS_LEARN_MORE })
+          }}
+          text={t('earnFlow.earnInfo.action.learn')}
+          type={BtnTypes.GRAY_WITH_BORDER}
+          size={BtnSizes.FULL}
+        />
+        <Button
+          onPress={() => {
+            navigate(Screens.EarnEnterAmount, { tokenId: depositTokenId })
+          }}
+          text={t('earnFlow.earnInfo.action.earn')}
+          type={BtnTypes.PRIMARY}
+          size={BtnSizes.FULL}
+        />
+      </View>
+    </SafeAreaView>
+  )
+}
+
+EarnInfoScreen.navigationOptions = () => ({
+  ...headerWithCloseButton,
+  headerTransparent: true,
+  headerShown: true,
+  headerStyle: {
+    backgroundColor: 'transparent',
+  },
+})
+
+const styles = StyleSheet.create({
+  safeAreaContainer: {
+    flex: 1,
+    backgroundColor: Colors.yellowishOrange,
+    paddingHorizontal: Spacing.Regular16,
+  },
+  title: {
+    color: Colors.black,
+    textAlign: 'center',
+    marginBottom: Spacing.Thick24,
+    ...typeScale.titleLarge,
+  },
+  detailsContainer: {
+    gap: Spacing.Large32,
+  },
+  detailsItemContainer: {
+    flexDirection: 'row',
+    gap: Spacing.Regular16,
+  },
+  detailsItemTitle: {
+    color: Colors.black,
+    ...typeScale.labelSemiBoldSmall,
+  },
+  detailsItemSubtitle: {
+    color: Colors.black,
+    ...typeScale.bodyXSmall,
+  },
+  detailsItemFootnote: {
+    color: Colors.black,
+    marginTop: Spacing.Smallest8,
+    ...typeScale.bodyXXSmall,
+  },
+  buttonContainer: {
+    gap: Spacing.Smallest8,
+    marginHorizontal: Spacing.Smallest8,
+  },
+})

--- a/src/icons/ArrowDown.tsx
+++ b/src/icons/ArrowDown.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react'
+import Svg, { Path } from 'react-native-svg'
+import { Colors } from 'src/styles/colors'
+
+interface Props {
+  color?: Colors
+  size?: number
+}
+
+const ArrowDown = ({ color = Colors.black, size = 24 }: Props) => (
+  <Svg width={size} height={size} viewBox="0 0 24 24" fill="none">
+    <Path
+      id="Vector"
+      d="M11.053 4.5L12.947 4.5L12.947 15.8636L18.1553 10.6553L19.5 12L12 19.5L4.5 12L5.8447 10.6553L11.053 15.8636L11.053 4.5Z"
+      fill={color}
+    />
+  </Svg>
+)
+
+export default React.memo(ArrowDown)

--- a/src/navigator/Navigator.tsx
+++ b/src/navigator/Navigator.tsx
@@ -33,6 +33,7 @@ import DappShortcutTransactionRequest from 'src/dapps/DappShortcutTransactionReq
 import DappShortcutsRewards from 'src/dapps/DappShortcutsRewards'
 import EarnCollectScreen from 'src/earn/EarnCollectScreen'
 import EarnEnterAmount from 'src/earn/EarnEnterAmount'
+import EarnInfoScreen from 'src/earn/EarnInfoScreen'
 import EscrowedPaymentListScreen from 'src/escrow/EscrowedPaymentListScreen'
 import ReclaimPaymentConfirmationScreen from 'src/escrow/ReclaimPaymentConfirmationScreen'
 import BidaliScreen from 'src/fiatExchanges/BidaliScreen'
@@ -547,6 +548,11 @@ const earnScreens = (Navigator: typeof Stack) => (
       name={Screens.EarnEnterAmount}
       component={EarnEnterAmount}
       options={noHeader}
+    />
+    <Navigator.Screen
+      name={Screens.EarnInfoScreen}
+      component={EarnInfoScreen}
+      options={EarnInfoScreen.navigationOptions}
     />
   </>
 )

--- a/src/navigator/Screens.tsx
+++ b/src/navigator/Screens.tsx
@@ -16,6 +16,7 @@ export enum Screens {
   DappShortcutsRewards = 'DappShortcutsRewards',
   DappShortcutTransactionRequest = 'DappShortcutTransactionRequest',
   Debug = 'Debug',
+  EarnInfoScreen = 'EarnInfoScreen',
   EarnEnterAmount = 'EarnEnterAmount',
   EarnCollectScreen = 'EarnCollectScreen',
   EnableBiometry = 'EnableBiometry',

--- a/src/navigator/types.tsx
+++ b/src/navigator/types.tsx
@@ -81,6 +81,9 @@ export type StackParamList = {
     rewardId: string
   }
   [Screens.Debug]: undefined
+  [Screens.EarnInfoScreen]: {
+    depositTokenId: string
+  }
   [Screens.EarnEnterAmount]: {
     tokenId: string
   }

--- a/src/styles/colors.tsx
+++ b/src/styles/colors.tsx
@@ -18,6 +18,7 @@ export enum Colors {
   warningLight = '#FFF9EA',
   errorDark = '#C93717',
   errorLight = '#FBF2F0',
+  yellowishOrange = '#F9F5ED',
 
   /** @deprecated */
   goldBrand = '#FBCC5C',


### PR DESCRIPTION
### Description

Adds the earn info screen in a way that takes populates APY details from tokenId.

### Test plan

- [ ] Tested locally on iOS
- [ ] Tested locally on Android
- [ ] Unit tests added

### Related issues

- Fixed ACT-1192

### Backwards compatibility

Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
