### PR TITLE
fix(swaps): hide incompatible selection banner on quote fetch

### DIFF
--- a/src/swap/SwapScreen.tsx
+++ b/src/swap/SwapScreen.tsx
@@ -619,11 +619,13 @@ export function SwapScreen({ route }: Props) {
       showUnsupportedTokensWarning:
         !quoteUpdatePending && fetchSwapQuoteError?.message.includes(NO_QUOTE_ERROR_MESSAGE),
       showInsufficientBalanceWarning: parsedSwapAmount[Field.FROM].gt(fromTokenBalance),
-      showCrossChainFeeWarning: crossChainFee?.nativeTokenBalanceDeficit.lt(0),
+      showCrossChainFeeWarning:
+        !quoteUpdatePending && crossChainFee?.nativeTokenBalanceDeficit.lt(0),
       showDecreaseSpendForGasWarning:
+        !quoteUpdatePending &&
         quote?.preparedTransactions.type === 'need-decrease-spend-amount-for-gas',
       showNotEnoughBalanceForGasWarning:
-        quote?.preparedTransactions.type === 'not-enough-balance-for-gas',
+        !quoteUpdatePending && quote?.preparedTransactions.type === 'not-enough-balance-for-gas',
       showMaxSwapAmountWarning: shouldShowMaxSwapAmountWarning && !confirmSwapFailed,
       showNoUsdPriceWarning:
         !confirmSwapFailed && !quoteUpdatePending && toToken && !toToken.priceUsd,
@@ -633,7 +635,7 @@ export function SwapScreen({ route }: Props) {
         (quote?.estimatedPriceImpact
           ? new BigNumber(quote.estimatedPriceImpact).gte(priceImpactWarningThreshold)
           : false),
-      showMissingPriceImpactWarning: quote && !quote.estimatedPriceImpact,
+      showMissingPriceImpactWarning: !quoteUpdatePending && quote && !quote.estimatedPriceImpact,
     }
 
     // Only ever show a single warning, according to precedence as above.

--- a/src/swap/SwapScreen.tsx
+++ b/src/swap/SwapScreen.tsx
@@ -9,8 +9,8 @@ import { ScrollView } from 'react-native-gesture-handler'
 import { getNumberFormatSettings } from 'react-native-localize'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { showError } from 'src/alert/actions'
-import { SwapEvents } from 'src/analytics/Events'
 import AppAnalytics from 'src/analytics/AppAnalytics'
+import { SwapEvents } from 'src/analytics/Events'
 import { ErrorMessages } from 'src/app/ErrorMessages'
 import { TRANSACTION_FEES_LEARN_MORE } from 'src/brandingConfig'
 import BackButton from 'src/components/BackButton'
@@ -616,7 +616,8 @@ export function SwapScreen({ route }: Props) {
     // the condition should prevent the user from swapping.
     const checks = {
       showSwitchedToNetworkWarning: !!switchedToNetworkId,
-      showUnsupportedTokensWarning: fetchSwapQuoteError?.message.includes(NO_QUOTE_ERROR_MESSAGE),
+      showUnsupportedTokensWarning:
+        !quoteUpdatePending && fetchSwapQuoteError?.message.includes(NO_QUOTE_ERROR_MESSAGE),
       showInsufficientBalanceWarning: parsedSwapAmount[Field.FROM].gt(fromTokenBalance),
       showCrossChainFeeWarning: crossChainFee?.nativeTokenBalanceDeficit.lt(0),
       showDecreaseSpendForGasWarning:


### PR DESCRIPTION
### Description

Observed behavior: incompatible selection banner disappears only after the new quote is fetched
Expected behavior: incompatible selection banner disappears right after another token is selected

Context: https://valora-app.slack.com/archives/C04B61SJ6DS/p1723220851805809?thread_ts=1723219373.676809&cid=C04B61SJ6DS

The same applies for other quote-dependent banners as well:
* cross-chain fee warning
* decrease spend amount for gas
* non enough balance for gas
* show missing price impact

| Before | After |
|--------|--------|
| ![before](https://github.com/user-attachments/assets/0853ff8a-01f4-4006-b6b0-dfaf2d923466) | ![after](https://github.com/user-attachments/assets/45d41d14-626e-4e08-8f4c-814a8650e41c) | 

### Test plan

Visual assessment

### Related issues

NA

### Backwards compatibility

Y

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
