### PR TITLE
refactor: use useAllowedNetworks in a hook

### DIFF
--- a/src/transactions/feed/TransactionFeed.tsx
+++ b/src/transactions/feed/TransactionFeed.tsx
@@ -15,7 +15,7 @@ import TokenApprovalFeedItem from 'src/transactions/feed/TokenApprovalFeedItem'
 import TransferFeedItem from 'src/transactions/feed/TransferFeedItem'
 import {
   deduplicateTransactions,
-  getAllowedNetworkIdsString,
+  useAllowedNetworkIds,
   useFetchTransactions,
 } from 'src/transactions/feed/queryHelper'
 import {
@@ -33,8 +33,7 @@ function TransactionFeed() {
   const cachedTransactions = useSelector(transactionsSelector)
   const allPendingTransactions = useSelector(pendingStandbyTransactionsSelector)
   const allConfirmedStandbyTransactions = useSelector(confirmedStandbyTransactionsSelector)
-  const allowedNetworksString = getAllowedNetworkIdsString()
-  const allowedNetworks = useMemo(() => allowedNetworksString.split(','), [allowedNetworksString])
+  const allowedNetworks = useAllowedNetworkIds()
 
   const confirmedFeedTransactions = useMemo(() => {
     // Filter out received pending transactions that are also in the pending

--- a/src/transactions/feed/TransactionFeed.tsx
+++ b/src/transactions/feed/TransactionFeed.tsx
@@ -15,7 +15,7 @@ import TokenApprovalFeedItem from 'src/transactions/feed/TokenApprovalFeedItem'
 import TransferFeedItem from 'src/transactions/feed/TransferFeedItem'
 import {
   deduplicateTransactions,
-  useAllowedNetworkIds,
+  useAllowedNetworkIdsForTransfers,
   useFetchTransactions,
 } from 'src/transactions/feed/queryHelper'
 import {
@@ -33,7 +33,7 @@ function TransactionFeed() {
   const cachedTransactions = useSelector(transactionsSelector)
   const allPendingTransactions = useSelector(pendingStandbyTransactionsSelector)
   const allConfirmedStandbyTransactions = useSelector(confirmedStandbyTransactionsSelector)
-  const allowedNetworks = useAllowedNetworkIds()
+  const allowedNetworks = useAllowedNetworkIdsForTransfers()
 
   const confirmedFeedTransactions = useMemo(() => {
     // Filter out received pending transactions that are also in the pending

--- a/src/transactions/feed/queryHelper.ts
+++ b/src/transactions/feed/queryHelper.ts
@@ -63,7 +63,7 @@ export const deduplicateTransactions = (
   return transactionsWithoutDuplicatedHash
 }
 
-export function useAllowedNetworkIds() {
+export function useAllowedNetworkIdsForTransfers() {
   // return a string to help react memoization
   const allowedNetworkIdsString = getMultichainFeatures().showTransfers.join(',')
   // N.B: This fetch-time filtering does not suffice to prevent non-Celo TXs from appearing
@@ -79,7 +79,7 @@ export function useFetchTransactions(): QueryHookResult {
   const address = useSelector(walletAddressSelector)
   const localCurrencyCode = useSelector(getLocalCurrencyCode)
   const transactionHashesByNetwork = useSelector(transactionHashesByNetworkIdSelector)
-  const allowedNetworkIds = useAllowedNetworkIds()
+  const allowedNetworkIds = useAllowedNetworkIdsForTransfers()
 
   // Track which networks are currently fetching transactions via polling to avoid duplicate requests
   const [activePollingRequests, setActivePollingRequestsState] = useState<ActiveRequests>(


### PR DESCRIPTION
### Description

This was a suggestion in #5699 but it was merged before being addressed. This also fixes a bad trailing space that was left in the string, which causes a 400 response from blockchain-api.

### Test plan

n/a

### Related issues

n/a

### Backwards compatibility

Y

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [ ] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
