### PR TITLE
fix(settings): header shown as white when bottom sheet is open

### DIFF
--- a/src/account/Settings.tsx
+++ b/src/account/Settings.tsx
@@ -1,3 +1,4 @@
+import { useHeaderHeight } from '@react-navigation/elements'
 import { NativeStackScreenProps } from '@react-navigation/native-stack'
 import * as Sentry from '@sentry/react-native'
 import locales from 'locales'
@@ -69,6 +70,7 @@ import {
 import { deleteKeylessBackupStarted, hideDeleteKeylessBackupError } from 'src/keylessBackup/slice'
 import { KeylessBackupDeleteStatus } from 'src/keylessBackup/types'
 import { getLocalCurrencyCode } from 'src/localCurrency/selectors'
+import { headerWithBackButton } from 'src/navigator/Headers'
 import { ensurePincode, navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import { StackParamList } from 'src/navigator/types'
@@ -116,6 +118,7 @@ export const Account = ({ navigation, route }: Props) => {
   const showDeleteKeylessBackupError = useSelector(showDeleteKeylessBackupErrorSelector)
   const walletConnectEnabled = v2
   const connectedApplications = sessions.length
+  const headerHeight = useHeaderHeight()
 
   useEffect(() => {
     if (ValoraAnalytics.getSessionId() !== sessionId) {
@@ -434,7 +437,10 @@ export const Account = ({ navigation, route }: Props) => {
   }
 
   return (
-    <SafeAreaView style={styles.container} edges={['bottom', 'left', 'right']}>
+    <SafeAreaView
+      style={[styles.container, { paddingTop: headerHeight }]}
+      edges={['bottom', 'left', 'right']}
+    >
       <ScrollView testID="SettingsScrollView">
         <TouchableWithoutFeedback onPress={onDevSettingsTriggerPress}>
           <Text style={styles.title} testID={'SettingsTitle'}>
@@ -603,6 +609,15 @@ export const Account = ({ navigation, route }: Props) => {
     </SafeAreaView>
   )
 }
+
+Account.navigationOptions = () => ({
+  ...headerWithBackButton,
+  headerTransparent: true,
+  headerShown: true,
+  headerStyle: {
+    backgroundColor: 'transparent',
+  },
+})
 
 const styles = StyleSheet.create({
   container: {

--- a/src/account/Settings.tsx
+++ b/src/account/Settings.tsx
@@ -1,4 +1,3 @@
-import { useHeaderHeight } from '@react-navigation/elements'
 import { NativeStackScreenProps } from '@react-navigation/native-stack'
 import * as Sentry from '@sentry/react-native'
 import locales from 'locales'
@@ -46,6 +45,7 @@ import {
   supportedBiometryTypeSelector,
   walletConnectEnabledSelector,
 } from 'src/app/selectors'
+import BackButton from 'src/components/BackButton'
 import BottomSheet, { BottomSheetRefType } from 'src/components/BottomSheet'
 import Button, { BtnSizes, BtnTypes } from 'src/components/Button'
 import Dialog from 'src/components/Dialog'
@@ -59,6 +59,7 @@ import {
   SettingsItemTextValue,
 } from 'src/components/SettingsItem'
 import Toast from 'src/components/Toast'
+import CustomHeader from 'src/components/header/CustomHeader'
 import { PRIVACY_LINK, TOS_LINK } from 'src/config'
 import { currentLanguageSelector } from 'src/i18n/selectors'
 import ForwardChevron from 'src/icons/ForwardChevron'
@@ -70,7 +71,7 @@ import {
 import { deleteKeylessBackupStarted, hideDeleteKeylessBackupError } from 'src/keylessBackup/slice'
 import { KeylessBackupDeleteStatus } from 'src/keylessBackup/types'
 import { getLocalCurrencyCode } from 'src/localCurrency/selectors'
-import { headerWithBackButton } from 'src/navigator/Headers'
+import { noHeader } from 'src/navigator/Headers'
 import { ensurePincode, navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import { StackParamList } from 'src/navigator/types'
@@ -81,6 +82,7 @@ import { StatsigFeatureGates } from 'src/statsig/types'
 import colors from 'src/styles/colors'
 import fontStyles from 'src/styles/fonts'
 import { Spacing } from 'src/styles/styles'
+import variables from 'src/styles/variables'
 import Logger from 'src/utils/Logger'
 import { navigateToURI } from 'src/utils/linking'
 import { useRevokeCurrentPhoneNumber } from 'src/verify/hooks'
@@ -118,7 +120,6 @@ export const Account = ({ navigation, route }: Props) => {
   const showDeleteKeylessBackupError = useSelector(showDeleteKeylessBackupErrorSelector)
   const walletConnectEnabled = v2
   const connectedApplications = sessions.length
-  const headerHeight = useHeaderHeight()
 
   useEffect(() => {
     if (ValoraAnalytics.getSessionId() !== sessionId) {
@@ -437,10 +438,8 @@ export const Account = ({ navigation, route }: Props) => {
   }
 
   return (
-    <SafeAreaView
-      style={[styles.container, { paddingTop: headerHeight }]}
-      edges={['bottom', 'left', 'right']}
-    >
+    <SafeAreaView style={styles.container} edges={['bottom', 'left', 'right', 'top']}>
+      <CustomHeader left={<BackButton />} style={{ paddingHorizontal: variables.contentPadding }} />
       <ScrollView testID="SettingsScrollView">
         <TouchableWithoutFeedback onPress={onDevSettingsTriggerPress}>
           <Text style={styles.title} testID={'SettingsTitle'}>
@@ -611,12 +610,7 @@ export const Account = ({ navigation, route }: Props) => {
 }
 
 Account.navigationOptions = () => ({
-  ...headerWithBackButton,
-  headerTransparent: true,
-  headerShown: true,
-  headerStyle: {
-    backgroundColor: 'transparent',
-  },
+  ...noHeader,
 })
 
 const styles = StyleSheet.create({

--- a/src/account/Settings.tsx
+++ b/src/account/Settings.tsx
@@ -437,8 +437,8 @@ export const Account = ({ navigation, route }: Props) => {
   }
 
   return (
-    <SafeAreaView style={styles.container} edges={['bottom', 'left', 'right', 'top']}>
-      <CustomHeader left={<BackButton />} style={{ paddingHorizontal: variables.contentPadding }} />
+    <SafeAreaView style={styles.container}>
+      <CustomHeader left={<BackButton />} style={styles.paddingHorizontal} />
       <ScrollView testID="SettingsScrollView">
         <TouchableWithoutFeedback onPress={onDevSettingsTriggerPress}>
           <Text style={styles.title} testID={'SettingsTitle'}>
@@ -646,6 +646,9 @@ const styles = StyleSheet.create({
     color: colors.gray4,
     marginRight: Spacing.Smallest8,
     marginLeft: 4,
+  },
+  paddingHorizontal: {
+    paddingHorizontal: variables.contentPadding,
   },
 })
 

--- a/src/account/Settings.tsx
+++ b/src/account/Settings.tsx
@@ -71,7 +71,6 @@ import {
 import { deleteKeylessBackupStarted, hideDeleteKeylessBackupError } from 'src/keylessBackup/slice'
 import { KeylessBackupDeleteStatus } from 'src/keylessBackup/types'
 import { getLocalCurrencyCode } from 'src/localCurrency/selectors'
-import { noHeader } from 'src/navigator/Headers'
 import { ensurePincode, navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import { StackParamList } from 'src/navigator/types'
@@ -608,10 +607,6 @@ export const Account = ({ navigation, route }: Props) => {
     </SafeAreaView>
   )
 }
-
-Account.navigationOptions = () => ({
-  ...noHeader,
-})
 
 const styles = StyleSheet.create({
   container: {

--- a/src/navigator/Navigator.tsx
+++ b/src/navigator/Navigator.tsx
@@ -12,7 +12,7 @@ import AccounSetupFailureScreen from 'src/account/AccountSetupFailureScreen'
 import GoldEducation from 'src/account/GoldEducation'
 import Licenses from 'src/account/Licenses'
 import Profile from 'src/account/Profile'
-import SettingsScreen from 'src/account/Settings'
+import SettingsScreen, { Account } from 'src/account/Settings'
 import StoreWipeRecoveryScreen from 'src/account/StoreWipeRecoveryScreen'
 import Support from 'src/account/Support'
 import SupportContact from 'src/account/SupportContact'
@@ -529,7 +529,7 @@ const generalScreens = (Navigator: typeof Stack) => (
     <Navigator.Screen
       name={Screens.Settings}
       component={SettingsScreen}
-      options={headerWithBackButton}
+      options={Account.navigationOptions}
     />
     <Navigator.Screen name={Screens.Invite} component={Invite} options={noHeader} />
     <Navigator.Screen name={Screens.Support} component={Support} options={headerWithBackButton} />

--- a/src/navigator/Navigator.tsx
+++ b/src/navigator/Navigator.tsx
@@ -12,7 +12,7 @@ import AccounSetupFailureScreen from 'src/account/AccountSetupFailureScreen'
 import GoldEducation from 'src/account/GoldEducation'
 import Licenses from 'src/account/Licenses'
 import Profile from 'src/account/Profile'
-import SettingsScreen, { Account } from 'src/account/Settings'
+import SettingsScreen from 'src/account/Settings'
 import StoreWipeRecoveryScreen from 'src/account/StoreWipeRecoveryScreen'
 import Support from 'src/account/Support'
 import SupportContact from 'src/account/SupportContact'
@@ -526,11 +526,7 @@ const generalScreens = (Navigator: typeof Stack) => (
       component={ProfileMenu}
       options={ProfileMenu.navigationOptions as NativeStackNavigationOptions}
     />
-    <Navigator.Screen
-      name={Screens.Settings}
-      component={SettingsScreen}
-      options={Account.navigationOptions}
-    />
+    <Navigator.Screen name={Screens.Settings} component={SettingsScreen} options={noHeader} />
     <Navigator.Screen name={Screens.Invite} component={Invite} options={noHeader} />
     <Navigator.Screen name={Screens.Support} component={Support} options={headerWithBackButton} />
   </>


### PR DESCRIPTION
### Description

When the bottom sheet was opened on setting the header was shown in white instead of the same gray opaque seen on the rest of the screen. This PR fixes that on Android and iOS. 

#### Screenshots

| iOS Before | Android Before | iOS After | Android After |
| ----- | ----- | ----- | ----- |
| ![](https://github.com/valora-inc/wallet/assets/26950305/a22329e5-9b58-402c-97b5-cfa10e7799c6 "iOS Before") | ![](https://github.com/valora-inc/wallet/assets/26950305/b1c38381-a80a-423b-8d9b-2867b1ebf28c "Android Before") | ![](https://github.com/valora-inc/wallet/assets/26950305/0e54ddfe-7e8a-4be9-8a56-421ad65abc33 "iOS After") | ![](https://github.com/valora-inc/wallet/assets/26950305/07276b59-6f3e-4121-b477-00b58c46b464 "Android After") |

### Test plan

- [x] Tested locally on iOS
- [x] Tested locally on Android

### Related issues

- Fixes ACT-1153

### Backwards compatibility

Yes

### Network scalability

N/A
