### PR TITLE
refactor: consolidate redux state changes on update transactions

### DIFF
--- a/src/transactions/actions.ts
+++ b/src/transactions/actions.ts
@@ -17,7 +17,6 @@ import {
 
 export enum Actions {
   ADD_STANDBY_TRANSACTION = 'TRANSACTIONS/ADD_STANDBY_TRANSACTION',
-  REMOVE_STANDBY_TRANSACTION = 'TRANSACTIONS/REMOVE_STANDBY_TRANSACTION',
   ADD_HASH_TO_STANDBY_TRANSACTIONS = 'TRANSACTIONS/ADD_HASH_TO_STANDBY_TRANSACTIONS',
   TRANSACTION_CONFIRMED = 'TRANSACTIONS/TRANSACTION_CONFIRMED',
   REFRESH_RECENT_TX_RECIPIENTS = 'TRANSACTIONS/REFRESH_RECENT_TX_RECIPIENTS',
@@ -40,11 +39,6 @@ export type BaseStandbyTransaction =
 export interface AddStandbyTransactionAction {
   type: Actions.ADD_STANDBY_TRANSACTION
   transaction: BaseStandbyTransaction
-}
-
-export interface RemoveStandbyTransactionAction {
-  type: Actions.REMOVE_STANDBY_TRANSACTION
-  idx: string
 }
 
 export interface AddHashToStandbyTransactionAction {
@@ -86,7 +80,6 @@ export interface UpdateInviteTransactionsAction {
 
 export type ActionTypes =
   | AddStandbyTransactionAction
-  | RemoveStandbyTransactionAction
   | AddHashToStandbyTransactionAction
   | UpdatedRecentTxRecipientsCacheAction
   | UpdateTransactionsAction
@@ -98,11 +91,6 @@ export const addStandbyTransaction = (
 ): AddStandbyTransactionAction => ({
   type: Actions.ADD_STANDBY_TRANSACTION,
   transaction,
-})
-
-export const removeStandbyTransaction = (idx: string): RemoveStandbyTransactionAction => ({
-  type: Actions.REMOVE_STANDBY_TRANSACTION,
-  idx,
 })
 
 export const updateRecentTxRecipientsCache = (

--- a/src/transactions/reducer.test.ts
+++ b/src/transactions/reducer.test.ts
@@ -1,0 +1,92 @@
+import { RootState } from 'src/redux/store'
+import { Actions } from 'src/transactions/actions'
+import { _initialState, reducer } from 'src/transactions/reducer'
+import {
+  NetworkId,
+  StandbyTransaction,
+  TokenTransaction,
+  TransactionStatus,
+} from 'src/transactions/types'
+
+describe('transactions reducer', () => {
+  describe('UPDATE_TRANSACTIONS action', () => {
+    it('should store incoming transactions and remove corresponding standby transactions', () => {
+      // Note the type assertions below, this is a shortcut to shorten the test
+      // data to only the properties needed for the test
+      const mockStandbyTransactions = [
+        {
+          transactionHash: '0x1111',
+          networkId: NetworkId['celo-mainnet'],
+        },
+        {
+          networkId: NetworkId['celo-mainnet'],
+        },
+        {
+          transactionHash: '0x1111',
+          networkId: NetworkId['ethereum-mainnet'],
+        },
+      ] as StandbyTransaction[]
+      const mockCeloTransactions = [
+        {
+          status: TransactionStatus.Complete,
+          transactionHash: '0x1234',
+          networkId: NetworkId['celo-mainnet'],
+        },
+        {
+          status: TransactionStatus.Complete,
+          transactionHash: '0xabcd',
+          networkId: NetworkId['celo-mainnet'],
+        },
+      ] as TokenTransaction[]
+      const mockEthTransactions = [
+        {
+          status: TransactionStatus.Complete,
+          transactionHash: '0x7890',
+          networkId: NetworkId['ethereum-mainnet'],
+        },
+        {
+          status: TransactionStatus.Complete,
+          transactionHash: '0xabcd',
+          networkId: NetworkId['ethereum-mainnet'],
+        },
+      ] as TokenTransaction[]
+
+      const state: RootState['transactions'] = {
+        ..._initialState,
+        standbyTransactions: mockStandbyTransactions,
+        transactionsByNetworkId: {
+          [NetworkId['celo-mainnet']]: mockCeloTransactions,
+          [NetworkId['ethereum-mainnet']]: mockEthTransactions,
+        },
+      }
+      const result = reducer(state, {
+        type: Actions.UPDATE_TRANSACTIONS,
+        networkId: NetworkId['ethereum-mainnet'],
+        transactions: [
+          {
+            status: TransactionStatus.Complete,
+            transactionHash: '0x1111',
+            networkId: NetworkId['ethereum-mainnet'],
+          },
+          ...mockEthTransactions,
+        ] as TokenTransaction[],
+      })
+
+      expect(result).toEqual({
+        ..._initialState,
+        transactionsByNetworkId: {
+          [NetworkId['celo-mainnet']]: mockCeloTransactions, // unchanged, since the networkId in the action is different
+          [NetworkId['ethereum-mainnet']]: [
+            {
+              status: TransactionStatus.Complete,
+              transactionHash: '0x1111',
+              networkId: NetworkId['ethereum-mainnet'],
+            }, // new transaction from the action is stored in the state
+            ...mockEthTransactions,
+          ],
+        },
+        standbyTransactions: mockStandbyTransactions.slice(0, 2), // the last standby transaction is removed since it matches a transaction in the action
+      })
+    })
+  })
+})

--- a/src/transactions/reducer.ts
+++ b/src/transactions/reducer.ts
@@ -169,7 +169,7 @@ export const reducer = (
 }
 
 const allStandbyTransactionsSelector = (state: RootState) => state.transactions.standbyTransactions
-export const standbyTransactionsSelector = createSelector(
+const standbyTransactionsSelector = createSelector(
   [allStandbyTransactionsSelector, getSupportedNetworkIdsForApprovalTxsInHomefeed],
   (standbyTransactions, supportedNetworkIdsForApprovalTxs) => {
     return standbyTransactions.filter((tx) => {


### PR DESCRIPTION
### Description

[Context](https://github.com/valora-inc/wallet/pull/5677#discussion_r1696537447)

On receiving new transactions from blockchain-api, the redux state that stores transactions is updated via the reducer. We then kick off a saga that dispatches another action to remove corresponding standby transactions via another action. This PR removes that complexity and updates the standby transactions via the original action. Sagas should be reserved for asynchronous side effects. 

### Test plan

n/a

### Related issues

- Related to RET-1118

### Backwards compatibility

Y

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
