### PR TITLE
fix: invalid style prop on earn home

### DIFF
--- a/src/earn/EarnHome.tsx
+++ b/src/earn/EarnHome.tsx
@@ -378,16 +378,16 @@ const styles = StyleSheet.create({
   },
   learnMoreTitle: {
     ...typeScale.titleSmall,
-    colors: Colors.black,
+    color: Colors.black,
   },
   learnMoreSubTitle: {
     ...typeScale.labelSemiBoldSmall,
-    colors: Colors.black,
+    color: Colors.black,
     marginBottom: Spacing.Tiny4,
   },
   learnMoreDescription: {
     ...typeScale.bodySmall,
-    colors: Colors.black,
+    color: Colors.black,
     marginBottom: Spacing.Thick24,
   },
   noPoolsContainer: {


### PR DESCRIPTION
### Description

Use `color` instead of `colors`  in styles as `colors` is an invalid style prop that causes a warning.

### Test plan

- [x] Tested locally by navigating to multi-pool earn home.

### Related issues

N/A

### Backwards compatibility

Yes

### Network scalability

N/A
