### PR TITLE
fix(earn): use statsig dynamic config for app fee

### DIFF
--- a/src/earn/prepareTransactions.test.ts
+++ b/src/earn/prepareTransactions.test.ts
@@ -5,6 +5,8 @@ import {
 } from 'src/earn/prepareTransactions'
 import { isGasSubsidizedForNetwork } from 'src/earn/utils'
 import { triggerShortcutRequest } from 'src/positions/saga'
+import { getDynamicConfigParams } from 'src/statsig'
+import { StatsigDynamicConfigs } from 'src/statsig/types'
 import { TokenBalance } from 'src/tokens/slice'
 import { NetworkId } from 'src/transactions/types'
 import { prepareTransactions } from 'src/viem/prepareTransactions'
@@ -57,6 +59,14 @@ describe('prepareTransactions', () => {
       feeCurrency: mockFeeCurrency,
     }))
     jest.mocked(isGasSubsidizedForNetwork).mockReturnValue(false)
+    jest.mocked(getDynamicConfigParams).mockImplementation(({ configName }) => {
+      if (configName === StatsigDynamicConfigs.SWAP_CONFIG) {
+        return {
+          enableAppFee: true,
+        }
+      }
+      return {} as any
+    })
   })
 
   describe('prepareDepositTransactions', () => {
@@ -121,6 +131,7 @@ describe('prepareTransactions', () => {
       expect(triggerShortcutRequest).toHaveBeenCalledWith('https://hooks.api', {
         address: '0x1234',
         appId: mockEarnPositions[0].appId,
+        enableSwapFee: true,
         networkId: mockEarnPositions[0].networkId,
         shortcutId: 'deposit',
         tokens: [{ tokenId: mockToken.tokenId, amount: '5' }],
@@ -198,6 +209,7 @@ describe('prepareTransactions', () => {
         expect(triggerShortcutRequest).toHaveBeenCalledWith('https://hooks.api', {
           address: '0x1234',
           appId: mockEarnPositions[0].appId,
+          enableSwapFee: true,
           networkId: mockEarnPositions[0].networkId,
           shortcutId: 'swap-deposit',
           swapFromToken: {

--- a/src/earn/prepareTransactions.test.ts
+++ b/src/earn/prepareTransactions.test.ts
@@ -131,7 +131,6 @@ describe('prepareTransactions', () => {
       expect(triggerShortcutRequest).toHaveBeenCalledWith('https://hooks.api', {
         address: '0x1234',
         appId: mockEarnPositions[0].appId,
-        enableSwapFee: true,
         networkId: mockEarnPositions[0].networkId,
         shortcutId: 'deposit',
         tokens: [{ tokenId: mockToken.tokenId, amount: '5' }],

--- a/src/earn/prepareTransactions.ts
+++ b/src/earn/prepareTransactions.ts
@@ -57,6 +57,7 @@ export async function prepareDepositTransactions({
             address: token.address,
             isNative: token.isNative ?? false,
           },
+          enableSwapFee,
         }
 
   const {
@@ -70,7 +71,6 @@ export async function prepareDepositTransactions({
       shortcutId,
       ...args,
       ...pool.shortcutTriggerArgs?.[shortcutId],
-      enableSwapFee,
     })
 
   if (shortcutId === 'swap-deposit' && !dataProps?.swapTransaction) {

--- a/src/earn/prepareTransactions.ts
+++ b/src/earn/prepareTransactions.ts
@@ -7,9 +7,6 @@ import { triggerShortcutRequest } from 'src/positions/saga'
 import { RawShortcutTransaction } from 'src/positions/slice'
 import { rawShortcutTransactionsToTransactionRequests } from 'src/positions/transactions'
 import { EarnPosition } from 'src/positions/types'
-import { getDynamicConfigParams } from 'src/statsig'
-import { DynamicConfigs } from 'src/statsig/constants'
-import { StatsigDynamicConfigs } from 'src/statsig/types'
 import { SwapTransaction } from 'src/swap/types'
 import { TokenBalance } from 'src/tokens/slice'
 import Logger from 'src/utils/Logger'
@@ -36,9 +33,7 @@ export async function prepareDepositTransactions({
   hooksApiUrl: string
   shortcutId: EarnDepositMode
 }) {
-  const enableSwapFee = getDynamicConfigParams(
-    DynamicConfigs[StatsigDynamicConfigs.SWAP_CONFIG]
-  ).enableAppFee
+  const enableSwapFee = false
   const args =
     shortcutId === 'deposit'
       ? {
@@ -57,6 +52,7 @@ export async function prepareDepositTransactions({
             address: token.address,
             isNative: token.isNative ?? false,
           },
+          enableSwapFee,
         }
 
   const {
@@ -70,7 +66,6 @@ export async function prepareDepositTransactions({
       shortcutId,
       ...args,
       ...pool.shortcutTriggerArgs?.[shortcutId],
-      enableSwapFee,
     })
 
   if (shortcutId === 'swap-deposit' && !dataProps?.swapTransaction) {

--- a/src/earn/prepareTransactions.ts
+++ b/src/earn/prepareTransactions.ts
@@ -7,6 +7,9 @@ import { triggerShortcutRequest } from 'src/positions/saga'
 import { RawShortcutTransaction } from 'src/positions/slice'
 import { rawShortcutTransactionsToTransactionRequests } from 'src/positions/transactions'
 import { EarnPosition } from 'src/positions/types'
+import { getDynamicConfigParams } from 'src/statsig'
+import { DynamicConfigs } from 'src/statsig/constants'
+import { StatsigDynamicConfigs } from 'src/statsig/types'
 import { SwapTransaction } from 'src/swap/types'
 import { TokenBalance } from 'src/tokens/slice'
 import Logger from 'src/utils/Logger'
@@ -33,6 +36,9 @@ export async function prepareDepositTransactions({
   hooksApiUrl: string
   shortcutId: EarnDepositMode
 }) {
+  const enableSwapFee = getDynamicConfigParams(
+    DynamicConfigs[StatsigDynamicConfigs.SWAP_CONFIG]
+  ).enableAppFee
   const args =
     shortcutId === 'deposit'
       ? {
@@ -64,6 +70,7 @@ export async function prepareDepositTransactions({
       shortcutId,
       ...args,
       ...pool.shortcutTriggerArgs?.[shortcutId],
+      enableSwapFee,
     })
 
   if (shortcutId === 'swap-deposit' && !dataProps?.swapTransaction) {

--- a/src/earn/prepareTransactions.ts
+++ b/src/earn/prepareTransactions.ts
@@ -7,6 +7,9 @@ import { triggerShortcutRequest } from 'src/positions/saga'
 import { RawShortcutTransaction } from 'src/positions/slice'
 import { rawShortcutTransactionsToTransactionRequests } from 'src/positions/transactions'
 import { EarnPosition } from 'src/positions/types'
+import { getDynamicConfigParams } from 'src/statsig'
+import { DynamicConfigs } from 'src/statsig/constants'
+import { StatsigDynamicConfigs } from 'src/statsig/types'
 import { SwapTransaction } from 'src/swap/types'
 import { TokenBalance } from 'src/tokens/slice'
 import Logger from 'src/utils/Logger'
@@ -33,7 +36,9 @@ export async function prepareDepositTransactions({
   hooksApiUrl: string
   shortcutId: EarnDepositMode
 }) {
-  const enableSwapFee = false
+  const enableSwapFee = getDynamicConfigParams(
+    DynamicConfigs[StatsigDynamicConfigs.SWAP_CONFIG]
+  ).enableAppFee
   const args =
     shortcutId === 'deposit'
       ? {
@@ -52,7 +57,6 @@ export async function prepareDepositTransactions({
             address: token.address,
             isNative: token.isNative ?? false,
           },
-          enableSwapFee,
         }
 
   const {
@@ -66,6 +70,7 @@ export async function prepareDepositTransactions({
       shortcutId,
       ...args,
       ...pool.shortcutTriggerArgs?.[shortcutId],
+      enableSwapFee,
     })
 
   if (shortcutId === 'swap-deposit' && !dataProps?.swapTransaction) {

--- a/src/positions/saga.ts
+++ b/src/positions/saga.ts
@@ -36,9 +36,8 @@ import {
 import { Position, Shortcut } from 'src/positions/types'
 import { SentryTransactionHub } from 'src/sentry/SentryTransactionHub'
 import { SentryTransaction } from 'src/sentry/SentryTransactions'
-import { getDynamicConfigParams, getFeatureGate, getMultichainFeatures } from 'src/statsig'
-import { DynamicConfigs } from 'src/statsig/constants'
-import { StatsigDynamicConfigs, StatsigFeatureGates } from 'src/statsig/types'
+import { getFeatureGate, getMultichainFeatures } from 'src/statsig'
+import { StatsigFeatureGates } from 'src/statsig/types'
 import { fetchTokenBalances } from 'src/tokens/slice'
 import Logger from 'src/utils/Logger'
 import { ensureError } from 'src/utils/ensureError'
@@ -259,7 +258,6 @@ export function* handleEnableHooksPreviewDeepLink(
 }
 
 export async function triggerShortcutRequest(hooksApiUrl: string, bodyJson: any) {
-  const { enableAppFee } = getDynamicConfigParams(DynamicConfigs[StatsigDynamicConfigs.SWAP_CONFIG])
   const response = await fetchWithTimeout(
     getHooksApiFunctionUrl(hooksApiUrl, 'triggerShortcut').toString(),
     {
@@ -267,10 +265,7 @@ export async function triggerShortcutRequest(hooksApiUrl: string, bodyJson: any)
       headers: {
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({
-        ...bodyJson,
-        enableSwapFee: enableAppFee,
-      }),
+      body: JSON.stringify(bodyJson),
     },
     30_000
   )

--- a/src/positions/saga.ts
+++ b/src/positions/saga.ts
@@ -36,8 +36,9 @@ import {
 import { Position, Shortcut } from 'src/positions/types'
 import { SentryTransactionHub } from 'src/sentry/SentryTransactionHub'
 import { SentryTransaction } from 'src/sentry/SentryTransactions'
-import { getFeatureGate, getMultichainFeatures } from 'src/statsig'
-import { StatsigFeatureGates } from 'src/statsig/types'
+import { getDynamicConfigParams, getFeatureGate, getMultichainFeatures } from 'src/statsig'
+import { DynamicConfigs } from 'src/statsig/constants'
+import { StatsigDynamicConfigs, StatsigFeatureGates } from 'src/statsig/types'
 import { fetchTokenBalances } from 'src/tokens/slice'
 import Logger from 'src/utils/Logger'
 import { ensureError } from 'src/utils/ensureError'
@@ -258,6 +259,7 @@ export function* handleEnableHooksPreviewDeepLink(
 }
 
 export async function triggerShortcutRequest(hooksApiUrl: string, bodyJson: any) {
+  const { enableAppFee } = getDynamicConfigParams(DynamicConfigs[StatsigDynamicConfigs.SWAP_CONFIG])
   const response = await fetchWithTimeout(
     getHooksApiFunctionUrl(hooksApiUrl, 'triggerShortcut').toString(),
     {
@@ -265,7 +267,10 @@ export async function triggerShortcutRequest(hooksApiUrl: string, bodyJson: any)
       headers: {
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify(bodyJson),
+      body: JSON.stringify({
+        ...bodyJson,
+        enableSwapFee: enableAppFee,
+      }),
     },
     30_000
   )


### PR DESCRIPTION
### Description

Uses the Statsig dynamic config to determine if swap fees should be waived.

### Test plan

- [x] Unit tests updated
- [x] Tested locally with current backend

### Related issues

Part of ACT-1379

### Backwards compatibility

Yes

### Network scalability

N/A
