### PR TITLE
fix(earn): ensure isNative is false and not undefined

### DIFF
--- a/src/earn/prepareTransactions.ts
+++ b/src/earn/prepareTransactions.ts
@@ -49,7 +49,7 @@ export async function prepareDepositTransactions({
             amount,
             decimals: token.decimals,
             address: token.address,
-            isNative: token.isNative,
+            isNative: token.isNative ?? false,
           },
         }
 


### PR DESCRIPTION
### Description

isNative is a required field on the triggerShortcut hook

### Test plan

Manually by preparing a swap + deposit tx w/ non native token (cusd -> usdt deposit)

### Related issues

- N/A

### Backwards compatibility

Y

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
