### PR TITLE
build(deps): install ninja on android

### DIFF
--- a/.github/workflows/e2e-android.yml
+++ b/.github/workflows/e2e-android.yml
@@ -50,6 +50,9 @@ jobs:
           yes | sdkmanager "platform-tools" "platforms;android-${{ inputs.android-api-level }}"
           set -o pipefail
 
+          # Install Ninja
+          apt-get install ninja-build
+
           # Allow the emulator to use /dev/kvm
           sudo adduser $USER kvm
           sudo chown $USER /dev/kvm

--- a/.github/workflows/e2e-android.yml
+++ b/.github/workflows/e2e-android.yml
@@ -51,7 +51,7 @@ jobs:
           set -o pipefail
 
           # Install Ninja
-          apt-get install ninja-build
+          sudo apt-get install ninja-build
 
           # Allow the emulator to use /dev/kvm
           sudo adduser $USER kvm


### PR DESCRIPTION
### Description

Resolves an issue with Android e2e builds:
```text
[CXX1416] Could not find Ninja on PATH or in SDK CMake bin folders.
```

### Test plan

- Tested via Android CI.

### Related issues

N/A

### Backwards compatibility

Yes

### Network scalability

N/A
