### PR TITLE
style: rename enableSwapFee to enableAppFee

### DIFF
--- a/src/earn/prepareTransactions.test.ts
+++ b/src/earn/prepareTransactions.test.ts
@@ -208,7 +208,7 @@ describe('prepareTransactions', () => {
         expect(triggerShortcutRequest).toHaveBeenCalledWith('https://hooks.api', {
           address: '0x1234',
           appId: mockEarnPositions[0].appId,
-          enableSwapFee: true,
+          enableAppFee: true,
           networkId: mockEarnPositions[0].networkId,
           shortcutId: 'swap-deposit',
           swapFromToken: {

--- a/src/earn/prepareTransactions.ts
+++ b/src/earn/prepareTransactions.ts
@@ -36,9 +36,7 @@ export async function prepareDepositTransactions({
   hooksApiUrl: string
   shortcutId: EarnDepositMode
 }) {
-  const enableSwapFee = getDynamicConfigParams(
-    DynamicConfigs[StatsigDynamicConfigs.SWAP_CONFIG]
-  ).enableAppFee
+  const { enableAppFee } = getDynamicConfigParams(DynamicConfigs[StatsigDynamicConfigs.SWAP_CONFIG])
   const args =
     shortcutId === 'deposit'
       ? {
@@ -57,7 +55,7 @@ export async function prepareDepositTransactions({
             address: token.address,
             isNative: token.isNative ?? false,
           },
-          enableSwapFee,
+          enableAppFee,
         }
 
   const {


### PR DESCRIPTION
### Description

Renames enableSwapFee to enableAppFee to match the dynamic config and [related Hooks PR](https://github.com/valora-inc/hooks/pull/577).

### Test plan

- Unit Tests

### Related issues

N/A

### Backwards compatibility

Yes

### Network scalability

N/A
