### PR TITLE
build(android): increase build tools and sdk version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,10 +4,10 @@ import org.apache.tools.ant.taskdefs.condition.Os
 
 buildscript {
     ext {
-        buildToolsVersion = "33.0.0"
+        buildToolsVersion = "34.0.0"
         minSdkVersion = 24
-        compileSdkVersion = 33
-        targetSdkVersion = 33
+        compileSdkVersion = 34
+        targetSdkVersion = 34
         supportLibVersion = "31.0.0"
         kotlinVersion = "1.9.20"
         // We use NDK 23 which has both M1 support and is the side-by-side NDK version from AGP.


### PR DESCRIPTION
### Description

Updates the Android SDK version to be Play Store compliant. I've opted to avoid updating the NDK version as a mismatch between the NDK version and the recommended NDK version for react-native can cause hard-to-diagnose bugs. React-native 0.73.x should also bump this version, but several issues with other dependencies and FB Flipper-related issues have caused complications.

### Test plan

- E2E tests in CI.

### Related issues

- Fixes ACT-1261

### Backwards compatibility

Yes

### Network scalability

N/A
