### PR TITLE
chore(points): send token ids with swap events

### DIFF
--- a/src/points/slice.test.ts
+++ b/src/points/slice.test.ts
@@ -15,7 +15,13 @@ const pendingCreateWalletEvent: PendingPointsEvent = {
 const pendingSwapEvent: PendingPointsEvent = {
   id: 'test-id-2',
   timestamp: '2024-04-22T12:00:00.000Z',
-  event: { activityId: 'swap', transactionHash: '0xTEST', networkId: NetworkId['celo-alfajores'] },
+  event: {
+    activityId: 'swap',
+    transactionHash: '0xTEST',
+    networkId: NetworkId['celo-alfajores'],
+    toTokenId: 'mockToTokenId',
+    fromTokenId: 'mockFromTokenId',
+  },
 }
 
 describe('pending points events', () => {

--- a/src/points/types.ts
+++ b/src/points/types.ts
@@ -86,6 +86,8 @@ interface PointsEventSwap {
   activityId: 'swap'
   transactionHash: string
   networkId: NetworkId
+  toTokenId: string
+  fromTokenId: string
 }
 
 export type PointsEvent = PointsEventCreateWallet | PointsEventSwap

--- a/src/swap/saga.test.ts
+++ b/src/swap/saga.test.ts
@@ -561,6 +561,8 @@ describe(swapSubmitSaga, () => {
           activityId: 'swap',
           transactionHash: '0x1',
           networkId: NetworkId['celo-alfajores'],
+          toTokenId: mockCeloTokenId,
+          fromTokenId: mockCeurTokenId,
         })
       )
       .run()

--- a/src/swap/saga.ts
+++ b/src/swap/saga.ts
@@ -277,6 +277,8 @@ export function* swapSubmitSaga(action: PayloadAction<SwapInfo>) {
         activityId: 'swap',
         transactionHash: swapTxReceipt.transactionHash,
         networkId,
+        toTokenId,
+        fromTokenId,
       })
     )
     ValoraAnalytics.track(SwapEvents.swap_execute_success, {

--- a/src/transactions/saga.test.ts
+++ b/src/transactions/saga.test.ts
@@ -263,6 +263,8 @@ describe('watchPendingTransactions', () => {
           activityId: 'swap',
           transactionHash,
           networkId: NetworkId['celo-alfajores'],
+          toTokenId: mockCeurTokenId,
+          fromTokenId: mockCusdTokenId,
         })
       )
       .run()

--- a/src/transactions/saga.ts
+++ b/src/transactions/saga.ts
@@ -276,7 +276,15 @@ export function* getTransactionReceipt(
 
     if (receipt.status === 'success') {
       if (__typename === 'TokenExchangeV3') {
-        yield* put(trackPointsEvent({ activityId: 'swap', transactionHash, networkId }))
+        yield* put(
+          trackPointsEvent({
+            activityId: 'swap',
+            transactionHash,
+            networkId,
+            fromTokenId: transaction.outAmount.tokenId,
+            toTokenId: transaction.inAmount.tokenId,
+          })
+        )
       }
     }
   } catch (e) {

--- a/test/RootStateSchema.json
+++ b/test/RootStateSchema.json
@@ -2834,8 +2834,14 @@
                     "const": "swap",
                     "type": "string"
                 },
+                "fromTokenId": {
+                    "type": "string"
+                },
                 "networkId": {
                     "$ref": "#/definitions/NetworkId"
+                },
+                "toTokenId": {
+                    "type": "string"
                 },
                 "transactionHash": {
                     "type": "string"
@@ -2843,7 +2849,9 @@
             },
             "required": [
                 "activityId",
+                "fromTokenId",
                 "networkId",
+                "toTokenId",
                 "transactionHash"
             ],
             "type": "object"


### PR DESCRIPTION
### Description

The core points logic doesn't rely on the to and from tokens in a swap, these are only used for display purposes. Since we already have them in the wallet, it'd save a lot of work to just pass them to the backend (rather than deriving them again using the transactions and adding logic for creating the token id's on the backend)

### Test plan

n/a

### Related issues

- Related to RET-1034

### Backwards compatibility

Y

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
