### PR TITLE
chore(ci): download Android platform matching the compile SDK version

### DIFF
--- a/.github/workflows/e2e-android.yml
+++ b/.github/workflows/e2e-android.yml
@@ -25,6 +25,8 @@ jobs:
           echo "$ANDROID_HOME/cmdline-tools/latest/bin" >> $GITHUB_PATH
           echo "$ANDROID_HOME/platform-tools" >> $GITHUB_PATH
           echo "$ANDROID_HOME/emulator" >> $GITHUB_PATH
+      - name: Store compileSdkVersion in env
+        run: echo "ANDROID_COMPILE_SDK_VERSION=$(grep 'compileSdkVersion' android/build.gradle | grep -o '[0-9]\+')" >> $GITHUB_ENV
       # See https://namespace.so/docs/actions/nscloud-cache-action
       - name: Cache
         uses: namespacelabs/nscloud-cache-action@v1
@@ -47,7 +49,7 @@ jobs:
 
           # Temporarily disable checking for EPIPE error and use yes to accept all licenses
           set +o pipefail
-          yes | sdkmanager "platform-tools" "platforms;android-${{ inputs.android-api-level }}"
+          yes | sdkmanager "platform-tools" "platforms;android-${{ env.ANDROID_COMPILE_SDK_VERSION }}"
           set -o pipefail
 
           # Install Ninja


### PR DESCRIPTION
### Description

We want to test against Android version provided in the the `android-api-level` parameter, but the build should always use the `compileSdkVersion` defined in the `build.gradle` file.

### Test plan

CI succeeds

### Related issues

Part of RET-1194

### Backwards compatibility

NA

### Network scalability

NA