### PR TITLE
fix: scroll aware header on discover screen

### DIFF
--- a/e2e/src/Discover.spec.js
+++ b/e2e/src/Discover.spec.js
@@ -13,7 +13,7 @@ describe('Discover tab', () => {
     })
     await waitForElementByIdAndTap('Tab/Discover')
 
-    await scrollIntoView('Explore All', 'DappsExplorerScrollView')
+    await scrollIntoView('Explore All', 'DiscoverScrollView')
     await element(by.text('Explore All')).tap()
 
     await waitFor(element(by.id(`DappsScreen/DappsList`)))

--- a/src/dappsExplorer/TabDiscover.tsx
+++ b/src/dappsExplorer/TabDiscover.tsx
@@ -36,8 +36,8 @@ function TabDiscover({ navigation }: Props) {
     navigation,
     title: t('bottomTabsNavigator.discover.title'),
     scrollPosition,
-    startFadeInPosition: titleHeight * 0.33,
-    animationDistance: titleHeight,
+    startFadeInPosition: titleHeight * 0.67,
+    animationDistance: titleHeight * 0.33,
   })
 
   return (

--- a/src/dappsExplorer/TabDiscover.tsx
+++ b/src/dappsExplorer/TabDiscover.tsx
@@ -41,7 +41,11 @@ function TabDiscover({ navigation }: Props) {
   })
 
   return (
-    <Animated.ScrollView scrollEventThrottle={16} onScroll={handleScroll}>
+    <Animated.ScrollView
+      testID="DiscoverScrollView"
+      scrollEventThrottle={16}
+      onScroll={handleScroll}
+    >
       <SafeAreaView testID="DAppsExplorerScreen" style={styles.safeAreaContainer} edges={[]}>
         <View style={styles.contentContainer}>
           <Text style={styles.title} onLayout={handleMeasureTitleHeight}>

--- a/src/dappsExplorer/TabDiscover.tsx
+++ b/src/dappsExplorer/TabDiscover.tsx
@@ -1,9 +1,8 @@
 import { NativeStackScreenProps } from '@react-navigation/native-stack'
 import React, { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { StyleSheet, Text, View } from 'react-native'
-import { ScrollView } from 'react-native-gesture-handler'
-import { useSharedValue } from 'react-native-reanimated'
+import { LayoutChangeEvent, StyleSheet, Text, View } from 'react-native'
+import Animated, { useAnimatedScrollHandler, useSharedValue } from 'react-native-reanimated'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { DappFeaturedActions } from 'src/dappsExplorer/DappFeaturedActions'
 import DiscoverDappsCard from 'src/dappsExplorer/DiscoverDappsCard'
@@ -22,23 +21,32 @@ type Props = NativeStackScreenProps<StackParamList, Screens.TabDiscover>
 function TabDiscover({ navigation }: Props) {
   const { t } = useTranslation()
 
-  // Scroll Aware Header
   const scrollPosition = useSharedValue(0)
-  const [titleHeight] = useState(0)
+  const [titleHeight, setTitleHeight] = useState(0)
+
+  const handleMeasureTitleHeight = (event: LayoutChangeEvent) => {
+    setTitleHeight(event.nativeEvent.layout.height)
+  }
+
+  const handleScroll = useAnimatedScrollHandler((event) => {
+    scrollPosition.value = event.contentOffset.y
+  })
 
   useScrollAwareHeader({
     navigation,
     title: t('bottomTabsNavigator.discover.title'),
     scrollPosition,
-    startFadeInPosition: titleHeight - titleHeight * 0.33,
-    animationDistance: titleHeight * 0.33,
+    startFadeInPosition: titleHeight * 0.33,
+    animationDistance: titleHeight,
   })
 
   return (
-    <ScrollView testID={'DappsExplorerScrollView'}>
+    <Animated.ScrollView scrollEventThrottle={16} onScroll={handleScroll}>
       <SafeAreaView testID="DAppsExplorerScreen" style={styles.safeAreaContainer} edges={[]}>
         <View style={styles.contentContainer}>
-          <Text style={styles.title}>{t('bottomTabsNavigator.discover.title')}</Text>
+          <Text style={styles.title} onLayout={handleMeasureTitleHeight}>
+            {t('bottomTabsNavigator.discover.title')}
+          </Text>
           <DappFeaturedActions />
           <PointsDiscoverCard />
           <EarnCardDiscover
@@ -48,7 +56,7 @@ function TabDiscover({ navigation }: Props) {
           <DiscoverDappsCard />
         </View>
       </SafeAreaView>
-    </ScrollView>
+    </Animated.ScrollView>
   )
 }
 


### PR DESCRIPTION
### Description

As the title.

### Test plan

https://github.com/user-attachments/assets/b8fc9ddb-677f-45ae-9a12-e9ad0073bb5a


### Related issues

- Fixes RET-1166

### Backwards compatibility

Y

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [ ] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
