### PR TITLE
fix(bottom-sheets): earn url open and onboarding skip

### DIFF
--- a/src/earn/EarnPoolInfoScreen.tsx
+++ b/src/earn/EarnPoolInfoScreen.tsx
@@ -8,6 +8,7 @@ import Animated, { useAnimatedScrollHandler, useSharedValue } from 'react-native
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context'
 import AppAnalytics from 'src/analytics/AppAnalytics'
 import { EarnEvents } from 'src/analytics/Events'
+import { openUrl } from 'src/app/actions'
 import BottomSheet, { BottomSheetModalRefType } from 'src/components/BottomSheet'
 import Button, { BtnSizes, BtnTypes } from 'src/components/Button'
 import { LabelWithInfo } from 'src/components/LabelWithInfo'
@@ -25,7 +26,7 @@ import useScrollAwareHeader from 'src/navigator/ScrollAwareHeader'
 import { StackParamList } from 'src/navigator/types'
 import type { EarningItem } from 'src/positions/types'
 import { EarnPosition } from 'src/positions/types'
-import { useSelector } from 'src/redux/hooks'
+import { useDispatch, useSelector } from 'src/redux/hooks'
 import { NETWORK_NAMES } from 'src/shared/conts'
 import Colors from 'src/styles/colors'
 import { typeScale } from 'src/styles/fonts'
@@ -686,13 +687,14 @@ function InfoBottomSheet({
   testId: string
 }) {
   const { t } = useTranslation()
+  const dispatch = useDispatch()
 
   const onPressDismiss = () => {
     infoBottomSheetRef.current?.close()
   }
 
   const onPressUrl = () => {
-    descriptionUrl && navigate(Screens.WebViewScreen, { uri: descriptionUrl })
+    descriptionUrl && dispatch(openUrl(descriptionUrl, true))
   }
 
   return (

--- a/src/keylessBackup/SignInWithEmail.tsx
+++ b/src/keylessBackup/SignInWithEmail.tsx
@@ -62,6 +62,7 @@ function SignInWithEmailBottomSheet({
       firstScreenInCurrentStep: Screens.SignInWithEmail,
       onboardingProps,
     })
+    bottomSheetRef.current?.close()
   }
 
   return (


### PR DESCRIPTION
### Description

Fixes two issues identified with the bottom sheets.
1. Dismisses bottom sheet on onboarding when a user skips cloud account backup.
2. Opens provider URLs in an external browser instead of behind the bottom sheet.

### Test plan

- Tested locally on iOS
- Tested locally on Android

### Related issues

N/A

### Backwards compatibility

Yes

### Network scalability

N/A