### PR TITLE
feat(viem): support using valora rpc endpoint if gas is subsidized

### DIFF
--- a/src/send/saga.test.ts
+++ b/src/send/saga.test.ts
@@ -139,7 +139,7 @@ describe(sendPaymentSaga, () => {
       await expectSaga(sendPaymentSaga, { ...sendAction, fromModal })
         .withState(createMockStore({}).getState())
         .provide(createDefaultProviders())
-        .call(getViemWallet, networkConfig.viemChain.celo)
+        .call(getViemWallet, networkConfig.viemChain.celo, false)
         .put(
           addStandbyTransaction({
             __typename: 'TokenTransferV3',
@@ -182,7 +182,7 @@ describe(sendPaymentSaga, () => {
     await expectSaga(sendPaymentSaga, { ...sendAction, tokenId: mockCeloTokenId })
       .withState(createMockStore({}).getState())
       .provide(createDefaultProviders())
-      .call(getViemWallet, networkConfig.viemChain.celo)
+      .call(getViemWallet, networkConfig.viemChain.celo, false)
       .put(
         addStandbyTransaction({
           __typename: 'TokenTransferV3',
@@ -245,7 +245,7 @@ describe(sendPaymentSaga, () => {
         [matchers.call.fn(mockViemWallet.sendRawTransaction), throwError(new Error('tx failed'))],
         ...createDefaultProviders(),
       ])
-      .call(getViemWallet, networkConfig.viemChain.celo)
+      .call(getViemWallet, networkConfig.viemChain.celo, false)
       .put(sendPaymentFailure())
       .put(showError(ErrorMessages.SEND_PAYMENT_FAILED))
       .not.put.actionType(TransactionActions.ADD_STANDBY_TRANSACTION)

--- a/src/swap/saga.test.ts
+++ b/src/swap/saga.test.ts
@@ -286,7 +286,7 @@ describe(swapSubmitSaga, () => {
   function createDefaultProviders(network: Network) {
     let callCount = 0
     const defaultProviders: (EffectProviders | StaticProvider)[] = [
-      [matchers.call(getViemWallet, networkConfig.viemChain[network]), mockViemWallet],
+      [matchers.call(getViemWallet, networkConfig.viemChain[network], false), mockViemWallet],
       [matchers.call.fn(getTransactionCount), 10],
       [matchers.call.fn(getConnectedUnlockedAccount), mockAccount],
       [

--- a/src/viem/getLockableWallet.test.ts
+++ b/src/viem/getLockableWallet.test.ts
@@ -23,18 +23,25 @@ jest.mock('src/viem', () => {
       celo: 'celoTransport',
       ethereum: 'ethereumTransport',
     },
+    valoraViemTransports: {
+      celo: 'celoValoraTransport',
+    },
   }
 })
 
 describe('getTransport', () => {
   it.each([
-    [celoAlfajores, 'celoTransport'],
-    [ethereumSepolia, 'ethereumTransport'],
-  ])('returns correct transport for $s', (chain, expectedTransport) => {
-    expect(getTransport(chain)).toEqual(expectedTransport)
+    [celoAlfajores, false, 'celoTransport'],
+    [celoAlfajores, true, 'celoValoraTransport'],
+    [ethereumSepolia, false, 'ethereumTransport'],
+  ])('returns correct transport for $s', (chain, useValora, expectedTransport) => {
+    expect(getTransport({ chain, useValora })).toEqual(expectedTransport)
   })
   it('throws if chain not found', () => {
-    expect(() => getTransport(ethereumGoerli)).toThrow()
+    expect(() => getTransport({ chain: ethereumGoerli })).toThrow()
+  })
+  it('throws if valora transport not found', () => {
+    expect(() => getTransport({ chain: ethereumSepolia, useValora: true })).toThrow()
   })
 })
 

--- a/src/viem/index.ts
+++ b/src/viem/index.ts
@@ -48,6 +48,10 @@ export const viemTransports: Record<Network, Transport> = {
   }),
 }
 
+export const valoraViemTransports = {
+  [Network.Arbitrum]: http(networkConfig.valoraRpcUrl.arbitrum),
+} satisfies Partial<Record<Network, Transport>>
+
 export const publicClient = {
   [Network.Celo]: createPublicClient({
     chain: networkConfig.viemChain.celo,
@@ -72,5 +76,12 @@ export const publicClient = {
   [Network.Base]: createPublicClient({
     chain: networkConfig.viemChain.base,
     transport: viemTransports[Network.Base],
+  }),
+}
+
+export const valoraPublicClient = {
+  [Network.Arbitrum]: createPublicClient({
+    chain: networkConfig.viemChain.arbitrum,
+    transport: valoraViemTransports[Network.Arbitrum],
   }),
 }

--- a/src/viem/saga.test.ts
+++ b/src/viem/saga.test.ts
@@ -118,7 +118,7 @@ describe('sendPreparedTransactions', () => {
     )
       .withState(createMockStore({}).getState())
       .provide(createDefaultProviders())
-      .call(getViemWallet, networkConfig.viemChain.celo)
+      .call(getViemWallet, networkConfig.viemChain.celo, false)
       .put(
         addStandbyTransaction({
           ...mockStandbyTransactions[0],

--- a/src/viem/saga.ts
+++ b/src/viem/saga.ts
@@ -28,6 +28,9 @@ const TAG = 'viem/saga'
  * @param {number} createBaseStandbyTransactions - functions that create the
  * standby transactions, each element corresponding to the prepared transaction
  * of the matching index
+ * @param {boolean} isGasSubsidized - an optional boolean that indicates whether
+ * gas is subsidized for the transaction, which means a valora rpc node will be
+ * used instead of the default alchemy rpc node
  */
 export function* sendPreparedTransactions(
   serializablePreparedTransactions: SerializableTransactionRequest[],
@@ -35,7 +38,8 @@ export function* sendPreparedTransactions(
   createBaseStandbyTransactions: ((
     transactionHash: string,
     feeCurrencyId?: string
-  ) => BaseStandbyTransaction)[]
+  ) => BaseStandbyTransaction)[],
+  isGasSubsidized: boolean = false
 ) {
   if (serializablePreparedTransactions.length !== createBaseStandbyTransactions.length) {
     throw new Error('Mismatch in number of prepared transactions and standby transaction creators')
@@ -46,7 +50,7 @@ export function* sendPreparedTransactions(
     throw new Error(`No matching network found for network id: ${networkId}`)
   }
 
-  const wallet = yield* call(getViemWallet, networkConfig.viemChain[network])
+  const wallet = yield* call(getViemWallet, networkConfig.viemChain[network], isGasSubsidized)
   if (!wallet.account) {
     // this should never happen
     throw new Error('No account found in the wallet')

--- a/src/web3/contracts.test.ts
+++ b/src/web3/contracts.test.ts
@@ -75,5 +75,25 @@ describe('getViemWallet', () => {
     // Verifying that the wallet is cached
     await expectSaga(getViemWallet, celo).returns('foo').run()
     expect(getLockableViemWallet).toHaveBeenCalledTimes(1)
+
+    // get a wallet with valora transport and ensure it is not from the cache
+    await expectSaga(getViemWallet, celo, true)
+      .provide([
+        [select(walletAddressSelector), '0x123'],
+        [call(listStoredAccounts), [{ address: '0x123', createdAt: date }]],
+        [call(getPasswordSaga, '0x123', true, false), 'password'],
+        [
+          call(getStoredPrivateKey, { address: '0x123', createdAt: new Date() }, 'password'),
+          'password',
+        ],
+      ])
+      .returns('foo')
+      .run()
+
+    expect(getLockableViemWallet).toHaveBeenCalledTimes(2)
+
+    // Verifying that the valora transport wallet is cached
+    await expectSaga(getViemWallet, celo, true).returns('foo').run()
+    expect(getLockableViemWallet).toHaveBeenCalledTimes(2)
   })
 })

--- a/src/web3/networkConfig.ts
+++ b/src/web3/networkConfig.ts
@@ -94,6 +94,7 @@ interface NetworkConfig {
   arbAavePoolV3ContractAddress: Address
   arbAaveIncentivesV3ContractAddress: Address
   aaveArbUsdcTokenId: string
+  valoraRpcUrl: Record<Network.Arbitrum, string>
 }
 
 const ALCHEMY_ETHEREUM_RPC_URL_STAGING = 'https://eth-sepolia.g.alchemy.com/v2/'
@@ -281,6 +282,9 @@ const GET_POINTS_BALANCE_MAINNET = `${CLOUD_FUNCTIONS_MAINNET}/getPointsBalance`
 const SIMULATE_TRANSACTIONS_ALFAJORES = `${CLOUD_FUNCTIONS_STAGING}/simulateTransactions`
 const SIMULATE_TRANSACTIONS_MAINNET = `${CLOUD_FUNCTIONS_MAINNET}/simulateTransactions`
 
+const VALORA_ARBITRUM_RPC_URL_STAGING = `${CLOUD_FUNCTIONS_STAGING}/rpc/${NetworkId['arbitrum-sepolia']}`
+const VALORA_ARBITRUM_RPC_URL_MAINNET = `${CLOUD_FUNCTIONS_MAINNET}/rpc/${NetworkId['arbitrum-one']}`
+
 const networkConfigs: { [testnet: string]: NetworkConfig } = {
   [Testnets.alfajores]: {
     networkId: '44787',
@@ -379,6 +383,9 @@ const networkConfigs: { [testnet: string]: NetworkConfig } = {
     arbAavePoolV3ContractAddress: ARB_AAVE_POOL_V3_CONTRACT_ADDRESS_STAGING,
     arbAaveIncentivesV3ContractAddress: ARB_AAVE_INCENTIVES_V3_CONTRACT_ADDRESS_STAGING,
     aaveArbUsdcTokenId: AAVE_ARB_USDC_TOKEN_ID_STAGING,
+    valoraRpcUrl: {
+      [Network.Arbitrum]: VALORA_ARBITRUM_RPC_URL_STAGING,
+    },
   },
   [Testnets.mainnet]: {
     networkId: '42220',
@@ -476,6 +483,9 @@ const networkConfigs: { [testnet: string]: NetworkConfig } = {
     arbAavePoolV3ContractAddress: ARB_AAVE_POOL_V3_CONTRACT_ADDRESS_MAINNET,
     arbAaveIncentivesV3ContractAddress: ARB_AAVE_INCENTIVES_V3_CONTRACT_ADDRESS_MAINNET,
     aaveArbUsdcTokenId: AAVE_ARB_USDC_TOKEN_ID_MAINNET,
+    valoraRpcUrl: {
+      [Network.Arbitrum]: VALORA_ARBITRUM_RPC_URL_MAINNET,
+    },
   },
 }
 


### PR DESCRIPTION
### Description

In preparation for using syndicate's rpc node for earn transactions when gas is subsidized, update the viem functions to use a different rpc endpoint for both estimating gas and submitting transaction

### Test plan

CI, a follow up PR will have comprehensive testing

### Related issues

- Part of ACT-1194

### Backwards compatibility

Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
