### PR TITLE
refactor: make generic add assets bottom sheet component

### DIFF
--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -2614,5 +2614,10 @@
       "openPools": "Open Pools",
       "myPools": "My Pools"
     }
+  },
+  "addFundsActions": {
+    "buy": "Buy",
+    "transfer": "Transfer",
+    "swap": "Swap"
   }
 }

--- a/src/analytics/Properties.tsx
+++ b/src/analytics/Properties.tsx
@@ -51,6 +51,7 @@ import {
   WalletConnectPairingOrigin,
 } from 'src/analytics/types'
 import { ErrorMessages } from 'src/app/ErrorMessages'
+import { AddAssetsActionType } from 'src/components/AddAssetsBottomSheet'
 import { TokenPickerOrigin } from 'src/components/TokenBottomSheet'
 import { DappSection } from 'src/dapps/types'
 import { SerializableRewardsInfo } from 'src/earn/types'
@@ -1590,7 +1591,7 @@ interface EarnEventsProperties {
   [EarnEvents.earn_cta_press]: EarnCommonProperties
   [EarnEvents.earn_entrypoint_press]: undefined
   [EarnEvents.earn_add_crypto_action_press]: {
-    action: TokenActionName
+    action: AddAssetsActionType
   } & TokenProperties
   [EarnEvents.earn_deposit_provider_info_press]: EarnDepositProperties
   [EarnEvents.earn_deposit_terms_and_conditions_press]: EarnDepositProperties

--- a/src/components/AddAssetsBottomSheet.tsx
+++ b/src/components/AddAssetsBottomSheet.tsx
@@ -40,15 +40,15 @@ export default function AddAssetsBottomSheet({
   const actionExtraProps = {
     [TokenActionName.Add]: {
       iconComponent: QuickActionsAdd,
-      title: t('earnFlow.addCryptoBottomSheet.actions.add'),
+      title: t('addFundsActions.add'),
     },
     [TokenActionName.Transfer]: {
       iconComponent: QuickActionsSend,
-      title: t('earnFlow.addCryptoBottomSheet.actions.transfer'),
+      title: t('addFundsActions.transfer'),
     },
     [TokenActionName.Swap]: {
       iconComponent: QuickActionsSwap,
-      title: t('earnFlow.addCryptoBottomSheet.actions.swap'),
+      title: t('addFundsActions.swap'),
     },
   }
 

--- a/src/components/AddAssetsBottomSheet.tsx
+++ b/src/components/AddAssetsBottomSheet.tsx
@@ -1,0 +1,119 @@
+import React, { RefObject } from 'react'
+import { useTranslation } from 'react-i18next'
+import { StyleSheet, Text, View } from 'react-native'
+import BottomSheet, { BottomSheetRefType } from 'src/components/BottomSheet'
+import Touchable from 'src/components/Touchable'
+import QuickActionsAdd from 'src/icons/quick-actions/Add'
+import QuickActionsSend from 'src/icons/quick-actions/Send'
+import QuickActionsSwap from 'src/icons/quick-actions/Swap'
+import { Colors } from 'src/styles/colors'
+import { typeScale } from 'src/styles/fonts'
+import { Spacing } from 'src/styles/styles'
+import { TokenActionName } from 'src/tokens/types'
+
+export type AddAssetsActionType =
+  | TokenActionName.Add
+  | TokenActionName.Transfer
+  | TokenActionName.Swap
+
+export interface AddAssetsAction {
+  name: AddAssetsActionType
+  details: string
+  onPress: () => void
+}
+
+export default function AddAssetsBottomSheet({
+  forwardedRef,
+  actions,
+  title,
+  description,
+  testId,
+}: {
+  forwardedRef: RefObject<BottomSheetRefType>
+  actions: AddAssetsAction[]
+  title: string
+  description: string
+  testId: string
+}) {
+  const { t } = useTranslation()
+
+  const actionExtraProps = {
+    [TokenActionName.Add]: {
+      iconComponent: QuickActionsAdd,
+      title: t('earnFlow.addCryptoBottomSheet.actions.add'),
+    },
+    [TokenActionName.Transfer]: {
+      iconComponent: QuickActionsSend,
+      title: t('earnFlow.addCryptoBottomSheet.actions.transfer'),
+    },
+    [TokenActionName.Swap]: {
+      iconComponent: QuickActionsSwap,
+      title: t('earnFlow.addCryptoBottomSheet.actions.swap'),
+    },
+  }
+
+  const addAssetsActions = actions.map((action) => ({
+    ...action,
+    ...actionExtraProps[action.name],
+  }))
+
+  return (
+    <BottomSheet
+      forwardedRef={forwardedRef}
+      title={title}
+      description={description}
+      titleStyle={styles.title}
+      testId={testId}
+    >
+      <View style={styles.actionsContainer}>
+        {addAssetsActions.map((action) => (
+          <Touchable
+            style={styles.touchable}
+            key={action.name}
+            borderRadius={20}
+            onPress={action.onPress}
+            testID={`${testId}/${action.name}`}
+          >
+            <>
+              <action.iconComponent color={Colors.black} />
+              <View style={styles.contentContainer}>
+                <Text style={styles.actionTitle}>{action.title}</Text>
+                <Text style={styles.actionDetails}>{action.details}</Text>
+              </View>
+            </>
+          </Touchable>
+        ))}
+      </View>
+    </BottomSheet>
+  )
+}
+
+const styles = StyleSheet.create({
+  actionsContainer: {
+    flex: 1,
+    gap: Spacing.Regular16,
+    marginVertical: Spacing.Thick24,
+  },
+  actionTitle: {
+    ...typeScale.labelMedium,
+    color: Colors.black,
+  },
+  actionDetails: {
+    ...typeScale.bodySmall,
+    color: Colors.black,
+  },
+  title: {
+    ...typeScale.titleSmall,
+    color: Colors.black,
+  },
+  touchable: {
+    backgroundColor: Colors.gray1,
+    padding: Spacing.Regular16,
+    flexDirection: 'row',
+    gap: Spacing.Regular16,
+    alignItems: 'center',
+  },
+  contentContainer: {
+    flex: 1,
+  },
+})

--- a/src/earn/EarnAddCryptoBottomSheet.test.tsx
+++ b/src/earn/EarnAddCryptoBottomSheet.test.tsx
@@ -2,8 +2,8 @@ import { fireEvent, render } from '@testing-library/react-native'
 import BigNumber from 'bignumber.js'
 import React from 'react'
 import { Provider } from 'react-redux'
-import { EarnEvents } from 'src/analytics/Events'
 import AppAnalytics from 'src/analytics/AppAnalytics'
+import { EarnEvents } from 'src/analytics/Events'
 import EarnAddCryptoBottomSheet from 'src/earn/EarnAddCryptoBottomSheet'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
@@ -84,9 +84,9 @@ describe('EarnAddCryptoBottomSheet', () => {
       </Provider>
     )
 
-    expect(getByText('earnFlow.addCryptoBottomSheet.actions.transfer')).toBeTruthy()
-    expect(getByText('earnFlow.addCryptoBottomSheet.actions.swap')).toBeTruthy()
-    expect(getByText('earnFlow.addCryptoBottomSheet.actions.add')).toBeTruthy()
+    expect(getByText('addFundsActions.transfer')).toBeTruthy()
+    expect(getByText('addFundsActions.swap')).toBeTruthy()
+    expect(getByText('addFundsActions.add')).toBeTruthy()
   })
 
   it('Does not render swap action when no tokens available to swap', () => {
@@ -113,9 +113,9 @@ describe('EarnAddCryptoBottomSheet', () => {
       </Provider>
     )
 
-    expect(getByText('earnFlow.addCryptoBottomSheet.actions.transfer')).toBeTruthy()
-    expect(queryByText('earnFlow.addCryptoBottomSheet.actions.swap')).toBeFalsy()
-    expect(getByText('earnFlow.addCryptoBottomSheet.actions.add')).toBeTruthy()
+    expect(getByText('addFundsActions.transfer')).toBeTruthy()
+    expect(queryByText('addFundsActions.swap')).toBeFalsy()
+    expect(getByText('addFundsActions.add')).toBeTruthy()
   })
 
   it('Does not render swap or add when network is not in dynamic config', () => {
@@ -133,15 +133,15 @@ describe('EarnAddCryptoBottomSheet', () => {
       </Provider>
     )
 
-    expect(getByText('earnFlow.addCryptoBottomSheet.actions.transfer')).toBeTruthy()
-    expect(queryByText('earnFlow.addCryptoBottomSheet.actions.swap')).toBeFalsy()
-    expect(queryByText('earnFlow.addCryptoBottomSheet.actions.add')).toBeFalsy()
+    expect(getByText('addFundsActions.transfer')).toBeTruthy()
+    expect(queryByText('addFundsActions.swap')).toBeFalsy()
+    expect(queryByText('addFundsActions.add')).toBeFalsy()
   })
 
   it.each([
     {
       actionName: TokenActionName.Add,
-      actionTitle: 'earnFlow.addCryptoBottomSheet.actions.add',
+      actionTitle: 'addFundsActions.add',
       navigateScreen: Screens.SelectProvider,
       navigateProps: {
         amount: { crypto: 100, fiat: 154 },
@@ -151,13 +151,13 @@ describe('EarnAddCryptoBottomSheet', () => {
     },
     {
       actionName: TokenActionName.Transfer,
-      actionTitle: 'earnFlow.addCryptoBottomSheet.actions.transfer',
+      actionTitle: 'addFundsActions.transfer',
       navigateScreen: Screens.ExchangeQR,
       navigateProps: { exchanges: [], flow: 'CashIn' },
     },
     {
       actionName: TokenActionName.Swap,
-      actionTitle: 'earnFlow.addCryptoBottomSheet.actions.swap',
+      actionTitle: 'addFundsActions.swap',
       navigateScreen: Screens.SwapScreenWithBack,
       navigateProps: { toTokenId: 'arbitrum-sepolia:0x123' },
     },

--- a/src/earn/EarnAddCryptoBottomSheet.tsx
+++ b/src/earn/EarnAddCryptoBottomSheet.tsx
@@ -1,25 +1,18 @@
 import BigNumber from 'bignumber.js'
-import React, { RefObject } from 'react'
+import React, { RefObject, useMemo } from 'react'
 import { useAsync } from 'react-async-hook'
 import { useTranslation } from 'react-i18next'
-import { StyleSheet, Text, View } from 'react-native'
 import { useSelector } from 'react-redux'
-import { EarnEvents } from 'src/analytics/Events'
 import AppAnalytics from 'src/analytics/AppAnalytics'
-import BottomSheet, { BottomSheetRefType } from 'src/components/BottomSheet'
-import Touchable from 'src/components/Touchable'
+import { EarnEvents } from 'src/analytics/Events'
+import AddAssetsBottomSheet, { AddAssetsAction } from 'src/components/AddAssetsBottomSheet'
+import { BottomSheetRefType } from 'src/components/BottomSheet'
 import { CICOFlow, fetchExchanges } from 'src/fiatExchanges/utils'
-import QuickActionsAdd from 'src/icons/quick-actions/Add'
-import QuickActionsSend from 'src/icons/quick-actions/Send'
-import QuickActionsSwap from 'src/icons/quick-actions/Swap'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import { isAppSwapsEnabledSelector } from 'src/navigator/selectors'
 import { userLocationDataSelector } from 'src/networkInfo/selectors'
 import { NETWORK_NAMES } from 'src/shared/conts'
-import { Colors } from 'src/styles/colors'
-import { typeScale } from 'src/styles/fonts'
-import { Spacing } from 'src/styles/styles'
 import { useCashInTokens, useSwappableTokens, useTokenToLocalAmount } from 'src/tokens/hooks'
 import { TokenBalance } from 'src/tokens/slice'
 import { TokenActionName } from 'src/tokens/types'
@@ -64,115 +57,77 @@ export default function EarnAddCryptoBottomSheet({
   }, [])
   const exchanges = asyncExchanges.result ?? []
 
-  const actions = [
-    {
-      name: TokenActionName.Add,
-      title: t('earnFlow.addCryptoBottomSheet.actions.add'),
-      details: t('earnFlow.addCryptoBottomSheet.actionDescriptions.add', {
-        tokenSymbol: token.symbol,
-        tokenNetwork: NETWORK_NAMES[token.networkId],
-      }),
-      iconComponent: QuickActionsAdd,
-      onPress: () => {
-        navigate(Screens.SelectProvider, {
-          tokenId: token.tokenId,
-          flow: CICOFlow.CashIn,
-          amount: addAmount,
-        })
-      },
-      visible: showAdd,
-    },
-    {
+  const actions = useMemo(() => {
+    const visibleActions: AddAssetsAction[] = []
+    if (showAdd) {
+      visibleActions.push({
+        name: TokenActionName.Add,
+        details: t('earnFlow.addCryptoBottomSheet.actionDescriptions.add', {
+          tokenSymbol: token.symbol,
+          tokenNetwork: NETWORK_NAMES[token.networkId],
+        }),
+        onPress: () => {
+          AppAnalytics.track(EarnEvents.earn_add_crypto_action_press, {
+            action: TokenActionName.Add,
+            ...getTokenAnalyticsProps(token),
+          })
+
+          navigate(Screens.SelectProvider, {
+            tokenId: token.tokenId,
+            flow: CICOFlow.CashIn,
+            amount: addAmount,
+          })
+        },
+      })
+    }
+
+    visibleActions.push({
       name: TokenActionName.Transfer,
-      title: t('earnFlow.addCryptoBottomSheet.actions.transfer'),
       details: t('earnFlow.addCryptoBottomSheet.actionDescriptions.transfer', {
         tokenSymbol: token.symbol,
         tokenNetwork: NETWORK_NAMES[token.networkId],
       }),
-      iconComponent: QuickActionsSend,
       onPress: () => {
+        AppAnalytics.track(EarnEvents.earn_add_crypto_action_press, {
+          action: TokenActionName.Transfer,
+          ...getTokenAnalyticsProps(token),
+        })
+
         navigate(Screens.ExchangeQR, { flow: CICOFlow.CashIn, exchanges })
       },
-      visible: true,
-    },
-    {
-      name: TokenActionName.Swap,
-      title: t('earnFlow.addCryptoBottomSheet.actions.swap'),
-      details: t('earnFlow.addCryptoBottomSheet.actionDescriptions.swap', {
-        tokenSymbol: token.symbol,
-        tokenNetwork: NETWORK_NAMES[token.networkId],
-      }),
-      iconComponent: QuickActionsSwap,
-      onPress: () => {
-        navigate(Screens.SwapScreenWithBack, { toTokenId: token.tokenId })
-      },
-      visible: showSwap,
-    },
-  ].filter((action) => action.visible)
+    })
+
+    if (showSwap) {
+      visibleActions.push({
+        name: TokenActionName.Swap,
+        details: t('earnFlow.addCryptoBottomSheet.actionDescriptions.swap', {
+          tokenSymbol: token.symbol,
+          tokenNetwork: NETWORK_NAMES[token.networkId],
+        }),
+        onPress: () => {
+          AppAnalytics.track(EarnEvents.earn_add_crypto_action_press, {
+            action: TokenActionName.Swap,
+            ...getTokenAnalyticsProps(token),
+          })
+
+          navigate(Screens.SwapScreenWithBack, { toTokenId: token.tokenId })
+        },
+      })
+    }
+
+    return visibleActions
+  }, [showAdd, showSwap, token, exchanges, tokenAmount])
 
   return (
-    <BottomSheet
+    <AddAssetsBottomSheet
       forwardedRef={forwardedRef}
+      actions={actions}
       title={t('earnFlow.addCryptoBottomSheet.title', {
         tokenSymbol: token.symbol,
         tokenNetwork: NETWORK_NAMES[token.networkId],
       })}
       description={t('earnFlow.addCryptoBottomSheet.description')}
       testId={'Earn/AddCrypto'}
-      titleStyle={styles.title}
-    >
-      <View style={styles.actionsContainer}>
-        {actions.map((action) => (
-          <Touchable
-            style={styles.touchable}
-            key={action.name}
-            borderRadius={20}
-            onPress={() => {
-              AppAnalytics.track(EarnEvents.earn_add_crypto_action_press, {
-                action: action.name,
-                ...getTokenAnalyticsProps(token),
-              })
-              action.onPress()
-            }}
-            testID={`Earn/AddCrypto/${action.name}`}
-          >
-            <>
-              <action.iconComponent color={Colors.black} />
-              <View style={{ flex: 1 }}>
-                <Text style={styles.actionTitle}>{action.title}</Text>
-                <Text style={styles.actionDetails}>{action.details}</Text>
-              </View>
-            </>
-          </Touchable>
-        ))}
-      </View>
-    </BottomSheet>
+    />
   )
 }
-
-const styles = StyleSheet.create({
-  actionsContainer: {
-    flex: 1,
-    gap: Spacing.Regular16,
-    marginVertical: Spacing.Thick24,
-  },
-  actionTitle: {
-    ...typeScale.labelMedium,
-    color: Colors.black,
-  },
-  actionDetails: {
-    ...typeScale.bodySmall,
-    color: Colors.black,
-  },
-  title: {
-    ...typeScale.titleSmall,
-    color: Colors.black,
-  },
-  touchable: {
-    backgroundColor: Colors.gray1,
-    padding: Spacing.Regular16,
-    flexDirection: 'row',
-    gap: Spacing.Regular16,
-    alignItems: 'center',
-  },
-})


### PR DESCRIPTION
### Description

As the title. This change makes it easier to implement a similar component for the points [design](https://www.figma.com/design/6sJ4fCxCptTybHB6ZZ7Pqi/Escrow-Feature?node-id=3341-3388&t=wNp4q9sJM0JyZxXQ-0).

The new component doesn't contain much logic so I didn't invest time in making unit tests.

### Test plan

n/a

### Related issues

- Related to RET-1177

### Backwards compatibility

Y

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [ ] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
