### PR TITLE
chore: move walletconnect universal link to config

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -229,3 +229,5 @@ export const ENABLED_QUICK_ACTIONS = (
   ) as HomeActionName[]
 
 export const FETCH_FIATCONNECT_QUOTES = true
+
+export const WALLETCONNECT_UNIVERSAL_LINK = 'https://valoraapp.com/wc'

--- a/src/walletConnect/walletConnect.ts
+++ b/src/walletConnect/walletConnect.ts
@@ -1,8 +1,9 @@
 import { parseUri } from '@walletconnect/utils'
+import AppAnalytics from 'src/analytics/AppAnalytics'
 import { WalletConnectEvents } from 'src/analytics/Events'
 import { WalletConnectPairingOrigin } from 'src/analytics/types'
-import AppAnalytics from 'src/analytics/AppAnalytics'
 import { getDappRequestOrigin } from 'src/app/utils'
+import { DEEPLINK_PREFIX, WALLETCONNECT_UNIVERSAL_LINK } from 'src/config'
 import { activeDappSelector } from 'src/dapps/selectors'
 import { ActiveDapp } from 'src/dapps/types'
 import { navigate } from 'src/navigator/NavigationService'
@@ -12,12 +13,9 @@ import { initialiseWalletConnect } from 'src/walletConnect/saga'
 import { selectHasPendingState } from 'src/walletConnect/selectors'
 import { WalletConnectRequestType } from 'src/walletConnect/types'
 import { call, delay, fork, race, select, take } from 'typed-redux-saga'
-import { DEEPLINK_PREFIX } from 'src/config'
 
 const WC_PREFIX = 'wc:'
 const APP_DEEPLINK_PREFIX = `${DEEPLINK_PREFIX}://wallet/wc?uri=`
-const UNIVERSAL_LINK_PREFIX = 'https://valoraapp.com/wc?uri='
-const UNIVERSAL_LINK_PREFIX_WITHOUT_URI = 'https://valoraapp.com/wc'
 const CONNECTION_TIMEOUT = 45_000
 
 /**
@@ -35,8 +33,9 @@ export function* handleWalletConnectDeepLink(deepLink: string) {
     link = deepLink.substring(APP_DEEPLINK_PREFIX.length)
   }
 
-  if (link.startsWith(UNIVERSAL_LINK_PREFIX)) {
-    link = deepLink.substring(UNIVERSAL_LINK_PREFIX.length)
+  const wcLinkWithUri = `${WALLETCONNECT_UNIVERSAL_LINK}?uri=`
+  if (link.startsWith(wcLinkWithUri)) {
+    link = deepLink.substring(wcLinkWithUri.length)
   }
 
   link = decodeURIComponent(link)
@@ -59,7 +58,7 @@ export function* handleWalletConnectDeepLink(deepLink: string) {
 }
 
 export function isWalletConnectDeepLink(deepLink: string) {
-  return [WC_PREFIX, APP_DEEPLINK_PREFIX, UNIVERSAL_LINK_PREFIX_WITHOUT_URI].some((prefix) =>
+  return [WC_PREFIX, APP_DEEPLINK_PREFIX, WALLETCONNECT_UNIVERSAL_LINK].some((prefix) =>
     decodeURIComponent(deepLink).startsWith(prefix)
   )
 }


### PR DESCRIPTION
### Description

As the title

### Test plan

n/a

### Related issues

- Related to RET-1157

### Backwards compatibility

Y

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [ ] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
