### PR TITLE
fix: ensure allowedNetworks does not trigger unnecessary rerenders

### DIFF
--- a/src/transactions/feed/TransactionFeed.tsx
+++ b/src/transactions/feed/TransactionFeed.tsx
@@ -15,7 +15,7 @@ import TokenApprovalFeedItem from 'src/transactions/feed/TokenApprovalFeedItem'
 import TransferFeedItem from 'src/transactions/feed/TransferFeedItem'
 import {
   deduplicateTransactions,
-  getAllowedNetworkIds,
+  getAllowedNetworkIdsString,
   useFetchTransactions,
 } from 'src/transactions/feed/queryHelper'
 import {
@@ -33,7 +33,8 @@ function TransactionFeed() {
   const cachedTransactions = useSelector(transactionsSelector)
   const allPendingTransactions = useSelector(pendingStandbyTransactionsSelector)
   const allConfirmedStandbyTransactions = useSelector(confirmedStandbyTransactionsSelector)
-  const allowedNetworks = getAllowedNetworkIds()
+  const allowedNetworksString = getAllowedNetworkIdsString()
+  const allowedNetworks = useMemo(() => allowedNetworksString.split(','), [allowedNetworksString])
 
   const confirmedFeedTransactions = useMemo(() => {
     const confirmedTokenTransactions: TokenTransaction[] =

--- a/src/transactions/feed/queryHelper.ts
+++ b/src/transactions/feed/queryHelper.ts
@@ -64,6 +64,7 @@ export const deduplicateTransactions = (
 }
 
 export function getAllowedNetworkIdsString() {
+  // return a string to help react memoization
   return getMultichainFeatures().showTransfers.join(', ')
 }
 

--- a/src/transactions/feed/queryHelper.ts
+++ b/src/transactions/feed/queryHelper.ts
@@ -1,5 +1,5 @@
 import { isEmpty } from 'lodash'
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useAsync } from 'react-async-hook'
 import { useTranslation } from 'react-i18next'
 import Toast from 'react-native-simple-toast'
@@ -63,8 +63,8 @@ export const deduplicateTransactions = (
   return transactionsWithoutDuplicatedHash
 }
 
-export function getAllowedNetworkIds(): Array<NetworkId> {
-  return getMultichainFeatures().showTransfers
+export function getAllowedNetworkIdsString() {
+  return getMultichainFeatures().showTransfers.join(', ')
 }
 
 export function useFetchTransactions(): QueryHookResult {
@@ -74,9 +74,12 @@ export function useFetchTransactions(): QueryHookResult {
   const localCurrencyCode = useSelector(getLocalCurrencyCode)
   const transactionHashesByNetwork = useSelector(transactionHashesByNetworkIdSelector)
 
+  const allowedNetworkIdsString = getAllowedNetworkIdsString()
   // N.B: This fetch-time filtering does not suffice to prevent non-Celo TXs from appearing
   // on the home feed, since they get cached in Redux -- this is just a network optimization.
-  const allowedNetworkIds = getAllowedNetworkIds()
+  const allowedNetworkIds = useMemo(() => {
+    return allowedNetworkIdsString.split(',') as NetworkId[]
+  }, [allowedNetworkIdsString])
 
   // Track which networks are currently fetching transactions via polling to avoid duplicate requests
   const [activePollingRequests, setActivePollingRequestsState] = useState<ActiveRequests>(


### PR DESCRIPTION
### Description

Rerenders are not (usually) the enemy but this `allowedNetworks` array is used in a few dependency arrays for computations on the homefeed which is slow already. I noticed that the `allowedNetworks` array was always triggering updates (can tell by logging something in a useEffect or useMemo with only `allowedNetworks` in the dependency array, the logs are printed frequently) and i think it is because the array does not preserve its identity when returned from the `getAllowedNetworkIds` function. I wasn't sure if it's safe to only get the allowed networks on mount (in case this screen is never remounted and the dynamic config changes) so opted for a hacky string solution here.

### Test plan

When logging something in a useEffect or useMemo with only `allowedNetworks` in the dependency array, the log should only be printed once.

### Related issues

n/a

### Backwards compatibility

Y

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
