### PR TITLE
ci: ignore emergetools errors

### DIFF
--- a/.github/workflows/e2e-ios.yml
+++ b/.github/workflows/e2e-ios.yml
@@ -57,6 +57,8 @@ jobs:
         if: |
           env.SECRETS_AVAILABLE
             && (github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group')
+        # This step is not critical, so we continue on error
+        continue-on-error: true
         run: yarn ts-node .github/scripts/uploadE2eBuildToEmerge.ts
         env:
           EMERGE_API_TOKEN: ${{ steps.google-secrets.outputs.EMERGE_API_TOKEN }}

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -8,13 +8,18 @@ end
 
 def fastlane_emerge(environment:, file_path:)
   # Note: this requires the EMERGE_API_TOKEN env var to be set
-  emerge(
-    file_path: file_path,
-    repo_name: "valora-inc/wallet",
-    sha: `git rev-parse HEAD`.strip,
-    branch: `git branch --show-current`.strip,
-    tag: environment,
-  )
+  begin
+    emerge(
+      file_path: file_path,
+      repo_name: "valora-inc/wallet",
+      sha: `git rev-parse HEAD`.strip,
+      branch: `git branch --show-current`.strip,
+      tag: environment,
+    )
+  rescue => ex
+    # Don't fail the build if Emerge fails (e.g. 429 or 500)
+    UI.important("Ignoring upload error to Emerge: #{ex}")
+  end
 end
 
 platform :android do


### PR DESCRIPTION
### Description

The new Emergetools indie plan is limited in the number of builds. Ignore errors for now until we decide what we want to do with it.

### Test plan

- Tests pass

### Related issues

N/A

### Backwards compatibility

Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
