### PR TITLE
fix: Use 2 letter code for hooks API language header

### DIFF
--- a/src/positions/saga.test.ts
+++ b/src/positions/saga.test.ts
@@ -141,7 +141,7 @@ describe(fetchPositionsSaga, () => {
       .provide([
         [select(walletAddressSelector), mockAccount],
         [select(hooksApiUrlSelector), networkConfig.hooksApiUrl],
-        [select(currentLanguageSelector), 'en-US'],
+        [select(currentLanguageSelector), 'en'],
       ])
       .put(fetchPositionsStart())
       .put(
@@ -165,7 +165,7 @@ describe(fetchPositionsSaga, () => {
       .provide([
         [select(walletAddressSelector), mockAccount],
         [select(hooksApiUrlSelector), networkConfig.hooksApiUrl],
-        [select(currentLanguageSelector), 'en-US'],
+        [select(currentLanguageSelector), 'en'],
       ])
       .put(fetchPositionsStart())
       .put(

--- a/src/positions/saga.ts
+++ b/src/positions/saga.ts
@@ -173,11 +173,12 @@ export function* fetchPositionsSaga() {
     yield* put(fetchPositionsStart())
     SentryTransactionHub.startTransaction(SentryTransaction.fetch_positions)
     const hooksApiUrl = yield* select(hooksApiUrlSelector)
-    const language = (yield* select(currentLanguageSelector)) || 'en-US'
+    const language = (yield* select(currentLanguageSelector)) || 'en'
+    const shortLanguage = language.split('-')[0]
     const { positions, earnPositionIds } = yield* call(fetchPositions, {
       hooksApiUrl,
       walletAddress: address,
-      language,
+      language: shortLanguage,
     })
     SentryTransactionHub.finishTransaction(SentryTransaction.fetch_positions)
     yield* put(fetchPositionsSuccess({ positions, earnPositionIds, fetchedAt: Date.now() }))


### PR DESCRIPTION
### Description

`hooks` repo `.crowdin.yml` ([here](https://github.com/valora-inc/hooks/blob/main/.crowdin.yml)) uses 2 letter code for language, update API header to use that. Same as `dapp-list`.

### Test plan

Unit tests updated

### Related issues

- Related to ACT-1331

### Backwards compatibility

Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [X] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
