### PR TITLE
fix(feed): use the right earn amount

### DIFF
--- a/src/transactions/feed/EarnFeedItem.test.tsx
+++ b/src/transactions/feed/EarnFeedItem.test.tsx
@@ -14,9 +14,10 @@ import { createMockStore } from 'test/utils'
 import {
   mockAaveArbUsdcAddress,
   mockArbArbTokenId,
+  mockArbUsdcTokenId,
   mockEarnClaimRewardTransaction,
   mockEarnDepositTransaction,
-  mockEarnSwapDepositTransactionNetworkConfigVersion,
+  mockEarnSwapDeposit,
   mockEarnWithdrawTransaction,
 } from 'test/values'
 
@@ -28,8 +29,8 @@ jest
 const store = createMockStore({
   tokens: {
     tokenBalances: {
-      [networkConfig.arbUsdcTokenId]: {
-        tokenId: networkConfig.arbUsdcTokenId,
+      [mockArbUsdcTokenId]: {
+        tokenId: mockArbUsdcTokenId,
         symbol: 'USDC',
         priceUsd: '1',
         priceFetchedAt: Date.now(),
@@ -123,7 +124,7 @@ describe.each([
   },
   {
     type: 'EarnSwapDeposit',
-    transaction: mockEarnSwapDepositTransactionNetworkConfigVersion,
+    transaction: mockEarnSwapDeposit,
     expectedTitle: 'earnFlow.transactionFeed.earnDepositTitle',
     expectedSubTitle: 'earnFlow.transactionFeed.earnDepositSubtitle, {"providerName":"Aave"}',
     expectedTotal: '-10.00 USDC',

--- a/src/transactions/feed/EarnFeedItem.tsx
+++ b/src/transactions/feed/EarnFeedItem.tsx
@@ -71,15 +71,15 @@ function AmountDisplay({ transaction, isLocal }: AmountDisplayProps) {
 
   switch (transaction.__typename) {
     case 'EarnDeposit':
-      amountValue = new BigNumber(-transaction.inAmount.value)
+      amountValue = new BigNumber(-transaction.outAmount.value)
       tokenId = transaction.outAmount.tokenId
       break
     case 'EarnSwapDeposit':
-      amountValue = new BigNumber(-transaction.deposit.inAmount.value)
+      amountValue = new BigNumber(-transaction.deposit.outAmount.value)
       tokenId = transaction.deposit.outAmount.tokenId
       break
     case 'EarnWithdraw':
-      amountValue = new BigNumber(transaction.outAmount.value)
+      amountValue = new BigNumber(transaction.inAmount.value)
       tokenId = transaction.inAmount.tokenId
       break
     case 'EarnClaimReward':

--- a/test/values.ts
+++ b/test/values.ts
@@ -2057,12 +2057,12 @@ export const mockEarnDepositTransaction: EarnDeposit = {
     localAmount: undefined,
     tokenAddress: mockAaveArbUsdcAddress,
     tokenId: networkConfig.aaveArbUsdcTokenId,
-    value: '10',
+    value: '10.01',
   },
   outAmount: {
     localAmount: undefined,
     tokenAddress: '0xdef',
-    tokenId: networkConfig.arbUsdcTokenId,
+    tokenId: mockArbUsdcTokenId,
     value: '10',
   },
   block: '210927567',
@@ -2085,56 +2085,6 @@ export const mockEarnDepositTransaction: EarnDeposit = {
   type: TokenTransactionTypeV2.EarnDeposit,
 }
 
-export const mockEarnSwapDepositTransactionNetworkConfigVersion: EarnSwapDeposit = {
-  __typename: 'EarnSwapDeposit',
-  deposit: {
-    inAmount: {
-      localAmount: undefined,
-      tokenAddress: mockAaveArbUsdcAddress,
-      tokenId: networkConfig.aaveArbUsdcTokenId,
-      value: '10',
-    },
-    outAmount: {
-      localAmount: undefined,
-      tokenAddress: '0xdef',
-      tokenId: networkConfig.arbUsdcTokenId,
-      value: '10',
-    },
-    providerId: 'aave',
-  },
-  swap: {
-    inAmount: {
-      localAmount: undefined,
-      tokenAddress: '0xdef',
-      tokenId: networkConfig.arbUsdcTokenId,
-      value: '10',
-    },
-    outAmount: {
-      localAmount: undefined,
-      tokenAddress: mockCeloAddress,
-      tokenId: mockCeloTokenId,
-      value: '50',
-    },
-  },
-  block: '210927567',
-  fees: [
-    {
-      amount: {
-        localAmount: undefined,
-        tokenAddress: mockArbArbAddress,
-        tokenId: mockArbArbTokenId,
-        value: '0.00000284243',
-      },
-      type: 'SECURITY_FEE',
-    },
-  ],
-  networkId: NetworkId['arbitrum-sepolia'],
-  timestamp: Date.now(),
-  transactionHash: '0xHASH1',
-  status: TransactionStatus.Complete,
-  type: TokenTransactionTypeV2.EarnDeposit,
-}
-
 export const mockEarnSwapDeposit: EarnSwapDeposit = {
   __typename: 'EarnSwapDeposit',
   deposit: {
@@ -2142,7 +2092,7 @@ export const mockEarnSwapDeposit: EarnSwapDeposit = {
       localAmount: undefined,
       tokenAddress: mockAaveArbUsdcAddress,
       tokenId: networkConfig.aaveArbUsdcTokenId,
-      value: '10',
+      value: '10.01',
     },
     outAmount: {
       localAmount: undefined,
@@ -2190,14 +2140,14 @@ export const mockEarnWithdrawTransaction: EarnWithdraw = {
   inAmount: {
     localAmount: undefined,
     tokenAddress: '0xdef',
-    tokenId: networkConfig.arbUsdcTokenId,
+    tokenId: mockArbUsdcTokenId,
     value: '1',
   },
   outAmount: {
     localAmount: undefined,
     tokenAddress: mockAaveArbUsdcAddress,
     tokenId: networkConfig.aaveArbUsdcTokenId,
-    value: '0.996614',
+    value: '0.986614',
   },
   block: '211276583',
   fees: [


### PR DESCRIPTION
### Description

Use the deposit out and withdraw in amounts in the tx feed item for earn deposit and withdraw instead of the deposit in and withdraw out amounts (which are the LP token amounts)

### Test plan

| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/dae7b9dd-393d-4935-bf20-cc7d6cffb65c" /> | <video src="https://github.com/user-attachments/assets/d72b4cbf-71b7-4c45-b2e7-eace230cee92" /> | 



### Related issues

- Part of ACT-1397



### Backwards compatibility

Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
