### PR TITLE
feat(earn): enable gas subsidy for transactions

### DIFF
--- a/src/earn/prepareTransactions.test.ts
+++ b/src/earn/prepareTransactions.test.ts
@@ -64,7 +64,7 @@ describe('prepareTransactions', () => {
     jest.mocked(encodeFunctionData).mockReturnValue('0xencodedData')
     jest.mocked(getDynamicConfigParams).mockImplementation(({ configName, defaultValues }) => {
       if (configName === StatsigDynamicConfigs.EARN_STABLECOIN_CONFIG) {
-        return { ...defaultValues, depositGasPadding: 100, approveGasPadding: 200 }
+        return { ...defaultValues, depositGasPadding: 100 }
       }
       return defaultValues
     })
@@ -93,7 +93,7 @@ describe('prepareTransactions', () => {
   })
 
   describe('prepareSupplyTransactions', () => {
-    it('prepares transactions with approve and supply if not already approved', async () => {
+    it('prepares transactions with approve and supply if not already approved with gas subsidy off', async () => {
       const result = await prepareSupplyTransactions({
         amount: '5',
         token: mockToken,
@@ -145,7 +145,18 @@ describe('prepareTransactions', () => {
         isGasSubsidized: false,
       })
     })
-    it('prepares fees from the cloud function for approve and supply when subsidizing gas fees', async () => {
+
+    it('prepares transactions with supply if already approved with gas subsidy on', async () => {
+      jest.spyOn(publicClient[Network.Arbitrum], 'readContract').mockResolvedValue(BigInt(5e6))
+      jest.mocked(simulateTransactions).mockResolvedValueOnce([
+        {
+          status: 'success',
+          blockNumber: '1',
+          gasNeeded: 50000,
+          gasUsed: 49800,
+          gasPrice: '1',
+        },
+      ])
       jest.mocked(getFeatureGate).mockImplementation((featureGate) => {
         if (featureGate === StatsigFeatureGates.SUBSIDIZE_STABLECOIN_EARN_GAS_FEES) {
           return true
@@ -164,13 +175,6 @@ describe('prepareTransactions', () => {
       const expectedTransactions = [
         {
           from: '0x1234',
-          to: mockTokenAddress,
-          data: '0xencodedData',
-          gas: BigInt(3200),
-          _estimatedGasUse: BigInt(2800),
-        },
-        {
-          from: '0x1234',
           to: '0x5678',
           data: '0xencodedData',
           gas: BigInt(50100),
@@ -189,11 +193,6 @@ describe('prepareTransactions', () => {
         args: ['0x1234', '0x5678'],
       })
       expect(encodeFunctionData).toHaveBeenNthCalledWith(1, {
-        abi: erc20.abi,
-        functionName: 'approve',
-        args: ['0x5678', BigInt(5e6)],
-      })
-      expect(encodeFunctionData).toHaveBeenNthCalledWith(2, {
         abi: aavePool,
         functionName: 'supply',
         args: [mockTokenAddress, BigInt(5e6), '0x1234', 0],
@@ -206,64 +205,16 @@ describe('prepareTransactions', () => {
         isGasSubsidized: true,
       })
     })
-
-    it('prepares transactions with supply if already approved', async () => {
-      jest.spyOn(publicClient[Network.Arbitrum], 'readContract').mockResolvedValue(BigInt(5e6))
-      jest.mocked(simulateTransactions).mockResolvedValueOnce([
-        {
-          status: 'success',
-          blockNumber: '1',
-          gasNeeded: 50000,
-          gasUsed: 49800,
-          gasPrice: '1',
-        },
-      ])
-
-      const result = await prepareSupplyTransactions({
-        amount: '5',
-        token: mockToken,
-        walletAddress: '0x1234',
-        feeCurrencies: [mockFeeCurrency],
-        poolContractAddress: '0x5678',
-      })
-
-      const expectedTransactions = [
-        {
-          from: '0x1234',
-          to: '0x5678',
-          data: '0xencodedData',
-          gas: BigInt(50100),
-          _estimatedGasUse: BigInt(49800),
-        },
-      ]
-      expect(result).toEqual({
-        type: 'possible',
-        feeCurrency: mockFeeCurrency,
-        transactions: expectedTransactions,
-      })
-      expect(publicClient[Network.Arbitrum].readContract).toHaveBeenCalledWith({
-        address: mockTokenAddress,
-        abi: erc20.abi,
-        functionName: 'allowance',
-        args: ['0x1234', '0x5678'],
-      })
-      expect(encodeFunctionData).toHaveBeenNthCalledWith(1, {
-        abi: aavePool,
-        functionName: 'supply',
-        args: [mockTokenAddress, BigInt(5e6), '0x1234', 0],
-      })
-      expect(prepareTransactions).toHaveBeenCalledWith({
-        baseTransactions: expectedTransactions,
-        feeCurrencies: [mockFeeCurrency],
-        spendToken: mockToken,
-        spendTokenAmount: new BigNumber(5),
-        isGasSubsidized: false,
-      })
-    })
   })
 
   describe('prepareWithdrawAndClaimTransactions', () => {
-    it('prepares withdraw and claim transactions', async () => {
+    it('prepares withdraw and claim transactions with gas subsidy on', async () => {
+      jest.mocked(getFeatureGate).mockImplementation((featureGate) => {
+        if (featureGate === StatsigFeatureGates.SUBSIDIZE_STABLECOIN_EARN_GAS_FEES) {
+          return true
+        }
+        throw new Error(`Unexpected feature gate: ${featureGate}`)
+      })
       const rewards = [
         {
           amount: '0.002',
@@ -324,10 +275,11 @@ describe('prepareTransactions', () => {
       expect(prepareTransactions).toHaveBeenCalledWith({
         baseTransactions: expectedTransactions,
         feeCurrencies: [mockFeeCurrency],
+        isGasSubsidized: true,
       })
     })
 
-    it('prepares only withdraw transaction if no rewards', async () => {
+    it('prepares only withdraw transaction if no rewards with gas subsidy off', async () => {
       const result = await prepareWithdrawAndClaimTransactions({
         amount: '5',
         token: mockToken,
@@ -358,158 +310,7 @@ describe('prepareTransactions', () => {
       expect(prepareTransactions).toHaveBeenCalledWith({
         baseTransactions: expectedTransactions,
         feeCurrencies: [mockFeeCurrency],
-      })
-    })
-    describe('when gas fees are subsidized', () => {
-      beforeEach(() => {
-        jest.mocked(getDynamicConfigParams).mockImplementation(({ configName, defaultValues }) => {
-          if (configName === StatsigDynamicConfigs.EARN_STABLECOIN_CONFIG) {
-            return { ...defaultValues, withdrawGasPadding: 100, rewardsGasPadding: 200 }
-          }
-          return defaultValues
-        })
-        jest.mocked(getFeatureGate).mockImplementation((featureGate) => {
-          if (featureGate === StatsigFeatureGates.SUBSIDIZE_STABLECOIN_EARN_GAS_FEES) {
-            return true
-          }
-          throw new Error(`Unexpected feature gate: ${featureGate}`)
-        })
-      })
-      it('prepares withdraw and claim transactions with gas fees added from the simulated transaction', async () => {
-        jest.mocked(simulateTransactions).mockResolvedValue([
-          {
-            status: 'success',
-            blockNumber: '1',
-            gasNeeded: 3000,
-            gasUsed: 2800,
-            gasPrice: '1',
-          },
-          {
-            status: 'success',
-            blockNumber: '1',
-            gasNeeded: 50000,
-            gasUsed: 49600,
-            gasPrice: '1',
-          },
-          {
-            status: 'success',
-            blockNumber: '1',
-            gasNeeded: 50000,
-            gasUsed: 49600,
-            gasPrice: '1',
-          },
-        ])
-        const rewards = [
-          {
-            amount: '0.002',
-            tokenInfo: mockArbArbTokenBalance,
-          },
-          {
-            amount: '0.003',
-            tokenInfo: mockToken,
-          },
-        ]
-        const result = await prepareWithdrawAndClaimTransactions({
-          amount: '5',
-          token: mockToken,
-          walletAddress: '0x1234',
-          feeCurrencies: [mockFeeCurrency],
-          rewards,
-          poolTokenAddress: '0x5678',
-        })
-
-        const expectedTransactions = [
-          {
-            from: '0x1234',
-            to: networkConfig.arbAavePoolV3ContractAddress,
-            data: '0xencodedData',
-            gas: BigInt(3100),
-            _estimatedGasUse: BigInt(2800),
-          },
-          {
-            from: '0x1234',
-            to: networkConfig.arbAaveIncentivesV3ContractAddress,
-            data: '0xencodedData',
-            gas: BigInt(50200),
-            _estimatedGasUse: BigInt(49600),
-          },
-          {
-            from: '0x1234',
-            to: networkConfig.arbAaveIncentivesV3ContractAddress,
-            data: '0xencodedData',
-            gas: BigInt(50200),
-            _estimatedGasUse: BigInt(49600),
-          },
-        ]
-        expect(result).toEqual({
-          type: 'possible',
-          feeCurrency: mockFeeCurrency,
-          transactions: expectedTransactions,
-        })
-        expect(encodeFunctionData).toHaveBeenCalledTimes(3)
-        expect(encodeFunctionData).toHaveBeenCalledWith({
-          abi: aavePool,
-          functionName: 'withdraw',
-          args: [mockTokenAddress, BigInt(5e6), '0x1234'],
-        })
-        expect(encodeFunctionData).toHaveBeenCalledWith({
-          abi: aaveIncentivesV3Abi,
-          functionName: 'claimRewardsToSelf',
-          args: [['0x5678'], BigInt(2e15), mockArbArbAddress],
-        })
-        expect(encodeFunctionData).toHaveBeenCalledWith({
-          abi: aaveIncentivesV3Abi,
-          functionName: 'claimRewardsToSelf',
-          args: [['0x5678'], BigInt(3000), mockTokenAddress],
-        })
-        expect(prepareTransactions).toHaveBeenCalledWith({
-          baseTransactions: expectedTransactions,
-          feeCurrencies: [mockFeeCurrency],
-        })
-      })
-      it('prepares only withdraw transaction if no rewards', async () => {
-        jest.mocked(simulateTransactions).mockResolvedValue([
-          {
-            status: 'success',
-            blockNumber: '1',
-            gasNeeded: 3000,
-            gasUsed: 2800,
-            gasPrice: '1',
-          },
-        ])
-        const result = await prepareWithdrawAndClaimTransactions({
-          amount: '5',
-          token: mockToken,
-          walletAddress: '0x1234',
-          feeCurrencies: [mockFeeCurrency],
-          rewards: [],
-          poolTokenAddress: '0x5678',
-        })
-
-        const expectedTransactions = [
-          {
-            from: '0x1234',
-            to: networkConfig.arbAavePoolV3ContractAddress,
-            data: '0xencodedData',
-            gas: BigInt(3100),
-            _estimatedGasUse: BigInt(2800),
-          },
-        ]
-        expect(result).toEqual({
-          type: 'possible',
-          feeCurrency: mockFeeCurrency,
-          transactions: expectedTransactions,
-        })
-        expect(encodeFunctionData).toHaveBeenCalledTimes(1)
-        expect(encodeFunctionData).toHaveBeenCalledWith({
-          abi: aavePool,
-          functionName: 'withdraw',
-          args: [mockTokenAddress, BigInt(5e6), '0x1234'],
-        })
-        expect(prepareTransactions).toHaveBeenCalledWith({
-          baseTransactions: expectedTransactions,
-          feeCurrencies: [mockFeeCurrency],
-        })
+        isGasSubsidized: false,
       })
     })
   })

--- a/src/earn/prepareTransactions.ts
+++ b/src/earn/prepareTransactions.ts
@@ -84,7 +84,7 @@ export async function prepareSupplyTransactions({
 
   const supplySimulatedTx = simulatedTransactions[simulatedTransactions.length - 1]
 
-  const { depositGasPadding, approveGasPadding } = getDynamicConfigParams(
+  const { depositGasPadding } = getDynamicConfigParams(
     DynamicConfigs[StatsigDynamicConfigs.EARN_STABLECOIN_CONFIG]
   )
 
@@ -94,12 +94,6 @@ export async function prepareSupplyTransactions({
   baseTransactions[baseTransactions.length - 1]._estimatedGasUse = BigInt(supplySimulatedTx.gasUsed)
 
   const isGasSubsidized = getFeatureGate(StatsigFeatureGates.SUBSIDIZE_STABLECOIN_EARN_GAS_FEES)
-  if (isGasSubsidized && baseTransactions.length > 1) {
-    // extract fee of the approve transaction and set gas fields
-    const approveSimulatedTx = simulatedTransactions[0]
-    baseTransactions[0].gas = BigInt(approveSimulatedTx.gasNeeded) + BigInt(approveGasPadding)
-    baseTransactions[0]._estimatedGasUse = BigInt(approveSimulatedTx.gasUsed)
-  }
 
   return prepareTransactions({
     feeCurrencies,
@@ -184,26 +178,9 @@ export async function prepareWithdrawAndClaimTransactions({
 
   const isGasSubsidized = getFeatureGate(StatsigFeatureGates.SUBSIDIZE_STABLECOIN_EARN_GAS_FEES)
 
-  if (isGasSubsidized) {
-    const simulatedTransactions = await simulateTransactions({
-      baseTransactions,
-      networkId: token.networkId,
-    })
-
-    const { withdrawGasPadding, rewardsGasPadding } = getDynamicConfigParams(
-      DynamicConfigs[StatsigDynamicConfigs.EARN_STABLECOIN_CONFIG]
-    )
-
-    baseTransactions.forEach((tx, index) => {
-      const simulatedTx = simulatedTransactions[index]
-      tx.gas =
-        BigInt(simulatedTx.gasNeeded) + BigInt(index === 0 ? withdrawGasPadding : rewardsGasPadding)
-      tx._estimatedGasUse = BigInt(simulatedTx.gasUsed)
-    })
-  }
-
   return prepareTransactions({
     feeCurrencies,
     baseTransactions,
+    isGasSubsidized,
   })
 }

--- a/src/earn/saga.ts
+++ b/src/earn/saga.ts
@@ -18,6 +18,8 @@ import {
 import { DepositInfo, WithdrawInfo } from 'src/earn/types'
 import { navigateHome } from 'src/navigator/NavigationService'
 import { CANCELLED_PIN_INPUT } from 'src/pincode/authentication'
+import { getFeatureGate } from 'src/statsig'
+import { StatsigFeatureGates } from 'src/statsig/types'
 import { vibrateError } from 'src/styles/hapticFeedback'
 import { getTokenInfo } from 'src/tokens/saga'
 import { tokensByIdSelector } from 'src/tokens/selectors'
@@ -173,7 +175,8 @@ export function* depositSubmitSaga(action: PayloadAction<DepositInfo>) {
       sendPreparedTransactions,
       serializablePreparedTransactions,
       networkId,
-      createDepositStandbyTxHandlers
+      createDepositStandbyTxHandlers,
+      getFeatureGate(StatsigFeatureGates.SUBSIDIZE_STABLECOIN_EARN_GAS_FEES)
     )
     txHashes.forEach((txHash, i) => {
       trackedTxs[i].txHash = txHash
@@ -332,7 +335,8 @@ export function* withdrawSubmitSaga(action: PayloadAction<WithdrawInfo>) {
       sendPreparedTransactions,
       serializablePreparedTransactions,
       networkId,
-      createWithdrawStandbyTxHandlers
+      createWithdrawStandbyTxHandlers,
+      getFeatureGate(StatsigFeatureGates.SUBSIDIZE_STABLECOIN_EARN_GAS_FEES)
     )
 
     Logger.debug(


### PR DESCRIPTION
### Description

Based on the feature gate, enable gas subsidy when preparing and submitting earn transactions. Also dropped tenderly simulation for gas estimation because we can use syndicate's rpc for this instead of alchemy and they should succeed even without enough amount for gas. 

### Test plan

CI, manually by enabling feature gate (and overriding the rpc url with syndicate's url as the proxy isn't ready yet) and trying deposit and withdraw from wallets with no or low ETH and ensured gas is covered. 

https://github.com/valora-inc/wallet/assets/5062591/4d4688bb-c89e-4661-b976-8558e1bbd1c0


https://github.com/valora-inc/wallet/assets/5062591/9d63e052-b7a6-4ee1-a955-d3c88056bad0



### Related issues

- Fixes ACT-1194

### Backwards compatibility

Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
