### PR TITLE
fix: network requests in fb flipper

### DIFF
--- a/ios/celo/AppDelegate.mm
+++ b/ios/celo/AppDelegate.mm
@@ -27,27 +27,6 @@
 
 static NSString *const kRNConcurrentRoot = @"concurrentRoot";
 
-#ifdef FB_SONARKIT_ENABLED
-#import <FlipperKit/FlipperClient.h>
-#import <FlipperKitLayoutPlugin/FlipperKitLayoutPlugin.h>
-#import <FlipperKitUserDefaultsPlugin/FKUserDefaultsPlugin.h>
-#import <FlipperKitNetworkPlugin/FlipperKitNetworkPlugin.h>
-#import <SKIOSNetworkPlugin/SKIOSNetworkAdapter.h>
-#import <FlipperKitReactPlugin/FlipperKitReactPlugin.h>
-
-static void InitializeFlipper(UIApplication *application)
-{
-  FlipperClient *client = [FlipperClient sharedClient];
-  SKDescriptorMapper *layoutDescriptorMapper = [[SKDescriptorMapper alloc] initWithDefaults];
-  [client addPlugin:[[FlipperKitLayoutPlugin alloc] initWithRootNode:application
-                                                withDescriptorMapper:layoutDescriptorMapper]];
-  [client addPlugin:[[FKUserDefaultsPlugin alloc] initWithSuiteName:nil]];
-  [client addPlugin:[FlipperKitReactPlugin new]];
-  [client addPlugin:[[FlipperKitNetworkPlugin alloc] initWithNetworkAdapter:[SKIOSNetworkAdapter new]]];
-  [client start];
-}
-#endif
-
 // Use same key as react-native-secure-key-store
 // so we don't reset already working installs
 static NSString * const kHasRunBeforeKey = @"RnSksIsAppInstalled";
@@ -77,10 +56,6 @@ static void SetCustomNSURLSessionConfiguration() {
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
-#ifdef FB_SONARKIT_ENABLED
-  InitializeFlipper(application);
-#endif
-
   // Reset keychain on first run to clear existing Firebase credentials
   // Note: react-native-secure-key-store also does that but is run too late
   // and hence can't clear Firebase credentials


### PR DESCRIPTION
### Description

Fixes the network plugin not showing requests not showing in iOS on Fb Flipper by removing the explicit initialization in `AppDelegate.mm`.
 
### Test plan

- [x] Tested locally on iOS
- [x] Tested locally on Android

### Related issues

https://github.com/facebook/flipper/issues/3945

### Backwards compatibility

Yes

### Network scalability

N/A