### PR TITLE
chore: remove deprecated h1 font

### DIFF
--- a/src/account/Education.tsx
+++ b/src/account/Education.tsx
@@ -21,7 +21,7 @@ import Times from 'src/icons/Times'
 import { navigateBack } from 'src/navigator/NavigationService'
 import { TopBarIconButton } from 'src/navigator/TopBarButton'
 import colors from 'src/styles/colors'
-import fontStyles from 'src/styles/fonts'
+import fontStyles, { typeScale } from 'src/styles/fonts'
 import progressDots from 'src/styles/progressDots'
 import variables from 'src/styles/variables'
 
@@ -194,7 +194,7 @@ const styles = StyleSheet.create({
     textAlign: 'center',
   },
   headingTop: {
-    ...fontStyles.h1,
+    ...typeScale.titleMedium,
     marginTop: 26,
     alignSelf: 'flex-start',
   },

--- a/src/account/SupportContact.tsx
+++ b/src/account/SupportContact.tsx
@@ -25,7 +25,7 @@ import { userLocationDataSelector } from 'src/networkInfo/selectors'
 import { hooksPreviewApiUrlSelector } from 'src/positions/selectors'
 import { useDispatch, useSelector } from 'src/redux/hooks'
 import colors from 'src/styles/colors'
-import fontStyles from 'src/styles/fonts'
+import fontStyles, { typeScale } from 'src/styles/fonts'
 import Logger from 'src/utils/Logger'
 import { currentAccountSelector } from 'src/web3/selectors'
 type Props = NativeStackScreenProps<StackParamList, Screens.SupportContact>
@@ -262,7 +262,7 @@ const styles = StyleSheet.create({
     marginVertical: 20,
   },
   title: {
-    ...fontStyles.h1,
+    ...typeScale.titleMedium,
     marginVertical: 16,
   },
 })

--- a/src/app/__snapshots__/ErrorScreen.test.tsx.snap
+++ b/src/app/__snapshots__/ErrorScreen.test.tsx.snap
@@ -35,9 +35,8 @@ exports[`ErrorScreen with errorMessage renders correctly 1`] = `
     <Text
       style={
         {
-          "color": "#2E3338",
-          "fontFamily": "Jost-Book",
-          "fontSize": 26,
+          "fontFamily": "Inter-Bold",
+          "fontSize": 24,
           "lineHeight": 32,
         }
       }
@@ -214,9 +213,8 @@ exports[`ErrorScreen without errorMessage renders correctly 1`] = `
     <Text
       style={
         {
-          "color": "#2E3338",
-          "fontFamily": "Jost-Book",
-          "fontSize": 26,
+          "fontFamily": "Inter-Bold",
+          "fontSize": 24,
           "lineHeight": 32,
         }
       }

--- a/src/backup/BackupComplete.tsx
+++ b/src/backup/BackupComplete.tsx
@@ -11,7 +11,7 @@ import { navigate, navigateHome } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import { StackParamList } from 'src/navigator/types'
 import { useSelector } from 'src/redux/hooks'
-import fontStyles from 'src/styles/fonts'
+import { typeScale } from 'src/styles/fonts'
 
 /**
  * Component shown to the user upon completion of the Recovery Phrase setup flow. Informs the user that
@@ -60,7 +60,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   h1: {
-    ...fontStyles.h1,
+    ...typeScale.titleMedium,
     marginTop: 20,
     paddingHorizontal: 40,
   },

--- a/src/backup/__snapshots__/BackupComplete.test.tsx.snap
+++ b/src/backup/__snapshots__/BackupComplete.test.tsx.snap
@@ -42,9 +42,8 @@ exports[`BackupComplete renders correctly 1`] = `
     <Text
       style={
         {
-          "color": "#2E3338",
-          "fontFamily": "Jost-Book",
-          "fontSize": 26,
+          "fontFamily": "Inter-Bold",
+          "fontSize": 24,
           "lineHeight": 32,
           "marginTop": 20,
           "paddingHorizontal": 40,

--- a/src/components/FullscreenCTA.tsx
+++ b/src/components/FullscreenCTA.tsx
@@ -3,7 +3,7 @@ import { StyleSheet, Text, View } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import Button, { BtnTypes } from 'src/components/Button'
 import Colors from 'src/styles/colors'
-import fontStyles from 'src/styles/fonts'
+import fontStyles, { typeScale } from 'src/styles/fonts'
 import variables from 'src/styles/variables'
 
 export interface Props {
@@ -21,7 +21,7 @@ class FullscreenCTA extends React.PureComponent<Props> {
     return (
       <SafeAreaView style={styles.container}>
         <View style={styles.header}>
-          <Text style={fontStyles.h1}>{title}</Text>
+          <Text style={typeScale.titleMedium}>{title}</Text>
           <Text style={fontStyles.h2}>{subtitle}</Text>
         </View>
         {this.props.children}

--- a/src/components/ReviewHeader.tsx
+++ b/src/components/ReviewHeader.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { StyleSheet, Text, View } from 'react-native'
 import colors from 'src/styles/colors'
-import fontStyles from 'src/styles/fonts'
+import fontStyles, { typeScale } from 'src/styles/fonts'
 
 interface Props {
   title: string
@@ -13,7 +13,7 @@ class ReviewHeader extends React.PureComponent<Props> {
     const { title, subtitle } = this.props
     return (
       <View style={styles.container}>
-        <Text style={[fontStyles.h1, styles.heading]}>{title}</Text>
+        <Text style={[typeScale.titleMedium, styles.heading]}>{title}</Text>
         {!!subtitle && subtitle.length > 0 && <Text style={fontStyles.regular}>{subtitle}</Text>}
       </View>
     )
@@ -29,7 +29,7 @@ const styles = StyleSheet.create({
   },
   heading: {
     padding: 10,
-    paddingBottom: 10, // overwrite h1
+    paddingBottom: 10,
     color: colors.black,
     alignSelf: 'center',
   },

--- a/src/components/__snapshots__/FullscreenCTA.test.tsx.snap
+++ b/src/components/__snapshots__/FullscreenCTA.test.tsx.snap
@@ -35,9 +35,8 @@ exports[`FullscreenCTA renders correctly 1`] = `
     <Text
       style={
         {
-          "color": "#2E3338",
-          "fontFamily": "Jost-Book",
-          "fontSize": 26,
+          "fontFamily": "Inter-Bold",
+          "fontSize": 24,
           "lineHeight": 32,
         }
       }

--- a/src/nfts/NftsInfoCarousel.tsx
+++ b/src/nfts/NftsInfoCarousel.tsx
@@ -15,7 +15,7 @@ import NftMedia from 'src/nfts/NftMedia'
 import NftsLoadError from 'src/nfts/NftsLoadError'
 import { Nft, NftOrigin } from 'src/nfts/types'
 import colors from 'src/styles/colors'
-import fontStyles from 'src/styles/fonts'
+import fontStyles, { typeScale } from 'src/styles/fonts'
 import { Spacing } from 'src/styles/styles'
 import variables from 'src/styles/variables'
 import { NetworkId } from 'src/transactions/types'
@@ -340,6 +340,6 @@ const styles = StyleSheet.create({
     ...fontStyles.regular,
   },
   title: {
-    ...fontStyles.h1,
+    ...typeScale.titleMedium,
   },
 })

--- a/src/onboarding/ChooseYourAdventure.tsx
+++ b/src/onboarding/ChooseYourAdventure.tsx
@@ -171,7 +171,7 @@ const styles = StyleSheet.create({
   header: {
     textAlign: 'center',
     marginTop: 50,
-    ...fontStyles.h1,
+    ...typeScale.titleMedium,
   },
   card: {
     marginTop: Spacing.Smallest8,

--- a/src/onboarding/registration/ProtectWallet.tsx
+++ b/src/onboarding/registration/ProtectWallet.tsx
@@ -17,7 +17,7 @@ import { StackParamList } from 'src/navigator/types'
 import { getOnboardingStepValues, onboardingPropsSelector } from 'src/onboarding/steps'
 import { useDispatch, useSelector } from 'src/redux/hooks'
 import colors from 'src/styles/colors'
-import fontStyles from 'src/styles/fonts'
+import fontStyles, { typeScale } from 'src/styles/fonts'
 import variables from 'src/styles/variables'
 import Logger from 'src/utils/Logger'
 import { walletAddressSelector } from 'src/web3/selectors'
@@ -144,6 +144,6 @@ const styles = StyleSheet.create({
   protectWalletTitle: {
     textAlign: 'center',
     marginTop: 36,
-    ...fontStyles.h1,
+    ...typeScale.titleMedium,
   },
 })

--- a/src/onboarding/registration/RegulatoryTerms.tsx
+++ b/src/onboarding/registration/RegulatoryTerms.tsx
@@ -214,7 +214,7 @@ const styles = StyleSheet.create({
     paddingHorizontal: MARGIN,
   },
   title: {
-    ...fontStyles.h1,
+    ...typeScale.titleMedium,
     marginTop: 30,
     marginBottom: 24,
   },

--- a/src/pincode/Pincode.tsx
+++ b/src/pincode/Pincode.tsx
@@ -9,7 +9,7 @@ import NumberKeypad from 'src/components/NumberKeypad'
 import { PIN_LENGTH } from 'src/pincode/authentication'
 import PincodeDisplay from 'src/pincode/PincodeDisplay'
 import colors from 'src/styles/colors'
-import fontStyles from 'src/styles/fonts'
+import fontStyles, { typeScale } from 'src/styles/fonts'
 import { Spacing } from 'src/styles/styles'
 
 interface Props {
@@ -95,7 +95,7 @@ const styles = StyleSheet.create({
     textAlign: 'center',
   },
   title: {
-    ...fontStyles.h1,
+    ...typeScale.titleMedium,
     textAlign: 'center',
     marginBottom: Spacing.Regular16,
   },

--- a/src/pincode/PincodeDisplay.tsx
+++ b/src/pincode/PincodeDisplay.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react'
 import { LayoutAnimation, StyleSheet, Text, View } from 'react-native'
 import colors from 'src/styles/colors'
-import fontStyles from 'src/styles/fonts'
+import { typeScale } from 'src/styles/fonts'
 
 // How long the last entered digit is visible
 const LAST_DIGIT_VISIBLE_INTERVAL = 2000 // 2secs
@@ -72,12 +72,12 @@ const styles = StyleSheet.create({
   },
   inputContainer: {
     flex: 1,
-    height: fontStyles.h1.lineHeight,
+    height: typeScale.titleMedium.lineHeight,
     alignItems: 'center',
     justifyContent: 'center',
   },
   char: {
-    ...fontStyles.h1,
+    ...typeScale.titleMedium,
   },
   dot: {
     width: DOT_SIZE,

--- a/src/styles/fonts.tsx
+++ b/src/styles/fonts.tsx
@@ -161,12 +161,6 @@ export const typeScale = StyleSheet.create({
  * Use typeScale instead
  */
 export const fontStyles = StyleSheet.create({
-  h1: {
-    fontSize: 26,
-    lineHeight: 32,
-    fontFamily: Jost.Book,
-    color: colors.black,
-  },
   h2: {
     fontSize: 22,
     lineHeight: 28,

--- a/src/verify/VerificationStartScreen.tsx
+++ b/src/verify/VerificationStartScreen.tsx
@@ -38,7 +38,7 @@ import {
 import { retrieveSignedMessage } from 'src/pincode/authentication'
 import { useDispatch, useSelector } from 'src/redux/hooks'
 import colors from 'src/styles/colors'
-import fontStyles from 'src/styles/fonts'
+import fontStyles, { typeScale } from 'src/styles/fonts'
 import { Spacing } from 'src/styles/styles'
 import { walletAddressSelector } from 'src/web3/selectors'
 
@@ -272,7 +272,7 @@ const styles = StyleSheet.create({
     width: '100%',
   },
   header: {
-    ...fontStyles.h1,
+    ...typeScale.titleMedium,
     marginBottom: Spacing.Regular16,
     textAlign: 'center',
   },

--- a/src/walletConnect/screens/ConnectionTimedOut.tsx
+++ b/src/walletConnect/screens/ConnectionTimedOut.tsx
@@ -4,7 +4,7 @@ import { StyleSheet, Text } from 'react-native'
 import Button, { BtnTypes } from 'src/components/Button'
 import { navigateBack } from 'src/navigator/NavigationService'
 import colors from 'src/styles/colors'
-import fontStyles from 'src/styles/fonts'
+import fontStyles, { typeScale } from 'src/styles/fonts'
 
 function ConnectionTimedOut() {
   const { t } = useTranslation()
@@ -19,7 +19,7 @@ function ConnectionTimedOut() {
 
 const styles = StyleSheet.create({
   title: {
-    ...fontStyles.h1,
+    ...typeScale.titleMedium,
     textAlign: 'center',
   },
   subtitle: {

--- a/src/walletConnect/screens/Logos.tsx
+++ b/src/walletConnect/screens/Logos.tsx
@@ -3,7 +3,7 @@ import { Image, StyleSheet, Text, View } from 'react-native'
 import { SvgUri } from 'react-native-svg'
 import Logo from 'src/icons/Logo'
 import { Colors } from 'src/styles/colors'
-import fontStyles from 'src/styles/fonts'
+import { typeScale } from 'src/styles/fonts'
 import { Shadow, Spacing, getShadowStyle } from 'src/styles/styles'
 
 const DAPP_IMAGE_SIZE = 40
@@ -82,7 +82,7 @@ const styles = StyleSheet.create({
     borderWidth: 1,
   },
   placeholderLogoText: {
-    ...fontStyles.h1,
+    ...typeScale.titleMedium,
     lineHeight: undefined,
     color: Colors.gray4,
   },


### PR DESCRIPTION
### Description

As the title. It seems like a straight replace for h1 -> titleMedium, this is what was asked for in RET-1165.

<img width="397" alt="Screenshot 2024-08-08 at 15 10 08" src="https://github.com/user-attachments/assets/0dede232-d83c-41ca-a7b0-3110ac13029f">


### Test plan

n/a

### Related issues

Related to RET-1174 

### Backwards compatibility

Y

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [ ] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
