### PR TITLE
fix(earn): Show correct fiat and token amount on earn collect screen

### DIFF
--- a/src/earn/EarnCollectScreen.test.tsx
+++ b/src/earn/EarnCollectScreen.test.tsx
@@ -116,9 +116,9 @@ describe('EarnCollectScreen', () => {
     expect(getByText('earnFlow.collect.title')).toBeTruthy()
     expect(getByText('earnFlow.collect.total')).toBeTruthy()
     expect(getByTestId(`EarnCollect/${mockArbUsdcTokenId}/CryptoAmount`)).toHaveTextContent(
-      '10.75 USDC'
+      '11.83 USDC'
     )
-    expect(getByTestId(`EarnCollect/${mockArbUsdcTokenId}/FiatAmount`)).toHaveTextContent('₱14.30')
+    expect(getByTestId(`EarnCollect/${mockArbUsdcTokenId}/FiatAmount`)).toHaveTextContent('₱15.73')
     expect(queryByTestId('EarnCollect/ApyLoading')).toBeFalsy()
     expect(getByTestId('EarnCollect/GasLoading')).toBeTruthy()
     expect(getByTestId('EarnCollectScreen/CTA')).toBeDisabled()
@@ -147,26 +147,6 @@ describe('EarnCollectScreen', () => {
     expect(store.getActions()).toEqual([])
   })
 
-  it('renders total balance correctly when pricePerShare is not 1', async () => {
-    const { getByText, getByTestId } = render(
-      <Provider store={store}>
-        <MockedNavigator
-          component={EarnCollectScreen}
-          params={{
-            pool: { ...mockEarnPositions[0], pricePerShare: ['2'] },
-          }}
-        />
-      </Provider>
-    )
-
-    expect(getByText('earnFlow.collect.title')).toBeTruthy()
-    expect(getByText('earnFlow.collect.total')).toBeTruthy()
-    expect(getByTestId(`EarnCollect/${mockArbUsdcTokenId}/CryptoAmount`)).toHaveTextContent(
-      '21.50 USDC'
-    )
-    expect(getByTestId(`EarnCollect/${mockArbUsdcTokenId}/FiatAmount`)).toHaveTextContent('₱28.60')
-  })
-
   it('skips rewards section when no rewards', async () => {
     const { getByText, getByTestId, queryByTestId, queryByText } = render(
       <Provider
@@ -193,9 +173,9 @@ describe('EarnCollectScreen', () => {
     expect(getByText('earnFlow.collect.title')).toBeTruthy()
     expect(getByText('earnFlow.collect.total')).toBeTruthy()
     expect(getByTestId(`EarnCollect/${mockArbUsdcTokenId}/CryptoAmount`)).toHaveTextContent(
-      '10.75 USDC'
+      '11.83 USDC'
     )
-    expect(getByTestId(`EarnCollect/${mockArbUsdcTokenId}/FiatAmount`)).toHaveTextContent('₱14.30')
+    expect(getByTestId(`EarnCollect/${mockArbUsdcTokenId}/FiatAmount`)).toHaveTextContent('₱15.73')
     expect(getByTestId('EarnCollectScreen/CTA')).toBeDisabled()
 
     expect(queryByText('earnFlow.collect.plus')).toBeFalsy()
@@ -298,7 +278,7 @@ describe('EarnCollectScreen', () => {
 
     expect(AppAnalytics.track).toHaveBeenCalledWith(EarnEvents.earn_collect_earnings_press, {
       depositTokenId: mockArbUsdcTokenId,
-      tokenAmount: '10.75',
+      tokenAmount: '11.825',
       networkId: NetworkId['arbitrum-sepolia'],
       providerId: mockEarnPositions[0].appId,
       rewards: [{ amount: '0.01', tokenId: mockArbArbTokenId }],

--- a/src/earn/EarnCollectScreen.test.tsx
+++ b/src/earn/EarnCollectScreen.test.tsx
@@ -147,6 +147,26 @@ describe('EarnCollectScreen', () => {
     expect(store.getActions()).toEqual([])
   })
 
+  it('renders total balance correctly when pricePerShare is not 1', async () => {
+    const { getByText, getByTestId } = render(
+      <Provider store={store}>
+        <MockedNavigator
+          component={EarnCollectScreen}
+          params={{
+            pool: { ...mockEarnPositions[0], pricePerShare: ['2'] },
+          }}
+        />
+      </Provider>
+    )
+
+    expect(getByText('earnFlow.collect.title')).toBeTruthy()
+    expect(getByText('earnFlow.collect.total')).toBeTruthy()
+    expect(getByTestId(`EarnCollect/${mockArbUsdcTokenId}/CryptoAmount`)).toHaveTextContent(
+      '21.50 USDC'
+    )
+    expect(getByTestId(`EarnCollect/${mockArbUsdcTokenId}/FiatAmount`)).toHaveTextContent('₱28.60')
+  })
+
   it('skips rewards section when no rewards', async () => {
     const { getByText, getByTestId, queryByTestId, queryByText } = render(
       <Provider

--- a/src/earn/EarnCollectScreen.tsx
+++ b/src/earn/EarnCollectScreen.tsx
@@ -80,6 +80,10 @@ export default function EarnCollectScreen({ route }: Props) {
     rewardsPositions,
   })
 
+  const withdrawAmountInDepositToken = useMemo(() => {
+    return withdrawToken.balance.multipliedBy(pool.pricePerShare[0] ?? 1)
+  }, [withdrawToken, pool.pricePerShare])
+
   const onPress = () => {
     if (prepareTransactionsResult?.type !== 'possible') {
       // should never happen because button is disabled if withdraw is not possible
@@ -98,7 +102,7 @@ export default function EarnCollectScreen({ route }: Props) {
 
     AppAnalytics.track(EarnEvents.earn_collect_earnings_press, {
       depositTokenId,
-      tokenAmount: withdrawToken.balance.toString(),
+      tokenAmount: withdrawAmountInDepositToken.toString(),
       networkId: withdrawToken.networkId,
       providerId: pool.appId,
       poolId: pool.positionId,
@@ -139,7 +143,7 @@ export default function EarnCollectScreen({ route }: Props) {
           <CollectItem
             title={t('earnFlow.collect.total')}
             tokenInfo={depositToken}
-            rewardAmount={withdrawToken.balance}
+            rewardAmount={withdrawAmountInDepositToken}
           />
           {rewardsTokens.map((token, index) => (
             <CollectItem

--- a/src/earn/EarnPoolInfoScreen.test.tsx
+++ b/src/earn/EarnPoolInfoScreen.test.tsx
@@ -147,7 +147,7 @@ describe('EarnPoolInfoScreen', () => {
     ).toBeTruthy()
     expect(
       within(getByTestId('DepositAndEarningsCard')).getByText(
-        'earnFlow.poolInfoScreen.lineItemAmountDisplay, {"localCurrencySymbol":"₱","localCurrencyAmount":"133.00","cryptoAmount":"100.00","cryptoSymbol":"USDC"}'
+        'earnFlow.poolInfoScreen.lineItemAmountDisplay, {"localCurrencySymbol":"₱","localCurrencyAmount":"146.30","cryptoAmount":"110.00","cryptoSymbol":"USDC"}'
       )
     ).toBeTruthy()
     expect(getAllByTestId('EarningItemLineItem')).toHaveLength(2)
@@ -187,7 +187,7 @@ describe('EarnPoolInfoScreen', () => {
     ).toBeTruthy()
     expect(
       within(getByTestId('DepositAndEarningsCard')).getByText(
-        'earnFlow.poolInfoScreen.lineItemAmountDisplay, {"localCurrencySymbol":"₱","localCurrencyAmount":"133.00","cryptoAmount":"100.00","cryptoSymbol":"USDC"}'
+        'earnFlow.poolInfoScreen.lineItemAmountDisplay, {"localCurrencySymbol":"₱","localCurrencyAmount":"146.30","cryptoAmount":"110.00","cryptoSymbol":"USDC"}'
       )
     ).toBeTruthy()
   })
@@ -224,7 +224,7 @@ describe('EarnPoolInfoScreen', () => {
     ).toBeTruthy()
     expect(
       within(getByTestId('DepositAndEarningsCard')).getByText(
-        'earnFlow.poolInfoScreen.lineItemAmountDisplay, {"localCurrencySymbol":"₱","localCurrencyAmount":"131.67","cryptoAmount":"99.00","cryptoSymbol":"USDC"}'
+        'earnFlow.poolInfoScreen.lineItemAmountDisplay, {"localCurrencySymbol":"₱","localCurrencyAmount":"144.97","cryptoAmount":"109.00","cryptoSymbol":"USDC"}'
       )
     ).toBeTruthy()
     expect(getAllByTestId('EarningItemLineItem')).toHaveLength(2)
@@ -271,7 +271,7 @@ describe('EarnPoolInfoScreen', () => {
     ).toBeTruthy()
     expect(
       within(getByTestId('DepositAndEarningsCard')).getByText(
-        'earnFlow.poolInfoScreen.lineItemAmountDisplay, {"localCurrencySymbol":"₱","localCurrencyAmount":"131.01","cryptoAmount":"98.50","cryptoSymbol":"USDC"}'
+        'earnFlow.poolInfoScreen.lineItemAmountDisplay, {"localCurrencySymbol":"₱","localCurrencyAmount":"144.31","cryptoAmount":"108.50","cryptoSymbol":"USDC"}'
       )
     ).toBeTruthy()
     expect(getAllByTestId('EarningItemLineItem')).toHaveLength(2)

--- a/test/values.ts
+++ b/test/values.ts
@@ -1782,7 +1782,7 @@ export const mockEarnPositions: EarnPosition[] = [
         balance: '0',
       },
     ],
-    pricePerShare: ['1'],
+    pricePerShare: ['1.1'],
     priceUsd: '1.2',
     balance: '0',
     supply: '190288.768509',


### PR DESCRIPTION
### Description

withdrawToken is not 1:1 with depositToken, need to convert withdrawToken balance to depositToken using pricePerShare

### Test plan

Without change (mismatch):

https://github.com/user-attachments/assets/160417bf-9047-4a63-ae16-5568c08a6861



With change (no mismatch):

https://github.com/user-attachments/assets/f4e01cd0-9005-4c99-a9b8-2a4d7e013fad



### Related issues

- Fixes N/A

### Backwards compatibility

Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [X] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
