### PR TITLE
chore: update discover dapp and dapp filter styles

### DIFF
--- a/src/components/BorderlessButton.tsx
+++ b/src/components/BorderlessButton.tsx
@@ -12,7 +12,7 @@ export type Props = Omit<TouchableProps, 'style'> & {
 export default function BorderlessButton(props: Props) {
   const { style, containerStyle, children, notScaleFont, ...passThroughProps } = props
   return (
-    <Touchable borderless={true} {...passThroughProps} style={containerStyle}>
+    <Touchable {...passThroughProps} borderless={true} style={containerStyle}>
       {notScaleFont ? (
         <Text allowFontScaling={false} style={style}>
           {children}

--- a/src/components/BorderlessButton.tsx
+++ b/src/components/BorderlessButton.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import { StyleProp, Text, TextStyle, ViewStyle } from 'react-native'
 import Touchable, { Props as TouchableProps } from 'src/components/Touchable'
-import variables from 'src/styles/variables'
 
 export type Props = Omit<TouchableProps, 'style'> & {
   style?: StyleProp<TextStyle>
@@ -13,12 +12,7 @@ export type Props = Omit<TouchableProps, 'style'> & {
 export default function BorderlessButton(props: Props) {
   const { style, containerStyle, children, notScaleFont, ...passThroughProps } = props
   return (
-    <Touchable
-      hitSlop={variables.iconHitslop}
-      borderless={true}
-      {...passThroughProps}
-      style={containerStyle}
-    >
+    <Touchable borderless={true} {...passThroughProps} style={containerStyle}>
       {notScaleFont ? (
         <Text allowFontScaling={false} style={style}>
           {children}

--- a/src/components/BorderlessButton.tsx
+++ b/src/components/BorderlessButton.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { StyleProp, Text, TextStyle, ViewStyle } from 'react-native'
 import Touchable, { Props as TouchableProps } from 'src/components/Touchable'
+import variables from 'src/styles/variables'
 
 export type Props = Omit<TouchableProps, 'style'> & {
   style?: StyleProp<TextStyle>
@@ -12,7 +13,12 @@ export type Props = Omit<TouchableProps, 'style'> & {
 export default function BorderlessButton(props: Props) {
   const { style, containerStyle, children, notScaleFont, ...passThroughProps } = props
   return (
-    <Touchable {...passThroughProps} borderless={true} style={containerStyle}>
+    <Touchable
+      {...passThroughProps}
+      borderless={true}
+      style={containerStyle}
+      hitSlop={variables.iconHitslop}
+    >
       {notScaleFont ? (
         <Text allowFontScaling={false} style={style}>
           {children}

--- a/src/components/BorderlessButton.tsx
+++ b/src/components/BorderlessButton.tsx
@@ -14,10 +14,10 @@ export default function BorderlessButton(props: Props) {
   const { style, containerStyle, children, notScaleFont, ...passThroughProps } = props
   return (
     <Touchable
-      {...passThroughProps}
-      borderless={true}
-      style={containerStyle}
       hitSlop={variables.iconHitslop}
+      borderless={true}
+      {...passThroughProps}
+      style={containerStyle}
     >
       {notScaleFont ? (
         <Text allowFontScaling={false} style={style}>

--- a/src/components/FilterChipsCarousel.tsx
+++ b/src/components/FilterChipsCarousel.tsx
@@ -54,7 +54,10 @@ function FilterChipsCarousel<T>({
       scrollEnabled={scrollEnabled}
       showsHorizontalScrollIndicator={false}
       style={[styles.container, style]}
-      contentContainerStyle={[styles.contentContainer, { width: scrollEnabled ? 'auto' : '100%' }]}
+      contentContainerStyle={[
+        styles.contentContainer,
+        { flexWrap: scrollEnabled ? 'nowrap' : 'wrap', width: scrollEnabled ? 'auto' : '100%' },
+      ]}
       ref={forwardedRef}
       testID="FilterChipsCarousel"
     >
@@ -108,7 +111,6 @@ const styles = StyleSheet.create({
   contentContainer: {
     paddingHorizontal: Spacing.Thick24,
     gap: Spacing.Smallest8,
-    flexWrap: 'wrap',
   },
   filterChipBackground: {
     overflow: 'hidden',

--- a/src/dapps/DappsScreen.tsx
+++ b/src/dapps/DappsScreen.tsx
@@ -276,6 +276,7 @@ function DappsScreen({ navigation }: Props) {
                   onFavoriteDapp={onFavoriteDapp}
                   showBorder={true}
                   testID={`${section.testID}/DappCard`}
+                  cardStyle={styles.dappCard}
                 />
               )
             }}
@@ -361,6 +362,9 @@ const styles = StyleSheet.create({
     ...typeScale.titleMedium,
     color: Colors.black,
     marginBottom: Spacing.Thick24,
+  },
+  dappCard: {
+    marginTop: Spacing.Regular16,
   },
 })
 

--- a/src/dappsExplorer/DappCard.tsx
+++ b/src/dappsExplorer/DappCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Image, StyleSheet, Text, View } from 'react-native'
+import { Image, StyleSheet, Text, View, ViewStyle } from 'react-native'
 import { DappExplorerEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import Card from 'src/components/Card'
@@ -19,17 +19,16 @@ interface DappCardContentProps {
   dapp: Dapp
   onFavoriteDapp?: (dapp: Dapp) => void
   favoritedFromSection: DappSection
-  disableFavoriting?: boolean
-  showBorder?: boolean
 }
 
 interface Props {
   onPressDapp: () => void
   dapp: Dapp
   testID: string
-  disableFavoriting?: boolean
   onFavoriteDapp?: (dapp: Dapp) => void
   showBorder?: boolean
+  cardContentContainerStyle?: ViewStyle
+  cardStyle?: ViewStyle
 }
 
 // Since this icon exists within a touchable, make the hitslop bigger than usual
@@ -39,13 +38,12 @@ export function DappCardContent({
   dapp,
   onFavoriteDapp,
   favoritedFromSection,
-  disableFavoriting,
-  showBorder,
 }: DappCardContentProps) {
   const dispatch = useDispatch()
   const favoriteDappIds = useSelector(favoriteDappIdsSelector)
 
   const isFavorited = favoriteDappIds.includes(dapp.id)
+  const favouritesEnabled = !!onFavoriteDapp
 
   const onPressFavorite = () => {
     const eventProperties = {
@@ -67,28 +65,21 @@ export function DappCardContent({
     vibrateSuccess()
   }
   return (
-    <View
-      style={[
-        styles.pressableCard,
-        {
-          paddingHorizontal: showBorder ? Spacing.Regular16 : Spacing.Smallest8,
-        },
-      ]}
-    >
+    <>
       <Image source={{ uri: dapp.iconUrl }} style={styles.dappIcon} />
       <View style={styles.itemTextContainer}>
         <Text style={styles.title}>{dapp.name}</Text>
         <Text style={styles.subtitle}>{dapp.description}</Text>
       </View>
       <Touchable
-        disabled={disableFavoriting}
+        disabled={!favouritesEnabled}
         onPress={onPressFavorite}
         hitSlop={favoriteIconHitslop}
         testID={`Dapp/Favorite/${dapp.id}`}
       >
-        {isFavorited ? <Star /> : !disableFavoriting ? <StarOutline /> : <></>}
+        {isFavorited ? <Star /> : favouritesEnabled ? <StarOutline /> : <></>}
       </Touchable>
-    </View>
+    </>
   )
 }
 
@@ -96,24 +87,28 @@ function DappCard({
   dapp,
   onPressDapp,
   onFavoriteDapp,
-  disableFavoriting,
   showBorder,
+  cardContentContainerStyle,
+  cardStyle,
   testID,
 }: Props) {
   return (
     <Card
       testID={testID}
-      style={[styles.card, showBorder ? styles.borderStyle : {}]}
+      style={[styles.card, showBorder ? styles.borderStyle : {}, cardStyle]}
       rounded={true}
       shadow={null}
     >
-      <Touchable onPress={onPressDapp} borderRadius={8} testID={`Dapp/${dapp.id}`}>
+      <Touchable
+        style={[styles.pressableCard, cardContentContainerStyle]}
+        onPress={onPressDapp}
+        borderRadius={showBorder ? 8 : undefined}
+        testID={`Dapp/${dapp.id}`}
+      >
         <DappCardContent
           dapp={dapp}
           onFavoriteDapp={onFavoriteDapp}
-          disableFavoriting={disableFavoriting}
           favoritedFromSection={DappSection.All}
-          showBorder={showBorder}
         />
       </Touchable>
     </Card>
@@ -139,10 +134,9 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     flex: 1,
-    paddingVertical: Spacing.Regular16,
+    padding: Spacing.Regular16,
   },
   card: {
-    marginTop: Spacing.Regular16,
     padding: 0,
   },
   title: {

--- a/src/dappsExplorer/DappCard.tsx
+++ b/src/dappsExplorer/DappCard.tsx
@@ -19,12 +19,14 @@ interface DappCardContentProps {
   dapp: Dapp
   onFavoriteDapp?: (dapp: Dapp) => void
   favoritedFromSection: DappSection
+  disableFavoriting?: boolean
 }
 
 interface Props {
   onPressDapp: () => void
   dapp: Dapp
   testID: string
+  disableFavoriting?: boolean
   onFavoriteDapp?: (dapp: Dapp) => void
   showBorder?: boolean
   cardContentContainerStyle?: ViewStyle
@@ -38,12 +40,12 @@ export function DappCardContent({
   dapp,
   onFavoriteDapp,
   favoritedFromSection,
+  disableFavoriting,
 }: DappCardContentProps) {
   const dispatch = useDispatch()
   const favoriteDappIds = useSelector(favoriteDappIdsSelector)
 
   const isFavorited = favoriteDappIds.includes(dapp.id)
-  const favouritesEnabled = !!onFavoriteDapp
 
   const onPressFavorite = () => {
     const eventProperties = {
@@ -72,12 +74,12 @@ export function DappCardContent({
         <Text style={styles.subtitle}>{dapp.description}</Text>
       </View>
       <Touchable
-        disabled={!favouritesEnabled}
+        disabled={disableFavoriting}
         onPress={onPressFavorite}
         hitSlop={favoriteIconHitslop}
         testID={`Dapp/Favorite/${dapp.id}`}
       >
-        {isFavorited ? <Star /> : favouritesEnabled ? <StarOutline /> : <></>}
+        {isFavorited ? <Star /> : !disableFavoriting ? <StarOutline /> : <></>}
       </Touchable>
     </>
   )
@@ -87,6 +89,7 @@ function DappCard({
   dapp,
   onPressDapp,
   onFavoriteDapp,
+  disableFavoriting,
   showBorder,
   cardContentContainerStyle,
   cardStyle,
@@ -108,6 +111,7 @@ function DappCard({
         <DappCardContent
           dapp={dapp}
           onFavoriteDapp={onFavoriteDapp}
+          disableFavoriting={disableFavoriting}
           favoritedFromSection={DappSection.All}
         />
       </Touchable>

--- a/src/dappsExplorer/DiscoverDappsCard.tsx
+++ b/src/dappsExplorer/DiscoverDappsCard.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useMemo, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { SectionList, StyleSheet, Text, View } from 'react-native'
-import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { DappExplorerEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import TextButton from 'src/components/TextButton'
@@ -10,7 +9,6 @@ import { fetchDappsList } from 'src/dapps/slice'
 import { ActiveDapp, Dapp, DappSection } from 'src/dapps/types'
 import DappCard from 'src/dappsExplorer/DappCard'
 import useOpenDapp from 'src/dappsExplorer/useOpenDapp'
-import { currentLanguageSelector } from 'src/i18n/selectors'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import { useDispatch, useSelector } from 'src/redux/hooks'
@@ -30,11 +28,8 @@ const MAX_DAPPS = 5
 function DiscoverDappsCard() {
   const { t } = useTranslation()
 
-  const insets = useSafeAreaInsets()
-
   const sectionListRef = useRef<SectionList>(null)
 
-  const language = useSelector(currentLanguageSelector)
   const dispatch = useDispatch()
   const favoriteDapps = useSelector(favoriteDappsSelector)
   const mostPopularDapps = useSelector(mostPopularDappsSelector)

--- a/src/dappsExplorer/DiscoverDappsCard.tsx
+++ b/src/dappsExplorer/DiscoverDappsCard.tsx
@@ -92,9 +92,11 @@ function DiscoverDappsCard() {
         scrollEnabled={false}
         ListHeaderComponent={<Text style={styles.title}>{t('dappsScreen.exploreDapps')}</Text>}
         ListFooterComponent={
-          <TextButton style={styles.footer} onPress={onPressExploreAll}>
-            {t('dappsScreen.exploreAll')}
-          </TextButton>
+          <View>
+            <TextButton style={styles.footer} onPress={onPressExploreAll}>
+              {t('dappsScreen.exploreAll')}
+            </TextButton>
+          </View>
         }
         sections={sections}
         renderItem={({ item: dapp, index, section }) => {
@@ -144,7 +146,6 @@ const styles = StyleSheet.create({
   },
   footer: {
     ...typeScale.labelSemiBoldXSmall,
-    flex: 1,
     color: Colors.primary,
   },
   title: {
@@ -154,7 +155,7 @@ const styles = StyleSheet.create({
   },
   dappCardContentContainer: {
     padding: 0,
-    paddingVertical: Spacing.Regular16,
+    marginVertical: Spacing.Regular16,
   },
 })
 

--- a/src/dappsExplorer/DiscoverDappsCard.tsx
+++ b/src/dappsExplorer/DiscoverDappsCard.tsx
@@ -107,6 +107,7 @@ function DiscoverDappsCard() {
             <DappCard
               dapp={dapp}
               onPressDapp={() => onPressDapp({ ...dapp, openedFrom: section.dappSection }, index)}
+              disableFavoriting={true}
               testID={`${section.testID}/DappCard`}
               cardContentContainerStyle={styles.dappCardContentContainer}
             />

--- a/src/dappsExplorer/DiscoverDappsCard.tsx
+++ b/src/dappsExplorer/DiscoverDappsCard.tsx
@@ -4,19 +4,19 @@ import { SectionList, StyleSheet, Text, View } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { DappExplorerEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
-import { mostPopularDappsSelector, favoriteDappsSelector } from 'src/dapps/selectors'
+import TextButton from 'src/components/TextButton'
+import { favoriteDappsSelector, mostPopularDappsSelector } from 'src/dapps/selectors'
 import { fetchDappsList } from 'src/dapps/slice'
 import { ActiveDapp, Dapp, DappSection } from 'src/dapps/types'
 import DappCard from 'src/dappsExplorer/DappCard'
 import useOpenDapp from 'src/dappsExplorer/useOpenDapp'
 import { currentLanguageSelector } from 'src/i18n/selectors'
+import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import { useDispatch, useSelector } from 'src/redux/hooks'
 import { Colors } from 'src/styles/colors'
-import fontStyles, { typeScale } from 'src/styles/fonts'
+import { typeScale } from 'src/styles/fonts'
 import { Spacing } from 'src/styles/styles'
-import TextButton from 'src/components/TextButton'
-import { navigate } from 'src/navigator/NavigationService'
 
 interface SectionData {
   data: Dapp[]
@@ -62,7 +62,7 @@ function DiscoverDappsCard() {
           data: mostPopularDapps
             .filter((dapp) => !favoriteDappIds.includes(dapp.id))
             .slice(0, MAX_DAPPS - favoriteDapps.length),
-          sectionName: t('dappsScreen.mostPopularDapps').toLocaleUpperCase(language ?? 'en-US'),
+          sectionName: t('dappsScreen.mostPopularDapps'),
           dappSection: DappSection.MostPopular,
           testID: 'DiscoverDappsCard/MostPopularSection',
         },
@@ -73,7 +73,7 @@ function DiscoverDappsCard() {
         ? [
             {
               data: favoriteDapps.slice(0, MAX_DAPPS),
-              sectionName: t('dappsScreen.favoriteDapps').toLocaleUpperCase(language ?? 'en-US'),
+              sectionName: t('dappsScreen.favoriteDapps'),
               dappSection: DappSection.FavoritesDappScreen,
               testID: 'DiscoverDappsCard/FavoritesSection',
             },
@@ -101,21 +101,15 @@ function DiscoverDappsCard() {
             {t('dappsScreen.exploreAll')}
           </TextButton>
         }
-        contentContainerStyle={[
-          styles.sectionListContentContainer,
-          { paddingBottom: Math.max(insets.bottom, Spacing.Regular16) },
-        ]}
         sections={sections}
         renderItem={({ item: dapp, index, section }) => {
           return (
-            <View style={styles.cardContainer}>
-              <DappCard
-                dapp={dapp}
-                onPressDapp={() => onPressDapp({ ...dapp, openedFrom: section.dappSection }, index)}
-                disableFavoriting={true}
-                testID={`${section.testID}/DappCard`}
-              />
-            </View>
+            <DappCard
+              dapp={dapp}
+              onPressDapp={() => onPressDapp({ ...dapp, openedFrom: section.dappSection }, index)}
+              testID={`${section.testID}/DappCard`}
+              cardContentContainerStyle={styles.dappCardContentContainer}
+            />
           )
         }}
         renderSectionHeader={({ section: { sectionName, testID } }) => {
@@ -139,26 +133,18 @@ function DiscoverDappsCard() {
 const styles = StyleSheet.create({
   container: {
     padding: Spacing.Regular16,
-    paddingBottom: 0,
-    gap: Spacing.Smallest8,
     borderColor: Colors.gray2,
     borderWidth: 1,
     borderRadius: Spacing.Smallest8,
   },
-  sectionListContentContainer: {
-    paddingTop: Spacing.Regular16,
-    flexGrow: 1,
-  },
   sectionTitle: {
-    ...fontStyles.label,
-    paddingTop: Spacing.Small12,
-    paddingLeft: Spacing.Regular16,
+    ...typeScale.labelXSmall,
     color: Colors.gray4,
+    marginTop: Spacing.Smallest8,
   },
   listFooterComponent: {
     flex: 1,
-    alignItems: 'center',
-    paddingTop: Spacing.Regular16,
+    alignSelf: 'center',
   },
   footer: {
     ...typeScale.labelSemiBoldXSmall,
@@ -166,13 +152,13 @@ const styles = StyleSheet.create({
     color: Colors.primary,
   },
   title: {
-    ...typeScale.titleMedium,
+    ...typeScale.labelSemiBoldMedium,
     color: Colors.black,
-    marginBottom: Spacing.Large32,
-    paddingLeft: Spacing.Regular16,
+    marginBottom: Spacing.Smallest8,
   },
-  cardContainer: {
-    paddingLeft: Spacing.Smallest8,
+  dappCardContentContainer: {
+    padding: 0,
+    paddingVertical: Spacing.Regular16,
   },
 })
 


### PR DESCRIPTION
### Description

[Context](https://valora-app.slack.com/archives/C0684TXDR3K/p1719510075150019) and [design](https://www.figma.com/design/FwRyq9HaKtZgywKVmIg0Zh/Discover-Page?node-id=1-3&t=uHdxyczMjeuYYBO2-0).

This PR only has styles changes. Also fixes the dapp filters appearing on more than 1 row. This PR breaks the dapp rankings styles but that is disabled and earmarked for deletion anyway. 

### Test plan

![Simulator Screenshot - iPhone 15 Pro - 2024-07-09 at 12 16 46](https://github.com/valora-inc/wallet/assets/20150449/c34c0855-6b06-4384-83e6-b18329f2e63a)

https://github.com/valora-inc/wallet/assets/20150449/7f1cd23b-8e5f-497a-88e9-174ad7afdf5a



### Related issues

n/a

### Backwards compatibility

yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
