### PR TITLE
fix(deps): add react-native-shake to renovate ignore list

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -102,5 +102,6 @@
   // A list of dependencies to be ignored by Renovate - "exact match" only
   ignoreDeps: [
     'lottie-react-native', // TODO (act-1187): handle 6.x breaking changes and upgrade
+    'react-native-shake', // https://github.com/Doko-Demo-Doa/react-native-shake/issues/62
   ],
 }


### PR DESCRIPTION
### Description

Upgrades `react-native-shake` have caused issues; adding to the Renovate ignore list. 

- [Closed PR from Renovate](https://github.com/valora-inc/wallet/pull/5240)
- [Merged PR from Renovate](https://github.com/valora-inc/wallet/pull/5962) - After closed PR.

### Test plan

N/A

### Related issues

N/A

### Backwards compatibility

Yes

### Network scalability

N/A
