### PR TITLE
feat(earn): consistent apy across screens

### DIFF
--- a/src/earn/EarnApyAndAmount.tsx
+++ b/src/earn/EarnApyAndAmount.tsx
@@ -1,11 +1,13 @@
 import BigNumber from 'bignumber.js'
-import React from 'react'
+import React, { useEffect } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import { StyleSheet, Text, View } from 'react-native'
 import SkeletonPlaceholder from 'src/components/SkeletonPlaceholder'
 import TokenDisplay from 'src/components/TokenDisplay'
 import TokenIcon, { IconSize } from 'src/components/TokenIcon'
-import { useAavePoolInfo } from 'src/earn/hooks'
+import { poolInfoFetchStatusSelector, poolInfoSelector } from 'src/earn/selectors'
+import { fetchPoolInfo } from 'src/earn/slice'
+import { useDispatch, useSelector } from 'src/redux/hooks'
 import { Colors } from 'src/styles/colors'
 import { typeScale } from 'src/styles/fonts'
 import { Spacing } from 'src/styles/styles'
@@ -21,9 +23,15 @@ export function EarnApyAndAmount({
   testIDPrefix?: string
 }) {
   const { t } = useTranslation()
+  const dispatch = useDispatch()
+  const poolInfo = useSelector(poolInfoSelector)
+  const poolInfoFetchStatus = useSelector(poolInfoFetchStatusSelector)
 
-  const asyncPoolInfo = useAavePoolInfo({ depositTokenId: token.tokenId })
-  const apy = asyncPoolInfo?.result?.apy
+  useEffect(() => {
+    dispatch(fetchPoolInfo())
+  }, [])
+
+  const apy = poolInfo?.apy
 
   const apyString = apy ? (apy * 100).toFixed(2) : '--'
   const earnUpTo =
@@ -49,7 +57,7 @@ export function EarnApyAndAmount({
         <View style={styles.apy}>
           <TokenIcon token={token} size={IconSize.XSMALL} />
 
-          {asyncPoolInfo?.loading && (
+          {poolInfoFetchStatus === 'loading' ? (
             <SkeletonPlaceholder
               backgroundColor={Colors.gray2}
               highlightColor={Colors.white}
@@ -57,8 +65,7 @@ export function EarnApyAndAmount({
             >
               <View style={styles.loadingSkeleton} />
             </SkeletonPlaceholder>
-          )}
-          {!asyncPoolInfo?.loading && (
+          ) : (
             <Text style={styles.valuesText} testID={`${testIDPrefix}/EarnApyAndAmount/Apy`}>
               {t('earnFlow.enterAmount.rate', {
                 rate: apyString,

--- a/src/earn/EarnCta.tsx
+++ b/src/earn/EarnCta.tsx
@@ -1,5 +1,5 @@
 import BigNumber from 'bignumber.js'
-import React from 'react'
+import React, { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { StyleSheet, Text, View } from 'react-native'
 import { EarnEvents } from 'src/analytics/Events'
@@ -7,10 +7,12 @@ import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import TokenIcon, { IconSize } from 'src/components/TokenIcon'
 import Touchable from 'src/components/Touchable'
 import { PROVIDER_ID } from 'src/earn/constants'
-import { useAavePoolInfo } from 'src/earn/hooks'
+import { poolInfoSelector } from 'src/earn/selectors'
+import { fetchPoolInfo } from 'src/earn/slice'
 import CircledIcon from 'src/icons/CircledIcon'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
+import { useDispatch, useSelector } from 'src/redux/hooks'
 import Colors from 'src/styles/colors'
 import { typeScale } from 'src/styles/fonts'
 import { Spacing } from 'src/styles/styles'
@@ -21,8 +23,13 @@ const TAG = 'earn/EarnCta'
 
 export default function EarnCta({ depositTokenId }: { depositTokenId: string }) {
   const { t } = useTranslation()
+  const dispatch = useDispatch()
   const depositToken = useTokenInfo(depositTokenId)
-  const asyncPoolInfo = useAavePoolInfo({ depositTokenId })
+  const poolInfo = useSelector(poolInfoSelector)
+
+  useEffect(() => {
+    dispatch(fetchPoolInfo())
+  }, [])
 
   if (!depositToken) {
     // should never happen
@@ -30,9 +37,7 @@ export default function EarnCta({ depositTokenId }: { depositTokenId: string }) 
     return null
   }
 
-  const apyDisplay = asyncPoolInfo.result
-    ? new BigNumber(asyncPoolInfo.result.apy).multipliedBy(100).toFixed(2)
-    : '--'
+  const apyDisplay = poolInfo ? new BigNumber(poolInfo.apy).multipliedBy(100).toFixed(2) : '--'
 
   return (
     <View style={styles.container}>

--- a/src/earn/EarnDepositBottomSheet.test.tsx
+++ b/src/earn/EarnDepositBottomSheet.test.tsx
@@ -6,7 +6,7 @@ import { EarnEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import EarnDepositBottomSheet from 'src/earn/EarnDepositBottomSheet'
 import { PROVIDER_ID } from 'src/earn/constants'
-import { depositStart } from 'src/earn/slice'
+import { depositStart, fetchPoolInfo } from 'src/earn/slice'
 import { navigate } from 'src/navigator/NavigationService'
 import { getDynamicConfigParams, getFeatureGate } from 'src/statsig'
 import { StatsigDynamicConfigs, StatsigFeatureGates } from 'src/statsig/types'
@@ -78,7 +78,12 @@ describe('EarnDepositBottomSheet', () => {
 
   it('renders all elements', () => {
     const { getByTestId, queryByTestId, getByText } = render(
-      <Provider store={createMockStore({ tokens: { tokenBalances: mockTokenBalances } })}>
+      <Provider
+        store={createMockStore({
+          tokens: { tokenBalances: mockTokenBalances },
+          earn: { poolInfoFetchStatus: 'loading' },
+        })}
+      >
         <EarnDepositBottomSheet
           forwardedRef={{ current: null }}
           amount={new BigNumber(100)}
@@ -134,6 +139,9 @@ describe('EarnDepositBottomSheet', () => {
       expectedAnalyticsProperties
     )
     expect(store.getActions()).toEqual([
+      {
+        type: fetchPoolInfo.type,
+      },
       {
         type: depositStart.type,
         payload: {

--- a/src/earn/EarnEnterAmount.test.tsx
+++ b/src/earn/EarnEnterAmount.test.tsx
@@ -6,7 +6,6 @@ import { Provider } from 'react-redux'
 import { EarnEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import EarnEnterAmount from 'src/earn/EarnEnterAmount'
-import { fetchAavePoolInfo } from 'src/earn/poolInfo'
 import { usePrepareSupplyTransactions } from 'src/earn/prepareTransactions'
 import { TokenBalance } from 'src/tokens/slice'
 import { NetworkId } from 'src/transactions/types'
@@ -17,7 +16,6 @@ import { createMockStore } from 'test/utils'
 import { mockAccount, mockArbEthTokenId, mockTokenBalances } from 'test/values'
 
 jest.mock('src/earn/prepareTransactions')
-jest.mock('src/earn/poolInfo')
 jest.mock('react-native-localize')
 
 const mockPreparedTransaction: PreparedTransactionsPossible = {
@@ -80,6 +78,7 @@ const store = createMockStore({
       },
     },
   },
+  earn: { poolInfoFetchStatus: 'loading' },
 })
 
 const refreshPreparedTransactionsSpy = jest.fn()
@@ -98,10 +97,10 @@ const params = {
 describe('EarnEnterAmount', () => {
   beforeEach(() => {
     jest.clearAllMocks()
-    jest.mocked(fetchAavePoolInfo).mockResolvedValue({ apy: 0.1 })
     jest
       .mocked(getNumberFormatSettings)
       .mockReturnValue({ decimalSeparator: '.', groupingSeparator: ',' })
+    store.clearActions()
   })
 
   it('should render APY and EarnUpTo', async () => {

--- a/src/earn/hooks.ts
+++ b/src/earn/hooks.ts
@@ -11,7 +11,7 @@ import { isAddress } from 'viem'
 
 const TAG = 'earn/hooks'
 
-export function useAavePoolInfo({ depositTokenId }: { depositTokenId: string }) {
+function useAavePoolInfo({ depositTokenId }: { depositTokenId: string }) {
   const depositToken = useTokenInfo(depositTokenId)
   const asyncPoolInfo = useAsync(
     async () => {

--- a/src/earn/hooks.ts
+++ b/src/earn/hooks.ts
@@ -1,44 +1,15 @@
 import { useAsync } from 'react-async-hook'
-import { fetchAavePoolInfo, fetchAaveRewards } from 'src/earn/poolInfo'
+import { fetchAaveRewards } from 'src/earn/poolInfo'
 import { prepareWithdrawAndClaimTransactions } from 'src/earn/prepareTransactions'
 import { useSelector } from 'src/redux/hooks'
 import { useTokenInfo, useTokensList } from 'src/tokens/hooks'
 import { TokenBalance } from 'src/tokens/slice'
 import Logger from 'src/utils/Logger'
-import networkConfig, { networkIdToNetwork } from 'src/web3/networkConfig'
+import networkConfig from 'src/web3/networkConfig'
 import { walletAddressSelector } from 'src/web3/selectors'
 import { isAddress } from 'viem'
 
 const TAG = 'earn/hooks'
-
-function useAavePoolInfo({ depositTokenId }: { depositTokenId: string }) {
-  const depositToken = useTokenInfo(depositTokenId)
-  const asyncPoolInfo = useAsync(
-    async () => {
-      if (!depositToken || !depositToken.address) {
-        throw new Error(`Token with id ${depositTokenId} not found`)
-      }
-
-      if (!isAddress(depositToken.address)) {
-        throw new Error(`Token with id ${depositTokenId} does not contain a valid address`)
-      }
-
-      return fetchAavePoolInfo({
-        assetAddress: depositToken.address,
-        contractAddress: networkConfig.arbAavePoolV3ContractAddress,
-        network: networkIdToNetwork[depositToken.networkId],
-      })
-    },
-    [],
-    {
-      onError: (error) => {
-        Logger.warn(`${TAG}/useAavePoolInfo`, error.message)
-      },
-    }
-  )
-
-  return asyncPoolInfo
-}
 
 export function useAaveRewardsInfoAndPrepareTransactions({
   poolTokenId,

--- a/src/earn/selectors.ts
+++ b/src/earn/selectors.ts
@@ -3,3 +3,7 @@ import { RootState } from 'src/redux/store'
 export const depositStatusSelector = (state: RootState) => state.earn.depositStatus
 
 export const withdrawStatusSelector = (state: RootState) => state.earn.withdrawStatus
+
+export const poolInfoFetchStatusSelector = (state: RootState) => state.earn.poolInfoFetchStatus
+
+export const poolInfoSelector = (state: RootState) => state.earn.poolInfo

--- a/src/earn/slice.ts
+++ b/src/earn/slice.ts
@@ -1,6 +1,6 @@
 import { PayloadAction, createSlice } from '@reduxjs/toolkit'
 import { REHYDRATE, RehydrateAction } from 'redux-persist'
-import { DepositInfo, WithdrawInfo } from 'src/earn/types'
+import { DepositInfo, PoolInfo, WithdrawInfo } from 'src/earn/types'
 import { getRehydratePayload } from 'src/redux/persist-helper'
 
 type Status = 'idle' | 'loading' | 'success' | 'error'
@@ -8,11 +8,14 @@ type Status = 'idle' | 'loading' | 'success' | 'error'
 interface State {
   depositStatus: Status
   withdrawStatus: Status
+  poolInfoFetchStatus: Status
+  poolInfo?: PoolInfo
 }
 
 const initialState: State = {
   depositStatus: 'idle',
   withdrawStatus: 'idle',
+  poolInfoFetchStatus: 'idle',
 }
 
 export const slice = createSlice({
@@ -43,6 +46,16 @@ export const slice = createSlice({
     withdrawCancel: (state) => {
       state.withdrawStatus = 'idle'
     },
+    fetchPoolInfo: (state) => {
+      state.poolInfoFetchStatus = 'loading'
+    },
+    fetchPoolInfoSuccess: (state, action: PayloadAction<PoolInfo>) => {
+      state.poolInfoFetchStatus = 'success'
+      state.poolInfo = action.payload
+    },
+    fetchPoolInfoError: (state) => {
+      state.poolInfoFetchStatus = 'error'
+    },
   },
   extraReducers: (builder) => {
     builder.addCase(REHYDRATE, (state, action: RehydrateAction) => ({
@@ -50,6 +63,8 @@ export const slice = createSlice({
       ...getRehydratePayload(action, 'earn'),
       depositStatus: 'idle',
       withdrawStatus: 'idle',
+      poolInfoFetchStatus: 'idle',
+      poolInfo: undefined,
     }))
   },
 })
@@ -63,6 +78,9 @@ export const {
   withdrawSuccess,
   withdrawError,
   withdrawCancel,
+  fetchPoolInfo,
+  fetchPoolInfoSuccess,
+  fetchPoolInfoError,
 } = slice.actions
 
 export default slice.reducer

--- a/src/earn/types.ts
+++ b/src/earn/types.ts
@@ -23,3 +23,7 @@ export interface WithdrawInfo {
   preparedTransactions: SerializableTransactionRequest[]
   rewards: SerializableRewardsInfo[]
 }
+
+export interface PoolInfo {
+  apy: number
+}

--- a/src/home/GetStarted.tsx
+++ b/src/home/GetStarted.tsx
@@ -6,12 +6,14 @@ import { FiatExchangeEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import TokenIcon, { IconSize } from 'src/components/TokenIcon'
 import Touchable from 'src/components/Touchable'
-import { useAavePoolInfo } from 'src/earn/hooks'
+import { poolInfoSelector } from 'src/earn/selectors'
+import { fetchPoolInfo } from 'src/earn/slice'
 import { FiatExchangeFlow } from 'src/fiatExchanges/utils'
 import CircledIcon from 'src/icons/CircledIcon'
 import ExploreTokens from 'src/icons/ExploreTokens'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
+import { useDispatch, useSelector } from 'src/redux/hooks'
 import colors from 'src/styles/colors'
 import { typeScale } from 'src/styles/fonts'
 import { Spacing } from 'src/styles/styles'
@@ -20,17 +22,21 @@ import networkConfig from 'src/web3/networkConfig'
 
 export default function GetStarted() {
   const { t } = useTranslation()
+  const dispatch = useDispatch()
+  const poolInfo = useSelector(poolInfoSelector)
+
   const goToAddFunds = () => {
     ValoraAnalytics.track(FiatExchangeEvents.cico_add_get_started_selected)
     navigate(Screens.FiatExchangeCurrencyBottomSheet, { flow: FiatExchangeFlow.CashIn })
   }
 
-  const earnToken = useTokenInfo(networkConfig.arbUsdcTokenId)
-  const asyncPoolInfo = useAavePoolInfo({ depositTokenId: networkConfig.arbUsdcTokenId })
+  useEffect(() => {
+    dispatch(fetchPoolInfo())
+  }, [])
 
-  const apyDisplay = asyncPoolInfo.result
-    ? new BigNumber(asyncPoolInfo.result.apy).multipliedBy(100).toFixed(2)
-    : '--'
+  const earnToken = useTokenInfo(networkConfig.arbUsdcTokenId)
+
+  const apyDisplay = poolInfo?.apy ? new BigNumber(poolInfo.apy).multipliedBy(100).toFixed(2) : '--'
 
   useEffect(() => {
     ValoraAnalytics.track(FiatExchangeEvents.cico_add_get_started_impression)

--- a/src/redux/migrations.ts
+++ b/src/redux/migrations.ts
@@ -1808,4 +1808,11 @@ export const migrations = {
       },
     },
   }),
+  218: (state: any) => ({
+    ...state,
+    earn: {
+      ...state.earn,
+      poolInfoFetchStatus: 'idle',
+    },
+  }),
 }

--- a/src/redux/store.test.ts
+++ b/src/redux/store.test.ts
@@ -98,7 +98,7 @@ describe('store state', () => {
       {
         "_persist": {
           "rehydrated": true,
-          "version": 217,
+          "version": 218,
         },
         "account": {
           "acceptedTerms": false,
@@ -189,6 +189,8 @@ describe('store state', () => {
         },
         "earn": {
           "depositStatus": "idle",
+          "poolInfo": undefined,
+          "poolInfoFetchStatus": "idle",
           "withdrawStatus": "idle",
         },
         "escrow": {

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -21,7 +21,7 @@ const persistConfig: PersistConfig<ReducersRootState> = {
   key: 'root',
   // default is -1, increment as we make migrations
   // See https://github.com/valora-inc/wallet/tree/main/WALLET.md#redux-state-migration
-  version: 217,
+  version: 218,
   keyPrefix: `reduxStore-`, // the redux-persist default is `persist:` which doesn't work with some file systems.
   storage: FSStorage(),
   blacklist: ['networkInfo', 'alert', 'imports', 'keylessBackup', 'jumpstart'],

--- a/test/RootStateSchema.json
+++ b/test/RootStateSchema.json
@@ -2855,6 +2855,18 @@
             ],
             "type": "object"
         },
+        "PoolInfo": {
+            "additionalProperties": false,
+            "properties": {
+                "apy": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "apy"
+            ],
+            "type": "object"
+        },
         "Position": {
             "anyOf": [
                 {
@@ -4936,12 +4948,19 @@
                 "depositStatus": {
                     "$ref": "#/definitions/Status_1"
                 },
+                "poolInfo": {
+                    "$ref": "#/definitions/PoolInfo"
+                },
+                "poolInfoFetchStatus": {
+                    "$ref": "#/definitions/Status_1"
+                },
                 "withdrawStatus": {
                     "$ref": "#/definitions/Status_1"
                 }
             },
             "required": [
                 "depositStatus",
+                "poolInfoFetchStatus",
                 "withdrawStatus"
             ],
             "type": "object"

--- a/test/schemas.ts
+++ b/test/schemas.ts
@@ -3361,6 +3361,18 @@ export const v217Schema = {
   },
 }
 
+export const v218Schema = {
+  ...v217Schema,
+  _persist: {
+    ...v217Schema._persist,
+    version: 218,
+  },
+  earn: {
+    ...v217Schema.earn,
+    poolInfoFetchStatus: 'idle',
+  },
+}
+
 export function getLatestSchema(): Partial<RootState> {
-  return v217Schema as Partial<RootState>
+  return v218Schema as Partial<RootState>
 }


### PR DESCRIPTION
### Description

Store APY in redux so going back doesn't use outdated values

### Test plan

Unit tests, manual

### Related issues

- Fixes ACT-1205

### Backwards compatibility

Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
