### PR TITLE
chore: update earn info screen

### DIFF
--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -2484,17 +2484,17 @@
       "details": {
         "earn": {
           "titleGasSubsidy": "Maximize Earnings without Gas Fees*",
-          "title": "Maximize Earnings",
-          "subtitle": "Earn on your stablecoins and get rewards when you supply a pool.",
+          "title": "Explore and Compare Pools",
+          "subtitle": "Compare earning potential and risks. Swap, buy, or transfer tokens to join the best pool for you.",
           "footnoteSubsidy": "*Gas fees are temporarily covered by Valora"
         },
         "manage": {
           "title": "Manage Directly from Valora",
-          "subtitle": "We’ll take care of the setup so you can manage your position directly from Valora."
+          "subtitle": "We'll auto-connect your wallet so you can manage pools without leaving Valora."
         },
         "access": {
           "title": "Easily Access your Funds",
-          "subtitle": "Collect your funds effortlessly with a single tap. Enjoy the same instant access as you would directly through your favorite protocols."
+          "subtitle": "Collect funds with a tap, just like your favorite protocols."
         }
       },
       "action": {

--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -2490,7 +2490,9 @@
         },
         "manage": {
           "title": "Manage Directly from Valora",
-          "subtitle": "We'll auto-connect your wallet so you can manage pools without leaving Valora."
+          "titleV1_92": "Manage Directly from {{appName}}",
+          "subtitle": "We'll auto-connect your wallet so you can manage pools without leaving Valora.",
+          "subtitleV1_92": "We'll auto-connect your wallet so you can manage pools without leaving {{appName}}."
         },
         "access": {
           "title": "Easily Access your Funds",

--- a/src/earn/EarnInfoScreen.test.tsx
+++ b/src/earn/EarnInfoScreen.test.tsx
@@ -1,14 +1,12 @@
 import { fireEvent, render } from '@testing-library/react-native'
 import React from 'react'
 import { Provider } from 'react-redux'
-import { EarnEvents } from 'src/analytics/Events'
 import AppAnalytics from 'src/analytics/AppAnalytics'
+import { EarnEvents } from 'src/analytics/Events'
 import { EARN_STABLECOINS_LEARN_MORE } from 'src/config'
 import EarnInfoScreen from 'src/earn/EarnInfoScreen'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
-import { getFeatureGate } from 'src/statsig'
-import { StatsigFeatureGates } from 'src/statsig/types'
 import networkConfig from 'src/web3/networkConfig'
 import MockedNavigator from 'test/MockedNavigator'
 import { createMockStore } from 'test/utils'
@@ -24,7 +22,7 @@ describe('EarnInfoScreen', () => {
     jest.clearAllMocks()
   })
 
-  it('should render correctly when no gas subsidy', async () => {
+  it('should render correctly', async () => {
     const { getByText, queryByText } = render(
       <Provider store={store}>
         <MockedNavigator component={EarnInfoScreen} />
@@ -48,22 +46,6 @@ describe('EarnInfoScreen', () => {
     // Buttons
     expect(getByText('earnFlow.earnInfo.action.learn')).toBeTruthy()
     expect(getByText('earnFlow.earnInfo.action.earn')).toBeTruthy()
-  })
-
-  it('should render correctly when gas subsidy enabled', () => {
-    jest
-      .mocked(getFeatureGate)
-      .mockImplementation((gate) => gate === StatsigFeatureGates.SUBSIDIZE_STABLECOIN_EARN_GAS_FEES)
-
-    const { getByText, queryByText } = render(
-      <Provider store={store}>
-        <MockedNavigator component={EarnInfoScreen} />
-      </Provider>
-    )
-
-    expect(getByText('earnFlow.earnInfo.details.earn.titleGasSubsidy')).toBeTruthy()
-    expect(getByText('earnFlow.earnInfo.details.earn.footnoteSubsidy')).toBeTruthy()
-    expect(queryByText('earnFlow.earnInfo.details.earn.title')).toBeFalsy()
   })
 
   it('should navigate and fire analytics correctly on Learn More button press', () => {

--- a/src/earn/EarnInfoScreen.test.tsx
+++ b/src/earn/EarnInfoScreen.test.tsx
@@ -36,8 +36,12 @@ describe('EarnInfoScreen', () => {
     expect(queryByText('earnFlow.earnInfo.details.earn.footnoteSubsidy')).toBeFalsy()
 
     // Second details item
-    expect(getByText('earnFlow.earnInfo.details.manage.title')).toBeTruthy()
-    expect(getByText('earnFlow.earnInfo.details.manage.subtitle')).toBeTruthy()
+    expect(
+      getByText('earnFlow.earnInfo.details.manage.titleV1_92, {"appName":"Valora"')
+    ).toBeTruthy()
+    expect(
+      getByText('earnFlow.earnInfo.details.manage.subtitleV1_92, {"appName":"Valora"}')
+    ).toBeTruthy()
 
     // Third details item
     expect(getByText('earnFlow.earnInfo.details.access.title')).toBeTruthy()

--- a/src/earn/EarnInfoScreen.tsx
+++ b/src/earn/EarnInfoScreen.tsx
@@ -6,7 +6,7 @@ import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context'
 import AppAnalytics from 'src/analytics/AppAnalytics'
 import { EarnEvents } from 'src/analytics/Events'
 import Button, { BtnSizes, BtnTypes } from 'src/components/Button'
-import { EARN_STABLECOINS_LEARN_MORE } from 'src/config'
+import { APP_NAME, EARN_STABLECOINS_LEARN_MORE } from 'src/config'
 import { EarnTabType } from 'src/earn/types'
 import ArrowDown from 'src/icons/ArrowDown'
 import Blob from 'src/icons/Blob'
@@ -80,8 +80,8 @@ export default function EarnInfoScreen() {
           />
           <DetailsItem
             icon={<Logo size={ICON_SIZE} color={Colors.black} />}
-            title={t('earnFlow.earnInfo.details.manage.title')}
-            subtitle={t('earnFlow.earnInfo.details.manage.subtitle')}
+            title={t('earnFlow.earnInfo.details.manage.titleV1_92', { appName: APP_NAME })}
+            subtitle={t('earnFlow.earnInfo.details.manage.subtitleV1_92', { appName: APP_NAME })}
           />
           <DetailsItem
             icon={<ArrowDown size={ICON_SIZE} color={Colors.black} />}

--- a/src/earn/EarnInfoScreen.tsx
+++ b/src/earn/EarnInfoScreen.tsx
@@ -58,7 +58,6 @@ function DetailsItem({
 
 export default function EarnInfoScreen() {
   const { t } = useTranslation()
-  const isGasSubsidized = getFeatureGate(StatsigFeatureGates.SUBSIDIZE_STABLECOIN_EARN_GAS_FEES)
   const showMultiplePools = getFeatureGate(StatsigFeatureGates.SHOW_MULTIPLE_EARN_POOLS)
 
   const headerHeight = useHeaderHeight()
@@ -76,15 +75,8 @@ export default function EarnInfoScreen() {
         <View style={styles.detailsContainer}>
           <DetailsItem
             icon={<EarnCoins size={ICON_SIZE} color={Colors.black} />}
-            title={
-              isGasSubsidized
-                ? t('earnFlow.earnInfo.details.earn.titleGasSubsidy')
-                : t('earnFlow.earnInfo.details.earn.title')
-            }
+            title={t('earnFlow.earnInfo.details.earn.title')}
             subtitle={t('earnFlow.earnInfo.details.earn.subtitle')}
-            footnote={
-              isGasSubsidized ? t('earnFlow.earnInfo.details.earn.footnoteSubsidy') : undefined
-            }
           />
           <DetailsItem
             icon={<Logo size={ICON_SIZE} color={Colors.black} />}
@@ -150,7 +142,7 @@ EarnInfoScreen.navigationOptions = () => ({
 const styles = StyleSheet.create({
   safeAreaContainer: {
     flex: 1,
-    paddingHorizontal: Spacing.Regular16,
+    paddingHorizontal: Spacing.Thick24,
   },
   flex: {
     flex: 1,
@@ -183,6 +175,5 @@ const styles = StyleSheet.create({
   },
   buttonContainer: {
     gap: Spacing.Smallest8,
-    marginHorizontal: Spacing.Smallest8,
   },
 })


### PR DESCRIPTION
### Description

Updates the `EarnInfoScreen.tsx` to use new text, removes references to gas subsidies, makes app name used in text dynamic based on the branding config and adjusts text padding to match button padding.


### Test plan

- [x] Unit tests updated
- [x] Tested locally on iOS

### Related issues

- Fixes ACT-1336

### Backwards compatibility

Yes

### Network scalability

N/A
