### PR TITLE
chore(docs): update rainbowkit recommendation

### DIFF
--- a/docs/connecting-dapps.md
+++ b/docs/connecting-dapps.md
@@ -2,7 +2,7 @@
 
 Valora supports [WalletConnect v2](https://docs.walletconnect.com/2.0/) for connecting Dapps to Valora. [WalletConnect v1 is end-of-life](https://docs.walletconnect.com/2.0/advanced/migration-from-v1.x/overview) and not supported.
 
-If you're building a Dapp we recommend [rainbowkit](https://github.com/rainbow-me/rainbowkit) or [Web3Modal](https://github.com/WalletConnect/web3modal) to make it easy to connect your Dapp to Valora via WalletConnect. Take a look to a [complete example](https://docs.celo.org/developer/rainbowkit-celo) to help you get started.
+If you're building a Dapp we recommend [rainbowkit](https://github.com/rainbow-me/rainbowkit) or [Web3Modal](https://github.com/WalletConnect/web3modal) to make it easy to connect your Dapp to Valora via WalletConnect. Take a look at a [complete example](https://docs.celo.org/developer/rainbowkit-celo) to help you get started.
 
 ## WalletConnect details
 

--- a/docs/connecting-dapps.md
+++ b/docs/connecting-dapps.md
@@ -2,7 +2,7 @@
 
 Valora supports [WalletConnect v2](https://docs.walletconnect.com/2.0/) for connecting Dapps to Valora. [WalletConnect v1 is end-of-life](https://docs.walletconnect.com/2.0/advanced/migration-from-v1.x/overview) and not supported.
 
-If you're building a Dapp we recommend [@celo/rainbowkit-celo](https://github.com/celo-org/rainbowkit-celo) or [Web3Modal](https://github.com/WalletConnect/web3modal) to make it easy to connect your Dapp to Valora via WalletConnect. [cLabs](https://clabs.co/) supports [@celo/rainbowkit-celo](https://github.com/celo-org/rainbowkit-celo) and it includes a [complete example](https://docs.celo.org/developer/rainbowkit-celo) to help you get started.
+If you're building a Dapp we recommend [rainbowkit](https://github.com/rainbow-me/rainbowkit) or [Web3Modal](https://github.com/WalletConnect/web3modal) to make it easy to connect your Dapp to Valora via WalletConnect. Take a look to a [complete example](https://docs.celo.org/developer/rainbowkit-celo) to help you get started.
 
 ## WalletConnect details
 


### PR DESCRIPTION
### Description

Update the links since Valora is now [supported in rainbowkit](https://github.com/rainbow-me/rainbowkit/releases/tag/%40rainbow-me%2Frainbowkit%402.1.6) and the [rainbowkit-celo](https://github.com/celo-org/rainbowkit-celo?tab=readme-ov-file#migrating-away-from-rainbowkit-celo) is sunset.

### Test plan

Visual assessment

### Related issues

Fixes #5983 

### Backwards compatibility

NA

### Network scalability

NA