### PR TITLE
fix(headers): use empty string for title

### DIFF
--- a/src/navigator/Headers.tsx
+++ b/src/navigator/Headers.tsx
@@ -76,7 +76,7 @@ export const nuxNavigationOptionsNoBackButton: NativeStackNavigationOptions = {
 }
 
 export const emptyHeader: NativeStackNavigationOptions = {
-  headerTitle: ' ',
+  headerTitle: '',
   headerShown: true,
   // Prevents double back button on Android
   headerBackVisible: false,


### PR DESCRIPTION
### Description

Fixes an iOS 18 only issue where header is shown as `" "`

### Test plan

Tested on multiple versions across iOS and Android w/ @MuckT 

| Before | After |
|--------|--------|
| <img src="https://github.com/user-attachments/assets/4b7521b1-762e-40c7-ab9b-7d78327d5238" width="250" /> | <img src="https://github.com/user-attachments/assets/b5c9aa75-3b0a-4fdf-ab6a-ddf35c1eeaaf" width="250" /> | 



### Related issues

- N/A

### Backwards compatibility

yes

### Network scalability

N/A
