### PR TITLE
fix(earn): show loading states when tx is prepared and submitted

### DIFF
--- a/src/earn/EarnCollectScreen.test.tsx
+++ b/src/earn/EarnCollectScreen.test.tsx
@@ -372,7 +372,7 @@ describe('EarnCollectScreen', () => {
 
   it('disables cta and shows loading spinner when withdraw is submitted', async () => {
     const store = createMockStore({ tokens: mockStoreTokens, earn: { withdrawStatus: 'loading' } })
-    const { getByTestId } = render(
+    const { getByTestId, queryByTestId } = render(
       <Provider store={store}>
         <MockedNavigator
           component={EarnCollectScreen}
@@ -383,6 +383,16 @@ describe('EarnCollectScreen', () => {
         />
       </Provider>
     )
+
+    await waitFor(() => {
+      expect(queryByTestId('EarnCollect/RewardsLoading')).toBeFalsy()
+    })
+    await waitFor(() => {
+      expect(queryByTestId('EarnCollect/ApyLoading')).toBeFalsy()
+    })
+    await waitFor(() => {
+      expect(queryByTestId('EarnCollect/GasLoading')).toBeFalsy()
+    })
 
     expect(getByTestId('EarnCollectScreen/CTA')).toBeDisabled()
     expect(getByTestId('EarnCollectScreen/CTA')).toContainElement(getByTestId('Button/Loading'))

--- a/src/earn/EarnCollectScreen.tsx
+++ b/src/earn/EarnCollectScreen.tsx
@@ -92,7 +92,8 @@ export default function EarnCollectScreen({ route }: Props) {
     asyncRewardsInfo.error ||
     asyncPreparedTransactions.loading ||
     asyncPreparedTransactions.error ||
-    asyncPreparedTransactions.result?.type !== 'possible'
+    asyncPreparedTransactions.result?.type !== 'possible' ||
+    withdrawStatus === 'loading'
 
   const { maxFeeAmount, feeCurrency } = getFeeCurrencyAndAmounts(asyncPreparedTransactions.result)
   let feeSection = <GasFeeLoading />

--- a/src/earn/EarnEnterAmount.test.tsx
+++ b/src/earn/EarnEnterAmount.test.tsx
@@ -86,6 +86,7 @@ jest.mocked(usePrepareSupplyTransactions).mockReturnValue({
   refreshPreparedTransactions: refreshPreparedTransactionsSpy,
   clearPreparedTransactions: jest.fn(),
   prepareTransactionError: undefined,
+  isPreparingTransactions: false,
 })
 
 const params = {
@@ -153,6 +154,7 @@ describe('EarnEnterAmount', () => {
       refreshPreparedTransactions: jest.fn(),
       clearPreparedTransactions: jest.fn(),
       prepareTransactionError: undefined,
+      isPreparingTransactions: false,
     })
     const { getByTestId, getByText } = render(
       <Provider store={store}>
@@ -186,6 +188,7 @@ describe('EarnEnterAmount', () => {
       refreshPreparedTransactions: jest.fn(),
       clearPreparedTransactions: jest.fn(),
       prepareTransactionError: undefined,
+      isPreparingTransactions: false,
     })
     const { getByTestId, getByText } = render(
       <Provider store={store}>
@@ -214,5 +217,29 @@ describe('EarnEnterAmount', () => {
     await waitFor(() =>
       expect(getByText('earnFlow.addCryptoBottomSheet.description')).toBeVisible()
     )
+  })
+
+  it('should show loading spinner when preparing transaction', async () => {
+    jest.mocked(usePrepareSupplyTransactions).mockReturnValue({
+      prepareTransactionsResult: undefined,
+      refreshPreparedTransactions: jest.fn(),
+      clearPreparedTransactions: jest.fn(),
+      prepareTransactionError: undefined,
+      isPreparingTransactions: true,
+    })
+    const { getByTestId } = render(
+      <Provider store={store}>
+        <MockedNavigator component={EarnEnterAmount} params={params} />
+      </Provider>
+    )
+
+    fireEvent.changeText(getByTestId('EarnEnterAmount/TokenAmountInput'), '8')
+
+    await waitFor(() =>
+      expect(getByTestId('EarnEnterAmount/Continue')).toContainElement(
+        getByTestId('Button/Loading')
+      )
+    )
+    expect(getByTestId('EarnEnterAmount/Continue')).toBeDisabled()
   })
 })

--- a/src/earn/EarnEnterAmount.tsx
+++ b/src/earn/EarnEnterAmount.tsx
@@ -61,6 +61,7 @@ type ProceedComponentProps = Omit<ProceedArgs, 'tokenAmount'> & {
   onPressInfo(): void
   disabled: boolean
   tokenAmount: BigNumber | null
+  loading: boolean
 }
 
 function EarnEnterAmount({ route }: Props) {
@@ -90,6 +91,7 @@ function EarnEnterAmount({ route }: Props) {
     refreshPreparedTransactions,
     clearPreparedTransactions,
     prepareTransactionError,
+    isPreparingTransactions,
   } = usePrepareSupplyTransactions()
 
   const walletAddress = useSelector(walletAddressSelector)
@@ -363,6 +365,7 @@ function EarnEnterAmount({ route }: Props) {
           onPressProceed={onPressContinue}
           onPressInfo={onPressInfo}
           disabled={disabled}
+          loading={isPreparingTransactions}
         />
         <KeyboardSpacer />
       </KeyboardAwareScrollView>
@@ -393,6 +396,7 @@ function EarnProceed({
   disabled,
   onPressProceed,
   onPressInfo,
+  loading,
 }: ProceedComponentProps) {
   const { t } = useTranslation()
 
@@ -407,6 +411,8 @@ function EarnProceed({
         style={styles.continueButton}
         size={BtnSizes.FULL}
         disabled={disabled}
+        showLoading={loading}
+        testID="EarnEnterAmount/Continue"
       />
       <View style={styles.row}>
         <Text style={styles.infoText}>{t('earnFlow.enterAmount.info')}</Text>

--- a/src/earn/prepareTransactions.ts
+++ b/src/earn/prepareTransactions.ts
@@ -126,6 +126,7 @@ export function usePrepareSupplyTransactions() {
     refreshPreparedTransactions: prepareTransactions.execute,
     clearPreparedTransactions: prepareTransactions.reset,
     prepareTransactionError: prepareTransactions.error,
+    isPreparingTransactions: prepareTransactions.loading,
   }
 }
 


### PR DESCRIPTION
### Description

- EarnEnterAmount - show spinner on button when tx is prepared
- EarnCollectScreen - disable button when showing spinner

### Test plan

| Screen | Before | After |
|--------|--------|--------|
| EnterAmount | <video src="https://github.com/valora-inc/wallet/assets/5062591/00f97cd6-7701-426a-bc31-b06dcb3ad76a" /> | <video src="https://github.com/valora-inc/wallet/assets/5062591/f88ed460-c104-4532-a7e1-4b512ba9056e" /> |
| Collect | <video src="https://github.com/valora-inc/wallet/assets/5062591/12291d60-0f48-49b8-a234-78902d7ee3ef" /> | <video src="https://github.com/valora-inc/wallet/assets/5062591/22a0ec65-fe47-458b-b637-21f9f110b737" /> | 


### Related issues

N/A

### Backwards compatibility

Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
