### PR TITLE
fix: only show withdraw when deposited in pool

### DIFF
--- a/src/earn/EarnPoolInfoScreen.test.tsx
+++ b/src/earn/EarnPoolInfoScreen.test.tsx
@@ -58,8 +58,8 @@ describe('EarnPoolInfoScreen', () => {
       within(getByTestId('AgeCard')).getByText('duration, {"context":"month","count":5}')
     ).toBeTruthy()
     expect(
-      within(getByTestId('ActionButtons')).getByText('earnFlow.poolInfoScreen.withdraw')
-    ).toBeTruthy()
+      within(getByTestId('ActionButtons')).queryByText('earnFlow.poolInfoScreen.withdraw')
+    ).toBeFalsy()
     expect(
       within(getByTestId('ActionButtons')).getByText('earnFlow.poolInfoScreen.deposit')
     ).toBeTruthy()

--- a/src/earn/EarnPoolInfoScreen.tsx
+++ b/src/earn/EarnPoolInfoScreen.tsx
@@ -450,8 +450,9 @@ function ActionButtons({ earnPosition }: { earnPosition: EarnPosition }) {
   }
   const { t } = useTranslation()
   const { availableShortcutIds } = earnPosition
-  const deposit = availableShortcutIds.includes('withdraw')
-  const withdraw = availableShortcutIds.includes('withdraw')
+  const deposit = availableShortcutIds.includes('deposit')
+  const withdraw =
+    availableShortcutIds.includes('withdraw') && new BigNumber(earnPosition.balance).gt(0)
 
   return (
     <View testID="ActionButtons" style={[styles.buttonContainer, insetsStyle]}>


### PR DESCRIPTION
### Description

Withdraw was incorrectly displayed when a user was not deposited in a pool. This PR fixes that.

### Test plan

- [x] Unit tests updated

### Related issues

N/A

### Backwards compatibility

Yes
### Network scalability

N/A
