### PR TITLE
chore(swap): remove 'popular' token filter as pre-selected

### DIFF
--- a/src/swap/useFilterChips.ts
+++ b/src/swap/useFilterChips.ts
@@ -37,7 +37,7 @@ export default function useFilterChip(selectingField: Field | null): FilterChip<
       id: 'popular',
       name: t('tokenBottomSheet.filters.popular'),
       filterFn: (token: TokenBalance) => popularTokenIds.includes(token.tokenId),
-      isSelected: selectingField === Field.TO,
+      isSelected: false,
     },
     {
       id: 'recently-swapped',


### PR DESCRIPTION
### Description

As discussed at retro with Laura and Kayla.

### Test plan

n/a

### Related issues

n/a

### Backwards compatibility

n/a

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
