### PR TITLE
fix: use mocked date in EarnPoolInfoScreen test

### DIFF
--- a/src/earn/EarnPoolInfoScreen.test.tsx
+++ b/src/earn/EarnPoolInfoScreen.test.tsx
@@ -34,6 +34,9 @@ const renderEarnPoolInfoScreen = (pool: EarnPosition) =>
 describe('EarnPoolInfoScreen', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    jest.useFakeTimers({
+      now: new Date('2024-08-15T00:00:00.000Z'),
+    })
   })
 
   it('renders correctly when not deposited in pool', () => {

--- a/src/earn/EarnPoolInfoScreen.test.tsx
+++ b/src/earn/EarnPoolInfoScreen.test.tsx
@@ -9,7 +9,7 @@ import { Screens } from 'src/navigator/Screens'
 import { EarnPosition } from 'src/positions/types'
 import { navigateToURI } from 'src/utils/linking'
 import MockedNavigator from 'test/MockedNavigator'
-import { createMockStore, getMockStackScreenProps } from 'test/utils'
+import { createMockStore } from 'test/utils'
 import { mockArbUsdcTokenId, mockEarnPositions, mockTokenBalances } from 'test/values'
 
 const mockPoolTokenId = mockEarnPositions[0].dataProps.depositTokenId
@@ -23,11 +23,7 @@ const store = createMockStore({
 const renderEarnPoolInfoScreen = (pool: EarnPosition) =>
   render(
     <Provider store={store}>
-      <MockedNavigator
-        component={() => (
-          <EarnPoolInfoScreen {...getMockStackScreenProps(Screens.EarnPoolInfoScreen, { pool })} />
-        )}
-      />
+      <MockedNavigator component={EarnPoolInfoScreen} params={{ pool }} />
     </Provider>
   )
 
@@ -258,17 +254,7 @@ describe('EarnPoolInfoScreen', () => {
   it('navigate to EarnEnterAmount when Deposit button is tapped', () => {
     const { getByText } = render(
       <Provider store={store}>
-        <MockedNavigator
-          component={() => {
-            return (
-              <EarnPoolInfoScreen
-                {...getMockStackScreenProps(Screens.EarnPoolInfoScreen, {
-                  pool: mockEarnPositions[0],
-                })}
-              />
-            )
-          }}
-        />
+        <MockedNavigator component={EarnPoolInfoScreen} params={{ pool: mockEarnPositions[0] }} />
       </Provider>
     )
     fireEvent.press(getByText('earnFlow.poolInfoScreen.deposit'))
@@ -287,14 +273,9 @@ describe('EarnPoolInfoScreen', () => {
     const { getByText } = render(
       <Provider store={store}>
         <MockedNavigator
-          component={() => {
-            return (
-              <EarnPoolInfoScreen
-                {...getMockStackScreenProps(Screens.EarnPoolInfoScreen, {
-                  pool: { ...mockEarnPositions[0], balance: '100' },
-                })}
-              />
-            )
+          component={EarnPoolInfoScreen}
+          params={{
+            pool: { ...mockEarnPositions[0], balance: '100' },
           }}
         />
       </Provider>


### PR DESCRIPTION
### Description

As the title.

Also fixes the following warning in the tests by updating the way we are using `MockedNavigator` in the tests.
```
Looks like you're passing an inline function for 'component' prop for the screen 'MockedScreen' (e.g. component={() => <SomeComponent />}). Passing an inline function will cause the component state to be lost on re-render and cause perf issues since it's re-created every render. You can pass the function as children to 'Screen' instead to achieve the desired behaviour.
```

### Test plan

n/a

### Related issues

n/a

### Backwards compatibility

Y

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [ ] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
