### PR TITLE
chore: fix Android build error when using Java > 11

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -44,6 +44,15 @@ allprojects {
             url 'https://sdk.withpersona.com/android/releases'
         }
     }
+
+    // Needed to avoid the following error
+    // `Inconsistent JVM-target compatibility detected for tasks 'compileDebugJavaWithJavac' (11) and 'compileDebugKotlin' (17).`
+    // For devs running Java > 11
+    tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile.class) {
+        kotlinOptions {
+            jvmTarget = "11"
+        }
+    }
 }
 
 subprojects {


### PR DESCRIPTION
I was getting build issues for Android because I'm running Java 17.

Here's a fix.

See Slack [thread](https://valora-app.slack.com/archives/C025V1D6F3J/p1724415154485749?thread_ts=1723827073.858059&cid=C025V1D6F3J).
