### PR TITLE
fix(points): remove wrong and redundant image style property

### DIFF
--- a/src/points/PointsDiscoverCard.tsx
+++ b/src/points/PointsDiscoverCard.tsx
@@ -70,7 +70,6 @@ const styles = StyleSheet.create({
   image: {
     width: '100%',
     height: 56,
-    imageResizeMode: 'cover',
   },
   content: {
     paddingTop: Spacing.Smallest8,


### PR DESCRIPTION
### Description

Remove the `imageResizeMode` style property:
* it is wrong, it should be `resizeMode`
* the value `cover` is [the default one](https://reactnative.dev/docs/image#resizemode), so this property is not needed at all

While not causing any harm to the users, it yields annoying RN error in dev mode:

![image](https://github.com/valora-inc/wallet/assets/2737872/3a10dbbf-3d1b-4df8-9c73-1e85a5e3bf25)

### Test plan

Tested manually

### Related issues

- Related to RET-1103

### Backwards compatibility

Y

### Network scalability

NA