### PR TITLE
feat(points): Support earning points for depositing into earn pool

### DIFF
--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -2350,6 +2350,10 @@
             "erc20": "Sent {{tokenSymbol}}",
             "erc721": "Sent NFT"
           }
+        },
+        "depositEarn": {
+          "title": "Deposited",
+          "subtitle": "to {{network}} Pool"
         }
       },
       "title": "My points activity",
@@ -2416,6 +2420,14 @@
           "title": "Send with a Live Link",
           "body": "Earn {{pointsValue}} points every time you send funds using a Live Link in {{appName}}. \n\nTap below to start sending and earning!",
           "cta": "Send with a Live Link"
+        }
+      },
+      "depositEarn": {
+        "title": "Deposit into an earn pool on {{appName}}",
+        "bottomSheet": {
+          "title": "Deposit into an earn pool",
+          "body": "Earn {{pointsValue}} points every time you deposit funds into an earn pool on {{appName}}. \n\nTap below to start earning yield and points!",
+          "cta": "Go to earn pools"
         }
       }
     },

--- a/src/earn/saga.test.ts
+++ b/src/earn/saga.test.ts
@@ -234,7 +234,13 @@ describe('depositSubmitSaga', () => {
     })
       .withState(createMockStore({ tokens: { tokenBalances: mockTokenBalances } }).getState())
       .provide(sagaProviders)
-      .put(depositSuccess())
+      .put(
+        depositSuccess({
+          tokenId: mockArbUsdcTokenId,
+          networkId: NetworkId['arbitrum-sepolia'],
+          transactionHash: '0x2',
+        })
+      )
       .put(fetchTokenBalances({ showLoading: false }))
       .call.like({ fn: sendPreparedTransactions })
       .call([publicClient[Network.Arbitrum], 'waitForTransactionReceipt'], { hash: '0x1' })
@@ -271,7 +277,13 @@ describe('depositSubmitSaga', () => {
     })
       .withState(createMockStore({ tokens: { tokenBalances: mockTokenBalances } }).getState())
       .provide(sagaProviders)
-      .put(depositSuccess())
+      .put(
+        depositSuccess({
+          tokenId: mockArbUsdcTokenId,
+          networkId: NetworkId['arbitrum-sepolia'],
+          transactionHash: '0x2',
+        })
+      )
       .put(fetchTokenBalances({ showLoading: false }))
       .call.like({ fn: sendPreparedTransactions })
       .call([publicClient[Network.Arbitrum], 'waitForTransactionReceipt'], { hash: '0x2' })

--- a/src/earn/saga.ts
+++ b/src/earn/saga.ts
@@ -222,7 +222,13 @@ export function* depositSubmitSaga(action: PayloadAction<DepositInfo>) {
       ...commonAnalyticsProps,
       ...getDepositTxsReceiptAnalyticsProperties(trackedTxs, networkId, tokensById),
     })
-    yield* put(depositSuccess())
+    yield* put(
+      depositSuccess({
+        tokenId: tokenInfo.tokenId,
+        networkId,
+        transactionHash: txHashes[txHashes.length - 1],
+      })
+    )
     yield* put(fetchTokenBalances({ showLoading: false }))
   } catch (err) {
     if (err === CANCELLED_PIN_INPUT) {

--- a/src/earn/slice.test.ts
+++ b/src/earn/slice.test.ts
@@ -8,6 +8,7 @@ import reducer, {
   withdrawStart,
   withdrawSuccess,
 } from './slice'
+import { NetworkId } from 'src/transactions/types'
 
 describe('Earn Slice', () => {
   it('should handle deposit start', () => {
@@ -20,7 +21,14 @@ describe('Earn Slice', () => {
   })
 
   it('should handle deposit success', () => {
-    const updatedState = reducer(undefined, depositSuccess())
+    const updatedState = reducer(
+      undefined,
+      depositSuccess({
+        tokenId: 'tokenId',
+        networkId: NetworkId['celo-alfajores'],
+        transactionHash: '0x3',
+      })
+    )
 
     expect(updatedState).toHaveProperty('depositStatus', 'success')
   })

--- a/src/earn/slice.ts
+++ b/src/earn/slice.ts
@@ -1,6 +1,6 @@
 import { PayloadAction, createSlice } from '@reduxjs/toolkit'
 import { REHYDRATE, RehydrateAction } from 'redux-persist'
-import { DepositInfo, PoolInfo, WithdrawInfo } from 'src/earn/types'
+import { DepositInfo, PoolInfo, WithdrawInfo, DepositSuccess } from 'src/earn/types'
 import { getRehydratePayload } from 'src/redux/persist-helper'
 
 type Status = 'idle' | 'loading' | 'success' | 'error'
@@ -25,7 +25,7 @@ export const slice = createSlice({
     depositStart: (state, action: PayloadAction<DepositInfo>) => {
       state.depositStatus = 'loading'
     },
-    depositSuccess: (state) => {
+    depositSuccess: (state, _action: PayloadAction<DepositSuccess>) => {
       state.depositStatus = 'success'
     },
     depositError: (state) => {

--- a/src/earn/types.ts
+++ b/src/earn/types.ts
@@ -1,10 +1,18 @@
 import { TokenBalance } from 'src/tokens/slice'
 import { SerializableTransactionRequest } from 'src/viem/preparedTransactionSerialization'
+import { NetworkId } from 'src/transactions/types'
+import { Hash } from 'viem'
 
 export interface DepositInfo {
   amount: string
   tokenId: string
   preparedTransactions: SerializableTransactionRequest[]
+}
+
+export interface DepositSuccess {
+  tokenId: string
+  transactionHash: Hash
+  networkId: NetworkId
 }
 
 export interface RewardsInfo {

--- a/src/points/ActivityCardSection.tsx
+++ b/src/points/ActivityCardSection.tsx
@@ -12,6 +12,8 @@ import Colors from 'src/styles/colors'
 import { typeScale } from 'src/styles/fonts'
 import { Spacing } from 'src/styles/styles'
 import MagicWand from 'src/icons/MagicWand'
+import EarnCoins from 'src/icons/EarnCoins'
+import networkConfig from 'src/web3/networkConfig'
 
 interface Props {
   pointsActivities: PointsActivity[]
@@ -65,6 +67,28 @@ export default function ActivityCardSection({ pointsActivities, onCardPress }: P
                 text: t('points.activityCards.createLiveLink.bottomSheet.cta'),
                 onPress: () => {
                   navigate(Screens.JumpstartEnterAmount)
+                },
+              },
+            }),
+        }
+      case 'deposit-earn':
+        return {
+          ...activity,
+          title: t('points.activityCards.depositEarn.title'),
+          icon: <EarnCoins color={Colors.black} />,
+          onPress: () =>
+            onCardPress({
+              ...activity,
+              title: t('points.activityCards.depositEarn.bottomSheet.title'),
+              body: t('points.activityCards.depositEarn.bottomSheet.body', {
+                pointsValue: activity.pointsAmount,
+              }),
+              cta: {
+                text: t('points.activityCards.depositEarn.bottomSheet.cta'),
+                onPress: () => {
+                  navigate(Screens.EarnEnterAmount, {
+                    tokenId: networkConfig.arbUsdcTokenId,
+                  })
                 },
               },
             }),

--- a/src/points/PointsHistoryBottomSheet.test.tsx
+++ b/src/points/PointsHistoryBottomSheet.test.tsx
@@ -19,6 +19,14 @@ jest.mock('src/statsig', () => ({
 const MOCK_RESPONSE_NO_NEXT_PAGE: GetHistoryResponse = {
   data: [
     {
+      activityId: 'deposit-earn',
+      pointsAmount: 10,
+      createdAt: '2024-03-05T20:26:25.000Z',
+      metadata: {
+        tokenId: 'celo-alfajores:0x874069fa1eb16d44d622f2e0ca25eea172369bc1',
+      },
+    },
+    {
       activityId: 'create-live-link',
       pointsAmount: 10,
       createdAt: '2024-03-05T19:26:25.000Z',
@@ -47,7 +55,7 @@ const MOCK_RESPONSE_NO_NEXT_PAGE: GetHistoryResponse = {
     {
       activityId: 'swap',
       pointsAmount: 20,
-      createdAt: '2024-01-04T19:26:25.000Z',
+      createdAt: '2024-03-05T19:26:25.000Z',
       metadata: {
         to: 'celo-alfajores:0x874069fa1eb16d44d622f2e0ca25eea172369bc1',
         from: 'celo-alfajores:native',
@@ -102,8 +110,11 @@ describe(PointsHistoryBottomSheet, () => {
     const tree = renderScreen({
       points: { pointsHistory: MOCK_RESPONSE_NO_NEXT_PAGE.data, getHistoryStatus: 'loading' },
     })
-    await waitFor(() => expect(tree.getByTestId('PointsHistoryList').props.data.length).toBe(3))
+    await waitFor(() => expect(tree.getByTestId('PointsHistoryList').props.data.length).toBe(2))
 
+    expect(
+      tree.getByText('points.history.cards.depositEarn.subtitle, {"network":"Celo Alfajores"}')
+    ).toBeTruthy()
     expect(
       tree.getByText('points.history.cards.createLiveLink.subtitle.erc20, {"tokenSymbol":"CELO"}')
     ).toBeTruthy()
@@ -116,8 +127,8 @@ describe(PointsHistoryBottomSheet, () => {
     ).toBeTruthy()
     expect(tree.getByText('points.history.cards.createWallet.subtitle')).toBeTruthy()
 
-    expect(tree.getByText('January')).toBeTruthy()
     expect(tree.getByText('March')).toBeTruthy()
+    expect(tree.getByText('December 2023')).toBeTruthy()
     expect(tree.getByTestId('PointsHistoryBottomSheet/Loading')).toBeTruthy()
   })
 

--- a/src/points/PointsHistoryBottomSheet.tsx
+++ b/src/points/PointsHistoryBottomSheet.tsx
@@ -233,9 +233,8 @@ const styles = StyleSheet.create({
     paddingHorizontal: Spacing.Thick24,
   },
   cardIcon: {
-    backgroundColor: colors.successLight,
-    justifyContent: 'flex-end',
     alignItems: 'center',
+    justifyContent: 'center',
     borderRadius: 20,
     width: 40,
     height: 40,

--- a/src/points/PointsHome.test.tsx
+++ b/src/points/PointsHome.test.tsx
@@ -29,6 +29,9 @@ const renderPointsHome = (storeOverrides?: RecursivePartial<RootState>) => {
             'create-wallet': {
               pointsAmount: 20,
             },
+            'deposit-earn': {
+              pointsAmount: 50,
+            },
           },
         },
         pointsConfigStatus: 'success',
@@ -131,6 +134,8 @@ describe(PointsHome, () => {
 
     expect(getByText('points.activityCards.createWallet.title')).toBeTruthy()
     expect(getByText('points.activityCards.swap.title')).toBeTruthy()
+    expect(getByText('points.activityCards.createLiveLink.title')).toBeTruthy()
+    expect(getByText('points.activityCards.depositEarn.title')).toBeTruthy()
 
     expect(getByText('points.activityCards.moreComing.title')).toBeTruthy()
 

--- a/src/points/cardDefinitions.tsx
+++ b/src/points/cardDefinitions.tsx
@@ -11,8 +11,14 @@ import { getSupportedNetworkIdsForSwap } from 'src/tokens/utils'
 import Logger from 'src/utils/Logger'
 import { TokenBalances } from 'src/tokens/slice'
 import { TFunction } from 'i18next'
+import { NETWORK_NAMES } from 'src/shared/conts'
+import EarnCoins from 'src/icons/EarnCoins'
+import IconWithNetworkBadge from 'src/components/IconWithNetworkBadge'
+import CircledIcon from 'src/icons/CircledIcon'
 
 const TAG = 'Points/cardDefinitions'
+
+const ICON_SIZE = 40
 
 export interface HistoryCardMetadata {
   icon: React.ReactNode
@@ -57,7 +63,11 @@ export function useGetHistoryDefinition(): (
     switch (history.activityId) {
       case 'create-wallet': {
         return {
-          icon: <Celebration color={colors.successDark} />,
+          icon: (
+            <CircledIcon backgroundColor={colors.successLight} radius={ICON_SIZE}>
+              <Celebration color={colors.successDark} />
+            </CircledIcon>
+          ),
           title: t('points.history.cards.createWallet.title'),
           subtitle: t('points.history.cards.createWallet.subtitle'),
           pointsAmount: history.pointsAmount,
@@ -71,7 +81,11 @@ export function useGetHistoryDefinition(): (
           return undefined
         }
         return {
-          icon: <SwapArrows color={colors.successDark} />,
+          icon: (
+            <CircledIcon backgroundColor={colors.successLight} radius={ICON_SIZE}>
+              <SwapArrows color={colors.successDark} />
+            </CircledIcon>
+          ),
           title: t('points.history.cards.swap.title'),
           subtitle: t('points.history.cards.swap.subtitle', {
             fromToken: fromToken.symbol,
@@ -87,9 +101,34 @@ export function useGetHistoryDefinition(): (
           return
         }
         return {
-          icon: <MagicWand />,
+          icon: (
+            <CircledIcon backgroundColor={colors.successLight} radius={ICON_SIZE}>
+              <MagicWand />
+            </CircledIcon>
+          ),
           title: t('points.history.cards.createLiveLink.title'),
           subtitle,
+          pointsAmount: history.pointsAmount,
+        }
+      }
+      case 'deposit-earn': {
+        const token = tokensById[history.metadata.tokenId]
+        if (!token) {
+          Logger.error(TAG, `Cannot find token ${history.metadata.tokenId}`)
+          return undefined
+        }
+        return {
+          icon: (
+            <IconWithNetworkBadge networkId={token.networkId}>
+              <CircledIcon backgroundColor={colors.successLight} radius={ICON_SIZE}>
+                <EarnCoins size={24} color={colors.successDark} />
+              </CircledIcon>
+            </IconWithNetworkBadge>
+          ),
+          title: t('points.history.cards.depositEarn.title'),
+          subtitle: t('points.history.cards.depositEarn.subtitle', {
+            network: NETWORK_NAMES[token.networkId],
+          }),
           pointsAmount: history.pointsAmount,
         }
       }

--- a/src/points/cardDefinitions.tsx
+++ b/src/points/cardDefinitions.tsx
@@ -121,7 +121,7 @@ export function useGetHistoryDefinition(): (
           icon: (
             <IconWithNetworkBadge networkId={token.networkId}>
               <CircledIcon backgroundColor={colors.successLight} radius={ICON_SIZE}>
-                <EarnCoins size={24} color={colors.successDark} />
+                <EarnCoins color={colors.successDark} />
               </CircledIcon>
             </IconWithNetworkBadge>
           ),

--- a/src/points/saga.ts
+++ b/src/points/saga.ts
@@ -41,6 +41,7 @@ import { call, put, select, spawn, take, takeEvery, takeLeading } from 'typed-re
 import { v4 as uuidv4 } from 'uuid'
 import { depositTransactionSucceeded } from 'src/jumpstart/slice'
 import { swapSuccess } from 'src/swap/slice'
+import { depositSuccess } from 'src/earn/slice'
 
 const TAG = 'Points/saga'
 
@@ -328,6 +329,21 @@ export function* watchLiveLinkCreated() {
   yield* takeLeading(depositTransactionSucceeded.type, safely(watchLiveLinkCreatedTransformPayload))
 }
 
+export function* watchDepositSuccessTransformPayload({
+  payload: params,
+}: ReturnType<typeof depositSuccess>) {
+  yield* call(
+    sendPointsEvent,
+    trackPointsEvent({
+      ...params,
+      activityId: 'deposit-earn',
+    })
+  )
+}
+export function* watchDepositSuccess() {
+  yield* takeLeading(depositSuccess.type, safely(watchDepositSuccessTransformPayload))
+}
+
 export function* watchGetHistory() {
   yield* takeLeading(getHistoryStarted.type, safely(getHistory))
   yield* takeLeading(getHistoryStarted.type, safely(getPointsBalance))
@@ -361,4 +377,5 @@ export function* pointsSaga() {
   yield* spawn(watchHomeScreenVisit)
   yield* spawn(watchLiveLinkCreated)
   yield* spawn(watchSwapSuccess)
+  yield* spawn(watchDepositSuccess)
 }

--- a/src/points/types.ts
+++ b/src/points/types.ts
@@ -1,7 +1,7 @@
 import { NetworkId } from 'src/transactions/types'
 import { Address, Hash } from 'viem'
 
-const pointsActivities = ['create-wallet', 'swap', 'create-live-link'] as const
+const pointsActivities = ['create-wallet', 'swap', 'create-live-link', 'deposit-earn'] as const
 export type PointsActivityId = (typeof pointsActivities)[number]
 
 export function isPointsActivityId(activity: unknown): activity is PointsActivityId {
@@ -24,7 +24,7 @@ export interface BottomSheetParams extends PointsActivity {
   }
 }
 
-const claimActivities = ['create-wallet', 'swap', 'create-live-link'] as const
+const claimActivities = ['create-wallet', 'swap', 'create-live-link', 'deposit-earn'] as const
 type ClaimActivityId = (typeof claimActivities)[number]
 
 const liveLinkTypes = ['erc20', 'erc721'] as const
@@ -50,6 +50,12 @@ type SwapClaimHistory = BaseClaimHistory & {
     from: string
   }
 }
+type DepositEarnClaimHistory = BaseClaimHistory & {
+  activityId: 'deposit-earn'
+  metadata: {
+    tokenId: string
+  }
+}
 type BaseCreateLiveLinkClaimHistory = BaseClaimHistory & {
   activityId: 'create-live-link'
   metadata: {
@@ -71,7 +77,11 @@ export type CreateLiveLinkClaimHistory =
   | Erc20CreateLiveLinkClaimHistory
   | Erc721CreateLiveLinkClaimHistory
 
-export type ClaimHistory = CreateWalletClaimHistory | SwapClaimHistory | CreateLiveLinkClaimHistory
+export type ClaimHistory =
+  | CreateWalletClaimHistory
+  | SwapClaimHistory
+  | CreateLiveLinkClaimHistory
+  | DepositEarnClaimHistory
 
 // See https://stackoverflow.com/questions/59794474/omitting-a-shared-property-from-a-union-type-of-objects-results-in-error-when-us
 type DistributiveOmit<T, K extends keyof any> = T extends any ? Omit<T, K> : never
@@ -101,6 +111,13 @@ interface PointsEventSwap {
   fromTokenId: string
 }
 
+interface PointsEventDepositEarn {
+  activityId: 'deposit-earn'
+  transactionHash: Hash
+  networkId: NetworkId
+  tokenId: string
+}
+
 interface PointsEventBaseCreateLiveLink {
   activityId: 'create-live-link'
   liveLinkType: LiveLinkType
@@ -123,4 +140,8 @@ type PointsEventErc721CreateLiveLink = PointsEventBaseCreateLiveLink & {
 
 type PointsEventCreateLiveLink = PointsEventErc20CreateLiveLink | PointsEventErc721CreateLiveLink
 
-export type PointsEvent = PointsEventCreateWallet | PointsEventSwap | PointsEventCreateLiveLink
+export type PointsEvent =
+  | PointsEventCreateWallet
+  | PointsEventSwap
+  | PointsEventCreateLiveLink
+  | PointsEventDepositEarn

--- a/test/RootStateSchema.json
+++ b/test/RootStateSchema.json
@@ -838,6 +838,7 @@
             "enum": [
                 "create-live-link",
                 "create-wallet",
+                "deposit-earn",
                 "swap"
             ],
             "type": "string"
@@ -849,6 +850,9 @@
                 },
                 {
                     "$ref": "#/definitions/SwapClaimHistory"
+                },
+                {
+                    "$ref": "#/definitions/DepositEarnClaimHistory"
                 },
                 {
                     "$ref": "#/definitions/Erc20CreateLiveLinkClaimHistory"
@@ -1165,6 +1169,40 @@
                 "mostPopular"
             ],
             "type": "string"
+        },
+        "DepositEarnClaimHistory": {
+            "additionalProperties": false,
+            "properties": {
+                "activityId": {
+                    "const": "deposit-earn",
+                    "type": "string"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "metadata": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "tokenId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "tokenId"
+                    ],
+                    "type": "object"
+                },
+                "pointsAmount": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "activityId",
+                "createdAt",
+                "metadata",
+                "pointsAmount"
+            ],
+            "type": "object"
         },
         "E164NumberToAddressType": {
             "additionalProperties": {
@@ -2900,6 +2938,9 @@
                     "$ref": "#/definitions/PointsEventSwap"
                 },
                 {
+                    "$ref": "#/definitions/PointsEventDepositEarn"
+                },
+                {
                     "$ref": "#/definitions/PointsEventErc20CreateLiveLink"
                 },
                 {
@@ -2917,6 +2958,34 @@
             },
             "required": [
                 "activityId"
+            ],
+            "type": "object"
+        },
+        "PointsEventDepositEarn": {
+            "additionalProperties": false,
+            "properties": {
+                "activityId": {
+                    "const": "deposit-earn",
+                    "type": "string"
+                },
+                "networkId": {
+                    "$ref": "#/definitions/NetworkId"
+                },
+                "tokenId": {
+                    "type": "string"
+                },
+                "transactionHash": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "activityId",
+                "networkId",
+                "tokenId",
+                "transactionHash"
             ],
             "type": "object"
         },
@@ -5084,7 +5153,7 @@
                     "additionalProperties": false,
                     "properties": {
                         "activitiesById": {
-                            "$ref": "#/definitions/{swap?:{pointsAmount:number;previousPointsAmount?:number|undefined;}|undefined;\"create-wallet\"?:{pointsAmount:number;previousPointsAmount?:number|undefined;}|undefined;\"create-live-link\"?:{pointsAmount:number;previousPointsAmount?:number|undefined;}|undefined;}"
+                            "$ref": "#/definitions/{swap?:{pointsAmount:number;previousPointsAmount?:number|undefined;}|undefined;\"create-wallet\"?:{pointsAmount:number;previousPointsAmount?:number|undefined;}|undefined;\"create-live-link\"?:{pointsAmount:number;previousPointsAmount?:number|undefined;}|undefined;\"deposit-earn\"?:{pointsAmount:number;previousPointsAmount?:number|undefined;}|undefined;}"
                         }
                     },
                     "required": [
@@ -5108,7 +5177,7 @@
                     "type": "array"
                 },
                 "trackOnceActivities": {
-                    "$ref": "#/definitions/{swap?:boolean|undefined;\"create-wallet\"?:boolean|undefined;\"create-live-link\"?:boolean|undefined;}"
+                    "$ref": "#/definitions/{swap?:boolean|undefined;\"create-wallet\"?:boolean|undefined;\"create-live-link\"?:boolean|undefined;\"deposit-earn\"?:boolean|undefined;}"
                 }
             },
             "required": [
@@ -7003,7 +7072,7 @@
             },
             "type": "object"
         },
-        "{swap?:boolean|undefined;\"create-wallet\"?:boolean|undefined;\"create-live-link\"?:boolean|undefined;}": {
+        "{swap?:boolean|undefined;\"create-wallet\"?:boolean|undefined;\"create-live-link\"?:boolean|undefined;\"deposit-earn\"?:boolean|undefined;}": {
             "additionalProperties": false,
             "properties": {
                 "create-live-link": {
@@ -7012,13 +7081,16 @@
                 "create-wallet": {
                     "type": "boolean"
                 },
+                "deposit-earn": {
+                    "type": "boolean"
+                },
                 "swap": {
                     "type": "boolean"
                 }
             },
             "type": "object"
         },
-        "{swap?:{pointsAmount:number;previousPointsAmount?:number|undefined;}|undefined;\"create-wallet\"?:{pointsAmount:number;previousPointsAmount?:number|undefined;}|undefined;\"create-live-link\"?:{pointsAmount:number;previousPointsAmount?:number|undefined;}|undefined;}": {
+        "{swap?:{pointsAmount:number;previousPointsAmount?:number|undefined;}|undefined;\"create-wallet\"?:{pointsAmount:number;previousPointsAmount?:number|undefined;}|undefined;\"create-live-link\"?:{pointsAmount:number;previousPointsAmount?:number|undefined;}|undefined;\"deposit-earn\"?:{pointsAmount:number;previousPointsAmount?:number|undefined;}|undefined;}": {
             "additionalProperties": false,
             "properties": {
                 "create-live-link": {
@@ -7037,6 +7109,21 @@
                     "type": "object"
                 },
                 "create-wallet": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "pointsAmount": {
+                            "type": "number"
+                        },
+                        "previousPointsAmount": {
+                            "type": "number"
+                        }
+                    },
+                    "required": [
+                        "pointsAmount"
+                    ],
+                    "type": "object"
+                },
+                "deposit-earn": {
                     "additionalProperties": false,
                     "properties": {
                         "pointsAmount": {


### PR DESCRIPTION
### Description

For [RET-1090](https://linear.app/valora/issue/RET-1090/enable-points-for-deposit-into-earn-pool). Adds support for depositing into earn pools.

### Test plan

Manual and unit tested. See video below (excuse my laggy simulator!).

https://github.com/user-attachments/assets/38a8f8a1-5ac4-4c06-8ad1-ca4afd9563a8

### Related issues

- Fixes [RET-1090](https://linear.app/valora/issue/RET-1090/enable-points-for-deposit-into-earn-pool)

### Backwards compatibility

Yes.

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
