### PR TITLE
fix: handle received pending cross chain swaps correctly

### DIFF
--- a/src/transactions/feed/queryHelper.test.ts
+++ b/src/transactions/feed/queryHelper.test.ts
@@ -1,0 +1,126 @@
+import { vibrateSuccess } from 'src/styles/hapticFeedback'
+import { updateTransactions } from 'src/transactions/actions'
+import { QueryResponse, handlePollResponse } from 'src/transactions/feed/queryHelper'
+import { NetworkId, TokenTransaction, TransactionStatus } from 'src/transactions/types'
+
+jest.mock('src/styles/hapticFeedback')
+
+describe('handlePollResponse', () => {
+  const dispatchSpy = jest.fn()
+
+  const mockCompletedTransaction = {
+    transactionHash: '0x123',
+    status: TransactionStatus.Complete,
+  } as TokenTransaction
+
+  const mockPendingTransaction = {
+    transactionHash: '0xabc',
+    status: TransactionStatus.Pending,
+  } as TokenTransaction
+
+  const mockQueryResponse = (mockTransactions: TokenTransaction[]): QueryResponse => ({
+    data: {
+      tokenTransactionsV3: {
+        transactions: mockTransactions,
+        pageInfo: {
+          startCursor: null,
+          endCursor: null,
+          hasNextPage: false,
+          hasPreviousPage: false,
+        },
+      },
+    },
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should update cached transactions and vibrate when there are new completed transactions', () => {
+    const mockTransactions = [mockCompletedTransaction]
+    handlePollResponse({
+      pageInfo: {},
+      setFetchedResult: jest.fn(),
+      completedTxHashesByNetwork: {},
+      pendingTxHashesByNetwork: {},
+      dispatch: dispatchSpy,
+    })(NetworkId['celo-mainnet'], mockQueryResponse(mockTransactions))
+
+    expect(vibrateSuccess).toHaveBeenCalledTimes(1)
+    expect(dispatchSpy).toHaveBeenCalledTimes(1)
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      updateTransactions(NetworkId['celo-mainnet'], mockTransactions)
+    )
+  })
+
+  it('should update cached transactions and vibrate when the cached transaction was in the pending status', () => {
+    const mockTransactions = [mockCompletedTransaction]
+
+    handlePollResponse({
+      pageInfo: {},
+      setFetchedResult: jest.fn(),
+      completedTxHashesByNetwork: {},
+      pendingTxHashesByNetwork: {
+        [NetworkId['celo-mainnet']]: new Set([mockCompletedTransaction.transactionHash]),
+      },
+      dispatch: dispatchSpy,
+    })(NetworkId['celo-mainnet'], mockQueryResponse(mockTransactions))
+
+    expect(vibrateSuccess).toHaveBeenCalledTimes(1)
+    expect(dispatchSpy).toHaveBeenCalledTimes(1)
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      updateTransactions(NetworkId['celo-mainnet'], mockTransactions)
+    )
+  })
+
+  it('should not update cached transactions when there are no new completed transactions', () => {
+    const mockTransactions = [mockCompletedTransaction]
+
+    handlePollResponse({
+      pageInfo: {},
+      setFetchedResult: jest.fn(),
+      completedTxHashesByNetwork: {
+        [NetworkId['celo-mainnet']]: new Set([mockCompletedTransaction.transactionHash]),
+      },
+      pendingTxHashesByNetwork: {},
+      dispatch: dispatchSpy,
+    })(NetworkId['celo-mainnet'], mockQueryResponse(mockTransactions))
+
+    expect(dispatchSpy).not.toHaveBeenCalled()
+    expect(vibrateSuccess).not.toHaveBeenCalled()
+  })
+
+  it('should update cached transactions without vibration when there are new pending transactions', () => {
+    const mockTransactions = [mockPendingTransaction]
+    handlePollResponse({
+      pageInfo: {},
+      setFetchedResult: jest.fn(),
+      completedTxHashesByNetwork: {},
+      pendingTxHashesByNetwork: {},
+      dispatch: dispatchSpy,
+    })(NetworkId['celo-mainnet'], mockQueryResponse(mockTransactions))
+
+    expect(vibrateSuccess).not.toHaveBeenCalled()
+    expect(dispatchSpy).toHaveBeenCalledTimes(1)
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      updateTransactions(NetworkId['celo-mainnet'], mockTransactions)
+    )
+  })
+
+  it('should not update cached transactions when there are no new pending transactions', () => {
+    const mockTransactions = [mockPendingTransaction]
+
+    handlePollResponse({
+      pageInfo: {},
+      setFetchedResult: jest.fn(),
+      completedTxHashesByNetwork: {},
+      pendingTxHashesByNetwork: {
+        [NetworkId['celo-mainnet']]: new Set([mockPendingTransaction.transactionHash]),
+      },
+      dispatch: dispatchSpy,
+    })(NetworkId['celo-mainnet'], mockQueryResponse(mockTransactions))
+
+    expect(dispatchSpy).not.toHaveBeenCalled()
+    expect(vibrateSuccess).not.toHaveBeenCalled()
+  })
+})

--- a/src/transactions/reducer.ts
+++ b/src/transactions/reducer.ts
@@ -285,14 +285,32 @@ export const transactionsSelector = createSelector(
 export const inviteTransactionsSelector = (state: RootState) =>
   state.transactions.inviteTransactions
 
-export const transactionHashesByNetworkIdSelector = createSelector(
+export const pendingTxHashesByNetworkIdSelector = createSelector(
   [transactionsByNetworkIdSelector],
   (transactions) => {
     const hashesByNetwork: {
       [networkId in NetworkId]?: Set<string>
     } = {}
     Object.entries(transactions).forEach(([networkId, txs]) => {
-      hashesByNetwork[networkId as NetworkId] = new Set(txs.map((tx) => tx.transactionHash))
+      hashesByNetwork[networkId as NetworkId] = new Set(
+        txs.filter((tx) => tx.status === TransactionStatus.Pending).map((tx) => tx.transactionHash)
+      )
+    })
+
+    return hashesByNetwork
+  }
+)
+
+export const completedTxHashesByNetworkIdSelector = createSelector(
+  [transactionsByNetworkIdSelector],
+  (transactions) => {
+    const hashesByNetwork: {
+      [networkId in NetworkId]?: Set<string>
+    } = {}
+    Object.entries(transactions).forEach(([networkId, txs]) => {
+      hashesByNetwork[networkId as NetworkId] = new Set(
+        txs.filter((tx) => tx.status === TransactionStatus.Complete).map((tx) => tx.transactionHash)
+      )
     })
 
     return hashesByNetwork


### PR DESCRIPTION
### Description

This PR fixes a couple of bugs:
1. when a cross chain swap is pending for a long time, the app vibrates periodically for no apparent reason
2. when a user restores their wallet and there is a pending cross chain swap, and it is actually completed, it will show completed in the app session but on subsequent app sessions, it always starts off as pending.

The root cause for both is due to the query helper attributing the cross chain swap as new or existing incorrectly. For the scenarios:
1. the pending cross chain swap isn't stored with the other received blockchain-api transactions (it is instead stored with the pending standby transactions) so every poll interval, we receive the pending tx from blockchain-api -> it's not in the redux store that we expect -> we count it as new and vibrate
2. the pending tx received from blockchain-api doesn't exist in the standby redux store -> we store it in redux with the other received blockchain-api tx's -> later we receive from blockchain-api the updated status as complete -> we never update the cached transactions because this transaction [doesn't meet the definition of new transaction](https://github.com/valora-inc/wallet/blob/a75e5e5dc5dd5c6bb81d677abe3d0168b089a9b6/src/transactions/feed/queryHelper.ts#L196).

This PR fixes both by including a check for the transaction status when determining whether or not to dispatch the redux action. This is the second time I've had to fix something around the queryHelper so I also tried to add some tests focused on the action dispatch and haptic feedback.

### Test plan

n/a

### Related issues

n/a

### Backwards compatibility

Y

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [ ] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
