### PR TITLE
feat(cico): add token filters for cash in

### DIFF
--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -1957,7 +1957,9 @@
       "popular": "Popular",
       "recentlySwapped": "Recently swapped",
       "network": "{{networkName}} Network",
-      "selectNetwork": "Network"
+      "selectNetwork": "Network",
+      "stablecoins": "Stablecoins",
+      "gasTokens": "Gas Tokens"
     }
   },
   "homeActions": {

--- a/src/components/FilterChipsCarousel.tsx
+++ b/src/components/FilterChipsCarousel.tsx
@@ -56,6 +56,7 @@ function FilterChipsCarousel<T>({
       style={[styles.container, style]}
       contentContainerStyle={[styles.contentContainer, { width: scrollEnabled ? 'auto' : '100%' }]}
       ref={forwardedRef}
+      testID="FilterChipsCarousel"
     >
       {chips.map((chip) => {
         return (

--- a/src/components/TokenBottomSheet.tsx
+++ b/src/components/TokenBottomSheet.tsx
@@ -312,7 +312,12 @@ function TokenBottomSheet({
   return (
     <>
       {isScreen ? (
-        <View style={styles.screenContainer} testID="TokenBottomSheet">
+        <View
+          // use fixed height if there are filter chips, otherwise the bottom
+          // sheet height changes as tokens as filtered
+          style={filterChips.length ? styles.screenContainerFixed : styles.screenContainer}
+          testID="TokenBottomSheet"
+        >
           {content}
         </View>
       ) : (
@@ -349,6 +354,9 @@ const styles = StyleSheet.create({
   },
   screenContainer: {
     maxHeight: variables.height * 0.9,
+  },
+  screenContainerFixed: {
+    height: variables.height * 0.9,
   },
   searchInput: {
     marginTop: Spacing.Regular16,

--- a/src/fiatExchanges/FiatExchangeCurrencyBottomSheet.test.tsx
+++ b/src/fiatExchanges/FiatExchangeCurrencyBottomSheet.test.tsx
@@ -1,96 +1,25 @@
-import { render } from '@testing-library/react-native'
+import { fireEvent, render, within } from '@testing-library/react-native'
 import React from 'react'
 import { Provider } from 'react-redux'
 import FiatExchangeCurrencyBottomSheet from 'src/fiatExchanges/FiatExchangeCurrencyBottomSheet'
 import { FiatExchangeFlow } from 'src/fiatExchanges/utils'
-import { getDynamicConfigParams } from 'src/statsig'
-import { NetworkId } from 'src/transactions/types'
+import { getDynamicConfigParams, getFeatureGate } from 'src/statsig'
+import { StatsigDynamicConfigs, StatsigFeatureGates } from 'src/statsig/types'
 import MockedNavigator from 'test/MockedNavigator'
 import { createMockStore } from 'test/utils'
 import {
-  mockCeloAddress,
   mockCeloTokenId,
-  mockCeurAddress,
   mockCeurTokenId,
-  mockCrealAddress,
   mockCrealTokenId,
-  mockCusdAddress,
   mockCusdTokenId,
   mockEthTokenId,
+  mockTokenBalances,
 } from 'test/values'
-
-const mockDate = 1588200517518
 
 const MOCK_STORE_DATA = {
   tokens: {
     tokenBalances: {
-      [mockCusdTokenId]: {
-        tokenId: mockCusdTokenId,
-        networkId: NetworkId['celo-alfajores'],
-        name: 'cUSD',
-        address: mockCusdAddress,
-        balance: '50',
-        priceUsd: '1',
-        symbol: 'cUSD',
-        priceFetchedAt: mockDate,
-        isSwappable: true,
-        showZeroBalance: true,
-        isCashInEligible: true,
-        isCashOutEligible: true,
-      },
-      [mockCeurTokenId]: {
-        tokenId: mockCeurTokenId,
-        networkId: NetworkId['celo-alfajores'],
-        name: 'cEUR',
-        address: mockCeurAddress,
-        balance: '0',
-        priceUsd: '0.5',
-        symbol: 'cEUR',
-        isSupercharged: true,
-        priceFetchedAt: mockDate,
-        showZeroBalance: true,
-        isCashInEligible: true,
-        isCashOutEligible: true,
-      },
-      [mockCeloTokenId]: {
-        tokenId: mockCeloTokenId,
-        networkId: NetworkId['celo-alfajores'],
-        name: 'Celo',
-        address: mockCeloAddress,
-        balance: '0',
-        priceUsd: '0.2',
-        symbol: 'CELO',
-        isSupercharged: true,
-        priceFetchedAt: mockDate,
-        showZeroBalance: true,
-        isCashInEligible: true,
-        isCashOutEligible: true,
-      },
-      [mockCrealTokenId]: {
-        tokenId: mockCrealTokenId,
-        networkId: NetworkId['celo-alfajores'],
-        name: 'cREAL',
-        address: mockCrealAddress,
-        balance: '10',
-        priceUsd: '0.75',
-        symbol: 'cREAL',
-        isSupercharged: true,
-        priceFetchedAt: mockDate,
-        showZeroBalance: true,
-        isCashInEligible: true,
-      },
-      [mockEthTokenId]: {
-        tokenId: mockEthTokenId,
-        networkId: NetworkId['ethereum-sepolia'],
-        name: 'Ether',
-        balance: '0',
-        priceUsd: '0.1000',
-        symbol: 'ETH',
-        isSupercharged: true,
-        priceFetchedAt: mockDate,
-        showZeroBalance: true,
-        isCashInEligible: true,
-      },
+      ...mockTokenBalances,
     },
   },
 }
@@ -111,174 +40,244 @@ jest.mock('src/web3/networkConfig', () => {
   }
 })
 
-jest.mock('src/statsig', () => ({
-  getDynamicConfigParams: jest.fn(),
-}))
+jest.mock('src/statsig')
 
 describe(FiatExchangeCurrencyBottomSheet, () => {
   const mockStore = createMockStore(MOCK_STORE_DATA)
   beforeEach(() => {
     jest.clearAllMocks()
-    jest.mocked(getDynamicConfigParams).mockReturnValue({
-      showCico: ['celo-alfajores'],
-      tokenInfo: {
-        [mockEthTokenId]: { cicoOrder: 1 },
-        [mockCeloTokenId]: { cicoOrder: 2 },
-        [mockCusdTokenId]: { cicoOrder: 3 },
-        [mockCeurTokenId]: { cicoOrder: 4 },
-        [mockCrealTokenId]: { cicoOrder: 5 },
-      },
+    jest.mocked(getFeatureGate).mockReturnValue(false)
+    jest.mocked(getDynamicConfigParams).mockImplementation(({ configName, defaultValues }) => {
+      switch (configName) {
+        case StatsigDynamicConfigs.MULTI_CHAIN_FEATURES:
+          return {
+            ...defaultValues,
+            showCico: ['celo-alfajores', 'ethereum-sepolia'],
+          }
+        case StatsigDynamicConfigs.CICO_TOKEN_INFO:
+          return {
+            tokenInfo: {
+              [mockEthTokenId]: { cicoOrder: 1 },
+              [mockCeloTokenId]: { cicoOrder: 2 },
+              [mockCusdTokenId]: { cicoOrder: 3 },
+              [mockCeurTokenId]: { cicoOrder: 4 },
+              [mockCrealTokenId]: { cicoOrder: 5 },
+            },
+          }
+        case StatsigDynamicConfigs.SWAP_CONFIG:
+          return {
+            popularTokenIds: [mockEthTokenId, mockCeloTokenId],
+          }
+        default:
+          return defaultValues
+      }
     })
   })
-  it('shows the correct tokens for cash in (multichain disabled, no ETH)', () => {
-    const { queryByTestId, getAllByTestId } = render(
-      <Provider store={mockStore}>
-        <MockedNavigator
-          component={FiatExchangeCurrencyBottomSheet}
-          params={{
-            flow: FiatExchangeFlow.CashIn,
-          }}
-        />
-      </Provider>
-    )
-    expect(getAllByTestId('TokenBalanceItem')[0]).toHaveTextContent('CELO')
-    expect(getAllByTestId('TokenBalanceItem')[1]).toHaveTextContent('cUSD')
-    expect(getAllByTestId('TokenBalanceItem')[2]).toHaveTextContent('cEUR')
-    expect(getAllByTestId('TokenBalanceItem')[3]).toHaveTextContent('cREAL')
-    expect(queryByTestId('ETHSymbol')).toBeFalsy()
-  })
-  it('shows the correct tokens for cash in (multichain)', () => {
-    jest.mocked(getDynamicConfigParams).mockReturnValue({
-      showCico: ['celo-alfajores', 'ethereum-sepolia'],
-      tokenInfo: {
-        [mockEthTokenId]: { cicoOrder: 1 },
-        [mockCeloTokenId]: { cicoOrder: 2 },
-        [mockCusdTokenId]: { cicoOrder: 3 },
-        [mockCeurTokenId]: { cicoOrder: 4 },
-        [mockCrealTokenId]: { cicoOrder: 5 },
-      },
-    })
+  it('shows the correct tokens for cash in', () => {
     const { getAllByTestId } = render(
       <Provider store={mockStore}>
         <MockedNavigator
           component={FiatExchangeCurrencyBottomSheet}
-          params={{
-            flow: FiatExchangeFlow.CashIn,
-          }}
+          params={{ flow: FiatExchangeFlow.CashIn }}
         />
       </Provider>
     )
-    expect(getAllByTestId('TokenBalanceItem')[0]).toHaveTextContent('ETH')
-    expect(getAllByTestId('TokenBalanceItem')[1]).toHaveTextContent('CELO')
-    expect(getAllByTestId('TokenBalanceItem')[2]).toHaveTextContent('cUSD')
-    expect(getAllByTestId('TokenBalanceItem')[3]).toHaveTextContent('cEUR')
-    expect(getAllByTestId('TokenBalanceItem')[4]).toHaveTextContent('cREAL')
+    expect(getAllByTestId('TokenBalanceItem')).toHaveLength(6)
+    ;['ETH', 'CELO', 'cUSD', 'cEUR', 'cREAL', 'USDC'].forEach((token, index) => {
+      expect(getAllByTestId('TokenBalanceItem')[index]).toHaveTextContent(token)
+    })
   })
   it('shows the correct tokens for cash out', () => {
-    const { queryByTestId, getAllByTestId } = render(
+    const { getAllByTestId } = render(
       <Provider store={mockStore}>
         <MockedNavigator
           component={FiatExchangeCurrencyBottomSheet}
-          params={{
-            flow: FiatExchangeFlow.CashOut,
-          }}
+          params={{ flow: FiatExchangeFlow.CashOut }}
         />
       </Provider>
     )
-    expect(getAllByTestId('TokenBalanceItem')[0]).toHaveTextContent('CELO')
-    expect(getAllByTestId('TokenBalanceItem')[1]).toHaveTextContent('cUSD')
-    expect(getAllByTestId('TokenBalanceItem')[2]).toHaveTextContent('cEUR')
-    expect(queryByTestId('cREALSymbol')).toBeFalsy()
-  })
-  it('shows the correct tokens for cash out (multichain)', () => {
-    jest.mocked(getDynamicConfigParams).mockReturnValue({
-      showCico: ['celo-alfajores', 'ethereum-sepolia'],
-      tokenInfo: {
-        [mockEthTokenId]: { cicoOrder: 1 },
-        [mockCeloTokenId]: { cicoOrder: 2 },
-        [mockCusdTokenId]: { cicoOrder: 3 },
-        [mockCeurTokenId]: { cicoOrder: 4 },
-        [mockCrealTokenId]: { cicoOrder: 5 },
-      },
+    expect(getAllByTestId('TokenBalanceItem')).toHaveLength(2)
+    ;['CELO', 'cUSD'].forEach((token, index) => {
+      expect(getAllByTestId('TokenBalanceItem')[index]).toHaveTextContent(token)
     })
-    const { queryByTestId, getAllByTestId } = render(
-      <Provider store={mockStore}>
-        <MockedNavigator
-          component={FiatExchangeCurrencyBottomSheet}
-          params={{
-            flow: FiatExchangeFlow.CashOut,
-          }}
-        />
-      </Provider>
-    )
-    expect(getAllByTestId('TokenBalanceItem')[0]).toHaveTextContent('CELO')
-    expect(getAllByTestId('TokenBalanceItem')[1]).toHaveTextContent('cUSD')
-    expect(getAllByTestId('TokenBalanceItem')[2]).toHaveTextContent('cEUR')
-    expect(queryByTestId('cREALSymbol')).toBeFalsy()
-    expect(queryByTestId('ETHSymbol')).toBeFalsy()
   })
   it('shows the correct tokens for cash spend', () => {
-    const { queryByTestId, getAllByTestId } = render(
+    const { getAllByTestId } = render(
       <Provider store={mockStore}>
         <MockedNavigator
           component={FiatExchangeCurrencyBottomSheet}
-          params={{
-            flow: FiatExchangeFlow.Spend,
-          }}
+          params={{ flow: FiatExchangeFlow.Spend }}
         />
       </Provider>
     )
-    expect(getAllByTestId('TokenBalanceItem')[0]).toHaveTextContent('cUSD')
-    expect(getAllByTestId('TokenBalanceItem')[1]).toHaveTextContent('cEUR')
-    expect(queryByTestId('CELOSymbol')).toBeFalsy()
-    expect(queryByTestId('cREALSymbol')).toBeFalsy()
-  })
-  it('shows the correct tokens for cash spend (multichain)', () => {
-    jest.mocked(getDynamicConfigParams).mockReturnValue({
-      showCico: ['celo-alfajores', 'ethereum-sepolia'],
-      tokenInfo: {
-        [mockEthTokenId]: { cicoOrder: 1 },
-        [mockCeloTokenId]: { cicoOrder: 2 },
-        [mockCusdTokenId]: { cicoOrder: 3 },
-        [mockCeurTokenId]: { cicoOrder: 4 },
-        [mockCrealTokenId]: { cicoOrder: 5 },
-      },
+    expect(getAllByTestId('TokenBalanceItem')).toHaveLength(2)
+    ;['cUSD', 'cEUR'].forEach((token, index) => {
+      expect(getAllByTestId('TokenBalanceItem')[index]).toHaveTextContent(token)
     })
-    const { queryByTestId, getAllByTestId } = render(
-      <Provider store={mockStore}>
-        <MockedNavigator
-          component={FiatExchangeCurrencyBottomSheet}
-          params={{
-            flow: FiatExchangeFlow.Spend,
-          }}
-        />
-      </Provider>
-    )
-    expect(getAllByTestId('TokenBalanceItem')[0]).toHaveTextContent('cUSD')
-    expect(getAllByTestId('TokenBalanceItem')[1]).toHaveTextContent('cEUR')
-    expect(queryByTestId('CELOSymbol')).toBeFalsy()
-    expect(queryByTestId('cREALSymbol')).toBeFalsy()
-    expect(queryByTestId('ETHSymbol')).toBeFalsy()
   })
   it('shows the correct order when cicoOrder missing/same value', () => {
-    jest.mocked(getDynamicConfigParams).mockReturnValue({
-      showCico: ['celo-alfajores', 'ethereum-sepolia'],
-      tokenInfo: { [mockCusdTokenId]: { cicoOrder: 1 }, [mockCrealTokenId]: { cicoOrder: 1 } },
+    jest.mocked(getDynamicConfigParams).mockImplementation(({ configName, defaultValues }) => {
+      switch (configName) {
+        case StatsigDynamicConfigs.MULTI_CHAIN_FEATURES:
+          return {
+            ...defaultValues,
+            showCico: ['celo-alfajores', 'ethereum-sepolia'],
+          }
+        case StatsigDynamicConfigs.CICO_TOKEN_INFO:
+          return {
+            tokenInfo: {
+              [mockCusdTokenId]: { cicoOrder: 1 },
+              [mockCrealTokenId]: { cicoOrder: 1 },
+            },
+          }
+        default:
+          return defaultValues
+      }
     })
     const { getAllByTestId } = render(
       <Provider store={mockStore}>
         <MockedNavigator
           component={FiatExchangeCurrencyBottomSheet}
-          params={{
-            flow: FiatExchangeFlow.CashIn,
-          }}
+          params={{ flow: FiatExchangeFlow.CashIn }}
         />
       </Provider>
     )
-    expect(getAllByTestId('TokenBalanceItem')[0]).toHaveTextContent('cUSD')
-    expect(getAllByTestId('TokenBalanceItem')[1]).toHaveTextContent('cREAL')
-    expect(getAllByTestId('TokenBalanceItem')[2]).toHaveTextContent('cEUR')
-    expect(getAllByTestId('TokenBalanceItem')[3]).toHaveTextContent('CELO')
-    expect(getAllByTestId('TokenBalanceItem')[4]).toHaveTextContent('ETH')
+    expect(getAllByTestId('TokenBalanceItem')).toHaveLength(6)
+    ;['cUSD', 'cREAL', 'cEUR', 'CELO', 'ETH', 'USDC'].forEach((token, index) => {
+      expect(getAllByTestId('TokenBalanceItem')[index]).toHaveTextContent(token)
+    })
+  })
+
+  it.each([
+    { flow: FiatExchangeFlow.CashIn, gate: false },
+    { flow: FiatExchangeFlow.CashOut, gate: true },
+    { flow: FiatExchangeFlow.Spend, gate: true },
+  ])(`does not show filters for $flow when gate is $gate`, ({ flow, gate }) => {
+    jest
+      .mocked(getFeatureGate)
+      .mockImplementation(
+        (feature) => feature === StatsigFeatureGates.SHOW_CASH_IN_TOKEN_FILTERS && gate
+      )
+    const { queryByTestId } = render(
+      <Provider store={mockStore}>
+        <MockedNavigator component={FiatExchangeCurrencyBottomSheet} params={{ flow }} />
+      </Provider>
+    )
+    expect(queryByTestId('FilterChipsCarousel')).toBeFalsy()
+  })
+
+  it('shows filters for cash in when gate is true', () => {
+    jest
+      .mocked(getFeatureGate)
+      .mockImplementation((feature) => feature === StatsigFeatureGates.SHOW_CASH_IN_TOKEN_FILTERS)
+    const { getByTestId, getByText } = render(
+      <Provider store={mockStore}>
+        <MockedNavigator
+          component={FiatExchangeCurrencyBottomSheet}
+          params={{ flow: FiatExchangeFlow.CashIn }}
+        />
+      </Provider>
+    )
+    expect(getByTestId('FilterChipsCarousel')).toBeTruthy()
+    expect(getByText('tokenBottomSheet.filters.popular')).toBeTruthy()
+    expect(getByText('tokenBottomSheet.filters.stablecoins')).toBeTruthy()
+    expect(getByText('tokenBottomSheet.filters.gasTokens')).toBeTruthy()
+    expect(getByText('tokenBottomSheet.filters.selectNetwork')).toBeTruthy()
+  })
+
+  it('popular filter filters correctly', () => {
+    jest
+      .mocked(getFeatureGate)
+      .mockImplementation((feature) => feature === StatsigFeatureGates.SHOW_CASH_IN_TOKEN_FILTERS)
+    const { getAllByTestId, getByText } = render(
+      <Provider store={mockStore}>
+        <MockedNavigator
+          component={FiatExchangeCurrencyBottomSheet}
+          params={{ flow: FiatExchangeFlow.CashIn }}
+        />
+      </Provider>
+    )
+
+    expect(getAllByTestId('TokenBalanceItem')).toHaveLength(6)
+    fireEvent.press(getByText('tokenBottomSheet.filters.popular'))
+    expect(getAllByTestId('TokenBalanceItem')).toHaveLength(2)
+    ;['ETH', 'CELO'].forEach((token, index) => {
+      expect(getAllByTestId('TokenBalanceItem')[index]).toHaveTextContent(token)
+    })
+  })
+
+  it('stablecoin filter filters correctly', () => {
+    jest
+      .mocked(getFeatureGate)
+      .mockImplementation((feature) => feature === StatsigFeatureGates.SHOW_CASH_IN_TOKEN_FILTERS)
+    const { getAllByTestId, getByText } = render(
+      <Provider store={mockStore}>
+        <MockedNavigator
+          component={FiatExchangeCurrencyBottomSheet}
+          params={{ flow: FiatExchangeFlow.CashIn }}
+        />
+      </Provider>
+    )
+
+    expect(getAllByTestId('TokenBalanceItem')).toHaveLength(6)
+    fireEvent.press(getByText('tokenBottomSheet.filters.stablecoins'))
+    expect(getAllByTestId('TokenBalanceItem')).toHaveLength(4)
+    ;['cUSD', 'cEUR', 'cREAL', 'USDC'].forEach((token, index) => {
+      expect(getAllByTestId('TokenBalanceItem')[index]).toHaveTextContent(token)
+    })
+  })
+
+  it('gas tokens filter filters correctly', () => {
+    jest
+      .mocked(getFeatureGate)
+      .mockImplementation((feature) => feature === StatsigFeatureGates.SHOW_CASH_IN_TOKEN_FILTERS)
+    const { getAllByTestId, getByText } = render(
+      <Provider store={mockStore}>
+        <MockedNavigator
+          component={FiatExchangeCurrencyBottomSheet}
+          params={{ flow: FiatExchangeFlow.CashIn }}
+        />
+      </Provider>
+    )
+
+    expect(getAllByTestId('TokenBalanceItem')).toHaveLength(6)
+    fireEvent.press(getByText('tokenBottomSheet.filters.gasTokens'))
+    expect(getAllByTestId('TokenBalanceItem')).toHaveLength(5)
+    ;['ETH', 'CELO', 'cUSD', 'cEUR', 'cREAL'].forEach((token, index) => {
+      expect(getAllByTestId('TokenBalanceItem')[index]).toHaveTextContent(token)
+    })
+  })
+
+  it('network filter filters correctly', () => {
+    jest
+      .mocked(getFeatureGate)
+      .mockImplementation((feature) => feature === StatsigFeatureGates.SHOW_CASH_IN_TOKEN_FILTERS)
+    const { getAllByTestId, getByText } = render(
+      <Provider store={mockStore}>
+        <MockedNavigator
+          component={FiatExchangeCurrencyBottomSheet}
+          params={{ flow: FiatExchangeFlow.CashIn }}
+        />
+      </Provider>
+    )
+
+    const networkMultiSelect = getAllByTestId('MultiSelectBottomSheet')[0]
+
+    expect(getAllByTestId('TokenBalanceItem')).toHaveLength(6)
+    fireEvent.press(getByText('tokenBottomSheet.filters.selectNetwork'))
+
+    // select celo filter
+    fireEvent.press(within(networkMultiSelect).getByTestId('Celo Alfajores-icon'))
+    expect(getAllByTestId('TokenBalanceItem')).toHaveLength(4)
+    ;['CELO', 'cUSD', 'cEUR', 'cREAL'].forEach((token, index) => {
+      expect(getAllByTestId('TokenBalanceItem')[index]).toHaveTextContent(token)
+    })
+
+    // select eth filter
+    fireEvent.press(within(networkMultiSelect).getByTestId('Ethereum Sepolia-icon'))
+    expect(getAllByTestId('TokenBalanceItem')).toHaveLength(2)
+    ;['ETH', 'USDC'].forEach((token, index) => {
+      expect(getAllByTestId('TokenBalanceItem')[index]).toHaveTextContent(token)
+    })
   })
 })

--- a/src/fiatExchanges/FiatExchangeCurrencyBottomSheet.tsx
+++ b/src/fiatExchanges/FiatExchangeCurrencyBottomSheet.tsx
@@ -1,19 +1,78 @@
 import { BottomSheetScreenProps } from '@th3rdwave/react-navigation-bottom-sheet'
 import React, { useEffect, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
+import { FilterChip } from 'src/components/FilterChipsCarousel'
 import TokenBottomSheet, { TokenPickerOrigin } from 'src/components/TokenBottomSheet'
 import { fetchFiatConnectProviders } from 'src/fiatconnect/slice'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import { StackParamList } from 'src/navigator/types'
-import { useDispatch } from 'src/redux/hooks'
+import { useDispatch, useSelector } from 'src/redux/hooks'
+import { getDynamicConfigParams, getFeatureGate } from 'src/statsig'
+import { DynamicConfigs } from 'src/statsig/constants'
+import { StatsigDynamicConfigs, StatsigFeatureGates } from 'src/statsig/types'
 import { useCashInTokens, useCashOutTokens, useSpendTokens } from 'src/tokens/hooks'
+import { allFeeCurrenciesSelector } from 'src/tokens/selectors'
 import { TokenBalance } from 'src/tokens/slice'
 import { sortCicoTokens } from 'src/tokens/utils'
+import { NetworkId } from 'src/transactions/types'
 import { resolveCurrency } from 'src/utils/currencies'
 import { CICOFlow, FiatExchangeFlow } from './utils'
 
 type Props = BottomSheetScreenProps<StackParamList, Screens.FiatExchangeCurrencyBottomSheet>
+
+function useFilterChips(flow: FiatExchangeFlow): FilterChip<TokenBalance>[] {
+  const { t } = useTranslation()
+  const feeCurrencies = useSelector(allFeeCurrenciesSelector)
+  const feeTokenIds = useMemo(
+    () => new Set(feeCurrencies.map((currency) => currency.tokenId)),
+    [feeCurrencies]
+  )
+  if (
+    flow !== FiatExchangeFlow.CashIn ||
+    !getFeatureGate(StatsigFeatureGates.SHOW_CASH_IN_TOKEN_FILTERS)
+  ) {
+    return []
+  }
+  const supportedNetworkIds = getDynamicConfigParams(
+    DynamicConfigs[StatsigDynamicConfigs.MULTI_CHAIN_FEATURES]
+  ).showCico
+  // reuse the same popular tokens as for swap
+  const popularTokenIds: string[] = getDynamicConfigParams(
+    DynamicConfigs[StatsigDynamicConfigs.SWAP_CONFIG]
+  ).popularTokenIds
+
+  return [
+    {
+      id: 'popular',
+      name: t('tokenBottomSheet.filters.popular'),
+      filterFn: (token: TokenBalance) => popularTokenIds.includes(token.tokenId),
+      isSelected: false,
+    },
+    {
+      id: 'stablecoins',
+      name: t('tokenBottomSheet.filters.stablecoins'),
+      filterFn: (token: TokenBalance) => !!token.isStableCoin,
+      isSelected: false,
+    },
+    {
+      id: 'gas-tokens',
+      name: t('tokenBottomSheet.filters.gasTokens'),
+      filterFn: (token: TokenBalance) => feeTokenIds.has(token.tokenId),
+      isSelected: false,
+    },
+    {
+      id: 'network-ids',
+      name: t('tokenBottomSheet.filters.selectNetwork'),
+      filterFn: (token: TokenBalance, selected?: NetworkId[]) => {
+        return !!selected && selected.includes(token.networkId)
+      },
+      isSelected: false,
+      allNetworkIds: supportedNetworkIds,
+      selectedNetworkIds: supportedNetworkIds,
+    },
+  ]
+}
 
 function FiatExchangeCurrencyBottomSheet({ route }: Props) {
   const { t } = useTranslation()
@@ -29,7 +88,8 @@ function FiatExchangeCurrencyBottomSheet({ route }: Props) {
         ? cashOutTokens
         : spendTokens
 
-  const tokenList = useMemo(() => unsortedTokenList.sort(sortCicoTokens), [unsortedTokenList])
+  const tokenList = useMemo(() => [...unsortedTokenList].sort(sortCicoTokens), [unsortedTokenList])
+  const filterChips = useFilterChips(flow)
 
   // Fetch FiatConnect providers silently in the background early in the CICO funnel
   useEffect(() => {
@@ -64,6 +124,7 @@ function FiatExchangeCurrencyBottomSheet({ route }: Props) {
             ? TokenPickerOrigin.CashOut
             : TokenPickerOrigin.Spend
       }
+      filterChips={filterChips}
     />
   )
 }

--- a/src/statsig/constants.ts
+++ b/src/statsig/constants.ts
@@ -29,6 +29,7 @@ export const FeatureGates = {
   [StatsigFeatureGates.SHOW_POINTS]: false,
   [StatsigFeatureGates.SHOW_STABLECOIN_EARN]: false,
   [StatsigFeatureGates.SUBSIDIZE_STABLECOIN_EARN_GAS_FEES]: false,
+  [StatsigFeatureGates.SHOW_CASH_IN_TOKEN_FILTERS]: false,
 } satisfies { [key in StatsigFeatureGates]: boolean }
 
 export const ExperimentConfigs = {

--- a/src/statsig/types.ts
+++ b/src/statsig/types.ts
@@ -32,6 +32,7 @@ export enum StatsigFeatureGates {
   SHOW_POINTS = 'show_points',
   SHOW_STABLECOIN_EARN = 'show_stablecoin_earn',
   SUBSIDIZE_STABLECOIN_EARN_GAS_FEES = 'subsidize_stablecoin_earn_gas_fees',
+  SHOW_CASH_IN_TOKEN_FILTERS = 'show_cash_in_token_filters',
 }
 
 export enum StatsigExperiments {

--- a/src/tokens/hooks.test.tsx
+++ b/src/tokens/hooks.test.tsx
@@ -25,6 +25,7 @@ import {
   mockCusdTokenId,
   mockPoofTokenId,
   mockTokenBalances,
+  mockUSDCTokenId,
 } from 'test/values'
 
 jest.mock('src/statsig')
@@ -345,6 +346,7 @@ describe('useCashInTokens', () => {
       mockCeloTokenId,
       mockCrealTokenId,
       ethTokenId,
+      mockUSDCTokenId,
     ])
   })
 })

--- a/src/tokens/selectors.ts
+++ b/src/tokens/selectors.ts
@@ -492,6 +492,13 @@ export const feeCurrenciesSelector = createSelector(
   }
 )
 
+export const allFeeCurrenciesSelector = createSelector(
+  feeCurrenciesByNetworkIdSelector,
+  (feeCurrencies) => {
+    return Object.values(feeCurrencies).flat()
+  }
+)
+
 // Note this takes a networkId as parameter
 export const feeCurrenciesWithPositiveBalancesSelector = createSelector(
   feeCurrenciesSelector,

--- a/test/values.ts
+++ b/test/values.ts
@@ -468,6 +468,7 @@ export const mockTokenBalances: Record<string, StoredTokenBalance> = {
     priceFetchedAt: Date.now(),
     isCashInEligible: true,
     isCashOutEligible: true,
+    isStableCoin: true,
   },
   [mockCusdTokenId]: {
     priceUsd: '1.001',
@@ -486,6 +487,7 @@ export const mockTokenBalances: Record<string, StoredTokenBalance> = {
     showZeroBalance: true,
     isCashInEligible: true,
     isCashOutEligible: true,
+    isStableCoin: true,
   },
   [mockCeloTokenId]: {
     priceUsd: '13.25085583155252100584',
@@ -521,6 +523,7 @@ export const mockTokenBalances: Record<string, StoredTokenBalance> = {
     canTransferWithComment: true,
     priceFetchedAt: Date.now(),
     isCashInEligible: true,
+    isStableCoin: true,
   },
   [mockEthTokenId]: {
     priceUsd: '1500',
@@ -535,6 +538,8 @@ export const mockTokenBalances: Record<string, StoredTokenBalance> = {
     balance: '0',
     priceFetchedAt: Date.now(),
     isNative: true,
+    isCashInEligible: true,
+    isCashOutEligible: true,
   },
   [mockUSDCTokenId]: {
     name: 'USDC coin',
@@ -547,6 +552,9 @@ export const mockTokenBalances: Record<string, StoredTokenBalance> = {
     balance: '0',
     priceUsd: '1',
     priceFetchedAt: Date.now(),
+    isStableCoin: true,
+    isCashInEligible: true,
+    isCashOutEligible: true,
   },
   [mockArbEthTokenId]: {
     name: 'Ethereum',


### PR DESCRIPTION
### Description

Adds token filters for cash in flow only, gated by [statsig feature gate](https://console.statsig.com/4plizaPmWwPL21ASV4QAO0/gates/show_cash_in_token_filters)

### Test plan

Unit tests, manual

https://github.com/valora-inc/wallet/assets/5062591/ab18b07a-11df-4628-8305-cc43691fdba9


### Related issues

- Fixes ACT-1170

### Backwards compatibility

Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
