### PR TITLE
feat(config): Parameterize whether or not fiatconnect quotes are supported

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -226,3 +226,5 @@ export const ENABLED_QUICK_ACTIONS = (
   .filter(
     (value) => !!value && Object.values(HomeActionName).includes(value as HomeActionName)
   ) as HomeActionName[]
+
+export const FETCH_FIATCONNECT_QUOTES = true

--- a/src/fiatExchanges/SelectProvider.tsx
+++ b/src/fiatExchanges/SelectProvider.tsx
@@ -70,6 +70,7 @@ import {
   filterProvidersByPaymentMethod,
   getProviderSelectionAnalyticsData,
 } from './utils'
+import { FETCH_FIATCONNECT_QUOTES } from 'src/config'
 
 const TAG = 'SelectProviderScreen'
 
@@ -110,14 +111,16 @@ export default function SelectProviderScreen({ route, navigation }: Props) {
   const appId = appIdResponse.result
 
   useEffect(() => {
-    dispatch(
-      fetchFiatConnectQuotes({
-        flow,
-        digitalAsset: tokenInfo.symbol,
-        cryptoAmount,
-        fiatAmount,
-      })
-    )
+    if (FETCH_FIATCONNECT_QUOTES) {
+      dispatch(
+        fetchFiatConnectQuotes({
+          flow,
+          digitalAsset: tokenInfo.symbol,
+          cryptoAmount,
+          fiatAmount,
+        })
+      )
+    }
   }, [flow, tokenInfo.symbol, cryptoAmount])
 
   useEffect(() => {


### PR DESCRIPTION
### Description

Adds a static config parameter to enable/disable fetching FiatConnect quotes.

### Test plan

<!-- Demonstrate the change is solid, or why it doesn't need testing.
Example: add any manual testing steps or scenarios (if not obvious), screenshots / videos if the pull request changes the user interface.
-->

### Related issues

- Fixes [RET-1145](https://linear.app/valora/issue/RET-1145/[fiatconnect]-make-fetching-fc-quotes-configurable-in-valora)

### Backwards compatibility

Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
