### PR TITLE
fix(points): app mount sagas have not been running #2

### DIFF
--- a/src/points/saga.test.ts
+++ b/src/points/saga.test.ts
@@ -105,7 +105,7 @@ const mockServerErrorResponse = {
   text: jest.fn(() => Promise.resolve(mockServerErrorMessage)),
 }
 
-xdescribe('fetchHistory', () => {
+describe('fetchHistory', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     mockFetch.resetMocks()
@@ -138,7 +138,7 @@ xdescribe('fetchHistory', () => {
   })
 })
 
-xdescribe('getHistory', () => {
+describe('getHistory', () => {
   beforeEach(() => {
     jest.clearAllMocks()
   })
@@ -235,7 +235,7 @@ xdescribe('getHistory', () => {
   })
 })
 
-xdescribe('getPointsConfig', () => {
+describe('getPointsConfig', () => {
   beforeEach(() => {
     jest.clearAllMocks()
   })
@@ -332,7 +332,7 @@ xdescribe('getPointsConfig', () => {
   })
 })
 
-xdescribe('getPointsBalance', () => {
+describe('getPointsBalance', () => {
   beforeEach(() => {
     jest.clearAllMocks()
   })
@@ -384,7 +384,7 @@ xdescribe('getPointsBalance', () => {
   })
 })
 
-xdescribe('sendPointsEvent', () => {
+describe('sendPointsEvent', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     jest.useFakeTimers({ now: new Date(mockTime).getTime() })
@@ -449,7 +449,7 @@ xdescribe('sendPointsEvent', () => {
   })
 })
 
-xdescribe('sendPendingPointsEvents', () => {
+describe('sendPendingPointsEvents', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     jest.useFakeTimers({ now: new Date(mockTime).getTime() })
@@ -567,7 +567,7 @@ describe('watchAppMounted', () => {
       .dispatch(mockAction)
       .run()
 
-    expect(result.effects.call).toEqual([
+    expect(result.effects.fork).toEqual([
       spawn(getPointsConfig),
       spawn(getPointsBalance, getHistoryStarted({ getNextPage: false })),
       spawn(sendPendingPointsEvents),
@@ -575,7 +575,7 @@ describe('watchAppMounted', () => {
   })
 })
 
-xdescribe('fetchTrackPointsEventsEndpoint', () => {
+describe('fetchTrackPointsEventsEndpoint', () => {
   it('should call fetch with correct params', async () => {
     const mockEvent: PointsEvent = { activityId: 'create-wallet' }
     mockFetch.mockResponseOnce(JSON.stringify({ ok: true }))

--- a/src/points/saga.test.ts
+++ b/src/points/saga.test.ts
@@ -4,7 +4,7 @@ import { FetchMock } from 'jest-fetch-mock/types'
 import { expectSaga } from 'redux-saga-test-plan'
 import * as matchers from 'redux-saga-test-plan/matchers'
 import { throwError } from 'redux-saga-test-plan/providers'
-import { call, select } from 'redux-saga/effects'
+import { call, select, spawn } from 'redux-saga/effects'
 import { Actions as AppActions } from 'src/app/actions'
 import { retrieveSignedMessage } from 'src/pincode/authentication'
 import * as pointsSaga from 'src/points/saga'
@@ -105,7 +105,7 @@ const mockServerErrorResponse = {
   text: jest.fn(() => Promise.resolve(mockServerErrorMessage)),
 }
 
-describe('fetchHistory', () => {
+xdescribe('fetchHistory', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     mockFetch.resetMocks()
@@ -138,7 +138,7 @@ describe('fetchHistory', () => {
   })
 })
 
-describe('getHistory', () => {
+xdescribe('getHistory', () => {
   beforeEach(() => {
     jest.clearAllMocks()
   })
@@ -235,7 +235,7 @@ describe('getHistory', () => {
   })
 })
 
-describe('getPointsConfig', () => {
+xdescribe('getPointsConfig', () => {
   beforeEach(() => {
     jest.clearAllMocks()
   })
@@ -332,7 +332,7 @@ describe('getPointsConfig', () => {
   })
 })
 
-describe('getPointsBalance', () => {
+xdescribe('getPointsBalance', () => {
   beforeEach(() => {
     jest.clearAllMocks()
   })
@@ -384,7 +384,7 @@ describe('getPointsBalance', () => {
   })
 })
 
-describe('sendPointsEvent', () => {
+xdescribe('sendPointsEvent', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     jest.useFakeTimers({ now: new Date(mockTime).getTime() })
@@ -449,7 +449,7 @@ describe('sendPointsEvent', () => {
   })
 })
 
-describe('sendPendingPointsEvents', () => {
+xdescribe('sendPendingPointsEvents', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     jest.useFakeTimers({ now: new Date(mockTime).getTime() })
@@ -554,30 +554,28 @@ describe('watchAppMounted', () => {
     jest.clearAllMocks()
   })
 
-  it('should call sendPendingPointsEvents only once even if multiple "app mounted" actions are dispatched', async () => {
-    const mockSendPendingPointsEvents = jest.fn()
-    const mockGetPointsBalance = jest.fn()
-    const mockGetPointsConfig = jest.fn()
+  it('should spawn all sagas only once even if multiple "app mounted" actions are dispatched', async () => {
     const mockAction = { type: AppActions.APP_MOUNTED }
 
-    await expectSaga(watchAppMounted)
-      .withState(createMockStore().getState())
+    const result = await expectSaga(watchAppMounted)
       .provide([
-        [matchers.call.fn(pointsSaga.sendPendingPointsEvents), mockSendPendingPointsEvents()],
-        [matchers.call.fn(pointsSaga.getPointsBalance), mockGetPointsBalance()],
-        [matchers.call.fn(pointsSaga.getPointsConfig), mockGetPointsConfig()],
+        [spawn(getPointsConfig), null],
+        [spawn(getPointsBalance, getHistoryStarted({ getNextPage: false })), null],
+        [spawn(sendPendingPointsEvents), null],
       ])
       .dispatch(mockAction)
       .dispatch(mockAction)
       .run()
 
-    expect(mockSendPendingPointsEvents).toHaveBeenCalledTimes(1)
-    expect(mockGetPointsBalance).toHaveBeenCalledTimes(1)
-    expect(mockGetPointsConfig).toHaveBeenCalledTimes(1)
+    expect(result.effects.call).toEqual([
+      spawn(getPointsConfig),
+      spawn(getPointsBalance, getHistoryStarted({ getNextPage: false })),
+      spawn(sendPendingPointsEvents),
+    ])
   })
 })
 
-describe('fetchTrackPointsEventsEndpoint', () => {
+xdescribe('fetchTrackPointsEventsEndpoint', () => {
   it('should call fetch with correct params', async () => {
     const mockEvent: PointsEvent = { activityId: 'create-wallet' }
     mockFetch.mockResponseOnce(JSON.stringify({ ok: true }))

--- a/src/points/saga.ts
+++ b/src/points/saga.ts
@@ -36,7 +36,7 @@ import { fetchWithTimeout } from 'src/utils/fetchWithTimeout'
 import { safely } from 'src/utils/safely'
 import networkConfig from 'src/web3/networkConfig'
 import { walletAddressSelector } from 'src/web3/selectors'
-import { all, call, put, select, spawn, take, takeEvery, takeLeading } from 'typed-redux-saga'
+import { call, put, select, spawn, take, takeEvery, takeLeading } from 'typed-redux-saga'
 import { v4 as uuidv4 } from 'uuid'
 
 const TAG = 'Points/saga'
@@ -263,7 +263,9 @@ function* watchTrackPointsEvent() {
 
 export function* watchAppMounted() {
   yield* take(AppActions.APP_MOUNTED)
-  yield* all([safely(getPointsConfig), safely(getPointsBalance), safely(sendPendingPointsEvents)])
+  yield* spawn(getPointsConfig)
+  yield* spawn(getPointsBalance, getHistoryStarted({ getNextPage: false }))
+  yield* spawn(sendPendingPointsEvents)
 }
 
 export function* pointsSaga() {


### PR DESCRIPTION
### Description

Follow up PR to #5466 

1. Uses `spawn` to start sagas

`spawn` does not propagate errors to the parent, so if one of the spawned sagas will fail, this won't affect others -- effectively the same as when `safely` wrapper was used.

2.  Added simplified unit test to ensure the sagas are spawned only once during user session.

### Test plan

* Tested manually
* Added unit test

### Related issues

NA

### Backwards compatibility

Y

### Network scalability

NA