### PR TITLE
chore(renovate): set low priority for grandle dependencies

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -48,6 +48,11 @@
       prPriority: 0,
     },
     {
+      // Low priority for gradle dependencies
+      matchManagers: ['gradle', 'gradle-wrapper'],
+      prPriority: -1,
+    },
+    {
       // Group updates for @celo packages
       matchPackagePatterns: ['^@celo/'],
       groupName: 'celo',


### PR DESCRIPTION
### Description

Renovate recently started prioritizing gradle dependencies higher than npm dependencies, which looks related to https://github.com/renovatebot/renovate/discussions/29298, setting an explicit priority to see if it helps before the latest renovate version is used (this happened when renovate version went from 37.368.10 to 37.377.8)

### Test plan

Watch renovate after merge

### Related issues

N/A

### Backwards compatibility

N/A

### Network scalability

N/A
