### PR TITLE
fix(e2e): Fix funding script

### DIFF
--- a/e2e/scripts/utils.ts
+++ b/e2e/scripts/utils.ts
@@ -24,7 +24,8 @@ export async function getCeloTokensBalance(walletAddress: Address) {
       '0x10c892a6ec43a53e45d0b916b4b7d383b1b78c0f',
       '0xf194afdf50b03e69bd7d057c1aa9e10c9954e4c9',
       '0xe4d517785d091d3c54818832db6094bcc2744545',
-    ] // CUSD, CEUR, CELO, cREAL
+    ] // cUSD, cEUR, CELO, cREAL
+    const supportedTokenSymbols: string[] = ['cUSD', 'cEUR', 'CELO', 'cREAL']
 
     const celoClient = createPublicClient({
       chain: celoAlfajores,
@@ -41,9 +42,9 @@ export async function getCeloTokensBalance(walletAddress: Address) {
       allowFailure: false,
     })
 
-    const balances: Record<Address, number> = {}
+    const balances: Record<string, number> = {}
     results.forEach((result, index) => {
-      balances[supportedTokenAddresses[index]] = Number(BigInt(result) / BigInt(10 ** 18))
+      balances[supportedTokenSymbols[index]] = Number(BigInt(result) / BigInt(10 ** 18))
     })
     return balances
   } catch (err) {


### PR DESCRIPTION
### Description

In an effort to [remove Celo dependencies from our e2e tests](https://github.com/valora-inc/wallet/pull/5782), the way we check wallet balances was changed in a subtle way such that wallet balances were being returned as a map from token address to balance rather than token symbol to balance. This caused our funding script to silently stop working, despite never actually failing (it would just decide that the e2e wallets don't need any tokens, and succeed without attempting to send funds). This PR restores the original behavior, fixing the funding scripts.

### Test plan

Manual tested

### Related issues

- Fixes #[issue number here]

### Backwards compatibility

<!-- Brief explanation of why these changes are/are not backwards compatible. -->

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [ ] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
