### PR TITLE
feat(earn): show swappable tokens on enter amount screen

### DIFF
--- a/src/earn/EarnEnterAmount.test.tsx
+++ b/src/earn/EarnEnterAmount.test.tsx
@@ -30,6 +30,7 @@ import {
 
 jest.mock('src/earn/prepareTransactions')
 jest.mock('react-native-localize')
+jest.mock('src/statsig') // statsig isn't used directly but the hooksApiSelector uses it
 
 const mockPreparedTransaction: PreparedTransactionsPossible = {
   type: 'possible' as const,
@@ -159,7 +160,6 @@ describe('EarnEnterAmount', () => {
           priceUsd: new BigNumber(1),
           lastKnownPriceUsd: new BigNumber(1),
           balance: new BigNumber(10),
-          minimumAppVersionToSwap: '1.0.0',
         },
         walletAddress: mockAccount.toLowerCase(),
         pool: mockEarnPositions[0],

--- a/src/earn/EarnEnterAmount.test.tsx
+++ b/src/earn/EarnEnterAmount.test.tsx
@@ -21,6 +21,7 @@ import MockedNavigator from 'test/MockedNavigator'
 import { createMockStore } from 'test/utils'
 import {
   mockAccount,
+  mockArbArbTokenId,
   mockArbEthTokenId,
   mockArbUsdcTokenId,
   mockEarnPositions,
@@ -61,7 +62,7 @@ const mockPreparedTransaction: PreparedTransactionsPossible = {
   },
 }
 
-const mockePreparedTransactionNotEnough: PreparedTransactionsNotEnoughBalanceForGas = {
+const mockPreparedTransactionNotEnough: PreparedTransactionsNotEnoughBalanceForGas = {
   type: 'not-enough-balance-for-gas' as const,
   feeCurrencies: [
     {
@@ -84,26 +85,24 @@ const mockFeeCurrencies: TokenBalance[] = [
   },
 ]
 
-const priceFetchedAt = Date.now()
-
 const store = createMockStore({
   tokens: {
     tokenBalances: {
       [mockArbUsdcTokenId]: {
-        tokenId: mockArbUsdcTokenId,
-        symbol: 'USDC',
-        priceUsd: '1',
-        priceFetchedAt: priceFetchedAt,
-        networkId: NetworkId['arbitrum-sepolia'],
+        ...mockTokenBalances[mockArbUsdcTokenId],
         balance: '10',
       },
       mockArbEthTokenId: {
         ...mockTokenBalances[mockArbEthTokenId],
         balance: '1',
       },
+      mockArbArbTokenId: {
+        ...mockTokenBalances[mockArbArbTokenId],
+        minimumAppVersionToSwap: '1.0.0',
+        balance: '1',
+      },
     },
   },
-  earn: { poolInfoFetchStatus: 'loading' },
 })
 
 const refreshPreparedTransactionsSpy = jest.fn()
@@ -128,73 +127,142 @@ describe('EarnEnterAmount', () => {
     store.clearActions()
   })
 
-  it('should prepare transactions with the expected inputs', async () => {
-    const { getByTestId } = render(
-      <Provider store={store}>
-        <MockedNavigator component={EarnEnterAmount} params={params} />
-      </Provider>
-    )
+  describe('deposit', () => {
+    const depositParams = { ...params, mode: 'deposit' }
+    it('should show only the deposit token and not include the token dropdown', async () => {
+      const { getByTestId, queryByTestId } = render(
+        <Provider store={store}>
+          <MockedNavigator component={EarnEnterAmount} params={depositParams} />
+        </Provider>
+      )
 
-    fireEvent.changeText(getByTestId('EarnEnterAmount/TokenAmountInput'), '.25')
+      expect(getByTestId('EarnEnterAmount/TokenSelect')).toBeTruthy()
+      expect(getByTestId('EarnEnterAmount/TokenSelect')).toHaveTextContent('USDC')
+      expect(getByTestId('EarnEnterAmount/TokenSelect')).toBeDisabled()
+      expect(queryByTestId('downArrowIcon')).toBeFalsy()
+    })
 
-    await waitFor(() => expect(refreshPreparedTransactionsSpy).toHaveBeenCalledTimes(1))
-    expect(refreshPreparedTransactionsSpy).toHaveBeenCalledWith({
-      amount: '0.25',
-      token: {
-        tokenId: mockArbUsdcTokenId,
-        symbol: 'USDC',
-        priceUsd: new BigNumber(1),
-        lastKnownPriceUsd: new BigNumber(1),
-        priceFetchedAt: priceFetchedAt,
+    it('should prepare transactions with the expected inputs', async () => {
+      const { getByTestId } = render(
+        <Provider store={store}>
+          <MockedNavigator component={EarnEnterAmount} params={depositParams} />
+        </Provider>
+      )
+
+      fireEvent.changeText(getByTestId('EarnEnterAmount/TokenAmountInput'), '.25')
+
+      await waitFor(() => expect(refreshPreparedTransactionsSpy).toHaveBeenCalledTimes(1))
+      expect(refreshPreparedTransactionsSpy).toHaveBeenCalledWith({
+        amount: '0.25',
+        token: {
+          ...mockTokenBalances[mockArbUsdcTokenId],
+          priceUsd: new BigNumber(1),
+          lastKnownPriceUsd: new BigNumber(1),
+          balance: new BigNumber(10),
+          minimumAppVersionToSwap: '1.0.0',
+        },
+        walletAddress: mockAccount.toLowerCase(),
+        pool: mockEarnPositions[0],
+        hooksApiUrl: networkConfig.hooksApiUrl,
+        feeCurrencies: mockFeeCurrencies,
+      })
+    })
+
+    it('should handle navigating to the deposit bottom sheet', async () => {
+      jest.mocked(usePrepareSupplyTransactions).mockReturnValue({
+        prepareTransactionsResult: mockPreparedTransaction,
+        refreshPreparedTransactions: jest.fn(),
+        clearPreparedTransactions: jest.fn(),
+        prepareTransactionError: undefined,
+        isPreparingTransactions: false,
+      })
+      const { getByTestId, getByText } = render(
+        <Provider store={store}>
+          <MockedNavigator component={EarnEnterAmount} params={depositParams} />
+        </Provider>
+      )
+
+      fireEvent.changeText(getByTestId('EarnEnterAmount/TokenAmountInput'), '8')
+
+      await waitFor(() => expect(getByText('earnFlow.enterAmount.continue')).not.toBeDisabled())
+
+      expect(getByTestId('EarnEnterAmount/Deposit/Crypto')).toBeTruthy()
+      expect(getByTestId('EarnEnterAmount/Deposit/Crypto')).toHaveTextContent('8.00 USDC')
+
+      expect(getByTestId('EarnEnterAmount/Deposit/Fiat')).toBeTruthy()
+      expect(getByTestId('EarnEnterAmount/Deposit/Fiat')).toHaveTextContent('₱10.64')
+
+      fireEvent.press(getByText('earnFlow.enterAmount.continue'))
+
+      await waitFor(() => expect(AppAnalytics.track).toHaveBeenCalledTimes(1))
+      expect(AppAnalytics.track).toHaveBeenCalledWith(EarnEvents.earn_enter_amount_continue_press, {
+        amountEnteredIn: 'token',
+        amountInUsd: '8.00',
         networkId: NetworkId['arbitrum-sepolia'],
-        balance: new BigNumber(10),
-      },
-      walletAddress: mockAccount.toLowerCase(),
-      pool: mockEarnPositions[0],
-      hooksApiUrl: networkConfig.hooksApiUrl,
-      feeCurrencies: mockFeeCurrencies,
+        tokenAmount: '8',
+        depositTokenId: mockArbUsdcTokenId,
+        userHasFunds: true,
+        providerId: mockEarnPositions[0].appId,
+        poolId: mockEarnPositions[0].positionId,
+      })
+      await waitFor(() => expect(getByText('earnFlow.depositBottomSheet.title')).toBeVisible())
     })
   })
 
-  it('should handle navigating to the deposit bottom sheet', async () => {
-    jest.mocked(usePrepareSupplyTransactions).mockReturnValue({
-      prepareTransactionsResult: mockPreparedTransaction,
-      refreshPreparedTransactions: jest.fn(),
-      clearPreparedTransactions: jest.fn(),
-      prepareTransactionError: undefined,
-      isPreparingTransactions: false,
+  describe('swap-deposit', () => {
+    const swapDepositParams = { ...params, mode: 'swap-deposit' }
+    it('should show the token dropdown and allow the user to select a token', async () => {
+      const { getByTestId, getAllByTestId } = render(
+        <Provider store={store}>
+          <MockedNavigator component={EarnEnterAmount} params={swapDepositParams} />
+        </Provider>
+      )
+
+      expect(getByTestId('EarnEnterAmount/TokenSelect')).toBeTruthy()
+      expect(getByTestId('EarnEnterAmount/TokenSelect')).toHaveTextContent('ETH')
+      expect(getByTestId('EarnEnterAmount/TokenSelect')).toBeEnabled()
+      expect(getByTestId('downArrowIcon')).toBeTruthy()
+      expect(getAllByTestId('TokenBalanceItem')).toHaveLength(2)
+      expect(getAllByTestId('TokenBalanceItem')[0]).toHaveTextContent('ETH')
+      expect(getAllByTestId('TokenBalanceItem')[1]).toHaveTextContent('ARB')
+      expect(getByTestId('TokenBottomSheet')).not.toHaveTextContent('USDC')
     })
-    const { getByTestId, getByText } = render(
-      <Provider store={store}>
-        <MockedNavigator component={EarnEnterAmount} params={params} />
-      </Provider>
-    )
 
-    fireEvent.changeText(getByTestId('EarnEnterAmount/TokenAmountInput'), '8')
+    it('should default to the swappable token if only one is eligible and not show dropdown', async () => {
+      const store = createMockStore({
+        tokens: {
+          tokenBalances: {
+            [mockArbUsdcTokenId]: {
+              ...mockTokenBalances[mockArbUsdcTokenId],
+              balance: '10',
+            },
+            mockArbEthTokenId: {
+              ...mockTokenBalances[mockArbEthTokenId],
+              minimumAppVersionToSwap: '1.0.0',
+              balance: '0', // not eligible for swap
+            },
+            mockArbArbTokenId: {
+              ...mockTokenBalances[mockArbArbTokenId],
+              balance: '1', // eligible for swap
+            },
+          },
+        },
+      })
 
-    await waitFor(() => expect(getByText('earnFlow.enterAmount.continue')).not.toBeDisabled())
+      const { getByTestId, queryByTestId } = render(
+        <Provider store={store}>
+          <MockedNavigator component={EarnEnterAmount} params={swapDepositParams} />
+        </Provider>
+      )
 
-    expect(getByTestId('EarnEnterAmount/Deposit/Crypto')).toBeTruthy()
-    expect(getByTestId('EarnEnterAmount/Deposit/Crypto')).toHaveTextContent('8.00 USDC')
-
-    expect(getByTestId('EarnEnterAmount/Deposit/Fiat')).toBeTruthy()
-    expect(getByTestId('EarnEnterAmount/Deposit/Fiat')).toHaveTextContent('₱10.64')
-
-    fireEvent.press(getByText('earnFlow.enterAmount.continue'))
-
-    await waitFor(() => expect(AppAnalytics.track).toHaveBeenCalledTimes(1))
-    expect(AppAnalytics.track).toHaveBeenCalledWith(EarnEvents.earn_enter_amount_continue_press, {
-      amountEnteredIn: 'token',
-      amountInUsd: '8.00',
-      networkId: NetworkId['arbitrum-sepolia'],
-      tokenAmount: '8',
-      depositTokenId: mockArbUsdcTokenId,
-      userHasFunds: true,
-      providerId: mockEarnPositions[0].appId,
-      poolId: mockEarnPositions[0].positionId,
+      expect(getByTestId('EarnEnterAmount/TokenSelect')).toBeTruthy()
+      expect(getByTestId('EarnEnterAmount/TokenSelect')).toHaveTextContent('ARB')
+      expect(getByTestId('EarnEnterAmount/TokenSelect')).toBeDisabled()
+      expect(queryByTestId('downArrowIcon')).toBeFalsy()
     })
-    await waitFor(() => expect(getByText('earnFlow.depositBottomSheet.title')).toBeVisible())
   })
+
+  // tests independent of deposit / swap-deposit
   it('should show a warning and not allow the user to continue if they input an amount greater than balance', async () => {
     jest.mocked(usePrepareSupplyTransactions).mockReturnValue({
       prepareTransactionsResult: mockPreparedTransaction,
@@ -263,11 +331,7 @@ describe('EarnEnterAmount', () => {
       tokens: {
         tokenBalances: {
           [mockArbUsdcTokenId]: {
-            tokenId: mockArbUsdcTokenId,
-            symbol: 'USDC',
-            priceUsd: '1',
-            priceFetchedAt: priceFetchedAt,
-            networkId: NetworkId['arbitrum-sepolia'],
+            ...mockTokenBalances[mockArbUsdcTokenId],
             balance: '100000.42',
           },
         },
@@ -293,7 +357,7 @@ describe('EarnEnterAmount', () => {
 
   it('should track analytics and navigate correctly when tapping cta to add gas', async () => {
     jest.mocked(usePrepareSupplyTransactions).mockReturnValue({
-      prepareTransactionsResult: mockePreparedTransactionNotEnough,
+      prepareTransactionsResult: mockPreparedTransactionNotEnough,
       refreshPreparedTransactions: jest.fn(),
       clearPreparedTransactions: jest.fn(),
       prepareTransactionError: undefined,

--- a/src/earn/EarnEnterAmount.tsx
+++ b/src/earn/EarnEnterAmount.tsx
@@ -13,6 +13,7 @@ import Button, { BtnSizes } from 'src/components/Button'
 import InLineNotification, { NotificationVariant } from 'src/components/InLineNotification'
 import KeyboardAwareScrollView from 'src/components/KeyboardAwareScrollView'
 import KeyboardSpacer from 'src/components/KeyboardSpacer'
+import TokenBottomSheet, { TokenPickerOrigin } from 'src/components/TokenBottomSheet'
 import TokenDisplay from 'src/components/TokenDisplay'
 import TokenIcon, { IconSize } from 'src/components/TokenIcon'
 import Touchable from 'src/components/Touchable'
@@ -20,6 +21,7 @@ import CustomHeader from 'src/components/header/CustomHeader'
 import EarnDepositBottomSheet from 'src/earn/EarnDepositBottomSheet'
 import { usePrepareSupplyTransactions } from 'src/earn/prepareTransactions'
 import { CICOFlow } from 'src/fiatExchanges/utils'
+import DownArrowIcon from 'src/icons/DownArrowIcon'
 import InfoIcon from 'src/icons/InfoIcon'
 import { LocalCurrencySymbol } from 'src/localCurrency/consts'
 import { getLocalCurrencySymbol } from 'src/localCurrency/selectors'
@@ -36,7 +38,7 @@ import Colors from 'src/styles/colors'
 import { typeScale } from 'src/styles/fonts'
 import { Spacing } from 'src/styles/styles'
 import { useLocalToTokenAmount, useTokenInfo, useTokenToLocalAmount } from 'src/tokens/hooks'
-import { feeCurrenciesSelector } from 'src/tokens/selectors'
+import { feeCurrenciesSelector, swappableFromTokensByNetworkIdSelector } from 'src/tokens/selectors'
 import { TokenBalance } from 'src/tokens/slice'
 import Logger from 'src/utils/Logger'
 import { parseInputAmount } from 'src/utils/parsing'
@@ -52,17 +54,41 @@ const TOKEN_SELECTOR_BORDER_RADIUS = 100
 const MAX_BORDER_RADIUS = 96
 const FETCH_UPDATED_TRANSACTIONS_DEBOUNCE_TIME = 250
 
-function EarnEnterAmount({ route }: Props) {
-  const { t } = useTranslation()
+function useTokens({ pool, mode }: { pool: EarnPosition; mode: 'deposit' | 'swap-deposit' }) {
+  const depositToken = useTokenInfo(pool.dataProps.depositTokenId)
+  const swappableTokens = useSelector((state) =>
+    swappableFromTokensByNetworkIdSelector(state, [pool.networkId])
+  )
 
-  const { pool } = route.params
-  const token = useTokenInfo(pool.dataProps.depositTokenId)
+  const eligibleSwappableTokens = useMemo(
+    () =>
+      swappableTokens.filter(
+        ({ tokenId, balance }) =>
+          tokenId !== pool.dataProps.depositTokenId &&
+          tokenId !== pool.dataProps.withdrawTokenId &&
+          balance.gt(0)
+      ),
+    [swappableTokens, pool.dataProps.depositTokenId, pool.dataProps.withdrawTokenId]
+  )
 
-  if (!token) {
+  if (!depositToken) {
+    // should never happen
     throw new Error(`Token info not found for token ID ${pool.dataProps.depositTokenId}`)
   }
 
+  return mode === 'deposit' ? [depositToken] : eligibleSwappableTokens
+}
+
+function EarnEnterAmount({ route }: Props) {
+  const { t } = useTranslation()
+
+  const { pool, mode = 'deposit' } = route.params
+  const tokens = useTokens({ pool, mode })
+
+  const [token, setToken] = useState<TokenBalance>(() => tokens[0])
+
   const reviewBottomSheetRef = useRef<BottomSheetModalRefType>(null)
+  const tokenBottomSheetRef = useRef<BottomSheetModalRefType>(null)
   const tokenAmountInputRef = useRef<RNTextInput>(null)
   const localAmountInputRef = useRef<RNTextInput>(null)
 
@@ -72,6 +98,21 @@ function EarnEnterAmount({ route }: Props) {
   // this should never be null, just adding a default to make TS happy
   const localCurrencySymbol = useSelector(getLocalCurrencySymbol) ?? LocalCurrencySymbol.USD
   const hooksApiUrl = useSelector(hooksApiUrlSelector)
+
+  const onTokenPickerSelect = () => {
+    tokenBottomSheetRef.current?.snapToIndex(0)
+    AppAnalytics.track(SendEvents.token_dropdown_opened, {
+      currentTokenId: token.tokenId,
+      currentTokenAddress: token.address,
+      currentNetworkId: token.networkId,
+    })
+  }
+
+  const onSelectToken = (token: TokenBalance) => {
+    setToken(token)
+    tokenBottomSheetRef.current?.close()
+    // NOTE: analytics is already fired by the bottom sheet, don't need one here
+  }
 
   const {
     prepareTransactionsResult,
@@ -271,12 +312,19 @@ function EarnEnterAmount({ route }: Props) {
                 placeholder={new BigNumber(0).toFormat(2)}
                 testID="EarnEnterAmount/TokenAmountInput"
               />
-              <View style={styles.tokenView} testID="EarnEnterAmount/TokenSelect">
+              <Touchable
+                borderRadius={TOKEN_SELECTOR_BORDER_RADIUS}
+                onPress={onTokenPickerSelect}
+                style={styles.tokenSelectButton}
+                disabled={tokens.length === 1}
+                testID="EarnEnterAmount/TokenSelect"
+              >
                 <>
                   <TokenIcon token={token} size={IconSize.SMALL} />
                   <Text style={styles.tokenName}>{token.symbol}</Text>
+                  {tokens.length > 1 && <DownArrowIcon color={Colors.gray5} />}
                 </>
-              </View>
+              </Touchable>
             </View>
             <View style={styles.localAmountRow}>
               <AmountInput
@@ -380,6 +428,15 @@ function EarnEnterAmount({ route }: Props) {
           pool={pool}
         />
       )}
+      <TokenBottomSheet
+        forwardedRef={tokenBottomSheetRef}
+        snapPoints={['50%', '90%']}
+        origin={TokenPickerOrigin.Earn}
+        onTokenSelected={onSelectToken}
+        tokens={tokens}
+        title={t('sendEnterAmountScreen.selectToken')}
+        titleStyle={styles.title}
+      />
     </SafeAreaView>
   )
 }
@@ -501,7 +558,7 @@ const styles = StyleSheet.create({
     ...typeScale.titleMedium,
     color: Colors.black,
   },
-  tokenView: {
+  tokenSelectButton: {
     flexDirection: 'row',
     alignItems: 'center',
     backgroundColor: Colors.white,

--- a/src/earn/EarnEnterAmount.tsx
+++ b/src/earn/EarnEnterAmount.tsx
@@ -430,7 +430,6 @@ function EarnEnterAmount({ route }: Props) {
       )}
       <TokenBottomSheet
         forwardedRef={tokenBottomSheetRef}
-        snapPoints={['50%', '90%']}
         origin={TokenPickerOrigin.Earn}
         onTokenSelected={onSelectToken}
         tokens={tokens}

--- a/src/navigator/types.tsx
+++ b/src/navigator/types.tsx
@@ -80,7 +80,7 @@ export type StackParamList = {
   [Screens.Debug]: undefined
   [Screens.DebugImages]: undefined
   [Screens.EarnInfoScreen]: undefined
-  [Screens.EarnEnterAmount]: { pool: EarnPosition }
+  [Screens.EarnEnterAmount]: { pool: EarnPosition; mode?: 'deposit' | 'swap-deposit' }
   [Screens.EarnCollectScreen]: { pool: EarnPosition }
   [Screens.EarnHome]: { activeEarnTab?: EarnTabType } | undefined
   [Screens.EarnPoolInfoScreen]: { pool: EarnPosition }


### PR DESCRIPTION
### Description

Part 1 of implementing swap and deposit on the enter amount screen. Adds token bottom sheet for selecting a swappable token. If only one token is eligible, defaults to it and no dropdown is shown. Preparing swap + deposit tx will be in a follow up PR

### Test plan

Unit tests, manual (by forcing swap-deposit flow)


https://github.com/user-attachments/assets/707fa7c2-10cb-484b-aad1-d0b9c566674d



### Related issues

- Part of ACT-1356

### Backwards compatibility

Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [ ] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
