### PR TITLE
chore: remove ivory onboarding background

### DIFF
--- a/src/backup/BackupPhraseContainer.tsx
+++ b/src/backup/BackupPhraseContainer.tsx
@@ -179,7 +179,7 @@ const styles = StyleSheet.create({
     flexWrap: 'wrap',
     flexDirection: 'row',
     marginTop: 8,
-    backgroundColor: colors.onboardingBackground,
+    backgroundColor: colors.ivory,
     borderRadius: 8,
     alignContent: 'center',
     justifyContent: 'center',

--- a/src/fiatconnect/kyc/KycPending.tsx
+++ b/src/fiatconnect/kyc/KycPending.tsx
@@ -41,11 +41,7 @@ function KycPending({ route, navigation }: Props) {
   return (
     <SafeAreaView style={styles.container}>
       <View style={styles.iconContainer}>
-        <CircledIcon
-          radius={80}
-          backgroundColor={colors.onboardingBackground}
-          style={styles.bankIcon}
-        >
+        <CircledIcon radius={80} backgroundColor={colors.ivory} style={styles.bankIcon}>
           <BankIcon color={colors.black} height={24} width={24} />
         </CircledIcon>
         <CircledIcon radius={85} backgroundColor={colors.white} style={styles.clockIcon}>

--- a/src/import/ImportWallet.tsx
+++ b/src/import/ImportWallet.tsx
@@ -33,7 +33,6 @@ import { useDispatch, useSelector } from 'src/redux/hooks'
 import { isAppConnected } from 'src/redux/selectors'
 import { getFeatureGate } from 'src/statsig'
 import { StatsigFeatureGates } from 'src/statsig/types'
-import colors from 'src/styles/colors'
 import fontStyles from 'src/styles/fonts'
 import Logger from 'src/utils/Logger'
 import { Currency } from 'src/utils/currencies'
@@ -267,7 +266,6 @@ ImportWallet.navigationOptions = {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: colors.onboardingBackground,
   },
   scrollContainer: {
     paddingVertical: 16,

--- a/src/navigator/Headers.tsx
+++ b/src/navigator/Headers.tsx
@@ -66,8 +66,7 @@ export const nuxNavigationOptions: NativeStackNavigationOptions = {
 
 export const nuxNavigationOptionsOnboarding: NativeStackNavigationOptions = {
   ...nuxNavigationOptions,
-  headerLeft: ({ canGoBack }) =>
-    canGoBack ? <BackButton color={colors.onboardingBrownLight} /> : <View />,
+  headerLeft: ({ canGoBack }) => (canGoBack ? <BackButton color={colors.black} /> : <View />),
 }
 
 export const nuxNavigationOptionsNoBackButton: NativeStackNavigationOptions = {

--- a/src/navigator/Navigator.tsx
+++ b/src/navigator/Navigator.tsx
@@ -171,7 +171,7 @@ const verificationScreens = (Navigator: typeof Stack) => {
       <Navigator.Screen
         name={Screens.VerificationCodeInputScreen}
         component={VerificationCodeInputScreen}
-        options={VerificationCodeInputScreen.navigationOptions}
+        options={nuxNavigationOptions}
       />
     </>
   )

--- a/src/onboarding/ChooseYourAdventure.tsx
+++ b/src/onboarding/ChooseYourAdventure.tsx
@@ -157,7 +157,6 @@ const styles = StyleSheet.create({
   container: {
     flexGrow: 1,
     justifyContent: 'space-between',
-    backgroundColor: colors.onboardingBackground,
   },
   scrollContainer: {
     padding: 24,
@@ -176,6 +175,7 @@ const styles = StyleSheet.create({
   },
   card: {
     marginTop: Spacing.Smallest8,
+    backgroundColor: colors.gray1,
     flex: 1,
     padding: 0,
   },
@@ -199,6 +199,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   skip: {
-    color: colors.onboardingBrownLight,
+    color: colors.gray3,
   },
 })

--- a/src/onboarding/registration/OnboardingRecoveryPhrase.tsx
+++ b/src/onboarding/registration/OnboardingRecoveryPhrase.tsx
@@ -177,7 +177,7 @@ const styles = StyleSheet.create({
     borderColor: colors.gray2,
     borderRadius: 8,
     marginTop: 0,
-    backgroundColor: colors.ivory,
+    backgroundColor: colors.gray1,
   },
   contentContainer: {
     flexGrow: 1,

--- a/src/onboarding/registration/OnboardingRecoveryPhrase.tsx
+++ b/src/onboarding/registration/OnboardingRecoveryPhrase.tsx
@@ -56,7 +56,7 @@ function OnboardingRecoveryPhrase({ navigation }: Props) {
           testID="helpButton"
           title={t('help')}
           onPress={onPressHelp}
-          titleStyle={{ color: colors.onboardingBrownLight }}
+          titleStyle={{ color: colors.black }}
         />
       ),
     })

--- a/src/onboarding/registration/OnboardingRecoveryPhrase.tsx
+++ b/src/onboarding/registration/OnboardingRecoveryPhrase.tsx
@@ -162,7 +162,7 @@ const styles = StyleSheet.create({
     marginTop: 37,
     marginBottom: 9,
     textAlign: 'center',
-    color: colors.onboardingBrownLight,
+    color: colors.gray3,
   },
   bottomSheetTitle: {
     ...fontStyles.h2,
@@ -177,7 +177,7 @@ const styles = StyleSheet.create({
     borderColor: colors.gray2,
     borderRadius: 8,
     marginTop: 0,
-    backgroundColor: colors.white,
+    backgroundColor: colors.ivory,
   },
   contentContainer: {
     flexGrow: 1,
@@ -187,7 +187,6 @@ const styles = StyleSheet.create({
   },
   container: {
     flex: 1,
-    backgroundColor: colors.onboardingBackground,
   },
   recoveryPhraseBody: {
     textAlign: 'center',

--- a/src/onboarding/registration/ProtectWallet.tsx
+++ b/src/onboarding/registration/ProtectWallet.tsx
@@ -126,7 +126,6 @@ const styles = StyleSheet.create({
   },
   container: {
     flex: 1,
-    backgroundColor: colors.onboardingBackground,
   },
   contentContainer: {
     justifyContent: 'flex-start',

--- a/src/pincode/PincodeSet.tsx
+++ b/src/pincode/PincodeSet.tsx
@@ -39,7 +39,6 @@ import {
 import { getCachedPin, setCachedPin } from 'src/pincode/PasswordCache'
 import Pincode from 'src/pincode/Pincode'
 import { RootState } from 'src/redux/reducers'
-import colors from 'src/styles/colors'
 import Logger from 'src/utils/Logger'
 import { currentAccountSelector } from 'src/web3/selectors'
 
@@ -266,7 +265,6 @@ export class PincodeSet extends React.Component<Props, State> {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: colors.onboardingBackground,
     justifyContent: 'space-between',
     paddingTop: 72,
   },

--- a/src/styles/colors.tsx
+++ b/src/styles/colors.tsx
@@ -4,6 +4,7 @@ export enum Colors {
   primary = '#1AB775',
   primaryDisabled = `${primary}80`, // 50% opacity
   white = '#FFFFFF',
+  ivory = '#F9F6F0',
   black = '#2E3338',
   gray5 = '#505050',
   gray4 = '#666666',
@@ -23,8 +24,6 @@ export enum Colors {
   goldBrand = '#FBCC5C',
   /** @deprecated */
   onboardingBrownLight = '#A49B80',
-  /** @deprecated */
-  onboardingBackground = '#F9F6F0',
 }
 
 export default Colors

--- a/src/verify/VerificationCodeInputScreen.tsx
+++ b/src/verify/VerificationCodeInputScreen.tsx
@@ -97,16 +97,9 @@ function VerificationCodeInputScreen({
   )
 }
 
-VerificationCodeInputScreen.navigationOptions = {
-  headerStyle: {
-    backgroundColor: colors.onboardingBackground,
-  },
-}
-
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: colors.onboardingBackground,
   },
 })
 

--- a/src/verify/VerificationCodeInputScreen.tsx
+++ b/src/verify/VerificationCodeInputScreen.tsx
@@ -66,10 +66,10 @@ function VerificationCodeInputScreen({
           title={t('phoneVerificationInput.help')}
           testID="PhoneVerificationHelpHeader"
           onPress={onPressHelp}
-          titleStyle={{ color: colors.onboardingBrownLight }}
+          titleStyle={{ color: colors.black }}
         />
       ),
-      headerLeft: () => <BackButton color={colors.onboardingBrownLight} />,
+      headerLeft: () => <BackButton color={colors.black} />,
       headerTransparent: true,
     })
   }, [navigation, route.params])

--- a/src/verify/VerificationStartScreen.tsx
+++ b/src/verify/VerificationStartScreen.tsx
@@ -264,7 +264,6 @@ function VerificationStartScreen({
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: colors.onboardingBackground,
     justifyContent: 'center',
   },
   scrollContainer: {

--- a/src/verify/VerificationStartScreen.tsx
+++ b/src/verify/VerificationStartScreen.tsx
@@ -125,7 +125,7 @@ function VerificationStartScreen({
             title={t('skip')}
             testID="PhoneVerificationSkipHeader"
             onPress={onPressSkip}
-            titleStyle={{ color: colors.onboardingBrownLight }}
+            titleStyle={{ color: colors.black }}
           />
         ),
       headerLeft: () => route.params?.hasOnboarded && <BackButton />,
@@ -292,7 +292,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   learnMore: {
-    color: colors.onboardingBrownLight,
+    color: colors.gray3,
   },
 })
 


### PR DESCRIPTION
### Description

Removes usages of onboardingBackground as background and sets color name to ivory for those places where it is used. Some screens such as `ChooseYourAdventure.tsx`, which relied on the background to display the buttons, now use a button background color.

| CYA iOS Before | CYA iOS After | Phrase iOS Before | Phrase iOS After |
| ----- | ----- | ----- | ----- | 
| ![](https://github.com/valora-inc/wallet/assets/26950305/78982487-e20b-4c3e-8613-8f9255980efc) | ![](https://github.com/valora-inc/wallet/assets/26950305/b330d563-205a-4806-a587-64ada57ca833) | ![](https://github.com/valora-inc/wallet/assets/26950305/746d58cf-fc87-4992-8c03-b5eba1c1388f) | ![](https://github.com/valora-inc/wallet/assets/26950305/35348657-3629-4305-b251-5ee1e551a193) |



### Test plan

- [x] Tested locally on iOS

### Related issues

N/A

### Backwards compatibility

Yes

### Network scalability

N/A
