### PR TITLE
chore(ci): accept all Android licenses

### DIFF
--- a/.github/workflows/e2e-android.yml
+++ b/.github/workflows/e2e-android.yml
@@ -48,7 +48,9 @@ jobs:
           mv "$ANDROID_HOME/cmdline-tools/cmdline-tools" "$ANDROID_HOME/cmdline-tools/latest"
 
           # Accept all licenses
+          set +o pipefail
           yes | sdkmanager --licenses
+          set -o pipefail
 
           # Install Android SDK
           sdkmanager "platform-tools" "platforms;android-${{ env.ANDROID_COMPILE_SDK_VERSION }}"

--- a/.github/workflows/e2e-android.yml
+++ b/.github/workflows/e2e-android.yml
@@ -47,10 +47,11 @@ jobs:
           rm -rf "$ANDROID_HOME/cmdline-tools/latest"
           mv "$ANDROID_HOME/cmdline-tools/cmdline-tools" "$ANDROID_HOME/cmdline-tools/latest"
 
-          # Temporarily disable checking for EPIPE error and use yes to accept all licenses
-          set +o pipefail
-          yes | sdkmanager "platform-tools" "platforms;android-${{ env.ANDROID_COMPILE_SDK_VERSION }}"
-          set -o pipefail
+          # Accept all licenses
+          yes | sdkmanager --licenses
+
+          # Install Android SDK
+          sdkmanager "platform-tools" "platforms;android-${{ env.ANDROID_COMPILE_SDK_VERSION }}"
 
           # Install Ninja
           sudo apt-get install ninja-build

--- a/.github/workflows/e2e-android.yml
+++ b/.github/workflows/e2e-android.yml
@@ -47,7 +47,7 @@ jobs:
           rm -rf "$ANDROID_HOME/cmdline-tools/latest"
           mv "$ANDROID_HOME/cmdline-tools/cmdline-tools" "$ANDROID_HOME/cmdline-tools/latest"
 
-          # Accept all licenses
+          # Temporarily disable checking for EPIPE error and use yes to accept all licenses
           set +o pipefail
           yes | sdkmanager --licenses
           set -o pipefail


### PR DESCRIPTION
### Description

Add an explicit step to accept all `sdkmanager` [licenses](https://developer.android.com/tools/sdkmanager#accept-licenses), so the subsequent tooling installations do not fail.

For instance, emulator installation with Android 28 will not fail like it did in this action:
https://github.com/valora-inc/wallet/actions/runs/10996847867/job/30569279072?pr=6031

### Test plan

CI succeeds

### Related issues

Related to RET-1194

### Backwards compatibility

NA

### Network scalability

NA