### PR TITLE
chore: add feature gate for cab in onboarding

### DIFF
--- a/src/statsig/constants.ts
+++ b/src/statsig/constants.ts
@@ -30,6 +30,7 @@ export const FeatureGates = {
   [StatsigFeatureGates.SHOW_STABLECOIN_EARN]: false,
   [StatsigFeatureGates.SUBSIDIZE_STABLECOIN_EARN_GAS_FEES]: false,
   [StatsigFeatureGates.SHOW_CASH_IN_TOKEN_FILTERS]: false,
+  [StatsigFeatureGates.SHOW_CAB_IN_ONBOARDING]: false,
 } satisfies { [key in StatsigFeatureGates]: boolean }
 
 export const ExperimentConfigs = {

--- a/src/statsig/types.ts
+++ b/src/statsig/types.ts
@@ -33,6 +33,7 @@ export enum StatsigFeatureGates {
   SHOW_STABLECOIN_EARN = 'show_stablecoin_earn',
   SUBSIDIZE_STABLECOIN_EARN_GAS_FEES = 'subsidize_stablecoin_earn_gas_fees',
   SHOW_CASH_IN_TOKEN_FILTERS = 'show_cash_in_token_filters',
+  SHOW_CAB_IN_ONBOARDING = 'show_cab_in_onboarding',
 }
 
 export enum StatsigExperiments {


### PR DESCRIPTION
### Description

Adds a feature gate for using CAB (Cloud Account Backup) screens in onboarding: [Statsig](https://console.statsig.com/4plizaPmWwPL21ASV4QAO0/gates/show_cab_in_onboarding).

### Test plan

N/A

### Related issues

- Fixes ACT-1231

### Backwards compatibility

Yes

### Network scalability

N/A
