### PR TITLE
chore(deps): remove @ethereumjs/utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
     "@badrap/result": "~0.2.13",
     "@coinbase/cbpay-js": "^2.2.1",
     "@crowdin/ota-client": "^0.7.0",
-    "@ethereumjs/util": "8.1.0",
     "@fiatconnect/fiatconnect-sdk": "^0.5.57",
     "@fiatconnect/fiatconnect-types": "^13.3.8",
     "@gorhom/bottom-sheet": "^4.6.4",

--- a/src/utils/io.ts
+++ b/src/utils/io.ts
@@ -3,10 +3,11 @@
  * Refactor to replace `io-ts` usage with `zod`
  */
 
-import { isValidAddress, toChecksumAddress } from '@ethereumjs/util'
 import { either } from 'fp-ts/lib/Either'
 import * as t from 'io-ts'
+import { isValidAddress } from 'src/utils/address'
 import { isE164NumberStrict } from 'src/utils/phoneNumbers'
+import { checksumAddress } from 'viem'
 
 // Ref: https://github.com/celo-org/developer-tooling/blob/5cfd16214ca7ef7a7ff428c7d397933b3e1eeb51/packages/sdk/phone-utils/src/io.ts#L6
 export const E164PhoneNumberType = new t.Type<string, string, unknown>(
@@ -31,7 +32,7 @@ export const AddressType = new t.Type<string, string, unknown>(
   (input, context) =>
     either.chain(t.string.validate(input, context), (stringValue) =>
       isValidAddress(stringValue)
-        ? t.success(toChecksumAddress(stringValue))
+        ? t.success(checksumAddress(stringValue))
         : t.failure(stringValue, context, 'is not a valid address')
     ),
   String

--- a/yarn.lock
+++ b/yarn.lock
@@ -1341,20 +1341,6 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.48.0.tgz#642633964e217905436033a2bd08bf322849b7fb"
   integrity sha512-ZSjtmelB7IJfWD2Fvb7+Z+ChTIKWq6kjda95fLcQKNS5aheVHn4IkfgRQE3sIIzTcSLwLcLZUD9UBt+V7+h+Pw==
 
-"@ethereumjs/rlp@^4.0.1":
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/@ethereumjs/rlp/-/rlp-4.0.1.tgz#626fabfd9081baab3d0a3074b0c7ecaf674aaa41"
-  integrity sha512-tqsQiBQDQdmPWE1xkkBq4rlSW5QZpLOUJ5RJh2/9fug+q9tnUhuZoVLk7s0scUIKTOzEtR72DFBXI4WiZcMpvw==
-
-"@ethereumjs/util@8.1.0":
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/@ethereumjs/util/-/util-8.1.0.tgz#299df97fb6b034e0577ce9f94c7d9d1004409ed4"
-  integrity sha512-zQ0IqbdX8FZ9aw11vP+dZkKDkS+kgIvQPHnSAXzP9pLu+Rfu3D3XEeLbicvoXJTYnhZiPmsZUxgdzXwNKxRPbA==
-  dependencies:
-    "@ethereumjs/rlp" "^4.0.1"
-    ethereum-cryptography "^2.0.0"
-    micro-ftch "^0.3.1"
-
 "@ethersproject/abi@5.0.7":
   version "5.0.7"
   resolved "https://registry.yarnpkg.com/@ethersproject/abi/-/abi-5.0.7.tgz#79e52452bd3ca2956d0e1c964207a58ad1a0ee7b"
@@ -12461,11 +12447,6 @@ metro@0.76.9, metro@^0.76.9:
     throat "^5.0.0"
     ws "^7.5.1"
     yargs "^17.6.2"
-
-micro-ftch@^0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/micro-ftch/-/micro-ftch-0.3.1.tgz#6cb83388de4c1f279a034fb0cf96dfc050853c5f"
-  integrity sha512-/0LLxhzP0tfiR5hcQebtudP56gUurs2CLkGarnCiB/OqEyUFQ6U3paQi/tgLv0hBJYt2rnr9MNpxz4fiiugstg==
 
 micromatch@4.0.5, micromatch@^4.0.2, micromatch@^4.0.4, micromatch@^4.0.5:
   version "4.0.5"


### PR DESCRIPTION
### Description
Replace left-over usage of `@ethereumjs/utils` with existing equivalent functions or with functions from `viem`

### Test plan
The only affected function is `uriDataFromJson` from `src/qrcode/schema.ts`.
All tests of this function from `src/qrcode/schema.test.ts` pass.

### Related issues
N/A

### Backwards compatibility
Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
