### PR TITLE
chore(ci): temp disable home feed

### DIFF
--- a/e2e/src/HomeFeed.spec.js
+++ b/e2e/src/HomeFeed.spec.js
@@ -6,7 +6,7 @@ beforeAll(async () => {
   await quickOnboarding()
 })
 
-describe('Home Feed', () => {
+xdescribe('Home Feed', () => {
   it('should show correct information on tap of feed item', async () => {
     // Load Wallet Home
     await waitForElementId('WalletHome')

--- a/e2e/src/HomeFeed.spec.js
+++ b/e2e/src/HomeFeed.spec.js
@@ -6,6 +6,9 @@ beforeAll(async () => {
   await quickOnboarding()
 })
 
+// TODO: Disabled to unlock the CI
+// To enable once the home feed issue on Alfajores is fixed
+// Context: https://valora-app.slack.com/archives/C025V1D6F3J/p1727427797940139
 xdescribe('Home Feed', () => {
   it('should show correct information on tap of feed item', async () => {
     // Load Wallet Home

--- a/e2e/src/usecases/SecureSend.js
+++ b/e2e/src/usecases/SecureSend.js
@@ -39,7 +39,10 @@ export default SecureSend = () => {
       await quickOnboarding({ mnemonic: SAMPLE_BACKUP_KEY_SINGLE_ADDRESS_VERIFIED })
     })
 
-    it('Send cUSD to phone number with multiple mappings', async () => {
+    // TODO: Disabled to unlock the CI
+    // To enable once the secure send issue on Alfajores is fixed
+    // Context: https://valora-app.slack.com/archives/C025V1D6F3J/p1727427797940139
+    xit('Send cUSD to phone number with multiple mappings', async () => {
       await waitForElementByIdAndTap('HomeAction-Send', 30_000)
       await waitForElementByIdAndTap('SendSelectRecipientSearchInput', 3000)
       await element(by.id('SendSelectRecipientSearchInput')).replaceText(VERIFIED_PHONE_NUMBER)

--- a/e2e/src/usecases/SecureSend.js
+++ b/e2e/src/usecases/SecureSend.js
@@ -39,10 +39,7 @@ export default SecureSend = () => {
       await quickOnboarding({ mnemonic: SAMPLE_BACKUP_KEY_SINGLE_ADDRESS_VERIFIED })
     })
 
-    // TODO: Disabled to unlock the CI
-    // To enable once the secure send issue on Alfajores is fixed
-    // Context: https://valora-app.slack.com/archives/C025V1D6F3J/p1727427797940139
-    xit('Send cUSD to phone number with multiple mappings', async () => {
+    it('Send cUSD to phone number with multiple mappings', async () => {
       await waitForElementByIdAndTap('HomeAction-Send', 30_000)
       await waitForElementByIdAndTap('SendSelectRecipientSearchInput', 3000)
       await element(by.id('SendSelectRecipientSearchInput')).replaceText(VERIFIED_PHONE_NUMBER)


### PR DESCRIPTION
### Description

To unblock the CI pipeline temporarily disable the constantly failing E2E tests:
* **Home Feed**, as it is constantly failing after Blockscout discontinued their legacy GraphQL API

Context: https://valora-app.slack.com/archives/C025V1D6F3J/p1727427797940139

### Test plan

CI succeeds

### Related issues

NA

### Backwards compatibility

NA

### Network scalability

NA