### PR TITLE
refactor: remove direct dependency on ethereumjs-util

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,7 +126,6 @@
     "crypto-js": "^4.2.0",
     "date-fns": "^3.6.0",
     "dot-prop-immutable": "^2.1.1",
-    "ethereumjs-util": "^7.1.5",
     "fast-levenshtein": "^3.0.0",
     "fp-ts": "2.16.9",
     "futoin-hkdf": "^1.5.3",

--- a/src/analytics/AppAnalytics.test.ts
+++ b/src/analytics/AppAnalytics.test.ts
@@ -44,7 +44,7 @@ jest.mock('src/web3/networkConfig', () => {
 })
 
 const mockDeviceId = 'abc-def-123' // mocked in __mocks__/react-native-device-info.ts (but importing from that file causes weird errors)
-const expectedSessionId = '205ac8350460ad427e35658006b409bbb0ee86c22c57648fe69f359c2da648'
+const expectedSessionId = '453e535d43b22002185f316d5b41561010d9224580bfb608da132e74b128227a'
 const mockWalletAddress = '0x12AE66CDc592e10B60f9097a7b0D3C59fce29876' // deliberately using checksummed version here
 
 const mockCreateSegmentClient = jest.mocked(createClient)
@@ -318,7 +318,7 @@ describe('AppAnalytics', () => {
     expect(mockSegmentClient.screen).toHaveBeenCalledWith('ScreenA', {
       ...defaultProperties,
       sCurrentScreenId: 'ScreenA',
-      sessionId: '97250a67361e6d463a59b4baed530010befe1d234ef0446b6197fbe08d5471',
+      sessionId: 'bdc761e455b9102eb141594eed7539166564fac4f8a249d19aa232b90e1bc457',
       timestamp,
     })
   })

--- a/src/analytics/AppAnalytics.ts
+++ b/src/analytics/AppAnalytics.ts
@@ -3,7 +3,6 @@ import { AdjustPlugin } from '@segment/analytics-react-native-plugin-adjust'
 import { ClevertapPlugin } from '@segment/analytics-react-native-plugin-clevertap'
 import { DestinationFiltersPlugin } from '@segment/analytics-react-native-plugin-destination-filters'
 import { FirebasePlugin } from '@segment/analytics-react-native-plugin-firebase'
-import { sha256FromString } from 'ethereumjs-util'
 import _ from 'lodash'
 import { Platform } from 'react-native'
 import DeviceInfo from 'react-native-device-info'
@@ -28,6 +27,7 @@ import { getSupportedNetworkIdsForTokenBalances } from 'src/tokens/utils'
 import { ensureError } from 'src/utils/ensureError'
 import Logger from 'src/utils/Logger'
 import { Statsig } from 'statsig-react-native'
+import { sha256 } from 'viem'
 
 const TAG = 'AppAnalytics'
 
@@ -125,9 +125,7 @@ class AppAnalytics {
         const deviceInfo = await getDeviceInfo()
         this.deviceInfo = deviceInfo
         uniqueID = deviceInfo.UniqueID
-        this.sessionId = sha256FromString('0x' + uniqueID.split('-').join('') + String(Date.now()))
-          .toString('hex')
-          .slice(2)
+        this.sessionId = sha256(Buffer.from(uniqueID + String(Date.now()))).slice(2)
       } catch (error) {
         Logger.error(TAG, 'getDeviceInfo error', error)
       }

--- a/src/pincode/authentication.test.ts
+++ b/src/pincode/authentication.test.ts
@@ -4,24 +4,10 @@ import { expectSaga } from 'redux-saga-test-plan'
 import { select } from 'redux-saga/effects'
 import { PincodeType } from 'src/account/reducer'
 import { pincodeTypeSelector } from 'src/account/selectors'
-import { AuthenticationEvents } from 'src/analytics/Events'
 import AppAnalytics from 'src/analytics/AppAnalytics'
+import { AuthenticationEvents } from 'src/analytics/Events'
 import { storedPasswordRefreshed } from 'src/identity/actions'
 import { navigate, navigateBack } from 'src/navigator/NavigationService'
-import {
-  CANCELLED_PIN_INPUT,
-  checkPin,
-  DEFAULT_CACHE_ACCOUNT,
-  getPasswordSaga,
-  getPincode,
-  getPincodeWithBiometry,
-  passwordHashStorageKey,
-  PinBlocklist,
-  removeStoredPin,
-  retrieveOrGeneratePepper,
-  setPincodeWithBiometry,
-  updatePin,
-} from 'src/pincode/authentication'
 import {
   clearPasswordCaches,
   getCachedPepper,
@@ -30,9 +16,24 @@ import {
   setCachedPepper,
   setCachedPin,
 } from 'src/pincode/PasswordCache'
+import {
+  CANCELLED_PIN_INPUT,
+  DEFAULT_CACHE_ACCOUNT,
+  PinBlocklist,
+  _getPasswordHash,
+  checkPin,
+  getPasswordSaga,
+  getPincode,
+  getPincodeWithBiometry,
+  passwordHashStorageKey,
+  removeStoredPin,
+  retrieveOrGeneratePepper,
+  setPincodeWithBiometry,
+  updatePin,
+} from 'src/pincode/authentication'
 import { store } from 'src/redux/store'
-import { ensureError } from 'src/utils/ensureError'
 import Logger from 'src/utils/Logger'
+import { ensureError } from 'src/utils/ensureError'
 import { getWalletAsync } from 'src/web3/contracts'
 import { getMockStoreData } from 'test/utils'
 import { mockAccount } from 'test/values'
@@ -647,5 +648,22 @@ describe(checkPin, () => {
     expect(mockUnlockAccount).toHaveBeenCalledWith(mockAccount, incorrectPassword, 600)
     expect(mockedKeychain.setGenericPassword).not.toHaveBeenCalled()
     expect(mockStore.dispatch).not.toHaveBeenCalled()
+  })
+})
+
+describe(_getPasswordHash, () => {
+  // See some these are producing the same hash
+  // Because the current implementation treats the input as hex string (without the '0x' prefix)
+  // But we'll change this to treat the input as a raw string/buffer in the future
+  it.each([
+    ['123456', 'bf7cbe09d71a1bcc373ab9a764917f730a6ed951ffa1a7399b7abd8f8fd73cb4'],
+    ['0x123456', 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'],
+    ['0x1234567', 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'],
+    ['abx', '087d80f7f182dd44f184aa86ca34488853ebcc04f0c60d5294919a466b463831'],
+    ['abxy', '087d80f7f182dd44f184aa86ca34488853ebcc04f0c60d5294919a466b463831'],
+    ['ABXY', '087d80f7f182dd44f184aa86ca34488853ebcc04f0c60d5294919a466b463831'],
+    ['0xabxy', 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'],
+  ])(`returns the expected password hash for %s`, (password, expectedHash) => {
+    expect(_getPasswordHash(password)).toBe(expectedHash)
   })
 })

--- a/src/pincode/authentication.ts
+++ b/src/pincode/authentication.ts
@@ -6,7 +6,6 @@
  */
 
 import { isValidAddress, normalizeAddress } from '@celo/utils/lib/address'
-import { sha256 } from 'ethereumjs-util'
 import * as Keychain from 'react-native-keychain'
 import { generateSecureRandom } from 'react-native-securerandom'
 import { PincodeType } from 'src/account/reducer'
@@ -44,6 +43,7 @@ import { sleep } from 'src/utils/sleep'
 import { UNLOCK_DURATION } from 'src/web3/consts'
 import { getWalletAsync } from 'src/web3/contracts'
 import { call, select } from 'typed-redux-saga'
+import { sha256 } from 'viem'
 
 const PIN_BLOCKLIST = require('src/pincode/pin-blocklist-hibpv7-top-25k-with-keyboard-translations.json')
 
@@ -164,9 +164,14 @@ async function getPasswordHashForPin(pin: string) {
   return getPasswordHash(password)
 }
 
-function getPasswordHash(password: string) {
-  return sha256(Buffer.from(password, 'hex')).toString('hex')
+// TODO: this existing implementation implies password is in hex (no '0x' prefix)
+// but we should lift that restriction as it's too easy to misuse
+function getPasswordHash(password: string): string {
+  return sha256(Buffer.from(password, 'hex')).slice(2)
 }
+
+// for testing
+export const _getPasswordHash = getPasswordHash
 
 export function passwordHashStorageKey(account: string) {
   if (!isValidAddress(account)) {

--- a/src/qrcode/schema.test.ts
+++ b/src/qrcode/schema.test.ts
@@ -1,6 +1,6 @@
-import { zeroAddress } from 'ethereumjs-util'
-import { UriData, uriDataFromJson, uriDataFromUrl, urlFromUriData } from 'src/qrcode/schema'
 import { DEEPLINK_PREFIX } from 'src/config'
+import { UriData, uriDataFromJson, uriDataFromUrl, urlFromUriData } from 'src/qrcode/schema'
+import { zeroAddress } from 'viem'
 
 const validAddressData = { address: zeroAddress() }
 const validUserData = {


### PR DESCRIPTION
### Description

As the title says.

This was using for sha256 hashing, but we can use viem's implementation instead.

### Test plan

- Updated tests
- Manually tested unlocking via PIN still work for existing accounts

### Related issues

- N/A

### Backwards compatibility

Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
