### PR TITLE
test: move common private keys and related values to test/values

### DIFF
--- a/src/viem/getLockableWallet.test.ts
+++ b/src/viem/getLockableWallet.test.ts
@@ -2,9 +2,14 @@ import { Network } from 'src/transactions/types'
 import { viemTransports } from 'src/viem'
 import getLockableViemWallet, { ViemWallet, getTransport } from 'src/viem/getLockableWallet'
 import { KeychainLock } from 'src/web3/KeychainLock'
-import { mockAccount2, mockContractAddress, mockTypedData } from 'test/values'
-import { Address, custom, erc20Abi, getAddress, toHex } from 'viem'
-import { privateKeyToAddress } from 'viem/accounts'
+import {
+  mockAccount2,
+  mockAddress,
+  mockContractAddress,
+  mockPrivateKey,
+  mockTypedData,
+} from 'test/values'
+import { custom, erc20Abi, getAddress, toHex } from 'viem'
 import {
   sendTransaction,
   signMessage,
@@ -28,9 +33,6 @@ jest.mock('src/viem', () => {
     },
   }
 })
-
-const PRIVATE_KEY1 = '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef'
-const ACCOUNT_ADDRESS1 = privateKeyToAddress(PRIVATE_KEY1).toLowerCase() as Address
 
 describe('getTransport', () => {
   it.each([
@@ -98,8 +100,8 @@ describe('getLockableWallet', () => {
     viemTransports[Network.Celo] = mockTransport
     viemTransports[Network.Ethereum] = mockTransport
     lock = new KeychainLock()
-    await lock.addAccount(PRIVATE_KEY1, 'password')
-    wallet = getLockableViemWallet(lock, celoAlfajores, ACCOUNT_ADDRESS1)
+    await lock.addAccount(mockPrivateKey, 'password')
+    wallet = getLockableViemWallet(lock, celoAlfajores, mockAddress)
   })
 
   it.each([

--- a/src/viem/keychainAccountToAccount.test.ts
+++ b/src/viem/keychainAccountToAccount.test.ts
@@ -1,10 +1,6 @@
 import { ViemKeychainAccount, keychainAccountToAccount } from 'src/viem/keychainAccountToAccount'
-import { mockTypedData } from 'test/values'
+import { mockAddress, mockPrivateKey, mockTypedData } from 'test/values'
 import { Hex } from 'viem'
-import { Address, privateKeyToAddress } from 'viem/accounts'
-
-const PRIVATE_KEY1 = '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef'
-const ACCOUNT_ADDRESS1 = privateKeyToAddress(PRIVATE_KEY1).toLowerCase() as Address
 
 describe(keychainAccountToAccount, () => {
   let viemAccount: ViemKeychainAccount
@@ -13,7 +9,7 @@ describe(keychainAccountToAccount, () => {
   beforeEach(() => {
     jest.clearAllMocks()
     viemAccount = keychainAccountToAccount({
-      address: ACCOUNT_ADDRESS1,
+      address: mockAddress,
       isUnlocked,
     })
   })
@@ -39,7 +35,7 @@ describe(keychainAccountToAccount, () => {
 
     describe('when unlocked', () => {
       beforeEach(() => {
-        viemAccount.unlock(PRIVATE_KEY1)
+        viemAccount.unlock(mockPrivateKey)
         isUnlocked.mockReturnValue(true)
       })
 
@@ -51,8 +47,8 @@ describe(keychainAccountToAccount, () => {
 
   describe('unlock', () => {
     it('throws if private key address does not match the account address', () => {
-      expect(() => viemAccount.unlock(PRIVATE_KEY1.replace('a', 'b') as Hex)).toThrow(
-        `Private key address (0x6eb87607F5C48CF769d43e92cF394655E9D6EFDA) does not match the expected account address (${ACCOUNT_ADDRESS1})`
+      expect(() => viemAccount.unlock(mockPrivateKey.replace('a', 'b') as Hex)).toThrow(
+        `Private key address (0x6eb87607F5C48CF769d43e92cF394655E9D6EFDA) does not match the expected account address (${mockAddress})`
       )
     })
   })

--- a/src/web3/KeychainLock.test.ts
+++ b/src/web3/KeychainLock.test.ts
@@ -3,19 +3,16 @@ import MockDate from 'mockdate'
 import { ErrorMessages } from 'src/app/ErrorMessages'
 import { KeychainLock, clearStoredAccounts, listStoredAccounts } from 'src/web3/KeychainLock'
 import * as mockedKeychain from 'test/mockedKeychain'
-import { privateKeyToAddress } from 'viem/accounts'
+import {
+  mockAddress,
+  mockAddress2,
+  mockKeychainEncryptedPrivateKey,
+  mockKeychainEncryptedPrivateKey2,
+  mockPrivateKey,
+} from 'test/values'
 
 // Use real encryption
 jest.unmock('crypto-js')
-
-const PRIVATE_KEY1 = '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef'
-const KEYCHAIN_ENCRYPTED_PRIVATE_KEY1 =
-  'U2FsdGVkX1+4Da/3VE98t6m9FNs+Q0fqJlckHnL2+XctJPyvhZY+b0TSAB9oGiAMNDow1bjA3NYyzA3aKhFhHwAySzPOArFI/RpPlArT2/IGZ/IxKtKzKnd1pa4+q4fx'
-const ACCOUNT_ADDRESS1 = privateKeyToAddress(PRIVATE_KEY1).toLowerCase()
-const PRIVATE_KEY2 = '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890fdeccc'
-const KEYCHAIN_ENCRYPTED_PRIVATE_KEY2 =
-  'U2FsdGVkX18191f7q1dS0CCvSGNjJ9PkcBGKaf+u1LVpuoBw2xSJe17hLW8QRXyKCtwvMknW2uTeWUeMRSfg/O1UdsEwdhMPxzqtOUTwT9evQri80JMGBImihFXKDdgN'
-const ACCOUNT_ADDRESS2 = privateKeyToAddress(PRIVATE_KEY2).toLowerCase()
 
 const MOCK_DATE = new Date('2016-12-21T23:36:07.071Z')
 
@@ -36,24 +33,24 @@ describe(listStoredAccounts, () => {
     // await lock.addAccount(PRIVATE_KEY2, 'password2')
     mockedKeychain.setItems({
       'account--2022-05-25T11:14:50.292Z--588e4b68193001e4d10928660ab4165b813717c0': {
-        password: KEYCHAIN_ENCRYPTED_PRIVATE_KEY2,
+        password: mockKeychainEncryptedPrivateKey2,
       },
       // This will be ignored
       'unrelated item': {
         password: 'unrelated password',
       },
       'account--2021-01-10T11:14:50.298Z--1be31a94361a391bbafb2a4ccd704f57dc04d4bb': {
-        password: KEYCHAIN_ENCRYPTED_PRIVATE_KEY1,
+        password: mockKeychainEncryptedPrivateKey,
       },
     })
 
     expect(await listStoredAccounts()).toEqual([
       {
-        address: ACCOUNT_ADDRESS1,
+        address: mockAddress,
         createdAt: new Date('2021-01-10T11:14:50.298Z'),
       },
       {
-        address: ACCOUNT_ADDRESS2,
+        address: mockAddress2,
         createdAt: new Date('2022-05-25T11:14:50.292Z'),
       },
     ])
@@ -89,9 +86,8 @@ describe('KeychainLock', () => {
     date = new Date()
   })
 
-  const mockAddress = ACCOUNT_ADDRESS1
-  const mockAddressInUpperCase = `0x${ACCOUNT_ADDRESS1.substring(2).toUpperCase()}`
-  const mockAddressInLowerCase = ACCOUNT_ADDRESS1.toLowerCase()
+  const mockAddressInUpperCase = `0x${mockAddress.substring(2).toUpperCase()}`
+  const mockAddressInLowerCase = mockAddress.toLowerCase()
 
   describe('addAccount', () => {
     beforeEach(() => {
@@ -99,24 +95,24 @@ describe('KeychainLock', () => {
     })
 
     it('adds a new account', async () => {
-      const account = await lock.addAccount(PRIVATE_KEY1, 'password')
+      const account = await lock.addAccount(mockPrivateKey, 'password')
 
       expect(account).toEqual({
-        address: ACCOUNT_ADDRESS1,
+        address: mockAddress,
         createdAt: MOCK_DATE,
       })
       expect(mockedKeychain.getAllKeys()).toEqual([
-        `account--2016-12-21T23:36:07.071Z--${ACCOUNT_ADDRESS1.substring(2)}`,
+        `account--2016-12-21T23:36:07.071Z--${mockAddress.substring(2)}`,
       ])
     })
     it('succeeds with a private key without 0x', async () => {
-      const account = await lock.addAccount(PRIVATE_KEY1.substring(2), 'password')
+      const account = await lock.addAccount(mockPrivateKey.substring(2), 'password')
       expect(account).toEqual({
-        address: ACCOUNT_ADDRESS1,
+        address: mockAddress,
         createdAt: MOCK_DATE,
       })
       expect(mockedKeychain.getAllKeys()).toEqual([
-        `account--2016-12-21T23:36:07.071Z--${ACCOUNT_ADDRESS1.substring(2)}`,
+        `account--2016-12-21T23:36:07.071Z--${mockAddress.substring(2)}`,
       ])
     })
     it('fails with an invalid private key', async () => {
@@ -125,8 +121,8 @@ describe('KeychainLock', () => {
       ).rejects.toThrowError('private key must be 32 bytes, hex or bigint, not string')
     })
     it('fails if the account already exists', async () => {
-      await lock.addAccount(PRIVATE_KEY1, 'password')
-      await expect(lock.addAccount(PRIVATE_KEY1, 'password')).rejects.toThrowError(
+      await lock.addAccount(mockPrivateKey, 'password')
+      await expect(lock.addAccount(mockPrivateKey, 'password')).rejects.toThrowError(
         ErrorMessages.KEYCHAIN_ACCOUNT_ALREADY_EXISTS
       )
     })
@@ -139,7 +135,7 @@ describe('KeychainLock', () => {
     it('returns false if the account has been added but not unlocked', async () => {
       mockedKeychain.setItems({
         [`account--${date.toISOString()}--${normalizeAddress(mockAddress)}`]: {
-          password: KEYCHAIN_ENCRYPTED_PRIVATE_KEY1,
+          password: mockKeychainEncryptedPrivateKey,
         },
       })
       await lock.loadExistingAccounts()
@@ -148,7 +144,7 @@ describe('KeychainLock', () => {
     it('returns false if the account has been added and unlocked but the duration has passed', async () => {
       mockedKeychain.setItems({
         [`account--${date.toISOString()}--${normalizeAddress(mockAddress)}`]: {
-          password: KEYCHAIN_ENCRYPTED_PRIVATE_KEY1,
+          password: mockKeychainEncryptedPrivateKey,
         },
       })
       await lock.loadExistingAccounts()
@@ -158,7 +154,7 @@ describe('KeychainLock', () => {
     it('returns true if the account has been added and unlocked and the duration has not passed', async () => {
       mockedKeychain.setItems({
         [`account--${date.toISOString()}--${normalizeAddress(mockAddress)}`]: {
-          password: KEYCHAIN_ENCRYPTED_PRIVATE_KEY1,
+          password: mockKeychainEncryptedPrivateKey,
         },
       })
       await lock.loadExistingAccounts()
@@ -177,7 +173,7 @@ describe('KeychainLock', () => {
     it('throws if the account has been added but private key is not in the keychain', async () => {
       mockedKeychain.setItems({
         [`account--${date.toISOString()}--${normalizeAddress(mockAddress)}`]: {
-          password: KEYCHAIN_ENCRYPTED_PRIVATE_KEY1,
+          password: mockKeychainEncryptedPrivateKey,
         },
       })
       await lock.loadExistingAccounts()
@@ -188,7 +184,7 @@ describe('KeychainLock', () => {
     it('returns true if account is unlocked with all uppercase address', async () => {
       mockedKeychain.setItems({
         [`account--${date.toISOString()}--${normalizeAddress(mockAddress)}`]: {
-          password: KEYCHAIN_ENCRYPTED_PRIVATE_KEY1,
+          password: mockKeychainEncryptedPrivateKey,
         },
       })
       await lock.loadExistingAccounts()
@@ -197,7 +193,7 @@ describe('KeychainLock', () => {
     it('unlocks the viem account', async () => {
       mockedKeychain.setItems({
         [`account--${date.toISOString()}--${normalizeAddress(mockAddress)}`]: {
-          password: KEYCHAIN_ENCRYPTED_PRIVATE_KEY1,
+          password: mockKeychainEncryptedPrivateKey,
         },
       })
       await lock.loadExistingAccounts()
@@ -220,7 +216,7 @@ describe('KeychainLock', () => {
     it('throws if the account has been added but private key is not in the keychain', async () => {
       mockedKeychain.setItems({
         [`account--${date.toISOString()}--${normalizeAddress(mockAddress)}`]: {
-          password: KEYCHAIN_ENCRYPTED_PRIVATE_KEY1,
+          password: mockKeychainEncryptedPrivateKey,
         },
       })
       await lock.loadExistingAccounts()
@@ -232,7 +228,7 @@ describe('KeychainLock', () => {
     it('returns true if the account and key is present and address is passed in different case', async () => {
       mockedKeychain.setItems({
         [`account--${date.toISOString()}--${normalizeAddress(mockAddress)}`]: {
-          password: KEYCHAIN_ENCRYPTED_PRIVATE_KEY1,
+          password: mockKeychainEncryptedPrivateKey,
         },
       })
       await lock.loadExistingAccounts()

--- a/test/values.ts
+++ b/test/values.ts
@@ -61,6 +61,7 @@ import {
 import { CiCoCurrency, Currency } from 'src/utils/currencies'
 import { ONE_DAY_IN_MILLIS } from 'src/utils/time'
 import networkConfig from 'src/web3/networkConfig'
+import { Address, privateKeyToAccount } from 'viem/accounts'
 
 export const nullAddress = '0x0'
 
@@ -78,6 +79,19 @@ export const mockMnemonicShard1 =
   'prosper winner find donate tape history measure umbrella agent patrol want rhythm celo'
 export const mockMnemonicShard2 =
   'celo old unable wash wrong need fluid hammer coach reveal plastic trust lake'
+
+export const mockPrivateKey = '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef'
+const mockViemAccount = privateKeyToAccount(mockPrivateKey)
+// This is encryptPrivateKey(mockPrivateKey, 'password'), but hardcoding for predictability in tests
+export const mockKeychainEncryptedPrivateKey =
+  'U2FsdGVkX1+4Da/3VE98t6m9FNs+Q0fqJlckHnL2+XctJPyvhZY+b0TSAB9oGiAMNDow1bjA3NYyzA3aKhFhHwAySzPOArFI/RpPlArT2/IGZ/IxKtKzKnd1pa4+q4fx'
+export const mockAddress = mockViemAccount.address.toLowerCase() as Address
+export const mockPrivateKey2 = '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890fdeccc'
+const mockViemAccount2 = privateKeyToAccount(mockPrivateKey2)
+// This is encryptPrivateKey(mockPrivateKey2, 'password'), but hardcoding for predictability in tests
+export const mockKeychainEncryptedPrivateKey2 =
+  'U2FsdGVkX18191f7q1dS0CCvSGNjJ9PkcBGKaf+u1LVpuoBw2xSJe17hLW8QRXyKCtwvMknW2uTeWUeMRSfg/O1UdsEwdhMPxzqtOUTwT9evQri80JMGBImihFXKDdgN'
+export const mockAddress2 = mockViemAccount2.address.toLowerCase() as Address
 
 export const mockPrivateDEK = '41e8e8593108eeedcbded883b8af34d2f028710355c57f4c10a056b72486aa04'
 export const mockPublicDEK = '02c9cacca8c5c5ebb24dc6080a933f6d52a072136a069083438293d71da36049dc'


### PR DESCRIPTION
### Description

As the title says.

### Test plan

- Tests pass

### Related issues

- Related to RET-1182

### Backwards compatibility

Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
