### PR TITLE
feat(earn): Add earn_supported_pools dynamic config

### DIFF
--- a/src/positions/saga.test.ts
+++ b/src/positions/saga.test.ts
@@ -139,6 +139,7 @@ describe(fetchPositionsSaga, () => {
     })
     jest.mocked(getDynamicConfigParams).mockReturnValue({
       supportedPools: ['arbitrum-sepolia:0x460b97bd498e1157530aeb3086301d5225b91216'],
+      supportedAppIds: ['aave'],
     })
     await expectSaga(fetchPositionsSaga)
       .provide([
@@ -166,6 +167,7 @@ describe(fetchPositionsSaga, () => {
     })
     jest.mocked(getDynamicConfigParams).mockReturnValue({
       supportedPools: ['arbitrum-sepolia:0x460b97bd498e1157530aeb3086301d5225b91216'],
+      supportedAppIds: ['aave'],
     })
     await expectSaga(fetchPositionsSaga)
       .provide([

--- a/src/positions/saga.test.ts
+++ b/src/positions/saga.test.ts
@@ -40,7 +40,7 @@ import {
   triggerShortcutSuccess,
 } from 'src/positions/slice'
 import { Position } from 'src/positions/types'
-import { getFeatureGate, getMultichainFeatures } from 'src/statsig'
+import { getDynamicConfigParams, getFeatureGate, getMultichainFeatures } from 'src/statsig'
 import { NetworkId } from 'src/transactions/types'
 import Logger from 'src/utils/Logger'
 import { sendPreparedTransactions } from 'src/viem/saga'
@@ -137,6 +137,11 @@ describe(fetchPositionsSaga, () => {
     jest.mocked(getMultichainFeatures).mockReturnValue({
       showPositions: [NetworkId['celo-mainnet']],
     })
+    jest
+      .mocked(getDynamicConfigParams)
+      .mockReturnValue({
+        supportedPools: ['arbitrum-sepolia:0x460b97bd498e1157530aeb3086301d5225b91216'],
+      })
     await expectSaga(fetchPositionsSaga)
       .provide([
         [select(walletAddressSelector), mockAccount],
@@ -161,6 +166,11 @@ describe(fetchPositionsSaga, () => {
     jest.mocked(getMultichainFeatures).mockReturnValue({
       showPositions: [NetworkId['celo-mainnet']],
     })
+    jest
+      .mocked(getDynamicConfigParams)
+      .mockReturnValue({
+        supportedPools: ['arbitrum-sepolia:0x460b97bd498e1157530aeb3086301d5225b91216'],
+      })
     await expectSaga(fetchPositionsSaga)
       .provide([
         [select(walletAddressSelector), mockAccount],

--- a/src/positions/saga.test.ts
+++ b/src/positions/saga.test.ts
@@ -137,11 +137,9 @@ describe(fetchPositionsSaga, () => {
     jest.mocked(getMultichainFeatures).mockReturnValue({
       showPositions: [NetworkId['celo-mainnet']],
     })
-    jest
-      .mocked(getDynamicConfigParams)
-      .mockReturnValue({
-        supportedPools: ['arbitrum-sepolia:0x460b97bd498e1157530aeb3086301d5225b91216'],
-      })
+    jest.mocked(getDynamicConfigParams).mockReturnValue({
+      supportedPools: ['arbitrum-sepolia:0x460b97bd498e1157530aeb3086301d5225b91216'],
+    })
     await expectSaga(fetchPositionsSaga)
       .provide([
         [select(walletAddressSelector), mockAccount],
@@ -166,11 +164,9 @@ describe(fetchPositionsSaga, () => {
     jest.mocked(getMultichainFeatures).mockReturnValue({
       showPositions: [NetworkId['celo-mainnet']],
     })
-    jest
-      .mocked(getDynamicConfigParams)
-      .mockReturnValue({
-        supportedPools: ['arbitrum-sepolia:0x460b97bd498e1157530aeb3086301d5225b91216'],
-      })
+    jest.mocked(getDynamicConfigParams).mockReturnValue({
+      supportedPools: ['arbitrum-sepolia:0x460b97bd498e1157530aeb3086301d5225b91216'],
+    })
     await expectSaga(fetchPositionsSaga)
       .provide([
         [select(walletAddressSelector), mockAccount],

--- a/src/positions/saga.ts
+++ b/src/positions/saga.ts
@@ -36,8 +36,9 @@ import {
 import { Position, Shortcut } from 'src/positions/types'
 import { SentryTransactionHub } from 'src/sentry/SentryTransactionHub'
 import { SentryTransaction } from 'src/sentry/SentryTransactions'
-import { getFeatureGate, getMultichainFeatures } from 'src/statsig'
-import { StatsigFeatureGates } from 'src/statsig/types'
+import { getDynamicConfigParams, getFeatureGate, getMultichainFeatures } from 'src/statsig'
+import { DynamicConfigs } from 'src/statsig/constants'
+import { StatsigDynamicConfigs, StatsigFeatureGates } from 'src/statsig/types'
 import { fetchTokenBalances } from 'src/tokens/slice'
 import Logger from 'src/utils/Logger'
 import { ensureError } from 'src/utils/ensureError'
@@ -90,9 +91,13 @@ async function fetchPositions({
   networkIds.forEach((networkId) => getPositionsUrl.searchParams.append('networkIds', networkId))
 
   const getEarnPositionsUrl = getHooksApiFunctionUrl(hooksApiUrl, 'getEarnPositions')
+  const { supportedPools } = getDynamicConfigParams(
+    DynamicConfigs[StatsigDynamicConfigs.SUPPORTED_EARN_POOLS]
+  )
   networkIds.forEach((networkId) =>
     getEarnPositionsUrl.searchParams.append('networkIds', networkId)
   )
+  supportedPools.forEach((pool) => getEarnPositionsUrl.searchParams.append('supportedPools', pool))
 
   const options: RequestInit = { headers: { 'Accept-Language': language } }
 

--- a/src/positions/saga.ts
+++ b/src/positions/saga.ts
@@ -91,13 +91,16 @@ async function fetchPositions({
   networkIds.forEach((networkId) => getPositionsUrl.searchParams.append('networkIds', networkId))
 
   const getEarnPositionsUrl = getHooksApiFunctionUrl(hooksApiUrl, 'getEarnPositions')
-  const { supportedPools } = getDynamicConfigParams(
-    DynamicConfigs[StatsigDynamicConfigs.SUPPORTED_EARN_POOLS]
+  const { supportedPools, supportedAppIds } = getDynamicConfigParams(
+    DynamicConfigs[StatsigDynamicConfigs.EARN_CONFIG]
   )
   networkIds.forEach((networkId) =>
     getEarnPositionsUrl.searchParams.append('networkIds', networkId)
   )
   supportedPools.forEach((pool) => getEarnPositionsUrl.searchParams.append('supportedPools', pool))
+  supportedAppIds.forEach((appId) =>
+    getEarnPositionsUrl.searchParams.append('supportedAppIds', appId)
+  )
 
   const options: RequestInit = { headers: { 'Accept-Language': language } }
 

--- a/src/statsig/constants.ts
+++ b/src/statsig/constants.ts
@@ -127,10 +127,11 @@ export const DynamicConfigs = {
       },
     },
   },
-  [StatsigDynamicConfigs.SUPPORTED_EARN_POOLS]: {
-    configName: StatsigDynamicConfigs.SUPPORTED_EARN_POOLS,
+  [StatsigDynamicConfigs.EARN_CONFIG]: {
+    configName: StatsigDynamicConfigs.EARN_CONFIG,
     defaultValues: {
       supportedPools: [] as string[],
+      supportedAppIds: [] as string[],
     },
   },
 } satisfies {

--- a/src/statsig/constants.ts
+++ b/src/statsig/constants.ts
@@ -127,6 +127,12 @@ export const DynamicConfigs = {
       },
     },
   },
+  [StatsigDynamicConfigs.SUPPORTED_EARN_POOLS]: {
+    configName: StatsigDynamicConfigs.SUPPORTED_EARN_POOLS,
+    defaultValues: {
+      supportedPools: [] as string[],
+    },
+  },
 } satisfies {
   [key in StatsigDynamicConfigs | StatsigMultiNetworkDynamicConfig]: {
     configName: key

--- a/src/statsig/types.ts
+++ b/src/statsig/types.ts
@@ -8,6 +8,7 @@ export enum StatsigDynamicConfigs {
   NFT_CELEBRATION_CONFIG = 'nft_celebration_config',
   EARN_STABLECOIN_CONFIG = 'earn_stablecoin_config',
   APP_CONFIG = 'app_config',
+  SUPPORTED_EARN_POOLS = 'supported_earn_pools',
 }
 
 // Separating into different enum from StatsigDynamicConfigs to allow for more strict typing

--- a/src/statsig/types.ts
+++ b/src/statsig/types.ts
@@ -8,7 +8,7 @@ export enum StatsigDynamicConfigs {
   NFT_CELEBRATION_CONFIG = 'nft_celebration_config',
   EARN_STABLECOIN_CONFIG = 'earn_stablecoin_config',
   APP_CONFIG = 'app_config',
-  SUPPORTED_EARN_POOLS = 'supported_earn_pools',
+  EARN_CONFIG = 'earn_config',
 }
 
 // Separating into different enum from StatsigDynamicConfigs to allow for more strict typing


### PR DESCRIPTION
### Description

and use in getEarnPositions query. Opted to have the default be the empty list and have the legacy default live in hooks ([here](https://github.com/valora-inc/hooks/pull/598)). That way if we need to change the legacy default we can and there won't be BC issues in the wallet (can just change on hooks side without release, goes to all versions).

Dynamic config: https://console.statsig.com/4plizaPmWwPL21ASV4QAO0/dynamic_configs/supported_earn_pools

### Test plan

CI

### Related issues

- Fixes ACT-1367

### Backwards compatibility

Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [X] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
