### PR TITLE
feat(earn): update earn discover card for multiple pools

### DIFF
--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -2479,6 +2479,11 @@
       "subtitle": "Buy {{symbol}}",
       "description": "Earn approximately {{apy}}% per year when you add {{symbol}} to a pool"
     },
+    "entrypoint": {
+      "title": "Earn on your stablecoins",
+      "subtitle": "Deposit and earn returns",
+      "description": "Explore pools to deposit assets and earn returns on your stablecoins"
+    },
     "enterAmount": {
       "earnUpToLabel": "You could earn up to:",
       "rateLabel": "Rate (est.)",

--- a/src/analytics/Events.tsx
+++ b/src/analytics/Events.tsx
@@ -677,6 +677,7 @@ export enum PointsEvents {
 
 export enum EarnEvents {
   earn_cta_press = 'earn_cta_press',
+  earn_entrypoint_press = 'earn_entrypoint_press',
   earn_add_crypto_action_press = 'earn_add_crypto_action_press',
   earn_deposit_provider_info_press = 'earn_deposit_provider_info_press',
   earn_deposit_terms_and_conditions_press = 'earn_deposit_terms_and_conditions_press',

--- a/src/analytics/Properties.tsx
+++ b/src/analytics/Properties.tsx
@@ -1595,6 +1595,7 @@ export type EarnDepositTxsReceiptProperties = Partial<ApproveTxReceiptProperties
 
 interface EarnEventsProperties {
   [EarnEvents.earn_cta_press]: EarnCommonProperties
+  [EarnEvents.earn_entrypoint_press]: undefined
   [EarnEvents.earn_add_crypto_action_press]: {
     action: TokenActionName
   } & TokenProperties
@@ -1638,9 +1639,7 @@ interface EarnEventsProperties {
   [EarnEvents.earn_withdraw_submit_cancel]: EarnWithdrawProperties
   [EarnEvents.earn_withdraw_add_gas_press]: { gasTokenId: string }
   [EarnEvents.earn_info_learn_press]: undefined
-  [EarnEvents.earn_info_earn_press]: {
-    tokenId: string
-  }
+  [EarnEvents.earn_info_earn_press]: undefined
 }
 
 export type AnalyticsPropertiesList = AppEventsProperties &

--- a/src/analytics/docs.ts
+++ b/src/analytics/docs.ts
@@ -593,7 +593,8 @@ export const eventDocs: Record<AnalyticsEventType, string> = {
   [TransactionDetailsEvents.transaction_details_tap_block_explorer]: `When a user press 'View on block explorer' on transaction details page`,
 
   // Events related to earn program
-  [EarnEvents.earn_cta_press]: `When a user taps on the earn your stablecoins CTA on the discover tab`,
+  [EarnEvents.earn_cta_press]: `When a user taps on the earn your stablecoins CTA on the discover tab (only for MVP w/ AAVE)`,
+  [EarnEvents.earn_entrypoint_press]: `When a user taps on the earn your stablecoins entrypoint on the discover tab (only for multiple pools)`,
   [EarnEvents.earn_add_crypto_action_press]: `When a user in the Earn flow enters an amount higher than their balance and chooses an option to add crypto`,
   [EarnEvents.earn_deposit_provider_info_press]: `When a user taps on the info icon next to the provider name on the deposit bottom sheet`,
   [EarnEvents.earn_deposit_terms_and_conditions_press]: `When a user taps on the terms and conditions link on the deposit bottom sheet`,

--- a/src/earn/EarnCard.test.tsx
+++ b/src/earn/EarnCard.test.tsx
@@ -69,7 +69,7 @@ describe('EarnCardDiscover', () => {
         (featureGateName) => featureGateName === StatsigFeatureGates.SHOW_STABLECOIN_EARN
       )
 
-    const { debug, getByTestId, queryByTestId } = render(
+    const { getByTestId, queryByTestId } = render(
       <Provider
         store={createMockStore({
           tokens: {
@@ -83,7 +83,6 @@ describe('EarnCardDiscover', () => {
       </Provider>
     )
 
-    debug()
     expect(getByTestId('EarnActivePool')).toBeTruthy()
     expect(queryByTestId('EarnEntryPoint')).toBeFalsy()
     expect(queryByTestId('EarnCta')).toBeFalsy()

--- a/src/earn/EarnCard.test.tsx
+++ b/src/earn/EarnCard.test.tsx
@@ -1,0 +1,108 @@
+import { render } from '@testing-library/react-native'
+import React from 'react'
+import { Provider } from 'react-redux'
+import { EarnCardDiscover } from 'src/earn/EarnCard'
+import { getFeatureGate } from 'src/statsig'
+import { StatsigFeatureGates } from 'src/statsig/types'
+import { createMockStore } from 'test/utils'
+import { mockArbUsdcTokenId, mockTokenBalances } from 'test/values'
+
+jest.mock('src/statsig')
+
+describe('EarnCardDiscover', () => {
+  beforeEach(() => {
+    jest.mocked(getFeatureGate).mockReturnValue(false)
+  })
+
+  it('renders EarnEntrypoint when multiple pools is enabled', () => {
+    jest
+      .mocked(getFeatureGate)
+      .mockImplementation(
+        (featureGateName) => featureGateName === StatsigFeatureGates.SHOW_MULTIPLE_EARN_POOLS
+      )
+
+    const { getByTestId, queryByTestId } = render(
+      <Provider store={createMockStore()}>
+        <EarnCardDiscover depositTokenId={mockArbUsdcTokenId} poolTokenId={mockArbUsdcTokenId} />
+      </Provider>
+    )
+
+    expect(getByTestId('EarnEntrypoint')).toBeTruthy()
+    expect(queryByTestId('EarnCta')).toBeFalsy()
+    expect(queryByTestId('EarnActivePool')).toBeFalsy()
+    expect(getFeatureGate).toHaveBeenCalledWith(StatsigFeatureGates.SHOW_MULTIPLE_EARN_POOLS)
+    expect(getFeatureGate).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders EarnCta when multiple pools is disabled and show stable coin earn is enabled', () => {
+    jest
+      .mocked(getFeatureGate)
+      .mockImplementation(
+        (featureGateName) => featureGateName === StatsigFeatureGates.SHOW_STABLECOIN_EARN
+      )
+
+    const { getByTestId, queryByTestId } = render(
+      <Provider
+        store={createMockStore({
+          tokens: {
+            tokenBalances: { [mockArbUsdcTokenId]: mockTokenBalances[mockArbUsdcTokenId] },
+          },
+        })}
+      >
+        <EarnCardDiscover depositTokenId={mockArbUsdcTokenId} poolTokenId={mockArbUsdcTokenId} />
+      </Provider>
+    )
+
+    expect(getByTestId('EarnCta')).toBeTruthy()
+    expect(queryByTestId('EarnEntryPoint')).toBeFalsy()
+    expect(queryByTestId('EarnActivePool')).toBeFalsy()
+    expect(getFeatureGate).toHaveBeenCalledWith(StatsigFeatureGates.SHOW_MULTIPLE_EARN_POOLS)
+    expect(getFeatureGate).toHaveBeenCalledWith(StatsigFeatureGates.SHOW_STABLECOIN_EARN)
+    expect(getFeatureGate).toHaveBeenCalledTimes(2)
+  })
+
+  it('renders EarnActivePool when multiple pools is disabled and show stable coin earn is enabled and pool token has balance', () => {
+    jest
+      .mocked(getFeatureGate)
+      .mockImplementation(
+        (featureGateName) => featureGateName === StatsigFeatureGates.SHOW_STABLECOIN_EARN
+      )
+
+    const { debug, getByTestId, queryByTestId } = render(
+      <Provider
+        store={createMockStore({
+          tokens: {
+            tokenBalances: {
+              [mockArbUsdcTokenId]: { ...mockTokenBalances[mockArbUsdcTokenId], balance: '10' },
+            },
+          },
+        })}
+      >
+        <EarnCardDiscover depositTokenId={mockArbUsdcTokenId} poolTokenId={mockArbUsdcTokenId} />
+      </Provider>
+    )
+
+    debug()
+    expect(getByTestId('EarnActivePool')).toBeTruthy()
+    expect(queryByTestId('EarnEntryPoint')).toBeFalsy()
+    expect(queryByTestId('EarnCta')).toBeFalsy()
+    expect(getFeatureGate).toHaveBeenCalledWith(StatsigFeatureGates.SHOW_MULTIPLE_EARN_POOLS)
+    expect(getFeatureGate).toHaveBeenCalledWith(StatsigFeatureGates.SHOW_STABLECOIN_EARN)
+    expect(getFeatureGate).toHaveBeenCalledTimes(2)
+  })
+
+  it('renders nothing if multiple pools and show stable coin earn are disabled', () => {
+    const { queryByTestId } = render(
+      <Provider store={createMockStore()}>
+        <EarnCardDiscover depositTokenId={mockArbUsdcTokenId} poolTokenId={mockArbUsdcTokenId} />
+      </Provider>
+    )
+
+    expect(queryByTestId('EarnEntryPoint')).toBeFalsy()
+    expect(queryByTestId('EarnCta')).toBeFalsy()
+    expect(queryByTestId('EarnActivePool')).toBeFalsy()
+    expect(getFeatureGate).toHaveBeenCalledWith(StatsigFeatureGates.SHOW_MULTIPLE_EARN_POOLS)
+    expect(getFeatureGate).toHaveBeenCalledWith(StatsigFeatureGates.SHOW_STABLECOIN_EARN)
+    expect(getFeatureGate).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/earn/EarnCard.test.tsx
+++ b/src/earn/EarnCard.test.tsx
@@ -11,6 +11,7 @@ jest.mock('src/statsig')
 
 describe('EarnCardDiscover', () => {
   beforeEach(() => {
+    jest.clearAllMocks()
     jest.mocked(getFeatureGate).mockReturnValue(false)
   })
 

--- a/src/earn/EarnCard.tsx
+++ b/src/earn/EarnCard.tsx
@@ -3,6 +3,7 @@ import { View } from 'react-native'
 import ItemSeparator from 'src/components/ItemSeparator'
 import EarnActivePool from 'src/earn/EarnActivePool'
 import EarnCta from 'src/earn/EarnCta'
+import EarnEntrypoint from 'src/earn/EarnEntrypoint'
 import { getFeatureGate } from 'src/statsig'
 import { StatsigFeatureGates } from 'src/statsig/types'
 import { Spacing } from 'src/styles/styles'
@@ -14,8 +15,15 @@ interface Props {
 }
 
 export function EarnCardDiscover({ depositTokenId, poolTokenId }: Props) {
-  const showStablecoinEarn = getFeatureGate(StatsigFeatureGates.SHOW_STABLECOIN_EARN)
+  const showMultiplePools = getFeatureGate(StatsigFeatureGates.SHOW_MULTIPLE_EARN_POOLS)
   const poolToken = useTokenInfo(poolTokenId)
+
+  if (showMultiplePools) {
+    // TODO(ACT-1257): show active pools
+    return <EarnEntrypoint />
+  }
+
+  const showStablecoinEarn = getFeatureGate(StatsigFeatureGates.SHOW_STABLECOIN_EARN)
 
   if (showStablecoinEarn) {
     return poolToken && poolToken.balance.gt(0) ? (

--- a/src/earn/EarnCta.test.tsx
+++ b/src/earn/EarnCta.test.tsx
@@ -65,6 +65,6 @@ describe('EarnCta', () => {
       providerId: 'aave-v3',
       networkId: NetworkId['arbitrum-sepolia'],
     })
-    expect(navigate).toHaveBeenCalledWith(Screens.EarnInfoScreen, { tokenId: mockArbUsdcTokenId })
+    expect(navigate).toHaveBeenCalledWith(Screens.EarnInfoScreen)
   })
 })

--- a/src/earn/EarnCta.tsx
+++ b/src/earn/EarnCta.tsx
@@ -50,7 +50,7 @@ export default function EarnCta({ depositTokenId }: { depositTokenId: string }) 
             providerId: PROVIDER_ID,
             networkId: depositToken.networkId,
           })
-          navigate(Screens.EarnInfoScreen, { tokenId: depositTokenId })
+          navigate(Screens.EarnInfoScreen)
         }}
         testID="EarnCta"
       >

--- a/src/earn/EarnEntrypoint.test.tsx
+++ b/src/earn/EarnEntrypoint.test.tsx
@@ -1,0 +1,30 @@
+import { fireEvent, render } from '@testing-library/react-native'
+import React from 'react'
+import { EarnEvents } from 'src/analytics/Events'
+import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
+import EarnEntrypoint from 'src/earn/EarnEntrypoint'
+import { navigate } from 'src/navigator/NavigationService'
+import { Screens } from 'src/navigator/Screens'
+
+describe('EarnEntrypoint', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('renders correctly', () => {
+    const { getByText } = render(<EarnEntrypoint />)
+
+    expect(getByText('earnFlow.entrypoint.title')).toBeTruthy()
+    expect(getByText('earnFlow.entrypoint.subtitle')).toBeTruthy()
+    expect(getByText('earnFlow.entrypoint.description')).toBeTruthy()
+  })
+
+  it('navigates to EarnInfoScreen when pressed', async () => {
+    const { getByTestId } = render(<EarnEntrypoint />)
+
+    fireEvent.press(getByTestId('EarnEntrypoint'))
+
+    expect(navigate).toHaveBeenCalledWith(Screens.EarnInfoScreen)
+    expect(ValoraAnalytics.track).toHaveBeenCalledWith(EarnEvents.earn_entrypoint_press)
+  })
+})

--- a/src/earn/EarnEntrypoint.tsx
+++ b/src/earn/EarnEntrypoint.tsx
@@ -1,0 +1,76 @@
+import React from 'react'
+import { useTranslation } from 'react-i18next'
+import { StyleSheet, Text, View } from 'react-native'
+import { EarnEvents } from 'src/analytics/Events'
+import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
+import Touchable from 'src/components/Touchable'
+import CircledIcon from 'src/icons/CircledIcon'
+import EarnCoins from 'src/icons/EarnCoins'
+import { navigate } from 'src/navigator/NavigationService'
+import { Screens } from 'src/navigator/Screens'
+import Colors from 'src/styles/colors'
+import { typeScale } from 'src/styles/fonts'
+import { Spacing } from 'src/styles/styles'
+
+export default function EarnEntrypoint() {
+  const { t } = useTranslation()
+
+  return (
+    <View style={styles.container}>
+      <Touchable
+        borderRadius={8}
+        style={styles.touchable}
+        onPress={() => {
+          ValoraAnalytics.track(EarnEvents.earn_entrypoint_press)
+          navigate(Screens.EarnInfoScreen)
+        }}
+        testID="EarnEntrypoint"
+      >
+        <>
+          <Text style={styles.title}>{t('earnFlow.entrypoint.title')}</Text>
+          <View style={styles.row}>
+            <CircledIcon radius={32} backgroundColor={Colors.successLight}>
+              <EarnCoins size={20} color={Colors.successDark} />
+            </CircledIcon>
+            <View style={styles.subtitleContainer}>
+              <Text style={styles.subtitle}>{t('earnFlow.entrypoint.subtitle')}</Text>
+              <Text style={styles.description}>{t('earnFlow.entrypoint.description')}</Text>
+            </View>
+          </View>
+        </>
+      </Touchable>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    marginBottom: Spacing.Thick24,
+  },
+  touchable: {
+    padding: Spacing.Regular16,
+    borderColor: Colors.gray2,
+    borderWidth: 1,
+    borderRadius: 8,
+  },
+  title: {
+    ...typeScale.labelSemiBoldMedium,
+    color: Colors.black,
+  },
+  row: {
+    flexDirection: 'row',
+    marginTop: Spacing.Regular16,
+    gap: Spacing.Smallest8,
+  },
+  subtitleContainer: {
+    flex: 1,
+  },
+  subtitle: {
+    ...typeScale.labelSemiBoldSmall,
+    color: Colors.black,
+  },
+  description: {
+    ...typeScale.bodySmall,
+    color: Colors.gray4,
+  },
+})

--- a/src/earn/EarnInfoScreen.test.tsx
+++ b/src/earn/EarnInfoScreen.test.tsx
@@ -18,7 +18,6 @@ jest.mock('src/statsig', () => ({
 }))
 
 const store = createMockStore({})
-const tokenId = networkConfig.arbUsdcTokenId
 
 describe('EarnInfoScreen', () => {
   beforeEach(() => {
@@ -28,7 +27,7 @@ describe('EarnInfoScreen', () => {
   it('should render correctly when no gas subsidy', async () => {
     const { getByText, queryByText } = render(
       <Provider store={store}>
-        <MockedNavigator component={EarnInfoScreen} params={{ tokenId }} />
+        <MockedNavigator component={EarnInfoScreen} />
       </Provider>
     )
 
@@ -58,7 +57,7 @@ describe('EarnInfoScreen', () => {
 
     const { getByText, queryByText } = render(
       <Provider store={store}>
-        <MockedNavigator component={EarnInfoScreen} params={{ tokenId }} />
+        <MockedNavigator component={EarnInfoScreen} />
       </Provider>
     )
 
@@ -70,7 +69,7 @@ describe('EarnInfoScreen', () => {
   it('should navigate and fire analytics correctly on Learn More button press', () => {
     const { getByText } = render(
       <Provider store={store}>
-        <MockedNavigator component={EarnInfoScreen} params={{ tokenId }} />
+        <MockedNavigator component={EarnInfoScreen} />
       </Provider>
     )
 
@@ -84,14 +83,14 @@ describe('EarnInfoScreen', () => {
   it('should navigate and fire analytics correctly on Start Earning button press', () => {
     const { getByText } = render(
       <Provider store={store}>
-        <MockedNavigator component={EarnInfoScreen} params={{ tokenId }} />
+        <MockedNavigator component={EarnInfoScreen} />
       </Provider>
     )
 
     fireEvent.press(getByText('earnFlow.earnInfo.action.earn'))
     expect(navigate).toHaveBeenCalledWith(Screens.EarnEnterAmount, {
-      tokenId,
+      tokenId: networkConfig.arbUsdcTokenId,
     })
-    expect(ValoraAnalytics.track).toHaveBeenCalledWith(EarnEvents.earn_info_earn_press, { tokenId })
+    expect(ValoraAnalytics.track).toHaveBeenCalledWith(EarnEvents.earn_info_earn_press)
   })
 })

--- a/src/earn/EarnInfoScreen.tsx
+++ b/src/earn/EarnInfoScreen.tsx
@@ -1,5 +1,4 @@
 import { useHeaderHeight } from '@react-navigation/elements'
-import { NativeStackScreenProps } from '@react-navigation/native-stack'
 import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ScrollView, StyleSheet, Text, View } from 'react-native'
@@ -17,12 +16,12 @@ import Palm from 'src/icons/Palm'
 import { headerWithCloseButton } from 'src/navigator/Headers'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
-import { StackParamList } from 'src/navigator/types'
 import { getFeatureGate } from 'src/statsig'
 import { StatsigFeatureGates } from 'src/statsig/types'
 import Colors from 'src/styles/colors'
 import { typeScale } from 'src/styles/fonts'
 import { Spacing } from 'src/styles/styles'
+import networkConfig from 'src/web3/networkConfig'
 
 const ICON_SIZE = 24
 const ICON_BACKGROUND_CIRCLE_SIZE = 36
@@ -52,11 +51,8 @@ function DetailsItem({
   )
 }
 
-type Props = NativeStackScreenProps<StackParamList, Screens.EarnInfoScreen>
-
-export default function EarnInfoScreen({ route }: Props) {
+export default function EarnInfoScreen() {
   const { t } = useTranslation()
-  const { tokenId } = route.params
   const isGasSubsidized = getFeatureGate(StatsigFeatureGates.SUBSIDIZE_STABLECOIN_EARN_GAS_FEES)
 
   const headerHeight = useHeaderHeight()
@@ -106,8 +102,9 @@ export default function EarnInfoScreen({ route }: Props) {
         />
         <Button
           onPress={() => {
-            ValoraAnalytics.track(EarnEvents.earn_info_earn_press, { tokenId })
-            navigate(Screens.EarnEnterAmount, { tokenId })
+            ValoraAnalytics.track(EarnEvents.earn_info_earn_press)
+            // TODO(ACT-1260): navigate to earn home page
+            navigate(Screens.EarnEnterAmount, { tokenId: networkConfig.arbUsdcTokenId })
           }}
           text={t('earnFlow.earnInfo.action.earn')}
           type={BtnTypes.PRIMARY}

--- a/src/navigator/types.tsx
+++ b/src/navigator/types.tsx
@@ -77,9 +77,7 @@ export type StackParamList = {
   }
   [Screens.DappsScreen]: undefined
   [Screens.Debug]: undefined
-  [Screens.EarnInfoScreen]: {
-    tokenId: string
-  }
+  [Screens.EarnInfoScreen]: undefined
   [Screens.EarnEnterAmount]: {
     tokenId: string
   }

--- a/src/statsig/constants.ts
+++ b/src/statsig/constants.ts
@@ -33,6 +33,7 @@ export const FeatureGates = {
   [StatsigFeatureGates.SHOW_CAB_IN_ONBOARDING]: false,
   [StatsigFeatureGates.ALLOW_CROSS_CHAIN_SWAPS]: false,
   [StatsigFeatureGates.SHOW_ONBOARDING_PHONE_VERIFICATION]: true,
+  [StatsigFeatureGates.SHOW_MULTIPLE_EARN_POOLS]: false,
 } satisfies { [key in StatsigFeatureGates]: boolean }
 
 export const ExperimentConfigs = {

--- a/src/statsig/types.ts
+++ b/src/statsig/types.ts
@@ -36,6 +36,7 @@ export enum StatsigFeatureGates {
   SHOW_CAB_IN_ONBOARDING = 'show_cab_in_onboarding',
   ALLOW_CROSS_CHAIN_SWAPS = 'allow_cross_chain_swaps',
   SHOW_ONBOARDING_PHONE_VERIFICATION = 'show_onboarding_phone_verification',
+  SHOW_MULTIPLE_EARN_POOLS = 'show_multiple_earn_pools',
 }
 
 export enum StatsigExperiments {


### PR DESCRIPTION
### Description

Sets up the statsig gate and shows the earn entrypoint card on the discover tab. Only changes the card for when there are no active pools. 
Also refactors the EarnInfoScreen to not take tokenId as a param because it is a generic screen.

[Figma](https://www.figma.com/design/E1rC3MG74qEg5V4tvbeUnU/Stablecoin-Enablement?node-id=4079-14115&t=VKwjwdsC2mZD4NcH-0)

### Test plan

<img src="https://github.com/user-attachments/assets/a99e5980-f5dc-4da6-8e44-f5b191fd4e2d" width="250" />


### Related issues

- Part of ACT-1257

### Backwards compatibility

Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
