### PR TITLE
fix: prevent duplicate cross chain pending swap tx items

### DIFF
--- a/src/transactions/feed/TransactionFeed.tsx
+++ b/src/transactions/feed/TransactionFeed.tsx
@@ -39,7 +39,7 @@ function TransactionFeed() {
     // Filter out received pending transactions that are also in the pending
     // standby array because those will be displayed with the pending
     // transactions
-    const completedTransactionsOrWithoutPendingStandby = transactions.filter(
+    const completedOrNotPendingStandbyTransactions = transactions.filter(
       (tx) =>
         tx.status === TransactionStatus.Complete ||
         !allPendingTransactions.find(
@@ -50,8 +50,8 @@ function TransactionFeed() {
     )
 
     const confirmedTokenTransactions: TokenTransaction[] =
-      completedTransactionsOrWithoutPendingStandby.length > 0
-        ? completedTransactionsOrWithoutPendingStandby
+      completedOrNotPendingStandbyTransactions.length > 0
+        ? completedOrNotPendingStandbyTransactions
         : cachedTransactions
     const allConfirmedTransactions = deduplicateTransactions(
       confirmedTokenTransactions,


### PR DESCRIPTION
### Description

This PR is a "quick fix" so I didn't bother with tests. I want to rework the transaction feed stuff because it's too complex and doesn't work well. There are a ton of rerenders constantly (possibly contributing to app slowness) and most of the issue stems from storing the fetched transactions in state which doesn't preserve the identity of the objects even if they change. It also means that fetched transactions are displayed right away, without being coordinated with other stored redux data.

The last part of this is really hard to work with. For pending cross chain swaps, any standby transaction should be augmented with the data (in effect, the standby transactions are the source of truth when available for pending transactions). With the current setup of the TransactionFeed, anything that comes back from blockchain-api goes straight to the display layer and this causes the standby tx in redux _and_ received tx from blockchain-api to be displayed at the same time if they both exist, like in a cross chain transaction made through the app.

This is what i saw once (note that this can only happen if we receive a pending tx from blockchain-api, for cross chain swaps that are quite fast the first tx we receive from blockchain-api is not in the pending state)
https://github.com/user-attachments/assets/96f82c56-7cc6-442b-af00-fc9ff8cd16ff


### Test plan

The duplicate transaction is not there anymore when doing cross chain swaps.

### Related issues

- Related to RET-1119

### Backwards compatibility

Y

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
