### PR TITLE
fix(earn): navigate to earn home from points screen

### DIFF
--- a/src/points/ActivityCardSection.tsx
+++ b/src/points/ActivityCardSection.tsx
@@ -11,6 +11,8 @@ import { Screens } from 'src/navigator/Screens'
 import ActivityCard, { Props as ActivityCardProps, MoreComingCard } from 'src/points/ActivityCard'
 import { compareAmountAndTitle } from 'src/points/cardSort'
 import { BottomSheetParams, PointsActivity } from 'src/points/types'
+import { getFeatureGate } from 'src/statsig'
+import { StatsigFeatureGates } from 'src/statsig/types'
 import Colors from 'src/styles/colors'
 import { typeScale } from 'src/styles/fonts'
 import { Spacing } from 'src/styles/styles'
@@ -87,10 +89,12 @@ export default function ActivityCardSection({ pointsActivities, onCardPress }: P
               cta: {
                 text: t('points.activityCards.depositEarn.bottomSheet.cta'),
                 onPress: () => {
-                  aavePosition &&
-                    navigate(Screens.EarnEnterAmount, {
-                      pool: aavePosition,
-                    })
+                  getFeatureGate(StatsigFeatureGates.SHOW_MULTIPLE_EARN_POOLS)
+                    ? navigate(Screens.EarnHome)
+                    : aavePosition &&
+                      navigate(Screens.EarnEnterAmount, {
+                        pool: aavePosition,
+                      })
                 },
               },
             }),


### PR DESCRIPTION
### Description

If multiple pools gate is enabled, navigate to EarnHome instead of Enter Amount screen.

### Test plan

Manually by testing navigation from points screen

### Related issues

N/A

### Backwards compatibility

Yes

### Network scalability

N/A