### PR TITLE
fix(send): Fix bug where you can't send max amount

### DIFF
--- a/src/send/EnterAmount.tsx
+++ b/src/send/EnterAmount.tsx
@@ -265,7 +265,7 @@ function EnterAmount({
     return () => clearTimeout(debouncedRefreshTransactions)
   }, [tokenAmount, token])
 
-  const isAmountLessThanBalance = tokenAmount && tokenAmount.lt(token.balance)
+  const isAmountLessThanBalance = tokenAmount && tokenAmount.lte(token.balance)
   const showLowerAmountError = !isAmountLessThanBalance && !disableBalanceCheck
   const showMaxAmountWarning =
     !showLowerAmountError &&


### PR DESCRIPTION
### Description

When pressing the max button a user would always get the error saying to enter a lower amount, this fixes it.

Explanation [here](https://valora-app.slack.com/archives/C02KBT0DAHJ/p1718034648230829).

### Test plan

CI

### Related issues

- N/A

### Backwards compatibility

Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [X] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
