### PR TITLE
fix(points): add stroke to "swap" icon

### DIFF
--- a/src/icons/SwapArrows.tsx
+++ b/src/icons/SwapArrows.tsx
@@ -12,6 +12,7 @@ const SwapArrows = ({ size = 24, color = Colors.black, testID }: Props) => (
   <Svg width={size} height={size} viewBox="0 0 24 24" fill="none" testID={testID}>
     <Path
       fill={color}
+      stroke={color}
       d="M15.722 17.567v.5h2.624l-3.235 3.227-3.235-3.227H14.5v-7.79h1.222v7.29ZM7.833 6.433v-.5H5.21l3.235-3.227 3.236 3.227H9.056v7.79H7.833v-7.29Z"
     />
   </Svg>


### PR DESCRIPTION
### Description

The swap icon lost its stroke compared to [one in figma](https://www.figma.com/design/erFfzHvSTm5g1sjK6jWyEH/Working-Design-System-Components?node-id=317-135&t=iNHByjTAhOFLGYKN-0). This fixes it.

Context: https://valora-app.slack.com/archives/C0684TXDR3K/p1720545011018399

| Before fix | After fix | In Figma |
|--------|--------|--------|
| ![image](https://github.com/valora-inc/wallet/assets/2737872/41834934-2382-4c4c-b529-6b85ad0a816f) | ![image](https://github.com/valora-inc/wallet/assets/2737872/0fc1cc45-9815-439d-a90c-d2a2ef591061) | <img width="64" alt="image" src="https://github.com/valora-inc/wallet/assets/2737872/b7bc2102-80f8-4dba-aaf8-c743d0f396f0"> | 

### Test plan

Visual assessment

### Related issues

- Related to RET-1103

### Backwards compatibility

Y

### Network scalability

NA