### PR TITLE
fix(points): prevent multiple track requests, fix balance mount animation

### DIFF
--- a/src/components/NumberTicker.tsx
+++ b/src/components/NumberTicker.tsx
@@ -92,7 +92,7 @@ export default function NumberTicker({
         const startValue = parseInt(startValueArray[index], 10)
         return (
           <Tick
-            key={`${value}-${index}}`}
+            key={`${value}-${index}`}
             startValue={startValue}
             endValue={endValue}
             textHeight={textHeight}

--- a/src/components/NumberTicker.tsx
+++ b/src/components/NumberTicker.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React, { useEffect, useRef } from 'react'
 import { Animated, StyleSheet, Text, TextStyle, View } from 'react-native'
 import { typeScale } from 'src/styles/fonts'
 
@@ -34,15 +34,20 @@ function TickText({ value, textStyle }: TickTextProps) {
 }
 
 function Tick({ startValue, endValue, textStyle, textHeight, animationDuration }: TickProps) {
-  const animatedValue = new Animated.Value(startValue * textHeight * -1)
-  const transformStyle = { transform: [{ translateY: animatedValue }] }
+  const animatedValue = useRef(new Animated.Value(startValue * textHeight * -1))
+
+  const transformStyle = { transform: [{ translateY: animatedValue.current }] }
   const duration = animationDuration ?? 1300
 
-  Animated.timing(animatedValue, {
-    toValue: endValue * textHeight * -1,
-    duration,
-    useNativeDriver: true,
-  }).start()
+  useEffect(() => {
+    if (animatedValue.current) {
+      Animated.timing(animatedValue.current, {
+        toValue: endValue * textHeight * -1,
+        duration,
+        useNativeDriver: true,
+      }).start()
+    }
+  }, [endValue])
 
   return (
     <Animated.View style={transformStyle}>
@@ -83,7 +88,7 @@ export default function NumberTicker({
         const startValue = parseInt(startValueArray[index], 10)
         return (
           <Tick
-            key={`${value}-${index}-${startValueArray[index]}`}
+            key={`${value}-${index}}`}
             startValue={startValue}
             endValue={endValue}
             textHeight={textHeight}

--- a/src/components/NumberTicker.tsx
+++ b/src/components/NumberTicker.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react'
+import React, { useEffect, useMemo, useRef } from 'react'
 import { Animated, StyleSheet, Text, TextStyle, View } from 'react-native'
 import { typeScale } from 'src/styles/fonts'
 
@@ -67,14 +67,18 @@ export default function NumberTicker({
 }: Props) {
   const textStyle = typeScale[typeScaleName]
   const textHeight = textStyle.lineHeight
-  const finalValueArray = value.toString().split('')
 
-  // For the startValueArray, map over each character in the finalValueArray to
-  // replace digits with random digits, do not change non-digit characters (e.g.
-  // decimal separator)
-  const startValueArray = finalValueArray.map((char) => {
-    return char.match(/\d/) ? Math.floor(Math.random() * 10).toString() : char
-  })
+  const { startValueArray, finalValueArray } = useMemo(() => {
+    const valueArray = value.toString().split('')
+    return {
+      finalValueArray: valueArray,
+      // map over each character in the value to replace digits with random
+      // digits, do not change non-digit characters (e.g. decimal separator)
+      startValueArray: valueArray.map((char) => {
+        return char.match(/\d/) ? Math.floor(Math.random() * 10).toString() : char
+      }),
+    }
+  }, [value])
 
   return (
     <View style={[styles.container, { height: textHeight }]} testID={testID}>

--- a/src/components/NumberTicker.tsx
+++ b/src/components/NumberTicker.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef } from 'react'
+import React, { useEffect, useRef } from 'react'
 import { Animated, StyleSheet, Text, TextStyle, View } from 'react-native'
 import { typeScale } from 'src/styles/fonts'
 
@@ -67,18 +67,14 @@ export default function NumberTicker({
 }: Props) {
   const textStyle = typeScale[typeScaleName]
   const textHeight = textStyle.lineHeight
+  const finalValueArray = value.toString().split('')
 
-  const { startValueArray, finalValueArray } = useMemo(() => {
-    const valueArray = value.toString().split('')
-    return {
-      finalValueArray: valueArray,
-      // map over each character in the value to replace digits with random
-      // digits, do not change non-digit characters (e.g. decimal separator)
-      startValueArray: valueArray.map((char) => {
-        return char.match(/\d/) ? Math.floor(Math.random() * 10).toString() : char
-      }),
-    }
-  }, [value])
+  // For the startValueArray, map over each character in the finalValueArray to
+  // replace digits with random digits, do not change non-digit characters (e.g.
+  // decimal separator)
+  const startValueArray = finalValueArray.map((char) => {
+    return char.match(/\d/) ? Math.floor(Math.random() * 10).toString() : char
+  })
 
   return (
     <View style={[styles.container, { height: textHeight }]} testID={testID}>

--- a/src/points/PointsHome.tsx
+++ b/src/points/PointsHome.tsx
@@ -46,7 +46,6 @@ export default function PointsHome({ route, navigation }: Props) {
   const pointsBalanceStatus = useSelector(pointsBalanceStatusSelector)
   const pointsHistoryStatus = useSelector(pointsHistoryStatusSelector)
 
-  const lastKnownPointsBalance = useRef(pointsBalance)
   const historyBottomSheetRef = useRef<BottomSheetRefType>(null)
   const activityCardBottomSheetRef = useRef<BottomSheetRefType>(null)
 
@@ -62,12 +61,6 @@ export default function PointsHome({ route, navigation }: Props) {
   useEffect(() => {
     onRefreshHistoryAndBalance()
   }, [])
-
-  useEffect(() => {
-    if (pointsBalanceStatus === 'success') {
-      lastKnownPointsBalance.current = pointsBalance
-    }
-  }, [pointsBalanceStatus])
 
   const onRefreshHistoryAndBalance = () => {
     dispatch(getHistoryStarted({ getNextPage: false }))
@@ -153,7 +146,7 @@ export default function PointsHome({ route, navigation }: Props) {
               <NumberTicker
                 testID="PointsBalance"
                 value={pointsBalance}
-                disableAnimation={lastKnownPointsBalance.current === pointsBalance}
+                disableAnimation={pointsBalanceStatus === 'loading'}
               />
               <LogoHeart size={28} />
             </View>

--- a/src/points/saga.ts
+++ b/src/points/saga.ts
@@ -1,9 +1,10 @@
 import { differenceInDays } from 'date-fns'
+import { isEqual } from 'lodash'
 import { Actions as AppActions } from 'src/app/actions'
 import { retrieveSignedMessage } from 'src/pincode/authentication'
 import {
   nextPageUrlSelector,
-  pendingPointsEvents,
+  pendingPointsEventsSelector,
   trackOnceActivitiesSelector,
 } from 'src/points/selectors'
 import {
@@ -192,6 +193,17 @@ export function* sendPointsEvent({ payload: event }: ReturnType<typeof trackPoin
     return
   }
 
+  const pendingPointsEvents = yield* select(pendingPointsEventsSelector)
+  if (pendingPointsEvents.some((pendingEvent) => isEqual(pendingEvent.event, event))) {
+    // this can happen for events that are tracked after a transaction is
+    // confirmed within the same app session, if it is also picked up by the
+    // internal transactions watcher. The trackPointsEvent action could be
+    // dispatched by the specific feature saga as well as the internal
+    // transactions watcher.
+    Logger.debug(TAG, `Skipping already pending tracked event: ${JSON.stringify(event)}`)
+    return
+  }
+
   const id = uuidv4()
 
   yield* put(
@@ -222,7 +234,7 @@ export function* sendPendingPointsEvents() {
   const LOG_TAG = `${TAG}@sendPendingPointsEvents`
 
   const now = new Date()
-  const pendingEvents = yield* select(pendingPointsEvents)
+  const pendingEvents = yield* select(pendingPointsEventsSelector)
 
   for (const pendingEvent of pendingEvents) {
     const { id, timestamp, event } = pendingEvent

--- a/src/points/selectors.ts
+++ b/src/points/selectors.ts
@@ -67,7 +67,7 @@ export const pointsSectionsSelector = createSelector(
   }
 )
 
-export const pendingPointsEvents = (state: RootState) => {
+export const pendingPointsEventsSelector = (state: RootState) => {
   return state.points.pendingPointsEvents
 }
 


### PR DESCRIPTION
### Description

This PR fixes 2 things:
1. if a transaction is settled within the same app session, it is most likely also picked up by our internal transaction watcher. previously, this was causing 2 almost simultaneous requests to our track points event backend (no bad side effects except we don't really need that extra request)
2. ensure that the points balance animates on screen open

### Test plan

The balance animates on mount but not on refresh if the balance hasn't changed:

https://github.com/valora-inc/wallet/assets/20150449/408ce7bc-a5b2-4b5b-bab1-d8f7432e5e2e


The balance animates on refresh if the balance has changed (I mocked the balance to return 1 of 3 random balances):

https://github.com/valora-inc/wallet/assets/20150449/31d53994-0165-4860-903a-0d442655e40e



### Related issues

n/a

### Backwards compatibility

Y

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [ ] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
