### PR TITLE
fix(home-actions): remove paddingTop from home action carousel

### DIFF
--- a/src/home/ActionsCarousel.tsx
+++ b/src/home/ActionsCarousel.tsx
@@ -126,7 +126,8 @@ const styles = StyleSheet.create({
     backgroundColor: Colors.white,
   },
   carouselContainer: {
-    padding: Spacing.Regular16,
+    paddingHorizontal: Spacing.Regular16,
+    paddingBottom: Spacing.Regular16,
     gap: Spacing.Regular16,
   },
   card: {


### PR DESCRIPTION
### Description

Removes the top padding from the home actions carousel.

### Test plan

- Tested locally on Android

### Related issues

N/A

### Backwards compatibility

Yes

### Network scalability

N/A
