### PR TITLE
fix(earn): navigate to earn info screen from CTA

### DIFF
--- a/src/earn/EarnCta.test.tsx
+++ b/src/earn/EarnCta.test.tsx
@@ -6,6 +6,7 @@ import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import EarnCta from 'src/earn/EarnCta'
 import { fetchAavePoolInfo } from 'src/earn/poolInfo'
 import { navigate } from 'src/navigator/NavigationService'
+import { Screens } from 'src/navigator/Screens'
 import { NetworkId } from 'src/transactions/types'
 import { createMockStore } from 'test/utils'
 import { mockArbUsdcTokenId, mockTokenBalances } from 'test/values'
@@ -61,7 +62,7 @@ describe('EarnCta', () => {
     )
   })
 
-  it('navigates to EarnEnterAmount when pressed', async () => {
+  it('navigates to EarnInfoScreen when pressed', async () => {
     const { getByTestId } = render(
       <Provider store={createStore()}>
         <EarnCta depositTokenId={mockArbUsdcTokenId} />
@@ -74,8 +75,6 @@ describe('EarnCta', () => {
       providerId: 'aave-v3',
       networkId: NetworkId['arbitrum-sepolia'],
     })
-    expect(navigate).toHaveBeenCalledWith('EarnEnterAmount', {
-      tokenId: mockArbUsdcTokenId,
-    })
+    expect(navigate).toHaveBeenCalledWith(Screens.EarnInfoScreen, { tokenId: mockArbUsdcTokenId })
   })
 })

--- a/src/earn/EarnCta.tsx
+++ b/src/earn/EarnCta.tsx
@@ -45,7 +45,7 @@ export default function EarnCta({ depositTokenId }: { depositTokenId: string }) 
             providerId: PROVIDER_ID,
             networkId: depositToken.networkId,
           })
-          navigate(Screens.EarnEnterAmount, { tokenId: depositTokenId })
+          navigate(Screens.EarnInfoScreen, { tokenId: depositTokenId })
         }}
         testID="EarnCta"
       >


### PR DESCRIPTION
### Description

Looks like this was missed when adding the screen

### Test plan

CI, manually ensuring the cta navigates to the info screen

### Related issues

N/A

### Backwards compatibility

Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
