### PR TITLE
fix(cab): text on restore in progress screen

### DIFF
--- a/src/keylessBackup/KeylessBackupProgress.tsx
+++ b/src/keylessBackup/KeylessBackupProgress.tsx
@@ -105,7 +105,7 @@ function Restore() {
             <View style={iconMarginTop}>
               <GreenLoadingSpinner />
             </View>
-            <Text style={styles.title}>{t('keylessBackupStatus.setup.inProgress.title')}</Text>
+            <Text style={styles.title}>{t('keylessBackupStatus.restore.inProgress.title')}</Text>
           </ScrollView>
         </SafeAreaView>
       )


### PR DESCRIPTION
### Description

Change cta for restore back to "Restoring your wallet", fixing a bug introduced in #5611 

### Test plan

Manually restoring and checking the CTA

### Related issues

N/A

### Backwards compatibility

Yes

### Network scalability

N/A