### PR TITLE
ci: fix fastlane error for android releases

### DIFF
--- a/.github/workflows/release-fastlane-android.yml
+++ b/.github/workflows/release-fastlane-android.yml
@@ -102,6 +102,7 @@ jobs:
           CELO_RELEASE_KEY_PASSWORD: ${{ steps.google-secrets.outputs.CELO_RELEASE_KEY_PASSWORD }}
           EMERGE_API_TOKEN: ${{ steps.google-secrets.outputs.EMERGE_API_TOKEN }}
           SUPPLY_UPLOAD_MAX_RETRIES: 5
+          RUBYOPT: '-rostruct' # TODO: Remove when https://github.com/fastlane/fastlane/pull/21950 gets released
         run: bundle exec fastlane android ${{ matrix.lane }}
       - name: Build notification
         if: always()


### PR DESCRIPTION
### Description

Fixes the following error:

```
Run bundle exec fastlane android alfajoresnightly
bundler: failed to load command: fastlane (/home/runner/work/wallet/wallet/vendor/bundle/ruby/2.7.0/bin/fastlane)
/home/runner/work/wallet/wallet/vendor/bundle/ruby/2.7.0/gems/fastlane-2.222.0/fastlane/lib/fastlane/erb_template_helper.rb:20:in `<module:Fastlane>': uninitialized constant Fastlane::OpenStruct (NameError)
	from /home/runner/work/wallet/wallet/vendor/bundle/ruby/2.7.0/gems/fastlane-2.222.0/fastlane/lib/fastlane/erb_template_helper.rb:1:in `<top (required)>'
```

Fix found in https://github.com/fastlane/fastlane/issues/21944

### Test plan

- Manually ran the [nightly workflow](https://github.com/valora-inc/wallet/actions/runs/10774509140)

### Related issues

See Slack [thread](https://valora-app.slack.com/archives/C02D08P412Q/p1725882986899909?thread_ts=1725882482.460489&cid=C02D08P412Q).

### Backwards compatibility

Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
