### PR TITLE
chore: remove swap buy amount flow

### DIFF
--- a/src/statsig/constants.ts
+++ b/src/statsig/constants.ts
@@ -37,12 +37,6 @@ export const FeatureGates = {
 
 export const ExperimentConfigs = {
   // NOTE: the keys of defaultValues MUST be parameter names
-  [StatsigExperiments.SWAP_BUY_AMOUNT]: {
-    experimentName: StatsigExperiments.SWAP_BUY_AMOUNT,
-    defaultValues: {
-      swapBuyAmountEnabled: true,
-    },
-  },
   [StatsigExperiments.ONBOARDING_TERMS_AND_CONDITIONS]: {
     experimentName: StatsigExperiments.ONBOARDING_TERMS_AND_CONDITIONS,
     defaultValues: {

--- a/src/statsig/types.ts
+++ b/src/statsig/types.ts
@@ -39,7 +39,6 @@ export enum StatsigFeatureGates {
 }
 
 export enum StatsigExperiments {
-  SWAP_BUY_AMOUNT = 'swap_buy_amount',
   ONBOARDING_TERMS_AND_CONDITIONS = 'onboarding_terms_and_conditions',
 }
 

--- a/src/swap/SwapAmountInput.tsx
+++ b/src/swap/SwapAmountInput.tsx
@@ -16,14 +16,14 @@ import TokenDisplay from 'src/components/TokenDisplay'
 import TokenIcon, { IconSize } from 'src/components/TokenIcon'
 import Touchable from 'src/components/Touchable'
 import DownArrowIcon from 'src/icons/DownArrowIcon'
+import { NETWORK_NAMES } from 'src/shared/conts'
 import Colors from 'src/styles/colors'
 import fontStyles, { typeScale } from 'src/styles/fonts'
 import { Spacing } from 'src/styles/styles'
 import { TokenBalance } from 'src/tokens/slice'
-import { NETWORK_NAMES } from 'src/shared/conts'
 
 interface Props {
-  onInputChange(value: string): void
+  onInputChange?(value: string): void
   inputValue?: string | null
   parsedInputValue?: BigNumber | null
   onPressMax?(): void
@@ -106,7 +106,7 @@ const SwapAmountInput = ({
               forwardedRef={textInputRef}
               onChangeText={(value) => {
                 handleSetStartPosition(undefined)
-                onInputChange(value)
+                onInputChange?.(value)
               }}
               value={inputValue || undefined}
               placeholder="0"

--- a/src/swap/SwapScreen.test.tsx
+++ b/src/swap/SwapScreen.test.tsx
@@ -507,47 +507,6 @@ describe('SwapScreen', () => {
     expect(getByText('swapScreen.confirmSwap')).not.toBeDisabled()
   })
 
-  it('should keep the from amount in sync with the exchange rate', async () => {
-    mockFetch.mockResponse(
-      JSON.stringify({
-        ...defaultQuote,
-        unvalidatedSwapTransaction: {
-          ...defaultQuote.unvalidatedSwapTransaction,
-          price: '0.12345678',
-        },
-      })
-    )
-    const { swapScreen, swapFromContainer, swapToContainer, getByText, getByTestId } = renderScreen(
-      {}
-    )
-
-    selectSwapTokens('CELO', 'cUSD', swapScreen)
-    fireEvent.changeText(within(swapToContainer).getByTestId('SwapAmountInput/Input'), '1.234')
-
-    await act(() => {
-      jest.runOnlyPendingTimers()
-    })
-    expect(mockFetch.mock.calls.length).toEqual(1)
-    expect(mockFetch.mock.calls[0][0]).toEqual(
-      `${
-        networkConfig.getSwapQuoteUrl
-      }?buyToken=${mockCusdAddress}&buyIsNative=false&buyNetworkId=${
-        NetworkId['celo-alfajores']
-      }&sellToken=${mockCeloAddress}&sellIsNative=true&sellNetworkId=${
-        NetworkId['celo-alfajores']
-      }&buyAmount=1234000000000000000&userAddress=${mockAccount.toLowerCase()}&slippagePercentage=0.3`
-    )
-
-    expect(getByTestId('SwapTransactionDetails/ExchangeRate')).toHaveTextContent(
-      '1 CELO ≈ 8.10000 cUSD'
-    )
-    expect(within(swapFromContainer).getByTestId('SwapAmountInput/Input').props.value).toBe(
-      '0.15234566652'
-    )
-    expect(within(swapToContainer).getByTestId('SwapAmountInput/Input').props.value).toBe('1.234')
-    expect(getByText('swapScreen.confirmSwap')).not.toBeDisabled()
-  })
-
   it('should allow selecting cross-chain tokens and show cross-chain message', async () => {
     jest
       .mocked(getFeatureGate)
@@ -881,55 +840,6 @@ describe('SwapScreen', () => {
       '~₱2,03'
     )
     expect(getByTestId('SwapTransactionDetails/Slippage')).toHaveTextContent('0,3%')
-    expect(getByText('swapScreen.confirmSwap')).not.toBeDisabled()
-  })
-
-  it('should support to amount with comma as the decimal separator', async () => {
-    // This only changes the display format, the input is parsed with getNumberFormatSettings
-    BigNumber.config({
-      FORMAT: {
-        decimalSeparator: ',',
-      },
-    })
-    mockGetNumberFormatSettings.mockReturnValue({ decimalSeparator: ',' })
-    mockFetch.mockResponse(
-      JSON.stringify({
-        ...defaultQuote,
-        unvalidatedSwapTransaction: {
-          ...defaultQuote.unvalidatedSwapTransaction,
-          price: '0.12345678',
-        },
-      })
-    )
-    const { swapScreen, swapFromContainer, swapToContainer, getByText, getByTestId } = renderScreen(
-      {}
-    )
-
-    selectSwapTokens('CELO', 'cUSD', swapScreen)
-    fireEvent.changeText(within(swapToContainer).getByTestId('SwapAmountInput/Input'), '1,234')
-
-    await act(() => {
-      jest.runOnlyPendingTimers()
-    })
-
-    expect(mockFetch.mock.calls.length).toEqual(1)
-    expect(mockFetch.mock.calls[0][0]).toEqual(
-      `${
-        networkConfig.getSwapQuoteUrl
-      }?buyToken=${mockCusdAddress}&buyIsNative=false&buyNetworkId=${
-        NetworkId['celo-alfajores']
-      }&sellToken=${mockCeloAddress}&sellIsNative=true&sellNetworkId=${
-        NetworkId['celo-alfajores']
-      }&buyAmount=1234000000000000000&userAddress=${mockAccount.toLowerCase()}&slippagePercentage=0.3`
-    )
-
-    expect(getByTestId('SwapTransactionDetails/ExchangeRate')).toHaveTextContent(
-      '1 CELO ≈ 8,10000 cUSD'
-    )
-    expect(within(swapFromContainer).getByTestId('SwapAmountInput/Input').props.value).toBe(
-      '0,15234566652'
-    )
-    expect(within(swapToContainer).getByTestId('SwapAmountInput/Input').props.value).toBe('1,234')
     expect(getByText('swapScreen.confirmSwap')).not.toBeDisabled()
   })
 
@@ -1322,10 +1232,7 @@ describe('SwapScreen', () => {
     expect(within(swapToContainer).getByTestId('SwapAmountInput/Input')).toBeTruthy()
   })
 
-  it('should disable buy amount input when swap buy amount experiment is set is false', () => {
-    jest.mocked(getExperimentParams).mockReturnValue({
-      swapBuyAmountEnabled: false,
-    })
+  it('should disable editing of the buy token amount', () => {
     const { swapFromContainer, swapToContainer, swapScreen } = renderScreen({})
 
     selectSwapTokens('CELO', 'cUSD', swapScreen)


### PR DESCRIPTION
### Description

As the title, this PR includes:
- removing the buy experiment statsig variables
- removing the `updatedField` swap screen state variable and its references (it always has the value `Field.FROM` now) - the `updatedField` value is only changed on the `changeAmount` action.
- removing some tests about the buy flow

### Test plan

Unit tests pass, i can still swap

### Related issues

- Fixes RET-920

### Backwards compatibility

Y

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [ ] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
