### PR TITLE
refactor(token-bottom-sheet): remove unused generic

### DIFF
--- a/src/components/TokenBottomSheet.test.tsx
+++ b/src/components/TokenBottomSheet.test.tsx
@@ -114,7 +114,7 @@ describe('TokenBottomSheet', () => {
     jest.clearAllMocks()
   })
 
-  function renderBottomSheet(props: Partial<TokenBottomSheetProps<TokenBalance>> = {}) {
+  function renderBottomSheet(props: Partial<TokenBottomSheetProps> = {}) {
     return render(
       <Provider store={mockStore}>
         <TokenBottomSheet

--- a/src/components/TokenBottomSheet.tsx
+++ b/src/components/TokenBottomSheet.tsx
@@ -34,15 +34,15 @@ export enum TokenPickerOrigin {
 
 export const DEBOUNCE_WAIT_TIME = 200
 
-export interface TokenBottomSheetProps<T extends TokenBalance> {
+export interface TokenBottomSheetProps {
   forwardedRef: RefObject<BottomSheetRefType>
   origin: TokenPickerOrigin
-  onTokenSelected: (token: T, tokenPositionInList: number) => void
+  onTokenSelected: (token: TokenBalance, tokenPositionInList: number) => void
   title: string
   titleStyle?: TextStyle
   searchEnabled?: boolean
   snapPoints?: (string | number)[]
-  tokens: T[]
+  tokens: TokenBalance[]
   TokenOptionComponent?: React.ComponentType<TokenOptionProps>
   showPriceUsdUnavailableWarning?: boolean
   filterChips?: FilterChip<TokenBalance>[]
@@ -87,7 +87,7 @@ function NoResults({
   )
 }
 
-function TokenBottomSheet<T extends TokenBalance>({
+function TokenBottomSheet({
   forwardedRef,
   snapPoints,
   origin,
@@ -99,7 +99,7 @@ function TokenBottomSheet<T extends TokenBalance>({
   showPriceUsdUnavailableWarning,
   filterChips = [],
   areSwapTokensShuffled,
-}: TokenBottomSheetProps<T>) {
+}: TokenBottomSheetProps) {
   const insets = useSafeAreaInsets()
 
   const filterChipsCarouselRef = useRef<ScrollView>(null)
@@ -157,7 +157,7 @@ function TokenBottomSheet<T extends TokenBalance>({
     }
   }
 
-  const onTokenPressed = (token: T, index: number) => () => {
+  const onTokenPressed = (token: TokenBalance, index: number) => () => {
     ValoraAnalytics.track(TokenBottomSheetEvents.token_selected, {
       origin,
       tokenAddress: token.address,


### PR DESCRIPTION
### Description

This was added in https://github.com/valora-inc/wallet/pull/4242 when we were working towards multichain, but now there shouldn't be a need for multiple TokenBalance types

### Test plan

CI

### Related issues

N/A

### Backwards compatibility

Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
