### PR TITLE
feat(earn): prepare swap + deposit transaction

### DIFF
--- a/src/analytics/types.ts
+++ b/src/analytics/types.ts
@@ -36,6 +36,7 @@ export type TransactionOrigin =
   | 'send'
   | 'swap'
   | 'earn-deposit'
+  | 'earn-swap-deposit'
   | 'earn-withdraw'
   | 'jumpstart-send'
   | 'jumpstart-claim'

--- a/src/earn/EarnEnterAmount.test.tsx
+++ b/src/earn/EarnEnterAmount.test.tsx
@@ -111,14 +111,13 @@ const params = {
 }
 
 describe('EarnEnterAmount', () => {
-  let refreshPreparedTransactionsSpy: jest.Mock
+  const refreshPreparedTransactionsSpy = jest.fn()
   beforeEach(() => {
     jest.clearAllMocks()
     jest
       .mocked(getNumberFormatSettings)
       .mockReturnValue({ decimalSeparator: '.', groupingSeparator: ',' })
     store.clearActions()
-    refreshPreparedTransactionsSpy = jest.fn()
     jest.mocked(usePrepareDepositTransactions).mockReturnValue({
       prepareTransactionsResult: undefined,
       refreshPreparedTransactions: refreshPreparedTransactionsSpy,

--- a/src/earn/EarnEnterAmount.tsx
+++ b/src/earn/EarnEnterAmount.tsx
@@ -19,7 +19,7 @@ import TokenIcon, { IconSize } from 'src/components/TokenIcon'
 import Touchable from 'src/components/Touchable'
 import CustomHeader from 'src/components/header/CustomHeader'
 import EarnDepositBottomSheet from 'src/earn/EarnDepositBottomSheet'
-import { usePrepareSupplyTransactions } from 'src/earn/prepareTransactions'
+import { usePrepareDepositTransactions } from 'src/earn/prepareTransactions'
 import { CICOFlow } from 'src/fiatExchanges/utils'
 import DownArrowIcon from 'src/icons/DownArrowIcon'
 import InfoIcon from 'src/icons/InfoIcon'
@@ -115,12 +115,12 @@ function EarnEnterAmount({ route }: Props) {
   }
 
   const {
-    prepareTransactionsResult,
+    prepareTransactionsResult: { prepareTransactionsResult } = {},
     refreshPreparedTransactions,
     clearPreparedTransactions,
     prepareTransactionError,
     isPreparingTransactions,
-  } = usePrepareSupplyTransactions()
+  } = usePrepareDepositTransactions()
 
   const walletAddress = useSelector(walletAddressSelector)
 
@@ -141,6 +141,7 @@ function EarnEnterAmount({ route }: Props) {
       feeCurrencies,
       pool,
       hooksApiUrl,
+      shortcutId: mode,
     })
   }
 


### PR DESCRIPTION
### Description

Part 2 of swap + deposit. Builds on #5998. Update existing `prepareDepositTransactions` (renamed from `prepareSupplyTransactions`) to prepare either `deposit` or `swap-deposit` transactions. Displaying swap info will be in the next PR

### Test plan

CI, manual

### Related issues

- Part of ACT-1356

### Backwards compatibility

Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
