### PR TITLE
fix: text overflow on CYA

### DIFF
--- a/src/onboarding/ChooseYourAdventure.tsx
+++ b/src/onboarding/ChooseYourAdventure.tsx
@@ -24,7 +24,7 @@ import { Screens } from 'src/navigator/Screens'
 import { AdventureCardName } from 'src/onboarding/types'
 import { useSelector } from 'src/redux/hooks'
 import colors from 'src/styles/colors'
-import fontStyles from 'src/styles/fonts'
+import fontStyles, { typeScale } from 'src/styles/fonts'
 import { Shadow, Spacing } from 'src/styles/styles'
 import { shuffle } from 'src/utils/random'
 import networkConfig from 'src/web3/networkConfig'
@@ -202,7 +202,7 @@ const styles = StyleSheet.create({
     color: colors.gray3,
   },
   cardText: {
-    ...fontStyles.small500,
+    ...typeScale.bodySmall,
     flex: 1,
     flexWrap: 'wrap',
   },

--- a/src/onboarding/ChooseYourAdventure.tsx
+++ b/src/onboarding/ChooseYourAdventure.tsx
@@ -53,7 +53,7 @@ const AdventureCard = ({
     <Touchable style={styles.pressableCard} onPress={onPress}>
       <>
         <View style={styles.iconContainer}>{icon}</View>
-        <Text style={fontStyles.small500}>{text}</Text>
+        <Text style={styles.cardText}>{text}</Text>
       </>
     </Touchable>
   </Card>
@@ -200,5 +200,10 @@ const styles = StyleSheet.create({
   },
   skip: {
     color: colors.gray3,
+  },
+  cardText: {
+    ...fontStyles.small500,
+    flex: 1,
+    flexWrap: 'wrap',
   },
 })


### PR DESCRIPTION
### Description

Nitpick style fix for possible text overflows for CYA cards.

### Screenshots

| iOS Before | iOS After |
| ----- | ----- |
| ![](https://github.com/user-attachments/assets/da99c837-b316-4f7c-a97e-dc19fcd43e83 "iOS Before") | ![](https://github.com/user-attachments/assets/d7f6f3e0-91aa-4d1f-b2cc-3cb6c5992d30 "iOS After") |

### Test plan

- [x] Tested locally on iOS

### Related issues

- Fixes ACT-1033

### Backwards compatibility

Yes

### Network scalability

N/A