### PR TITLE
feat(analytics): add event for insufficient gas warnings

### DIFF
--- a/src/analytics/Events.tsx
+++ b/src/analytics/Events.tsx
@@ -355,6 +355,7 @@ export enum TransactionEvents {
   transaction_confirmed = 'transaction_confirmed',
   transaction_error = 'transaction_error',
   transaction_exception = 'transaction_exception',
+  transaction_prepare_insufficient_gas = 'transaction_prepare_insufficient_gas',
 }
 
 export enum CeloExchangeEvents {

--- a/src/analytics/Properties.tsx
+++ b/src/analytics/Properties.tsx
@@ -707,6 +707,17 @@ interface TransactionEventsProperties {
     error: string
     feeCurrencyAddress?: string
   } & Web3LibraryProps
+  [TransactionEvents.transaction_prepare_insufficient_gas]: {
+    networkId: NetworkId
+    origin:
+      | 'send'
+      | 'swap'
+      | 'earn-deposit'
+      | 'earn-withdraw'
+      | 'jumpstart-send'
+      | 'jumpstart-claim'
+      | 'walletconnect'
+  }
 }
 
 interface CeloExchangeEventsProperties {

--- a/src/analytics/docs.ts
+++ b/src/analytics/docs.ts
@@ -367,6 +367,7 @@ export const eventDocs: Record<AnalyticsEventType, string> = {
   [TransactionEvents.transaction_confirmed]: `when a transaction is confirmed by the blockchain`,
   [TransactionEvents.transaction_error]: `when a transaction submission emits an error (only for contract-kit)`,
   [TransactionEvents.transaction_exception]: `when a transaction submission throws`,
+  [TransactionEvents.transaction_prepare_insufficient_gas]: `when a transaction cannot be prepared due to insufficient gas. Includes networkId and origin props to identify the transaction being attempted. For swaps, the networkId is always the source network`,
   [CeloExchangeEvents.celo_withdraw_completed]: `when the transaction for the withdrawal is completed`,
 
   // The CICO landing page accessible from the Settings Menu

--- a/src/earn/EarnCollectScreen.test.tsx
+++ b/src/earn/EarnCollectScreen.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, waitFor } from '@testing-library/react-native'
 import BigNumber from 'bignumber.js'
 import React from 'react'
 import { Provider } from 'react-redux'
-import { EarnEvents } from 'src/analytics/Events'
+import { EarnEvents, TransactionEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import EarnCollectScreen from 'src/earn/EarnCollectScreen'
 import { fetchAaveRewards } from 'src/earn/poolInfo'
@@ -143,6 +143,7 @@ describe('EarnCollectScreen', () => {
       walletAddress: mockAccount.toLowerCase(),
     })
     expect(store.getActions()).toEqual([fetchPoolInfo()])
+    expect(ValoraAnalytics.track).not.toHaveBeenCalled()
   })
 
   it('skips rewards section when no rewards', async () => {
@@ -180,6 +181,7 @@ describe('EarnCollectScreen', () => {
       expect(queryByTestId('EarnCollect/GasLoading')).toBeFalsy()
     })
     expect(getByTestId('EarnCollectScreen/CTA')).toBeEnabled()
+    expect(ValoraAnalytics.track).not.toHaveBeenCalled()
   })
 
   it('shows error and keeps cta disabled if rewards loading fails', async () => {
@@ -245,6 +247,7 @@ describe('EarnCollectScreen', () => {
     expect(getByText('earnFlow.collect.errorTitle')).toBeTruthy()
     expect(getByTestId('EarnCollect/GasError')).toBeTruthy()
     expect(getByTestId('EarnCollectScreen/CTA')).toBeDisabled()
+    expect(ValoraAnalytics.track).not.toHaveBeenCalled()
   })
 
   it('skips error and enables cta if only apy loading fails', async () => {
@@ -281,6 +284,7 @@ describe('EarnCollectScreen', () => {
     expect(getByText('earnFlow.collect.plus')).toBeTruthy()
     expect(getByTestId('EarnCollectScreen/CTA')).toBeEnabled()
     expect(queryByText('earnFlow.collect.errorTitle')).toBeFalsy()
+    expect(ValoraAnalytics.track).not.toHaveBeenCalled()
   })
 
   it('enables cta when everything other than APY finishes loading', async () => {
@@ -317,6 +321,7 @@ describe('EarnCollectScreen', () => {
     expect(getByText('earnFlow.collect.plus')).toBeTruthy()
     expect(getByTestId('EarnCollectScreen/CTA')).toBeEnabled()
     expect(queryByText('earnFlow.collect.errorTitle')).toBeFalsy()
+    expect(ValoraAnalytics.track).not.toHaveBeenCalled()
   })
 
   it('disables cta if not enough balance for gas', async () => {
@@ -350,6 +355,14 @@ describe('EarnCollectScreen', () => {
     })
     expect(getByTestId('EarnCollectScreen/CTA')).toBeDisabled()
     expect(getByTestId('EarnCollect/GasError')).toBeTruthy()
+    expect(ValoraAnalytics.track).toHaveBeenCalledWith(
+      TransactionEvents.transaction_prepare_insufficient_gas,
+      {
+        networkId: NetworkId['arbitrum-sepolia'],
+        origin: 'earn-withdraw',
+      }
+    )
+    expect(ValoraAnalytics.track).toHaveBeenCalledTimes(1)
   })
 
   it('pressing cta dispatches withdraw action and fires analytics event', async () => {
@@ -393,6 +406,7 @@ describe('EarnCollectScreen', () => {
       providerId: 'aave-v3',
       rewards: [{ amount: '0.01', tokenId: mockArbArbTokenId }],
     })
+    expect(ValoraAnalytics.track).toHaveBeenCalledTimes(1)
   })
 
   it('disables cta and shows loading spinner when withdraw is submitted', async () => {
@@ -457,6 +471,7 @@ describe('EarnCollectScreen', () => {
     expect(ValoraAnalytics.track).toBeCalledWith(EarnEvents.earn_withdraw_add_gas_press, {
       gasTokenId: mockArbEthTokenId,
     })
+    expect(ValoraAnalytics.track).toHaveBeenCalledTimes(1)
   })
 
   it('shows gas subsidized copy when feature gate is true', async () => {

--- a/src/earn/EarnCollectScreen.tsx
+++ b/src/earn/EarnCollectScreen.tsx
@@ -4,7 +4,7 @@ import React, { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { SafeAreaView, ScrollView, StyleSheet, Text, View } from 'react-native'
 import SkeletonPlaceholder from 'react-native-skeleton-placeholder'
-import { EarnEvents } from 'src/analytics/Events'
+import { EarnEvents, TransactionEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import Button, { BtnSizes } from 'src/components/Button'
 import InLineNotification, { NotificationVariant } from 'src/components/InLineNotification'
@@ -58,6 +58,19 @@ export default function EarnCollectScreen({ route }: Props) {
     depositTokenId,
     feeCurrencies,
   })
+
+  useEffect(() => {
+    if (
+      asyncPreparedTransactions.result?.type === 'need-decrease-spend-amount-for-gas' ||
+      asyncPreparedTransactions.result?.type === 'not-enough-balance-for-gas'
+    ) {
+      ValoraAnalytics.track(TransactionEvents.transaction_prepare_insufficient_gas, {
+        origin: 'earn-withdraw',
+        networkId: depositToken.networkId,
+      })
+    }
+  }, [asyncPreparedTransactions.result?.type, depositToken.networkId])
+
   const onPress = () => {
     if (!asyncRewardsInfo.result || asyncPreparedTransactions.result?.type !== 'possible') {
       // should never happen because button is disabled if withdraw is not possible

--- a/src/earn/EarnEnterAmount.tsx
+++ b/src/earn/EarnEnterAmount.tsx
@@ -6,7 +6,7 @@ import { Trans, useTranslation } from 'react-i18next'
 import { TextInput as RNTextInput, StyleSheet, Text, TouchableOpacity, View } from 'react-native'
 import { getNumberFormatSettings } from 'react-native-localize'
 import { SafeAreaView } from 'react-native-safe-area-context'
-import { EarnEvents, SendEvents } from 'src/analytics/Events'
+import { EarnEvents, SendEvents, TransactionEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import BackButton from 'src/components/BackButton'
 import BottomSheet, { BottomSheetRefType } from 'src/components/BottomSheet'
@@ -183,6 +183,18 @@ function EarnEnterAmount({ route }: Props) {
     }, FETCH_UPDATED_TRANSACTIONS_DEBOUNCE_TIME)
     return () => clearTimeout(debouncedRefreshTransactions)
   }, [tokenAmount, token])
+
+  useEffect(() => {
+    if (
+      prepareTransactionsResult?.type === 'need-decrease-spend-amount-for-gas' ||
+      prepareTransactionsResult?.type === 'not-enough-balance-for-gas'
+    ) {
+      ValoraAnalytics.track(TransactionEvents.transaction_prepare_insufficient_gas, {
+        origin: 'earn-deposit',
+        networkId: token.networkId,
+      })
+    }
+  }, [token.networkId, prepareTransactionsResult?.type])
 
   const isAmountLessThanBalance = tokenAmount && tokenAmount.lte(token.balance)
   const showNotEnoughBalanceForGasWarning =

--- a/src/jumpstart/JumpstartEnterAmount.tsx
+++ b/src/jumpstart/JumpstartEnterAmount.tsx
@@ -176,6 +176,7 @@ function JumpstartEnterAmount() {
       onPressProceed={handleProceed.execute}
       disableProceed={disableProceed}
       ProceedComponent={SendProceed}
+      origin="jumpstart-send"
     >
       {sendAmountExceedsThreshold && (
         <InLineNotification

--- a/src/jumpstart/JumpstartTransactionDetailsScreen.tsx
+++ b/src/jumpstart/JumpstartTransactionDetailsScreen.tsx
@@ -6,7 +6,7 @@ import { Trans, useTranslation } from 'react-i18next'
 import { StyleSheet, Text, View } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import walletJumpstart from 'src/abis/IWalletJumpstart'
-import { JumpstartEvents } from 'src/analytics/Events'
+import { JumpstartEvents, TransactionEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import BackButton from 'src/components/BackButton'
 import BottomSheet, { BottomSheetRefType } from 'src/components/BottomSheet'
@@ -104,6 +104,10 @@ function JumpstartTransactionDetailsScreen({ route }: Props) {
       switch (preparedTransactions.type) {
         case 'need-decrease-spend-amount-for-gas': // fallthrough on purpose
         case 'not-enough-balance-for-gas':
+          ValoraAnalytics.track(TransactionEvents.transaction_prepare_insufficient_gas, {
+            origin: 'jumpstart-claim',
+            networkId,
+          })
           throw new Error('Not enough balance for gas')
         case 'possible':
           return {

--- a/src/send/SendEnterAmount.tsx
+++ b/src/send/SendEnterAmount.tsx
@@ -117,6 +117,7 @@ function SendEnterAmount({ route }: Props) {
       tokenSelectionDisabled={!!forceTokenId}
       onPressProceed={handleReviewSend}
       ProceedComponent={SendProceed}
+      origin="send"
     />
   )
 }

--- a/src/swap/SwapScreen.test.tsx
+++ b/src/swap/SwapScreen.test.tsx
@@ -5,7 +5,7 @@ import React from 'react'
 import { Provider } from 'react-redux'
 import { ReactTestInstance } from 'react-test-renderer'
 import { showError } from 'src/alert/actions'
-import { SwapEvents } from 'src/analytics/Events'
+import { SwapEvents, TransactionEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import { ErrorMessages } from 'src/app/ErrorMessages'
 import { TRANSACTION_FEES_LEARN_MORE } from 'src/brandingConfig'
@@ -1447,6 +1447,10 @@ describe('SwapScreen', () => {
         'swapScreen.notEnoughBalanceForGas.description, {"feeCurrencies":"CELO, cEUR, cUSD"}'
       )
     ).toBeTruthy()
+    expect(ValoraAnalytics.track).toHaveBeenCalledWith(
+      TransactionEvents.transaction_prepare_insufficient_gas,
+      { origin: 'swap', networkId: NetworkId['celo-alfajores'] }
+    )
   })
 
   it('should warn when the balances for feeCurrencies are too low to cover the fee', async () => {
@@ -1471,6 +1475,10 @@ describe('SwapScreen', () => {
         'swapScreen.notEnoughBalanceForGas.description, {"feeCurrencies":"CELO, cUSD, cEUR"} '
       )
     ).toBeTruthy()
+    expect(ValoraAnalytics.track).toHaveBeenCalledWith(
+      TransactionEvents.transaction_prepare_insufficient_gas,
+      { origin: 'swap', networkId: NetworkId['celo-alfajores'] }
+    )
   })
 
   it('should prompt the user to decrease the swap amount when swapping the max amount of a feeCurrency, and no other feeCurrency has enough balance to pay for the fee', async () => {
@@ -1520,6 +1528,10 @@ describe('SwapScreen', () => {
     })
 
     expect(queryByText('swapScreen.decreaseSwapAmountForGasWarning.cta')).toBeFalsy()
+    expect(ValoraAnalytics.track).toHaveBeenCalledWith(
+      TransactionEvents.transaction_prepare_insufficient_gas,
+      { origin: 'swap', networkId: NetworkId['celo-alfajores'] }
+    )
   })
 
   it('should prompt the user to decrease the swap amount when swapping close to the max amount of a feeCurrency, and no other feeCurrency has enough balance to pay for the fee', async () => {
@@ -1573,6 +1585,10 @@ describe('SwapScreen', () => {
     })
 
     expect(queryByText('swapScreen.decreaseSwapAmountForGasWarning.cta')).toBeFalsy()
+    expect(ValoraAnalytics.track).toHaveBeenCalledWith(
+      TransactionEvents.transaction_prepare_insufficient_gas,
+      { origin: 'swap', networkId: NetworkId['celo-alfajores'] }
+    )
   })
 
   it("should allow swapping the entered amount of a feeCurrency when there's enough balance to cover for the fee, while no other feeCurrency can pay for the fee", async () => {
@@ -1603,6 +1619,10 @@ describe('SwapScreen', () => {
 
     expect(queryByTestId('QuoteResultNotEnoughBalanceForGasBottomSheet')).toBeFalsy()
     expect(queryByTestId('QuoteResultNeedDecreaseSwapAmountForGasBottomSheet')).toBeFalsy()
+    expect(ValoraAnalytics.track).not.toHaveBeenCalledWith(
+      TransactionEvents.transaction_prepare_insufficient_gas,
+      { origin: 'swap', networkId: NetworkId['celo-alfajores'] }
+    )
   })
 
   it("should allow swapping the max balance of a feeCurrency when there's another feeCurrency to pay for the fee", async () => {
@@ -1629,6 +1649,10 @@ describe('SwapScreen', () => {
 
     expect(queryByTestId('QuoteResultNotEnoughBalanceForGasBottomSheet')).toBeFalsy()
     expect(queryByTestId('QuoteResultNeedDecreaseSwapAmountForGasBottomSheet')).toBeFalsy()
+    expect(ValoraAnalytics.track).not.toHaveBeenCalledWith(
+      TransactionEvents.transaction_prepare_insufficient_gas,
+      { origin: 'swap', networkId: NetworkId['celo-alfajores'] }
+    )
   })
 
   describe('filter tokens', () => {

--- a/src/swap/SwapScreen.tsx
+++ b/src/swap/SwapScreen.tsx
@@ -9,7 +9,7 @@ import { ScrollView } from 'react-native-gesture-handler'
 import { getNumberFormatSettings } from 'react-native-localize'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { showError } from 'src/alert/actions'
-import { SwapEvents } from 'src/analytics/Events'
+import { SwapEvents, TransactionEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import { ErrorMessages } from 'src/app/ErrorMessages'
 import { TRANSACTION_FEES_LEARN_MORE } from 'src/brandingConfig'
@@ -359,6 +359,19 @@ export function SwapScreen({ route }: Props) {
   useEffect(() => {
     localDispatch(quoteUpdated({ quote }))
   }, [quote])
+
+  useEffect(() => {
+    if (
+      fromToken?.networkId &&
+      (quote?.preparedTransactions.type === 'need-decrease-spend-amount-for-gas' ||
+        quote?.preparedTransactions.type === 'not-enough-balance-for-gas')
+    ) {
+      ValoraAnalytics.track(TransactionEvents.transaction_prepare_insufficient_gas, {
+        networkId: fromToken.networkId,
+        origin: 'swap',
+      })
+    }
+  }, [quote?.preparedTransactions.type, fromToken?.networkId])
 
   const handleConfirmSwap = () => {
     if (!quote) {

--- a/src/walletConnect/saga.ts
+++ b/src/walletConnect/saga.ts
@@ -7,7 +7,7 @@ import { buildApprovedNamespaces, getSdkError, parseUri } from '@walletconnect/u
 import { IWeb3Wallet, Web3Wallet, Web3WalletTypes } from '@walletconnect/web3wallet'
 import { EventChannel, eventChannel } from 'redux-saga'
 import { showMessage } from 'src/alert/actions'
-import { WalletConnectEvents } from 'src/analytics/Events'
+import { TransactionEvents, WalletConnectEvents } from 'src/analytics/Events'
 import { WalletConnect2Properties } from 'src/analytics/Properties'
 import { DappRequestOrigin, WalletConnectPairingOrigin } from 'src/analytics/types'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
@@ -495,6 +495,16 @@ function* showActionRequest(request: Web3WalletTypes.EventArguments['session_req
     preparedTransactionsResult?.type,
     preparedTransaction
   )
+
+  if (
+    preparedTransactionsResult?.type === 'not-enough-balance-for-gas' ||
+    preparedTransactionsResult?.type === 'need-decrease-spend-amount-for-gas'
+  ) {
+    ValoraAnalytics.track(TransactionEvents.transaction_prepare_insufficient_gas, {
+      networkId,
+      origin: 'walletconnect',
+    })
+  }
 
   navigate(Screens.WalletConnectRequest, {
     type: WalletConnectRequestType.Action,


### PR DESCRIPTION
### Description

When preparing a tx in the various flows, if it fails with insufficient gas, add an analytics event. 

### Test plan

Unit tests, manual

### Related issues

- Fixes ACT-1256

### Backwards compatibility

Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
