### PR TITLE
fix(points): hide live links when user has no jumpstart tokens

### DIFF
--- a/src/points/selectors.test.ts
+++ b/src/points/selectors.test.ts
@@ -1,5 +1,9 @@
 import { pointsActivitiesSelector, pointsHistorySelector } from 'src/points/selectors'
+import { getDynamicConfigParams, getFeatureGate } from 'src/statsig'
+import { NetworkId } from 'src/transactions/types'
 import { getMockStoreData } from 'test/utils'
+
+jest.mock('src/statsig')
 
 describe('pointsHistorySelector', () => {
   it('returns UNIX timestamp', () => {
@@ -27,6 +31,12 @@ describe('pointsHistorySelector', () => {
 })
 
 describe('pointsActivitiesSelector', () => {
+  beforeEach(() => {
+    jest
+      .mocked(getDynamicConfigParams)
+      .mockReturnValue({ jumpstartContracts: { 'celo-alfajores': '0x1234' } })
+  })
+
   it('should return an empty array if there are no activities', () => {
     const stateWithoutPointsConfig = getMockStoreData({
       points: {
@@ -60,5 +70,86 @@ describe('pointsActivitiesSelector', () => {
       { activityId: 'swap', pointsAmount: 10, completed: false },
       { activityId: 'create-wallet', pointsAmount: 10, completed: true },
     ])
+  })
+
+  it('should return points activities with live links when enabled and user has jumpstart tokens', () => {
+    jest.mocked(getFeatureGate).mockReturnValue(true)
+
+    const stateWithPointsConfig = getMockStoreData({
+      points: {
+        pointsConfig: {
+          activitiesById: {
+            'create-live-link': { pointsAmount: 10 },
+          },
+        },
+      },
+      tokens: {
+        tokenBalances: {
+          ['celo-alfajores:0xusd']: {
+            tokenId: 'celo-alfajores:0xabcd',
+            address: '0xabcd',
+            networkId: NetworkId['celo-alfajores'],
+            balance: '10',
+          },
+        },
+      },
+    })
+    const result = pointsActivitiesSelector(stateWithPointsConfig)
+
+    expect(result).toEqual([{ activityId: 'create-live-link', pointsAmount: 10, completed: false }])
+  })
+
+  it('should return points activities without live links if they are disabled', () => {
+    jest.mocked(getFeatureGate).mockReturnValue(false)
+
+    const stateWithPointsConfig = getMockStoreData({
+      points: {
+        pointsConfig: {
+          activitiesById: {
+            'create-live-link': { pointsAmount: 10 },
+          },
+        },
+      },
+      tokens: {
+        tokenBalances: {
+          ['celo-alfajores:0xusd']: {
+            tokenId: 'celo-alfajores:0xabcd',
+            address: '0xabcd',
+            networkId: NetworkId['celo-alfajores'],
+            balance: '10',
+          },
+        },
+      },
+    })
+    const result = pointsActivitiesSelector(stateWithPointsConfig)
+
+    expect(result).toEqual([])
+  })
+
+  it('should return points activities without live links if user has no jumpstart tokens', () => {
+    jest.mocked(getFeatureGate).mockReturnValue(true)
+
+    const stateWithPointsConfig = getMockStoreData({
+      points: {
+        pointsConfig: {
+          activitiesById: {
+            'create-live-link': { pointsAmount: 10 },
+          },
+        },
+      },
+      tokens: {
+        tokenBalances: {
+          ['celo-alfajores:0xusd']: {
+            tokenId: 'celo-alfajores:0xabcd',
+            address: '0xabcd',
+            networkId: NetworkId['celo-alfajores'],
+            balance: '0',
+          },
+        },
+      },
+    })
+    const result = pointsActivitiesSelector(stateWithPointsConfig)
+
+    expect(result).toEqual([])
   })
 })

--- a/src/points/selectors.ts
+++ b/src/points/selectors.ts
@@ -38,14 +38,14 @@ export const pointsConfigStatusSelector = (state: RootState) => state.points.poi
 
 const pointsConfigSelector = (state: RootState) => state.points.pointsConfig
 
-const jumpstartFeatureGateSelector = () => getFeatureGate(StatsigFeatureGates.SHOW_JUMPSTART_SEND)
+const showJumpstartSendSelector = () => getFeatureGate(StatsigFeatureGates.SHOW_JUMPSTART_SEND)
 
 export const pointsActivitiesSelector = createSelector(
   [
     pointsConfigSelector,
     trackOnceActivitiesSelector,
     jumpstartSendTokensSelector,
-    jumpstartFeatureGateSelector,
+    showJumpstartSendSelector,
   ],
   (pointsConfig, trackOnceActivities, jumpstartTokens, jumpstartSendEnabled) => {
     const showJumpstart = jumpstartSendEnabled && jumpstartTokens.length > 0

--- a/src/points/selectors.ts
+++ b/src/points/selectors.ts
@@ -38,10 +38,16 @@ export const pointsConfigStatusSelector = (state: RootState) => state.points.poi
 
 const pointsConfigSelector = (state: RootState) => state.points.pointsConfig
 
+const jumpstartFeatureGateSelector = () => getFeatureGate(StatsigFeatureGates.SHOW_JUMPSTART_SEND)
+
 export const pointsActivitiesSelector = createSelector(
-  [pointsConfigSelector, trackOnceActivitiesSelector, jumpstartSendTokensSelector],
-  (pointsConfig, trackOnceActivities, jumpstartTokens) => {
-    const jumpstartSendEnabled = getFeatureGate(StatsigFeatureGates.SHOW_JUMPSTART_SEND)
+  [
+    pointsConfigSelector,
+    trackOnceActivitiesSelector,
+    jumpstartSendTokensSelector,
+    jumpstartFeatureGateSelector,
+  ],
+  (pointsConfig, trackOnceActivities, jumpstartTokens, jumpstartSendEnabled) => {
     const showJumpstart = jumpstartSendEnabled && jumpstartTokens.length > 0
     const excludedActivities = new Set<PointsActivityId>()
     if (!showJumpstart) {


### PR DESCRIPTION
### Description

Hide live links activity when a user has no jumpstart tokens (or live links are disabled).
This is consistent with the send flow behavior when the live link option is not shown when a user has no jumpstart tokens.

If the user tries to create a jumpstart link without having the jumpstart tokens the app will crash.

Context: https://valora-app.slack.com/archives/C04B61SJ6DS/p1723075264724759

### Test plan

* Tested manually
* Updated unit test

### Related issues

NA

### Backwards compatibility

Y

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [ ] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
