### PR TITLE
fix: android ripple on token bottom sheet

### DIFF
--- a/src/components/TokenBottomSheet.tsx
+++ b/src/components/TokenBottomSheet.tsx
@@ -274,7 +274,7 @@ function TokenBottomSheet({
       <FlatListComponent
         data={tokenList}
         keyExtractor={(item) => item.tokenId}
-        contentContainerStyle={[styles.tokenListContainer, { paddingBottom: insets.bottom }]}
+        contentContainerStyle={{ paddingBottom: insets.bottom }}
         scrollIndicatorInsets={{ top: headerHeight }}
         renderItem={({ item, index }) => {
           return (
@@ -393,7 +393,7 @@ const styles = StyleSheet.create({
     marginVertical: Spacing.Regular16,
   },
   tokenBalanceItemContainer: {
-    marginHorizontal: 0,
+    marginHorizontal: Spacing.Thick24,
   },
   filterChipsCarouselContainer: {
     paddingTop: Spacing.Thick24,
@@ -404,9 +404,6 @@ const styles = StyleSheet.create({
     padding: Spacing.Thick24,
     backgroundColor: colors.white,
     width: '100%',
-  },
-  tokenListContainer: {
-    paddingHorizontal: Spacing.Thick24,
   },
   title: {
     ...typeScale.titleSmall,


### PR DESCRIPTION
### Description

A small style nitpick for the ripple on Android within the token bottom sheet component.

### Screenshots

| Token Bottom Sheet Before (Swaps) | Token Bottom Sheet After (Swaps) |
| ----- | ----- |
| ![](https://github.com/user-attachments/assets/d7be98dc-3d91-47f6-b9e4-c0e59a9e4ba5 "Token Bottom Sheet Before (Swaps)") | ![](https://github.com/user-attachments/assets/51b77015-1a91-4336-86f6-dfa05047669a "Token Bottom Sheet After (Swaps)" ) |

### Test plan

- [x] Tested locally on Android
- [x] Tested locally on iOS

### Related issues

N/A

### Backwards compatibility

Yes

### Network scalability

N/A
