### PR TITLE
fix(onbaording): Disable CPV in onboarding

### DIFF
--- a/.env.alfajores
+++ b/.env.alfajores
@@ -11,3 +11,4 @@ APP_DISPLAY_NAME=Alfajores
 IOS_GOOGLE_SERVICE_PLIST=GoogleService-Info.alfajores.plist
 SENTRY_ENABLED=true
 AUTH0_DOMAIN=auth.alfajores.valora.xyz
+ONBOARDING_FEATURES_ENABLED=CloudBackupSetup,CloudBackupRestore,CloudBackupInOnboarding,EnableBiometry,ProtectWallet

--- a/.env.alfajoresdev
+++ b/.env.alfajoresdev
@@ -13,3 +13,4 @@ APP_DISPLAY_NAME=Alfajores (dev)
 IOS_GOOGLE_SERVICE_PLIST=GoogleService-Info.alfajoresdev.plist
 SENTRY_ENABLED=false
 AUTH0_DOMAIN=auth.alfajores.valora.xyz
+ONBOARDING_FEATURES_ENABLED=CloudBackupSetup,CloudBackupRestore,CloudBackupInOnboarding,EnableBiometry,ProtectWallet

--- a/.env.alfajoresnightly
+++ b/.env.alfajoresnightly
@@ -11,3 +11,4 @@ APP_DISPLAY_NAME=Alfajores (nightly)
 IOS_GOOGLE_SERVICE_PLIST=GoogleService-Info.alfajoresnightly.plist
 SENTRY_ENABLED=true
 AUTH0_DOMAIN=auth.alfajores.valora.xyz
+ONBOARDING_FEATURES_ENABLED=CloudBackupSetup,CloudBackupRestore,CloudBackupInOnboarding,EnableBiometry,ProtectWallet

--- a/.env.mainnet
+++ b/.env.mainnet
@@ -11,3 +11,4 @@ APP_DISPLAY_NAME=Valora
 IOS_GOOGLE_SERVICE_PLIST=GoogleService-Info.mainnet.plist
 SENTRY_ENABLED=true
 AUTH0_DOMAIN=auth.valora.xyz
+ONBOARDING_FEATURES_ENABLED=CloudBackupSetup,CloudBackupRestore,CloudBackupInOnboarding,EnableBiometry,ProtectWallet

--- a/.env.mainnetdev
+++ b/.env.mainnetdev
@@ -13,3 +13,4 @@ APP_DISPLAY_NAME=Valora (dev)
 IOS_GOOGLE_SERVICE_PLIST=GoogleService-Info.mainnetdev.plist
 SENTRY_ENABLED=false
 AUTH0_DOMAIN=auth.valora.xyz
+ONBOARDING_FEATURES_ENABLED=CloudBackupSetup,CloudBackupRestore,CloudBackupInOnboarding,EnableBiometry,ProtectWallet

--- a/.env.mainnetnightly
+++ b/.env.mainnetnightly
@@ -11,3 +11,4 @@ APP_DISPLAY_NAME=Valora (nightly)
 IOS_GOOGLE_SERVICE_PLIST=GoogleService-Info.mainnetnightly.plist
 SENTRY_ENABLED=true
 AUTH0_DOMAIN=auth.valora.xyz
+ONBOARDING_FEATURES_ENABLED=CloudBackupSetup,CloudBackupRestore,CloudBackupInOnboarding,EnableBiometry,ProtectWallet


### PR DESCRIPTION
### Description

We previously ported onboarding params to be locally configured as preparation for MS development, but forgot to set the environment variables as to disable CPV in onboarding.

### Test plan

Manual tested.

### Related issues

### Backwards compatibility

Y

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
