### PR TITLE
fix: close bottom sheet prior to points onPress navigation

### DIFF
--- a/src/points/PointsHome.tsx
+++ b/src/points/PointsHome.tsx
@@ -77,6 +77,7 @@ export default function PointsHome({ route, navigation }: Props) {
       AppAnalytics.track(PointsEvents.points_screen_card_cta_press, {
         activityId,
       })
+      activityCardBottomSheetRef.current?.close()
       onPress()
     }
   }


### PR DESCRIPTION
### Description

Points actions were not closing the bottom sheet after CTA press after #5928 was merged: [Slack Thread](https://valora-app.slack.com/archives/C04B61SJ6DS/p1726675188635229).

### Test plan

- [x] Tested locally on iOS
- [x] Tested locally on Android

### Related issues

N/A

### Backwards compatibility

Yes

### Network scalability

N/A