### PR TITLE
chore: parameterise app name used in auth

### DIFF
--- a/__mocks__/react-native-config.ts
+++ b/__mocks__/react-native-config.ts
@@ -5,4 +5,5 @@ export default {
   DEFAULT_TESTNET: 'alfajores',
   AUTH0_DOMAIN: 'auth0.com',
   DEEP_LINK_URL_SCHEME: 'celo',
+  APP_REGISTRY_NAME: 'app',
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -36,6 +36,7 @@ const configOrThrow = (key: string) => {
 }
 
 export const APP_NAME = 'Valora'
+export const APP_REGISTRY_NAME = configOrThrow('APP_REGISTRY_NAME')
 
 // DEV only related settings
 export const isE2EEnv = stringToBoolean(Config.IS_E2E || 'false')

--- a/src/web3/networkConfig.ts
+++ b/src/web3/networkConfig.ts
@@ -1,6 +1,12 @@
 import _ from 'lodash'
 import { Environment as PersonaEnvironment } from 'react-native-persona'
-import { BIDALI_URL, DEFAULT_FORNO_URL, DEFAULT_TESTNET, RECAPTCHA_SITE_KEY } from 'src/config'
+import {
+  APP_REGISTRY_NAME,
+  BIDALI_URL,
+  DEFAULT_FORNO_URL,
+  DEFAULT_TESTNET,
+  RECAPTCHA_SITE_KEY,
+} from 'src/config'
 import { Network, NetworkId } from 'src/transactions/types'
 import Logger from 'src/utils/Logger'
 import { CiCoCurrency, Currency } from 'src/utils/currencies'
@@ -281,8 +287,6 @@ const SIMULATE_TRANSACTIONS_MAINNET = `${CLOUD_FUNCTIONS_MAINNET}/simulateTransa
 const INTERNAL_ARBITRUM_RPC_URL_STAGING = `${CLOUD_FUNCTIONS_STAGING}/rpc/${NetworkId['arbitrum-sepolia']}`
 const INTERNAL_ARBITRUM_RPC_URL_MAINNET = `${CLOUD_FUNCTIONS_MAINNET}/rpc/${NetworkId['arbitrum-one']}`
 
-const AUTH_HEADER_ISSUER = 'Valora'
-
 const WEB3_AUTH_VERIFIER = 'valora-cab-auth0'
 
 const BASE_SET_REGISTRATION_PROPERTIES_AUTH = {
@@ -295,11 +299,11 @@ const BASE_SET_REGISTRATION_PROPERTIES_AUTH = {
     Message: [{ name: 'content', type: 'string' }],
   },
   domain: {
-    name: 'Valora',
+    name: APP_REGISTRY_NAME,
     version: '1',
   },
   message: {
-    content: 'valora auth message',
+    content: `${APP_REGISTRY_NAME.toLowerCase()} auth message`,
   },
   primaryType: 'Message',
 } as const
@@ -420,7 +424,7 @@ const networkConfigs: { [testnet: string]: NetworkConfig } = {
     internalRpcUrl: {
       [Network.Arbitrum]: INTERNAL_ARBITRUM_RPC_URL_STAGING,
     },
-    authHeaderIssuer: AUTH_HEADER_ISSUER,
+    authHeaderIssuer: APP_REGISTRY_NAME,
     web3AuthVerifier: WEB3_AUTH_VERIFIER,
     crossChainExplorerUrl: CROSS_CHAIN_EXPLORER_URL,
   },
@@ -522,7 +526,7 @@ const networkConfigs: { [testnet: string]: NetworkConfig } = {
     internalRpcUrl: {
       [Network.Arbitrum]: INTERNAL_ARBITRUM_RPC_URL_MAINNET,
     },
-    authHeaderIssuer: AUTH_HEADER_ISSUER,
+    authHeaderIssuer: APP_REGISTRY_NAME,
     web3AuthVerifier: WEB3_AUTH_VERIFIER,
     crossChainExplorerUrl: CROSS_CHAIN_EXPLORER_URL,
   },


### PR DESCRIPTION
### Description

This PR updates the network config file to use the APP_REGISTRY_NAME env variable for the auth headers in networkConfig.ts, to reduce the number of places we need to update the app name.

### Test plan

n/a

### Related issues

n/a

### Backwards compatibility

Y

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [ ] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
