### PR TITLE
chore: adjust learn account key images and button styles

### DIFF
--- a/scripts/sync_branding.sh
+++ b/scripts/sync_branding.sh
@@ -21,7 +21,7 @@ echo $mobile_root
 cd "$mobile_root"
 
 # Please update the sha when valora branding updates are needed
-valora_branding_sha=c02f48b2582f63b13ccfe74d7f61364835206791
+valora_branding_sha=5df16830b1a6ef7f4ede64f2b14637c9257a781f
 
 if [[ "$branding" == "valora" ]]; then
   # prevents git from asking credentials

--- a/src/account/Education.tsx
+++ b/src/account/Education.tsx
@@ -14,7 +14,7 @@ import { NativeSafeAreaViewProps, SafeAreaView } from 'react-native-safe-area-co
 import { OnboardingEvents } from 'src/analytics/Events'
 import { ScrollDirection } from 'src/analytics/types'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
-import Button, { BtnTypes } from 'src/components/Button'
+import Button, { BtnSizes, BtnTypes } from 'src/components/Button'
 import Pagination from 'src/components/Pagination'
 import BackChevron from 'src/icons/BackChevron'
 import Times from 'src/icons/Times'
@@ -160,15 +160,15 @@ const Education = (props: Props) => {
           dotStyle={dotStyle}
           activeDotStyle={activeDotStyle}
         />
-        <Button
-          testID="Education/progressButton"
-          onPress={nextStep}
-          text={currentIndex === stepInfo.length - 1 ? finalButtonText : buttonText}
-          type={currentIndex === stepInfo.length - 1 ? finalButtonType : buttonType}
-          touchableStyle={
-            currentIndex === stepInfo.length - 1 ? { backgroundColor: '#EEB93C' } : undefined
-          }
-        />
+        <View style={styles.buttonContainer}>
+          <Button
+            testID="Education/progressButton"
+            onPress={nextStep}
+            text={currentIndex === stepInfo.length - 1 ? finalButtonText : buttonText}
+            type={currentIndex === stepInfo.length - 1 ? finalButtonType : buttonType}
+            size={BtnSizes.FULL}
+          />
+        </View>
       </View>
     </SafeAreaView>
   )
@@ -186,9 +186,6 @@ const styles = StyleSheet.create({
   },
   container: {
     flex: 1,
-    flexWrap: 'wrap',
-    alignItems: 'center',
-    justifyContent: 'center',
     paddingBottom: 24,
   },
   heading: {
@@ -227,6 +224,9 @@ const styles = StyleSheet.create({
   },
   pagination: {
     paddingBottom: variables.contentPadding,
+  },
+  buttonContainer: {
+    paddingHorizontal: variables.contentPadding,
   },
 })
 

--- a/src/account/__snapshots__/AccountKeyEducation.test.tsx.snap
+++ b/src/account/__snapshots__/AccountKeyEducation.test.tsx.snap
@@ -105,10 +105,7 @@ exports[`AccountKeyEducation renders correctly 1`] = `
   <View
     style={
       {
-        "alignItems": "center",
         "flex": 1,
-        "flexWrap": "wrap",
-        "justifyContent": "center",
         "paddingBottom": 24,
       }
     }
@@ -476,96 +473,104 @@ exports[`AccountKeyEducation renders correctly 1`] = `
     </View>
     <View
       style={
-        [
-          {
-            "flexDirection": "row",
-          },
-          undefined,
-        ]
+        {
+          "paddingHorizontal": 16,
+        }
       }
     >
       <View
         style={
           [
             {
-              "overflow": "hidden",
+              "flexDirection": "column",
             },
-            {
-              "borderRadius": 100,
-            },
+            undefined,
           ]
         }
       >
         <View
-          accessibilityState={
-            {
-              "busy": undefined,
-              "checked": undefined,
-              "disabled": undefined,
-              "expanded": undefined,
-              "selected": undefined,
-            }
-          }
-          accessibilityValue={
-            {
-              "max": undefined,
-              "min": undefined,
-              "now": undefined,
-              "text": undefined,
-            }
-          }
-          accessible={true}
-          focusable={true}
-          nativeBackgroundAndroid={
-            {
-              "attribute": "selectableItemBackground",
-              "rippleRadius": undefined,
-              "type": "ThemeAttrAndroid",
-            }
-          }
-          onClick={[Function]}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
           style={
             [
               {
-                "alignItems": "center",
-                "backgroundColor": "#F8F9F9",
-                "borderColor": "#E6E6E6",
-                "borderRadius": 100,
-                "borderWidth": 1,
-                "flexDirection": "row",
-                "height": 48,
-                "justifyContent": "center",
-                "minWidth": 120,
-                "opacity": 1,
-                "paddingHorizontal": 24,
-                "paddingVertical": 5,
+                "overflow": "hidden",
               },
-              undefined,
+              {
+                "borderRadius": 100,
+              },
             ]
           }
-          testID="Education/progressButton"
         >
-          <Text
-            maxFontSizeMultiplier={1}
-            style={
+          <View
+            accessibilityState={
               {
-                "color": "#2E3338",
-                "fontFamily": "Inter-SemiBold",
-                "fontSize": 16,
-                "lineHeight": 24,
-                "marginLeft": 0,
-                "marginRight": 0,
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": undefined,
+                "expanded": undefined,
+                "selected": undefined,
               }
             }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            focusable={true}
+            nativeBackgroundAndroid={
+              {
+                "attribute": "selectableItemBackground",
+                "rippleRadius": undefined,
+                "type": "ThemeAttrAndroid",
+              }
+            }
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "backgroundColor": "#F8F9F9",
+                  "borderColor": "#E6E6E6",
+                  "borderRadius": 100,
+                  "borderWidth": 1,
+                  "flexDirection": "row",
+                  "flexGrow": 1,
+                  "height": 48,
+                  "justifyContent": "center",
+                  "opacity": 1,
+                  "paddingHorizontal": 24,
+                  "paddingVertical": 5,
+                },
+                undefined,
+              ]
+            }
+            testID="Education/progressButton"
           >
-            next
-          </Text>
+            <Text
+              maxFontSizeMultiplier={1}
+              style={
+                {
+                  "color": "#2E3338",
+                  "fontFamily": "Inter-SemiBold",
+                  "fontSize": 16,
+                  "lineHeight": 24,
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                }
+              }
+            >
+              next
+            </Text>
+          </View>
         </View>
       </View>
     </View>

--- a/src/account/__snapshots__/Education.test.tsx.snap
+++ b/src/account/__snapshots__/Education.test.tsx.snap
@@ -105,10 +105,7 @@ exports[`Education renders correctly 1`] = `
   <View
     style={
       {
-        "alignItems": "center",
         "flex": 1,
-        "flexWrap": "wrap",
-        "justifyContent": "center",
         "paddingBottom": 24,
       }
     }
@@ -183,95 +180,101 @@ exports[`Education renders correctly 1`] = `
     </RCTScrollView>
     <View
       style={
-        [
-          {
-            "flexDirection": "row",
-          },
-          undefined,
-        ]
+        {
+          "paddingHorizontal": 16,
+        }
       }
     >
       <View
         style={
           [
             {
-              "overflow": "hidden",
+              "flexDirection": "column",
             },
-            {
-              "borderRadius": 100,
-            },
+            undefined,
           ]
         }
       >
         <View
-          accessibilityState={
-            {
-              "busy": undefined,
-              "checked": undefined,
-              "disabled": undefined,
-              "expanded": undefined,
-              "selected": undefined,
-            }
-          }
-          accessibilityValue={
-            {
-              "max": undefined,
-              "min": undefined,
-              "now": undefined,
-              "text": undefined,
-            }
-          }
-          accessible={true}
-          focusable={true}
-          nativeBackgroundAndroid={
-            {
-              "attribute": "selectableItemBackground",
-              "rippleRadius": undefined,
-              "type": "ThemeAttrAndroid",
-            }
-          }
-          onClick={[Function]}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
           style={
             [
               {
-                "alignItems": "center",
-                "backgroundColor": "#2E3338",
-                "flexDirection": "row",
-                "height": 48,
-                "justifyContent": "center",
-                "minWidth": 120,
-                "opacity": 1,
-                "paddingHorizontal": 24,
-                "paddingVertical": 5,
+                "overflow": "hidden",
               },
               {
-                "backgroundColor": "#EEB93C",
+                "borderRadius": 100,
               },
             ]
           }
-          testID="Education/progressButton"
         >
-          <Text
-            maxFontSizeMultiplier={1}
-            style={
+          <View
+            accessibilityState={
               {
-                "color": "#FFFFFF",
-                "fontFamily": "Inter-SemiBold",
-                "fontSize": 16,
-                "lineHeight": 24,
-                "marginLeft": 0,
-                "marginRight": 0,
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": undefined,
+                "expanded": undefined,
+                "selected": undefined,
               }
             }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            focusable={true}
+            nativeBackgroundAndroid={
+              {
+                "attribute": "selectableItemBackground",
+                "rippleRadius": undefined,
+                "type": "ThemeAttrAndroid",
+              }
+            }
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "backgroundColor": "#2E3338",
+                  "flexDirection": "row",
+                  "flexGrow": 1,
+                  "height": 48,
+                  "justifyContent": "center",
+                  "opacity": 1,
+                  "paddingHorizontal": 24,
+                  "paddingVertical": 5,
+                },
+                undefined,
+              ]
+            }
+            testID="Education/progressButton"
           >
-            Done
-          </Text>
+            <Text
+              maxFontSizeMultiplier={1}
+              style={
+                {
+                  "color": "#FFFFFF",
+                  "fontFamily": "Inter-SemiBold",
+                  "fontSize": 16,
+                  "lineHeight": 24,
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                }
+              }
+            >
+              Done
+            </Text>
+          </View>
         </View>
       </View>
     </View>

--- a/src/account/__snapshots__/GoldEducation.test.tsx.snap
+++ b/src/account/__snapshots__/GoldEducation.test.tsx.snap
@@ -105,10 +105,7 @@ exports[`renders correctly 1`] = `
   <View
     style={
       {
-        "alignItems": "center",
         "flex": 1,
-        "flexWrap": "wrap",
-        "justifyContent": "center",
         "paddingBottom": 24,
       }
     }
@@ -476,96 +473,104 @@ exports[`renders correctly 1`] = `
     </View>
     <View
       style={
-        [
-          {
-            "flexDirection": "row",
-          },
-          undefined,
-        ]
+        {
+          "paddingHorizontal": 16,
+        }
       }
     >
       <View
         style={
           [
             {
-              "overflow": "hidden",
+              "flexDirection": "column",
             },
-            {
-              "borderRadius": 100,
-            },
+            undefined,
           ]
         }
       >
         <View
-          accessibilityState={
-            {
-              "busy": undefined,
-              "checked": undefined,
-              "disabled": undefined,
-              "expanded": undefined,
-              "selected": undefined,
-            }
-          }
-          accessibilityValue={
-            {
-              "max": undefined,
-              "min": undefined,
-              "now": undefined,
-              "text": undefined,
-            }
-          }
-          accessible={true}
-          focusable={true}
-          nativeBackgroundAndroid={
-            {
-              "attribute": "selectableItemBackground",
-              "rippleRadius": undefined,
-              "type": "ThemeAttrAndroid",
-            }
-          }
-          onClick={[Function]}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
           style={
             [
               {
-                "alignItems": "center",
-                "backgroundColor": "#F8F9F9",
-                "borderColor": "#E6E6E6",
-                "borderRadius": 100,
-                "borderWidth": 1,
-                "flexDirection": "row",
-                "height": 48,
-                "justifyContent": "center",
-                "minWidth": 120,
-                "opacity": 1,
-                "paddingHorizontal": 24,
-                "paddingVertical": 5,
+                "overflow": "hidden",
               },
-              undefined,
+              {
+                "borderRadius": 100,
+              },
             ]
           }
-          testID="Education/progressButton"
         >
-          <Text
-            maxFontSizeMultiplier={1}
-            style={
+          <View
+            accessibilityState={
               {
-                "color": "#2E3338",
-                "fontFamily": "Inter-SemiBold",
-                "fontSize": 16,
-                "lineHeight": 24,
-                "marginLeft": 0,
-                "marginRight": 0,
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": undefined,
+                "expanded": undefined,
+                "selected": undefined,
               }
             }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            focusable={true}
+            nativeBackgroundAndroid={
+              {
+                "attribute": "selectableItemBackground",
+                "rippleRadius": undefined,
+                "type": "ThemeAttrAndroid",
+              }
+            }
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "backgroundColor": "#F8F9F9",
+                  "borderColor": "#E6E6E6",
+                  "borderRadius": 100,
+                  "borderWidth": 1,
+                  "flexDirection": "row",
+                  "flexGrow": 1,
+                  "height": 48,
+                  "justifyContent": "center",
+                  "opacity": 1,
+                  "paddingHorizontal": 24,
+                  "paddingVertical": 5,
+                },
+                undefined,
+              ]
+            }
+            testID="Education/progressButton"
           >
-            next
-          </Text>
+            <Text
+              maxFontSizeMultiplier={1}
+              style={
+                {
+                  "color": "#2E3338",
+                  "fontFamily": "Inter-SemiBold",
+                  "fontSize": 16,
+                  "lineHeight": 24,
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                }
+              }
+            >
+              next
+            </Text>
+          </View>
         </View>
       </View>
     </View>


### PR DESCRIPTION
### Description

Adjust the button styles to match the new learn account key education: [Figma](https://www.figma.com/design/mthUlChSbWXXxLe2AV13Wd/Onboarding-2024?node-id=1-3&t=6oAJf921pKwnPmPe-0).

| iOS Before | iOS After |
| ----- | ----- |
| <video src="https://github.com/valora-inc/wallet/assets/26950305/f5e5fb71-8d60-432e-a641-e15c480c680f" /> | <video src="https://github.com/valora-inc/wallet/assets/26950305/1b745c68-e016-499c-9bb2-6f0c1c86c566" /> | 

Related Branding PR: https://github.com/valora-inc/valora-app-branding/pull/33

### Test plan

- [x] Tested locally on iOS
- [x] Tested locally on Android

### Related issues

- Fixes ACT-1220

### Backwards compatibility

Yes

### Network scalability

N/A
