### PR TITLE
feat: EstimatedNetworkFee with loading state and multiple TXs

### DIFF
--- a/src/jumpstart/JumpstartTransactionDetailsScreen.tsx
+++ b/src/jumpstart/JumpstartTransactionDetailsScreen.tsx
@@ -291,7 +291,7 @@ function JumpstartTransactionDetailsScreen({ route }: Props) {
           copySuccessMessage={t('walletConnectRequest.transactionDataCopied')}
           testID="JumpstarReclaimBottomSheet/RequestPayload"
         />
-        {reclaimTx && <EstimatedNetworkFee networkId={networkId} transaction={reclaimTx} />}
+        {reclaimTx && <EstimatedNetworkFee networkId={networkId} transactions={[reclaimTx]} />}
         <Button
           text={t('confirm')}
           showLoading={reclaimStatus === 'loading'}

--- a/src/jumpstart/JumpstartTransactionDetailsScreen.tsx
+++ b/src/jumpstart/JumpstartTransactionDetailsScreen.tsx
@@ -291,7 +291,9 @@ function JumpstartTransactionDetailsScreen({ route }: Props) {
           copySuccessMessage={t('walletConnectRequest.transactionDataCopied')}
           testID="JumpstarReclaimBottomSheet/RequestPayload"
         />
-        {reclaimTx && <EstimatedNetworkFee networkId={networkId} transactions={[reclaimTx]} />}
+        {reclaimTx && (
+          <EstimatedNetworkFee isLoading={false} networkId={networkId} transactions={[reclaimTx]} />
+        )}
         <Button
           text={t('confirm')}
           showLoading={reclaimStatus === 'loading'}

--- a/src/walletConnect/screens/ActionRequest.test.tsx
+++ b/src/walletConnect/screens/ActionRequest.test.tsx
@@ -114,6 +114,7 @@ describe('ActionRequest with WalletConnect V2', () => {
     maxFeePerGas: '12000000000',
     maxPriorityFeePerGas: '2000000000',
     gas: '100000',
+    _baseFeePerGas: '5000000000',
   }
 
   const supportedChains = ['eip155:44787']
@@ -208,8 +209,8 @@ describe('ActionRequest with WalletConnect V2', () => {
         getByText('walletConnectRequest.estimatedNetworkFee, {"networkName":"Celo Alfajores"}')
       ).toBeTruthy()
       const fee = within(getByTestId('EstimatedNetworkFee'))
-      expect(fee.getByText('0.0012 CELO')).toBeTruthy()
-      expect(fee.getByText('₱0.008')).toBeTruthy()
+      expect(fee.getByText('0.0007 CELO')).toBeTruthy() // gas * (_baseFeePerGas + maxPriorityFeePerGas)
+      expect(fee.getByText('₱0.0047')).toBeTruthy()
 
       fireEvent.press(getByText('walletConnectRequest.sendTransactionAction'))
       expect(store.getActions()).toEqual([

--- a/src/walletConnect/screens/ActionRequest.tsx
+++ b/src/walletConnect/screens/ActionRequest.tsx
@@ -180,7 +180,7 @@ function ActionRequest({
         preparedTransaction={preparedTransaction}
       />
       {preparedTransaction && (
-        <EstimatedNetworkFee networkId={networkId} transaction={preparedTransaction} />
+        <EstimatedNetworkFee networkId={networkId} transactions={[preparedTransaction]} />
       )}
       <DappsDisclaimer isDappListed={isDappListed} />
     </RequestContent>

--- a/src/walletConnect/screens/ActionRequest.tsx
+++ b/src/walletConnect/screens/ActionRequest.tsx
@@ -180,7 +180,11 @@ function ActionRequest({
         preparedTransaction={preparedTransaction}
       />
       {preparedTransaction && (
-        <EstimatedNetworkFee networkId={networkId} transactions={[preparedTransaction]} />
+        <EstimatedNetworkFee
+          isLoading={false}
+          networkId={networkId}
+          transactions={[preparedTransaction]}
+        />
       )}
       <DappsDisclaimer isDappListed={isDappListed} />
     </RequestContent>

--- a/src/walletConnect/screens/EstimatedNetworkFee.test.tsx
+++ b/src/walletConnect/screens/EstimatedNetworkFee.test.tsx
@@ -45,7 +45,7 @@ describe('EstimatedNetworkFee', () => {
 
   it("shows the loading state when the network fee hasn't been calculated yet", () => {
     const store = createMockStore({})
-    const { getByText, getByTestId, queryByTestId } = render(
+    const { getByText, getByTestId } = render(
       <Provider store={store}>
         <EstimatedNetworkFee
           isLoading={true}

--- a/src/walletConnect/screens/EstimatedNetworkFee.test.tsx
+++ b/src/walletConnect/screens/EstimatedNetworkFee.test.tsx
@@ -1,0 +1,84 @@
+import { render } from '@testing-library/react-native'
+import * as React from 'react'
+import { Provider } from 'react-redux'
+import { NetworkId } from 'src/transactions/types'
+import EstimatedNetworkFee from 'src/walletConnect/screens/EstimatedNetworkFee'
+import { createMockStore } from 'test/utils'
+import { parseGwei } from 'viem'
+
+describe('EstimatedNetworkFee', () => {
+  const mockTransaction = {
+    from: '0x2b8441ef13333ffa955c9ea5ab5b3692da95260d',
+    networkId: NetworkId['celo-alfajores'],
+    data: '0x3d18b912',
+    to: '0xda7f463c27ec862cfbf2369f3f74c364d050d93f',
+    gas: '100000',
+    maxFeePerGas: parseGwei('5').toString(),
+    _baseFeePerGas: parseGwei('1').toString(),
+  } as const
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('shows the estimate network fee', () => {
+    const store = createMockStore({})
+    const { getByText, getByTestId, queryByTestId } = render(
+      <Provider store={store}>
+        <EstimatedNetworkFee
+          isLoading={false}
+          networkId={NetworkId['celo-alfajores']}
+          transactions={[mockTransaction]}
+        />
+      </Provider>
+    )
+
+    expect(
+      getByText('walletConnectRequest.estimatedNetworkFee, {"networkName":"Celo Alfajores"}')
+    ).toBeTruthy()
+
+    expect(getByTestId('EstimatedNetworkFee/Amount')).toHaveTextContent('0.0001 CELO') // gas * _baseFeePerGas
+    expect(getByTestId('EstimatedNetworkFee/AmountLocal')).toHaveTextContent('₱0.00067')
+
+    expect(queryByTestId('EstimatedNetworkFee/Loading')).toBeFalsy()
+  })
+
+  it("shows the loading state when the network fee hasn't been calculated yet", () => {
+    const store = createMockStore({})
+    const { getByText, getByTestId, queryByTestId } = render(
+      <Provider store={store}>
+        <EstimatedNetworkFee
+          isLoading={true}
+          networkId={NetworkId['celo-alfajores']}
+          transactions={[]}
+        />
+      </Provider>
+    )
+
+    expect(
+      getByText('walletConnectRequest.estimatedNetworkFee, {"networkName":"Celo Alfajores"}')
+    ).toBeTruthy()
+
+    expect(getByTestId('EstimatedNetworkFee/Loading')).toBeTruthy()
+  })
+
+  it("renders null when there isn't enough information to display the fee", () => {
+    const store = createMockStore({})
+    const { queryByTestId } = render(
+      <Provider store={store}>
+        <EstimatedNetworkFee
+          isLoading={false}
+          networkId={NetworkId['celo-alfajores']}
+          transactions={[
+            {
+              ...mockTransaction,
+              _baseFeePerGas: undefined, // This is the missing information
+            },
+          ]}
+        />
+      </Provider>
+    )
+
+    expect(queryByTestId('EstimatedNetworkFee')).toBeFalsy()
+  })
+})

--- a/src/walletConnect/screens/EstimatedNetworkFee.tsx
+++ b/src/walletConnect/screens/EstimatedNetworkFee.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import { StyleSheet, Text, View } from 'react-native'
+import SkeletonPlaceholder from 'src/components/SkeletonPlaceholder'
 import TokenDisplay from 'src/components/TokenDisplay'
 import { useSelector } from 'src/redux/hooks'
 import { NETWORK_NAMES } from 'src/shared/conts'
@@ -8,62 +9,104 @@ import Colors from 'src/styles/colors'
 import { typeScale } from 'src/styles/fonts'
 import { Spacing } from 'src/styles/styles'
 import { tokensByIdSelector } from 'src/tokens/selectors'
+import { TokenBalances } from 'src/tokens/slice'
 import { NetworkId } from 'src/transactions/types'
 import Logger from 'src/utils/Logger'
-import { getFeeCurrencyToken, getFeeDecimals, getMaxGasFee } from 'src/viem/prepareTransactions'
+import {
+  getEstimatedGasFee,
+  getFeeCurrencyToken,
+  getFeeDecimals,
+} from 'src/viem/prepareTransactions'
 import {
   SerializableTransactionRequest,
   getPreparedTransaction,
 } from 'src/viem/preparedTransactionSerialization'
 
 interface Props {
+  isLoading: boolean
   networkId: NetworkId
-  transaction: SerializableTransactionRequest
+  transactions: SerializableTransactionRequest[]
 }
 
-export default function EstimatedNetworkFee({ networkId, transaction }: Props) {
+function getNetworkFee(
+  transactions: SerializableTransactionRequest[],
+  networkId: NetworkId,
+  tokensById: TokenBalances
+) {
+  try {
+    const preparedTransactions = transactions.map(getPreparedTransaction)
+    const feeCurrency = getFeeCurrencyToken(preparedTransactions, networkId, tokensById)
+    if (!feeCurrency) {
+      Logger.warn('WalletConnect', 'No fee token info found', { transactions, networkId })
+      return null
+    }
+
+    const feeDecimals = getFeeDecimals(preparedTransactions, feeCurrency)
+    return {
+      token: feeCurrency,
+      amount: getEstimatedGasFee(preparedTransactions).shiftedBy(-feeDecimals),
+    }
+  } catch (error) {
+    Logger.warn('WalletConnect', 'Failed to get estimated gas fee', error)
+    return null
+  }
+}
+
+export default function EstimatedNetworkFee({ isLoading, networkId, transactions }: Props) {
   const { t } = useTranslation()
 
   const tokensById = useSelector((state) => tokensByIdSelector(state, [networkId]))
-  const preparedTransaction = getPreparedTransaction(transaction)
-  const feeTokenInfo = getFeeCurrencyToken([preparedTransaction], networkId, tokensById)
+  const networkFee = getNetworkFee(transactions, networkId, tokensById)
 
   const networkName = NETWORK_NAMES[networkId]
 
-  if (!transaction.gas || !transaction.maxFeePerGas || !feeTokenInfo || !networkName) {
+  if (!networkFee || !networkName) {
     Logger.warn('WalletConnect', 'Insufficient information to display fee details', {
       networkName,
-      transaction,
-      feeTokenInfo,
+      transactions,
     })
     return null
   }
-
-  const feeDecimals = getFeeDecimals([preparedTransaction], feeTokenInfo)
-  // in base units
-  const maxFeeAmount = getMaxGasFee([preparedTransaction]).shiftedBy(-feeDecimals)
 
   return (
     <View style={styles.container} testID="EstimatedNetworkFee">
       <Text style={styles.labelText}>
         {t('walletConnectRequest.estimatedNetworkFee', { networkName })}
       </Text>
-      <TokenDisplay
-        style={styles.amountPrimaryText}
-        amount={maxFeeAmount}
-        tokenId={feeTokenInfo.tokenId}
-        showLocalAmount={false}
-        showSymbol={true}
-        hideSign={true}
-      />
-      <TokenDisplay
-        style={styles.amountSecondaryText}
-        amount={maxFeeAmount}
-        tokenId={feeTokenInfo.tokenId}
-        showLocalAmount={true}
-        showSymbol={true}
-        hideSign={true}
-      />
+      <View>
+        <View style={isLoading ? styles.contentLoading : undefined}>
+          <TokenDisplay
+            style={styles.amountPrimaryText}
+            amount={networkFee.amount}
+            tokenId={networkFee.token.tokenId}
+            showLocalAmount={false}
+            showSymbol={true}
+            hideSign={true}
+            testID="EstimatedNetworkFee/Amount"
+          />
+          <TokenDisplay
+            style={styles.amountSecondaryText}
+            amount={networkFee.amount}
+            tokenId={networkFee.token.tokenId}
+            showLocalAmount={true}
+            showSymbol={true}
+            hideSign={true}
+            testID="EstimatedNetworkFee/AmountLocal"
+          />
+        </View>
+        {!!isLoading && (
+          <View style={StyleSheet.absoluteFill}>
+            <SkeletonPlaceholder
+              borderRadius={100} // ensure rounded corners with font scaling
+              backgroundColor={Colors.gray2}
+              highlightColor={Colors.white}
+              testID="EstimatedNetworkFee/Loading"
+            >
+              <View style={styles.loader} />
+            </SkeletonPlaceholder>
+          </View>
+        )}
+      </View>
     </View>
   )
 }
@@ -84,5 +127,12 @@ const styles = StyleSheet.create({
   amountSecondaryText: {
     ...typeScale.bodyXSmall,
     color: Colors.gray4,
+  },
+  contentLoading: {
+    opacity: 0,
+  },
+  loader: {
+    height: '100%',
+    width: 100,
   },
 })

--- a/src/walletConnect/screens/EstimatedNetworkFee.tsx
+++ b/src/walletConnect/screens/EstimatedNetworkFee.tsx
@@ -22,6 +22,8 @@ import {
   getPreparedTransaction,
 } from 'src/viem/preparedTransactionSerialization'
 
+const TAG = 'WalletConnect/EstimatedNetworkFee'
+
 interface Props {
   isLoading: boolean
   networkId: NetworkId
@@ -37,7 +39,7 @@ function getNetworkFee(
     const preparedTransactions = transactions.map(getPreparedTransaction)
     const feeCurrency = getFeeCurrencyToken(preparedTransactions, networkId, tokensById)
     if (!feeCurrency) {
-      Logger.warn('WalletConnect', 'No fee token info found', { transactions, networkId })
+      Logger.warn(TAG, 'No fee token info found', { transactions, networkId })
       return null
     }
 
@@ -47,7 +49,7 @@ function getNetworkFee(
       amount: getEstimatedGasFee(preparedTransactions).shiftedBy(-feeDecimals),
     }
   } catch (error) {
-    Logger.warn('WalletConnect', 'Failed to get estimated gas fee', error)
+    Logger.warn(TAG, 'Failed to get estimated gas fee', error)
     return null
   }
 }
@@ -61,7 +63,7 @@ export default function EstimatedNetworkFee({ isLoading, networkId, transactions
   const networkName = NETWORK_NAMES[networkId]
 
   if (!networkFee || !networkName) {
-    Logger.warn('WalletConnect', 'Insufficient information to display fee details', {
+    Logger.warn(TAG, 'Insufficient information to display fee details', {
       networkName,
       transactions,
     })


### PR DESCRIPTION
### Description

Extend `<EstimatedNetworkFee />` so it can show a loading state (while preparing transactions) and use multiple TXs to show the total estimated fee.

It also now uses `getEstimatedFee` instead of `getMaxGasFee`. 
So it's closer to the actual fee.

### Test plan

- Updated tests

https://github.com/user-attachments/assets/e351f231-5885-435f-8555-07df348f9f48

Note: This video is just to show the loading state, this PR doesn't yet add it to the claim shortcut bottom sheet, it will be in another PR.

### Related issues

- Fixes RET-1108

### Backwards compatibility

Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
