### PR TITLE
refactor(statsig): remove defaults for feature gates

### DIFF
--- a/src/statsig/constants.ts
+++ b/src/statsig/constants.ts
@@ -1,42 +1,11 @@
 import {
   StatsigDynamicConfigs,
   StatsigExperiments,
-  StatsigFeatureGates,
   StatsigMultiNetworkDynamicConfig,
   StatsigParameter,
 } from 'src/statsig/types'
 import { NetworkId } from 'src/transactions/types'
 import networkConfig from 'src/web3/networkConfig'
-
-export const FeatureGates = {
-  [StatsigFeatureGates.SHOW_POSITIONS]: false,
-  [StatsigFeatureGates.SHOW_CLAIM_SHORTCUTS]: false,
-  [StatsigFeatureGates.ALLOW_HOOKS_PREVIEW]: true,
-  [StatsigFeatureGates.APP_REVIEW]: false,
-  [StatsigFeatureGates.SHOW_CLOUD_ACCOUNT_BACKUP_SETUP]: false,
-  [StatsigFeatureGates.SHOW_CLOUD_ACCOUNT_BACKUP_RESTORE]: false,
-  [StatsigFeatureGates.RESTRICT_SUPERCHARGE_FOR_CLAIM_ONLY]: false,
-  [StatsigFeatureGates.SHOW_IMPORT_TOKENS_FLOW]: false,
-  [StatsigFeatureGates.SHOW_MULTICHAIN_BETA_SCREEN]: false,
-  [StatsigFeatureGates.SHOW_BETA_TAG]: false,
-  [StatsigFeatureGates.SAVE_CONTACTS]: false,
-  [StatsigFeatureGates.SHOW_GET_STARTED]: false,
-  [StatsigFeatureGates.CLEVERTAP_INBOX]: false,
-  [StatsigFeatureGates.SHOW_SWAP_TOKEN_FILTERS]: false,
-  [StatsigFeatureGates.SHUFFLE_SWAP_TOKENS_ORDER]: false,
-  [StatsigFeatureGates.SHOW_NFT_CELEBRATION]: false,
-  [StatsigFeatureGates.SHOW_NFT_REWARD]: false,
-  [StatsigFeatureGates.SHOW_JUMPSTART_SEND]: false,
-  [StatsigFeatureGates.SHOW_POINTS]: false,
-  [StatsigFeatureGates.SHOW_STABLECOIN_EARN]: false,
-  [StatsigFeatureGates.SUBSIDIZE_STABLECOIN_EARN_GAS_FEES]: false,
-  [StatsigFeatureGates.SHOW_CASH_IN_TOKEN_FILTERS]: false,
-  [StatsigFeatureGates.SHOW_CAB_IN_ONBOARDING]: false,
-  [StatsigFeatureGates.ALLOW_CROSS_CHAIN_SWAPS]: false,
-  [StatsigFeatureGates.SHOW_ONBOARDING_PHONE_VERIFICATION]: true,
-  [StatsigFeatureGates.SHOW_MULTIPLE_EARN_POOLS]: false,
-  [StatsigFeatureGates.SHOW_APPLE_IN_CAB]: false,
-} satisfies { [key in StatsigFeatureGates]: boolean }
 
 export const ExperimentConfigs = {
   // NOTE: the keys of defaultValues MUST be parameter names

--- a/src/statsig/index.test.ts
+++ b/src/statsig/index.test.ts
@@ -1,7 +1,7 @@
 import { LaunchArguments } from 'react-native-launch-arguments'
 import { MultichainBetaStatus } from 'src/app/actions'
 import { store } from 'src/redux/store'
-import { DynamicConfigs, ExperimentConfigs, FeatureGates } from 'src/statsig/constants'
+import { DynamicConfigs, ExperimentConfigs } from 'src/statsig/constants'
 import {
   getDynamicConfigParams,
   getExperimentParams,
@@ -114,13 +114,13 @@ describe('Statsig helpers', () => {
   })
 
   describe('getFeatureGate', () => {
-    it('returns default values if getting statsig feature gate throws error', () => {
+    it('returns false if getting statsig feature gate throws error', () => {
       jest.mocked(Statsig.checkGate).mockImplementation(() => {
         throw new Error('mock error')
       })
       const output = getFeatureGate(StatsigFeatureGates.APP_REVIEW)
       expect(Logger.warn).toHaveBeenCalled()
-      expect(output).toEqual(FeatureGates[StatsigFeatureGates.APP_REVIEW])
+      expect(output).toEqual(false)
     })
     it('returns Statsig values if no error is thrown', () => {
       jest.mocked(Statsig.checkGate).mockImplementation(() => true)

--- a/src/statsig/index.ts
+++ b/src/statsig/index.ts
@@ -3,7 +3,7 @@ import { LaunchArguments } from 'react-native-launch-arguments'
 import { startOnboardingTimeSelector } from 'src/account/selectors'
 import { multichainBetaStatusSelector } from 'src/app/selectors'
 import { isE2EEnv } from 'src/config'
-import { DynamicConfigs, FeatureGates } from 'src/statsig/constants'
+import { DynamicConfigs } from 'src/statsig/constants'
 import {
   StatsigDynamicConfigs,
   StatsigExperiments,
@@ -115,7 +115,12 @@ export function getFeatureGate(featureGateName: StatsigFeatureGates) {
     return Statsig.checkGate(featureGateName)
   } catch (error) {
     Logger.warn(TAG, `Error getting feature gate: ${featureGateName}`, error)
-    return FeatureGates[featureGateName]
+    // gates should always default to false, this boolean is to just remain BC
+    // with two gates defaulting to true
+    return (
+      featureGateName === StatsigFeatureGates.ALLOW_HOOKS_PREVIEW ||
+      featureGateName === StatsigFeatureGates.SHOW_ONBOARDING_PHONE_VERIFICATION
+    )
   }
 }
 

--- a/src/statsig/types.ts
+++ b/src/statsig/types.ts
@@ -24,7 +24,6 @@ export enum StatsigFeatureGates {
   RESTRICT_SUPERCHARGE_FOR_CLAIM_ONLY = 'restrict_supercharge_for_claim_only',
   SHOW_IMPORT_TOKENS_FLOW = 'show_import_tokens_flow',
   SHOW_MULTICHAIN_BETA_SCREEN = 'show_multichain_beta_screen',
-  SHOW_BETA_TAG = 'show_beta_tag',
   SAVE_CONTACTS = 'save_contacts',
   SHOW_GET_STARTED = 'show_get_started',
   CLEVERTAP_INBOX = 'clevertap_inbox',


### PR DESCRIPTION
### Description

Unlike experiments and dynamic config, the feature gate sdk call `checkGate` doesn't take default params as an option. If the SDK is uninitialized it will always return `false`, so we should always model gates to default to false. The fallback default we currently have is only used in case of exceptions, which is a very unlikely scenario. This PR removes the default values and updates the checkGate exception handler to return false for all gates (except the 2 that currently defaults to true)

### Test plan

CI

### Related issues

- N/A

### Backwards compatibility

Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
