### PR TITLE
fix(points): ensure sagas are spawned on statsig refresh

### DIFF
--- a/src/points/saga.test.ts
+++ b/src/points/saga.test.ts
@@ -35,6 +35,8 @@ import pointsReducer, {
   trackPointsEvent,
 } from 'src/points/slice'
 import { ClaimHistory, GetHistoryResponse, PointsEvent } from 'src/points/types'
+import { getFeatureGate } from 'src/statsig'
+import { StatsigFeatureGates } from 'src/statsig/types'
 import { NetworkId } from 'src/transactions/types'
 import Logger from 'src/utils/Logger'
 import * as fetchWithTimeout from 'src/utils/fetchWithTimeout'
@@ -46,6 +48,12 @@ import { mockAccount } from 'test/values'
 import { v4 as uuidv4 } from 'uuid'
 
 jest.mock('src/statsig')
+jest.mocked(getFeatureGate).mockImplementation((featureGate) => {
+  if (featureGate === StatsigFeatureGates.SHOW_POINTS) {
+    return true
+  }
+  throw new Error(`Unexpected feature gate: ${featureGate}`)
+})
 
 jest.mock('uuid')
 jest.mock('src/utils/Logger')


### PR DESCRIPTION
### Description

[Context](https://valora-app.slack.com/archives/C04B61SJ6DS/p1720133654144139?thread_ts=1720105286.269059&cid=C04B61SJ6DS).

### Test plan

n/a

### Related issues

n/a

### Backwards compatibility

n/a

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [ ] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
