### PR TITLE
fix(earn-enter-amount): local earn up to amount

### DIFF
--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -2412,7 +2412,7 @@
       "earnUpToLabel": "You could earn up to:",
       "rateLabel": "Rate (est.)",
       "earnUpTo": "~{{fiatSymbol}}{{amount}} / yr",
-      "earnUpToV2": "<0></0> / yr",
+      "earnUpToV1_87": "<0></0> / yr",
       "rate": "{{rate}}% APY",
       "continue": "Continue",
       "info": "This pool is powered by Aave",

--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -2412,6 +2412,7 @@
       "earnUpToLabel": "You could earn up to:",
       "rateLabel": "Rate (est.)",
       "earnUpTo": "~{{fiatSymbol}}{{amount}} / yr",
+      "earnUpToV2": "<0></0> / yr",
       "rate": "{{rate}}% APY",
       "continue": "Continue",
       "info": "This pool is powered by Aave",

--- a/src/earn/EarnApyAndAmount.tsx
+++ b/src/earn/EarnApyAndAmount.tsx
@@ -1,14 +1,12 @@
 import BigNumber from 'bignumber.js'
 import React from 'react'
-import { useTranslation } from 'react-i18next'
+import { Trans, useTranslation } from 'react-i18next'
 import { StyleSheet, Text, View } from 'react-native'
 import { Colors } from 'react-native/Libraries/NewAppScreen'
-import { useSelector } from 'react-redux'
 import SkeletonPlaceholder from 'src/components/SkeletonPlaceholder'
+import TokenDisplay from 'src/components/TokenDisplay'
 import TokenIcon, { IconSize } from 'src/components/TokenIcon'
 import { useAavePoolInfo } from 'src/earn/hooks'
-import { LocalCurrencySymbol } from 'src/localCurrency/consts'
-import { getLocalCurrencySymbol } from 'src/localCurrency/selectors'
 import { typeScale } from 'src/styles/fonts'
 import { Spacing } from 'src/styles/styles'
 import { TokenBalance } from 'src/tokens/slice'
@@ -24,14 +22,12 @@ export function EarnApyAndAmount({
 }) {
   const { t } = useTranslation()
 
-  const localCurrencySymbol = useSelector(getLocalCurrencySymbol) ?? LocalCurrencySymbol.USD
-
   const asyncPoolInfo = useAavePoolInfo({ depositTokenId: token.tokenId })
   const apy = asyncPoolInfo?.result?.apy
 
   const apyString = apy ? (apy * 100).toFixed(2) : '--'
   const earnUpTo =
-    apy && tokenAmount?.gt(0) ? tokenAmount.multipliedBy(new BigNumber(apy)).toFormat(2) : '--'
+    apy && tokenAmount?.gt(0) ? tokenAmount.multipliedBy(new BigNumber(apy)) : new BigNumber(0)
 
   return (
     <>
@@ -40,23 +36,16 @@ export function EarnApyAndAmount({
         <Text style={styles.label}>{t('earnFlow.enterAmount.rateLabel')}</Text>
       </View>
       <View style={styles.line}>
-        {asyncPoolInfo?.loading && (
-          <SkeletonPlaceholder
-            backgroundColor={Colors.gray2}
-            highlightColor={Colors.white}
-            testID={`${testIDPrefix}/EarnApyAndAmount/EarnUpTo/Loading`}
-          >
-            <View style={styles.loadingSkeleton} />
-          </SkeletonPlaceholder>
-        )}
-        {!asyncPoolInfo?.loading && (
-          <Text style={styles.valuesText} testID={`${testIDPrefix}/EarnApyAndAmount/EarnUpTo`}>
-            {t('earnFlow.enterAmount.earnUpTo', {
-              fiatSymbol: localCurrencySymbol,
-              amount: earnUpTo,
-            })}
-          </Text>
-        )}
+        <Text style={styles.valuesText} testID={`${testIDPrefix}/EarnApyAndAmount/EarnUpTo`}>
+          <Trans i18nKey="earnFlow.enterAmount.earnUpToV2">
+            <TokenDisplay
+              tokenId={token.tokenId}
+              amount={earnUpTo}
+              showLocalAmount={token.priceUsd !== null}
+              showApprox={true}
+            />
+          </Trans>
+        </Text>
         <View style={styles.apy}>
           <TokenIcon token={token} size={IconSize.XSMALL} />
 

--- a/src/earn/EarnApyAndAmount.tsx
+++ b/src/earn/EarnApyAndAmount.tsx
@@ -37,7 +37,7 @@ export function EarnApyAndAmount({
       </View>
       <View style={styles.line}>
         <Text style={styles.valuesText} testID={`${testIDPrefix}/EarnApyAndAmount/EarnUpTo`}>
-          <Trans i18nKey="earnFlow.enterAmount.earnUpToV2">
+          <Trans i18nKey="earnFlow.enterAmount.earnUpToV1_87">
             <TokenDisplay
               tokenId={token.tokenId}
               amount={earnUpTo}

--- a/src/earn/EarnDepositBottomSheet.test.tsx
+++ b/src/earn/EarnDepositBottomSheet.test.tsx
@@ -92,7 +92,6 @@ describe('EarnDepositBottomSheet', () => {
     expect(getByText('earnFlow.depositBottomSheet.description')).toBeTruthy()
 
     expect(getByTestId('EarnDepositBottomSheet/EarnApyAndAmount/Apy/Loading')).toBeTruthy()
-    expect(getByTestId('EarnDepositBottomSheet/EarnApyAndAmount/EarnUpTo/Loading')).toBeTruthy()
 
     expect(queryByTestId('EarnDeposit/GasSubsidized')).toBeFalsy()
 

--- a/src/earn/EarnEnterAmount.test.tsx
+++ b/src/earn/EarnEnterAmount.test.tsx
@@ -112,7 +112,6 @@ describe('EarnEnterAmount', () => {
     )
     // Loading states
     expect(getByTestId('EarnEnterAmount/EarnApyAndAmount/Apy/Loading')).toBeTruthy()
-    expect(getByTestId('EarnEnterAmount/EarnApyAndAmount/EarnUpTo/Loading')).toBeTruthy()
   })
 
   it('should be able to tap info icon', async () => {


### PR DESCRIPTION
### Description

Fixes the display of the earn up to amount to display in the users selected local currency: [Slack Thread](https://valora-app.slack.com/archives/C04B61SJ6DS/p1718895183418909).


#### Screenshots

| iOS Before PHP | iOS After PHP |
| ----- | ----- |
| ![](https://github.com/valora-inc/wallet/assets/26950305/9305f436-ab5d-4521-8c5e-6eddb8ceacaf "iOS Before PHP") | ![](https://github.com/valora-inc/wallet/assets/26950305/c60253de-2a08-45a3-b308-15993d7e1eb5 "iOS After PHP") |

### Test plan

- [x] Tested locally on iOS

### Related issues

N/A

### Backwards compatibility

Yes

### Network scalability

N/A