### PR TITLE
chore(locales): add intellisense for translations

### DIFF
--- a/src/i18next.d.ts
+++ b/src/i18next.d.ts
@@ -1,0 +1,12 @@
+// import the original type declarations
+import 'i18next'
+import base from '../locales/base/translation.json'
+
+declare module 'i18next' {
+  interface CustomTypeOptions {
+    defaultNS: 'base'
+    resources: {
+      base: typeof base
+    }
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,9 @@
     "strictNullChecks": true,
     "skipLibCheck": true,
     "target": "es2015",
-    "strict": true
+    "strict": true,
+    "types": ["./src/i18next.d.ts"],
+    "resolveJsonModule": true
   },
   "files": ["jest_setup.ts"],
   "include": ["src"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,7 +23,6 @@
     "skipLibCheck": true,
     "target": "es2015",
     "strict": true,
-    "types": ["./src/i18next.d.ts"],
     "resolveJsonModule": true
   },
   "files": ["jest_setup.ts"],

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -5,6 +5,7 @@
     "target": "es2018",
     // workaround for a bug in ts-jest where moduleResolution gets overwritten https://github.com/kulshekhar/ts-jest/issues/4198
     // TODO: try removing this when ts-jest is updated
-    "moduleResolution": "Classic"
+    "moduleResolution": "Classic",
+    "resolveJsonModule": false
   }
 }


### PR DESCRIPTION
### Description
Add intellisense to translations by following the [official i18next guide](https://www.i18next.com/overview/typescript):
- Add `i18next.d.ts` file
- Add `"resolveJsonModule": true` to `tsconfig.json`
- Add `"resolveJsonModule": false` to `tsconfig.test.json` as setting this config to `true` conflicts with the existing `"moduleResolution": "Classic"` and fails all the tests with the following error:
```
error TS5070: Option '--resolveJsonModule' cannot be specified when 'moduleResolution' is set to 'classic'.
```

### Test plan
![Screenshot 2024-09-11 at 18 25 25](https://github.com/user-attachments/assets/daace6d6-21bb-40c6-b17c-7cf21dd4f5ae)
![Screenshot 2024-09-11 at 18 25 39](https://github.com/user-attachments/assets/1c502312-ebd2-4faa-a873-d90b47e600d2)


### Related issues
N/A

### Backwards compatibility
Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
