### PR TITLE
fix(points): ensure balance is displayed timely and correctly

### DIFF
--- a/src/components/NumberTicker.tsx
+++ b/src/components/NumberTicker.tsx
@@ -26,7 +26,11 @@ interface TickProps {
 const numberRange = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']
 
 function TickText({ value, textStyle }: TickTextProps) {
-  return <Text style={[styles.tickerText, textStyle]}>{value}</Text>
+  return (
+    <Text allowFontScaling={false} style={[styles.tickerText, textStyle]}>
+      {value}
+    </Text>
+  )
 }
 
 function Tick({ startValue, endValue, textStyle, textHeight, animationDuration }: TickProps) {

--- a/src/points/saga.test.ts
+++ b/src/points/saga.test.ts
@@ -557,6 +557,7 @@ describe('watchAppMounted', () => {
   it('should call sendPendingPointsEvents only once even if multiple "app mounted" actions are dispatched', async () => {
     const mockSendPendingPointsEvents = jest.fn()
     const mockGetPointsBalance = jest.fn()
+    const mockGetPointsConfig = jest.fn()
     const mockAction = { type: AppActions.APP_MOUNTED }
 
     await expectSaga(watchAppMounted)
@@ -564,6 +565,7 @@ describe('watchAppMounted', () => {
       .provide([
         [matchers.call.fn(pointsSaga.sendPendingPointsEvents), mockSendPendingPointsEvents()],
         [matchers.call.fn(pointsSaga.getPointsBalance), mockGetPointsBalance()],
+        [matchers.call.fn(pointsSaga.getPointsConfig), mockGetPointsConfig()],
       ])
       .dispatch(mockAction)
       .dispatch(mockAction)
@@ -571,6 +573,7 @@ describe('watchAppMounted', () => {
 
     expect(mockSendPendingPointsEvents).toHaveBeenCalledTimes(1)
     expect(mockGetPointsBalance).toHaveBeenCalledTimes(1)
+    expect(mockGetPointsConfig).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/src/points/saga.test.ts
+++ b/src/points/saga.test.ts
@@ -556,18 +556,21 @@ describe('watchAppMounted', () => {
 
   it('should call sendPendingPointsEvents only once even if multiple "app mounted" actions are dispatched', async () => {
     const mockSendPendingPointsEvents = jest.fn()
+    const mockGetPointsBalance = jest.fn()
     const mockAction = { type: AppActions.APP_MOUNTED }
 
     await expectSaga(watchAppMounted)
       .withState(createMockStore().getState())
       .provide([
         [matchers.call.fn(pointsSaga.sendPendingPointsEvents), mockSendPendingPointsEvents()],
+        [matchers.call.fn(pointsSaga.getPointsBalance), mockGetPointsBalance()],
       ])
       .dispatch(mockAction)
       .dispatch(mockAction)
       .run()
 
     expect(mockSendPendingPointsEvents).toHaveBeenCalledTimes(1)
+    expect(mockGetPointsBalance).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/src/points/saga.ts
+++ b/src/points/saga.ts
@@ -265,6 +265,7 @@ function* watchTrackPointsEvent() {
 export function* watchAppMounted() {
   yield* take(AppActions.APP_MOUNTED)
   yield* call(safely, sendPendingPointsEvents)
+  yield* call(safely, getPointsBalance)
 }
 
 export function* pointsSaga() {

--- a/src/points/saga.ts
+++ b/src/points/saga.ts
@@ -1,6 +1,5 @@
 import { differenceInDays } from 'date-fns'
 import { Actions as AppActions } from 'src/app/actions'
-import { Actions as HomeActions } from 'src/home/actions'
 import { retrieveSignedMessage } from 'src/pincode/authentication'
 import {
   nextPageUrlSelector,
@@ -37,7 +36,7 @@ import { fetchWithTimeout } from 'src/utils/fetchWithTimeout'
 import { safely } from 'src/utils/safely'
 import networkConfig from 'src/web3/networkConfig'
 import { walletAddressSelector } from 'src/web3/selectors'
-import { call, put, select, spawn, take, takeEvery, takeLeading } from 'typed-redux-saga'
+import { all, call, put, select, spawn, take, takeEvery, takeLeading } from 'typed-redux-saga'
 import { v4 as uuidv4 } from 'uuid'
 
 const TAG = 'Points/saga'
@@ -255,7 +254,7 @@ function* watchGetHistory() {
 }
 
 function* watchGetConfig() {
-  yield* takeLeading([getPointsConfigRetry.type, HomeActions.VISIT_HOME], safely(getPointsConfig))
+  yield* takeLeading(getPointsConfigRetry.type, safely(getPointsConfig))
 }
 
 function* watchTrackPointsEvent() {
@@ -264,8 +263,7 @@ function* watchTrackPointsEvent() {
 
 export function* watchAppMounted() {
   yield* take(AppActions.APP_MOUNTED)
-  yield* call(safely, sendPendingPointsEvents)
-  yield* call(safely, getPointsBalance)
+  yield* all([safely(getPointsConfig), safely(getPointsBalance), safely(sendPendingPointsEvents)])
 }
 
 export function* pointsSaga() {


### PR DESCRIPTION
### Description

This PR fixes:
1. the points balance was outdated on the discover tab because the balance fetch was only triggered on the points home screen. now we also trigger a balance fetch on app mount.
2. also fetch points config on app mount (consolidate logic, was previously being fetched on home screen visit)
3. disable font scaling on the points balance because the font size is large already, and font scaling messes with the animation.

### Test plan

n/a

### Related issues

n/a

### Backwards compatibility

Y

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
