### PR TITLE
feat: add info disclaimer on points screen

### DIFF
--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -2341,7 +2341,7 @@
     "allNetworks": "All Networks"
   },
   "points": {
-    "title": "Valora Points",
+    "title": "{{appName}} Points",
     "activity": "Activity",
     "history": {
       "cards": {
@@ -2449,6 +2449,11 @@
       "title": "Earn points effortlessly",
       "description": "Jump into a new way to earn! Your {{appName}} actions now earn points. Start earning today and unlock awesome benefits.",
       "cta": "Start your points journey"
+    },
+    "disclaimer": {
+      "learnMoreCta": "<0>Learn more</0> about {{appName}} Points",
+      "body": "<0>What are Points?</0>\nPoints are {{appName}}'s loyalty program. They're awarded to users when you use our app.\n\n<0>What are they good for?</0>\nYou collect them. They can’t be spent or traded or transferred.\n\n<0>Why are they in my wallet?</0>\nBecause they’re tokens. On chain, digital bits of happiness you earn by using the app.",
+      "dismiss": "Got it"
     }
   },
   "earnFlow": {

--- a/src/analytics/Events.tsx
+++ b/src/analytics/Events.tsx
@@ -674,6 +674,7 @@ export enum PointsEvents {
   points_screen_activity_try_again_press = 'points_screen_activity_try_again_press',
   points_screen_activity_fetch_more = 'points_screen_activity_fetch_more',
   points_screen_activity_learn_more_press = 'points_screen_activity_learn_more_press',
+  points_screen_disclaimer_press = 'points_screen_disclaimer_press',
 }
 
 export enum EarnEvents {

--- a/src/analytics/Properties.tsx
+++ b/src/analytics/Properties.tsx
@@ -1575,6 +1575,7 @@ interface PointsEventsProperties {
   }
   [PointsEvents.points_screen_activity_fetch_more]: undefined
   [PointsEvents.points_screen_activity_learn_more_press]: undefined
+  [PointsEvents.points_screen_disclaimer_press]: undefined
 }
 
 interface EarnCommonProperties {

--- a/src/analytics/docs.ts
+++ b/src/analytics/docs.ts
@@ -493,6 +493,7 @@ export const eventDocs: Record<AnalyticsEventType, string> = {
   [PointsEvents.points_screen_activity_try_again_press]: `when the Try Again button is pressed after an error while fetching Points activity`,
   [PointsEvents.points_screen_activity_fetch_more]: `when the user requests to fetch more Points history`,
   [PointsEvents.points_screen_activity_learn_more_press]: `when the Learn button is pressed when a user has no points history`,
+  [PointsEvents.points_screen_disclaimer_press]: `when the learn more button is pressed from Points activity screen`,
 
   // Events related to WalletConnect pairing (technical: opening up the communication channel via QR code or deeplink)
   [WalletConnectEvents.wc_pairing_start]: `when WC pairing is started (no UI at this point)`,

--- a/src/points/PointsHome.test.tsx
+++ b/src/points/PointsHome.test.tsx
@@ -148,9 +148,7 @@ describe(PointsHome, () => {
 
     fireEvent.press(getByText('points.disclaimer.learnMoreCta'))
 
-    expect(ValoraAnalytics.track).toHaveBeenCalledWith(
-      PointsEvents.points_screen_disclaimer_learn_more
-    )
+    expect(ValoraAnalytics.track).toHaveBeenCalledWith(PointsEvents.points_screen_disclaimer_press)
     expect(getByText('points.disclaimer.body')).toBeTruthy()
   })
 

--- a/src/points/PointsHome.test.tsx
+++ b/src/points/PointsHome.test.tsx
@@ -143,6 +143,17 @@ describe(PointsHome, () => {
     expect(queryByText('points.error.title')).toBeFalsy()
   })
 
+  it('renders disclaimer cta and information', () => {
+    const { getByText } = renderPointsHome()
+
+    fireEvent.press(getByText('points.disclaimer.learnMoreCta'))
+
+    expect(ValoraAnalytics.track).toHaveBeenCalledWith(
+      PointsEvents.points_screen_disclaimer_learn_more
+    )
+    expect(getByText('points.disclaimer.body')).toBeTruthy()
+  })
+
   it('renders only the balance if there are no supported activities', async () => {
     const { getByTestId, getByText, queryByText } = renderPointsHome({
       points: {

--- a/src/points/PointsHome.tsx
+++ b/src/points/PointsHome.tsx
@@ -1,6 +1,6 @@
 import { NativeStackScreenProps } from '@react-navigation/native-stack'
 import React, { useEffect, useRef, useState } from 'react'
-import { useTranslation } from 'react-i18next'
+import { Trans, useTranslation } from 'react-i18next'
 import { RefreshControl, ScrollView, StyleSheet, Text, View } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { PointsEvents } from 'src/analytics/Events'
@@ -12,6 +12,7 @@ import Button, { BtnSizes, BtnTypes } from 'src/components/Button'
 import InLineNotification, { NotificationVariant } from 'src/components/InLineNotification'
 import NumberTicker from 'src/components/NumberTicker'
 import Toast from 'src/components/Toast'
+import Touchable from 'src/components/Touchable'
 import CustomHeader from 'src/components/header/CustomHeader'
 import AttentionIcon from 'src/icons/Attention'
 import LogoHeart from 'src/icons/LogoHeart'
@@ -48,6 +49,7 @@ export default function PointsHome({ route, navigation }: Props) {
 
   const historyBottomSheetRef = useRef<BottomSheetRefType>(null)
   const activityCardBottomSheetRef = useRef<BottomSheetRefType>(null)
+  const disclaimerBottomSheetRef = useRef<BottomSheetRefType>(null)
 
   const [bottomSheetParams, setBottomSheetParams] = useState<BottomSheetParams | undefined>(
     undefined
@@ -86,6 +88,11 @@ export default function PointsHome({ route, navigation }: Props) {
 
   const onRetryLoadConfig = () => {
     dispatch(getPointsConfigRetry())
+  }
+
+  const onPressDisclaimer = () => {
+    ValoraAnalytics.track(PointsEvents.points_screen_disclaimer_press)
+    disclaimerBottomSheetRef.current?.snapToIndex(0)
   }
 
   return (
@@ -171,6 +178,14 @@ export default function PointsHome({ route, navigation }: Props) {
                 description={t('points.noActivities.body')}
               />
             )}
+
+            <Touchable onPress={onPressDisclaimer}>
+              <Text style={styles.disclaimerText}>
+                <Trans i18nKey="points.disclaimer.learnMoreCta">
+                  <Text style={styles.disclaimerLink} />
+                </Trans>
+              </Text>
+            </Touchable>
           </>
         )}
       </ScrollView>
@@ -209,6 +224,22 @@ export default function PointsHome({ route, navigation }: Props) {
             )}
           </>
         )}
+      </BottomSheet>
+      <BottomSheet forwardedRef={disclaimerBottomSheetRef} testId={`DisclaimerBottomSheet`}>
+        <Text style={typeScale.bodySmall}>
+          <Trans i18nKey="points.disclaimer.body">
+            <Text style={typeScale.labelSmall} />
+          </Trans>
+        </Text>
+        <Button
+          type={BtnTypes.SECONDARY}
+          size={BtnSizes.FULL}
+          onPress={() => {
+            disclaimerBottomSheetRef.current?.close()
+          }}
+          text={t('points.disclaimer.dismiss')}
+          style={styles.disclaimerCloseButton}
+        />
       </BottomSheet>
     </SafeAreaView>
   )
@@ -307,5 +338,18 @@ const styles = StyleSheet.create({
     height: undefined,
     paddingHorizontal: Spacing.Small12,
     paddingVertical: Spacing.Smallest8,
+  },
+  disclaimerText: {
+    ...typeScale.bodySmall,
+    color: Colors.gray4,
+    textAlign: 'center',
+    marginVertical: Spacing.Thick24,
+  },
+  disclaimerLink: {
+    ...typeScale.labelSmall,
+    textDecorationLine: 'underline',
+  },
+  disclaimerCloseButton: {
+    marginTop: Spacing.XLarge48,
   },
 })


### PR DESCRIPTION
### Description

As the title.

### Test plan


https://github.com/user-attachments/assets/f8cc7380-0b3e-495d-a249-ce1b37869ad8



### Related issues

- Fixes RET-1167

### Backwards compatibility

Y

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [ ] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
