### PR TITLE
chore: remove logging of homefeed response

### DIFF
--- a/src/transactions/feed/queryHelper.ts
+++ b/src/transactions/feed/queryHelper.ts
@@ -438,7 +438,7 @@ async function queryTransactionsFeed({
         networkId,
         afterCursor,
       })
-      Logger.info(TAG, `Fetched transactions for ${networkId}`, result)
+      Logger.info(TAG, `Fetched transactions for ${networkId}`)
       onNetworkResponse(networkId, result) // Update state as soon as data is available
     } finally {
       setActiveRequests((prev) => ({ ...prev, [networkId]: false }))


### PR DESCRIPTION
### Description

While debugging using someone's logs the other day, I found myself wading through tons of unnecessary lines of blockchain-api transaction responses. The response was being logged after every data fetch (every 10 seconds), which I think is unnecessary and bloats the stored file size.

### Test plan

n/a

### Related issues

n/a

### Backwards compatibility

Y

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [ ] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
