### PR TITLE
chore: add script to generate release notes

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "e2e:test:ios-debug": "detox test -c ios.debug -l verbose",
     "e2e:test:ios-release": "detox test -c ios.release -l verbose",
     "pre-deploy": "./scripts/pre-deploy.sh",
+    "generate-release-notes": "ts-node ./scripts/generate-release-notes.ts",
     "deploy:update-disclaimer": "yarn licenses generate-disclaimer --prod > src/account/LicenseDisclaimer.txt && ./scripts/copy_license_to_android_assets.sh",
     "postinstall": "patch-package && yarn keys:decrypt && ./scripts/copy_license_to_android_assets.sh",
     "keys:decrypt": "bash scripts/key_placer.sh decrypt",

--- a/scripts/generate-release-notes.ts
+++ b/scripts/generate-release-notes.ts
@@ -1,0 +1,174 @@
+// This script is used to generate release notes for a given release.
+// It correctly ignores cherry-picked commits from previous patch releases.
+
+import chalk from 'chalk'
+import shell from 'shelljs'
+import yargs from 'yargs'
+import { hideBin } from 'yargs/helpers'
+
+interface Commit {
+  hash: string
+  type: string
+  message: string
+}
+
+const argv = yargs(hideBin(process.argv))
+  .option('lastTag', {
+    type: 'string',
+    description: 'The last release tag (optional)',
+  })
+  .option('toRef', {
+    type: 'string',
+    description: 'The reference to generate release notes up to',
+    default: 'HEAD',
+  })
+  .option('verbose', {
+    type: 'boolean',
+    description: 'Enable verbose logging',
+    default: true,
+  })
+  .parseSync()
+
+function log(message: string) {
+  if (argv.verbose) {
+    console.error(message)
+  }
+}
+
+function getLastTag(): string {
+  log(chalk.blue('Fetching the last tag...'))
+  // We can't use `git describe --tags --abbrev=0` because that returns the latest tag that is a direct ancestor of the current branch
+  // But patch releases are not direct ancestors
+  const result = shell.exec('git tag --sort=-v:refname | grep "^valora-v" | head -n 1', {
+    silent: true,
+  })
+  if (result.code !== 0) {
+    console.error(chalk.red('Error fetching last tag:', result.stderr))
+    process.exit(1)
+  }
+  return result.stdout.trim()
+}
+
+function getCommits(lastTag: string, toRef: string): Commit[] {
+  log(chalk.blue(`Fetching commits between ${lastTag} and ${toRef}...`))
+  const range = `${lastTag}..${toRef}`
+  const result = shell.exec(`git rev-list ${range} --oneline | tail -r`, { silent: true })
+
+  if (result.code !== 0) {
+    console.error(chalk.red('Error fetching git commits:', result.stderr))
+    process.exit(1)
+  }
+
+  return result.stdout
+    .trim()
+    .split('\n')
+    .map((line) => {
+      const [hash, ...messageParts] = line.split(' ')
+      const message = messageParts.join(' ')
+      const match = message.match(/^(\w+)(\(.*?\))?:/)
+      const type = match ? match[1] : 'other'
+      return { hash, type, message }
+    })
+}
+
+function generateMainReleaseNotes(commits: Commit[], version: string): string {
+  const features = commits.filter((c) => c.type === 'feat')
+  const fixes = commits.filter((c) => c.type === 'fix')
+  const others = commits.filter((c) => !['feat', 'fix'].includes(c.type))
+
+  let notes = `# Summary
+
+We've updated Valora to fix bugs, enhance our features, and improve overall performance.
+
+`
+
+  if (features.length > 0) {
+    notes += `## Features
+
+${features.map((c) => `${c.hash} ${c.message}`).join('\n')}
+
+`
+  }
+
+  if (fixes.length > 0) {
+    notes += `## Bug Fixes
+
+${fixes.map((c) => `${c.hash} ${c.message}`).join('\n')}
+
+`
+  }
+
+  if (others.length > 0) {
+    notes += `## Other
+
+${others.map((c) => `${c.hash} ${c.message}`).join('\n')}
+`
+  }
+
+  return notes.trim()
+}
+
+function generatePatchReleaseNotes(commits: Commit[], version: string): string {
+  const [major, minor, patch] = version.split('.')
+  const previousVersion = `${major}.${minor}.${parseInt(patch) - 1}`
+
+  return `# Summary
+
+This release is a patch on top of v${previousVersion}, with additional commits.
+
+## Commits included
+
+${commits.map((c) => `${c.hash} ${c.message}`).join('\n')}
+`
+}
+
+function main() {
+  const { lastTag: userProvidedLastTag, toRef } = argv
+
+  const packageJson = require('../package.json')
+  const currentVersion = packageJson.version
+
+  log(chalk.blue(`Generating release notes for ${currentVersion}...`))
+
+  const lastTag = userProvidedLastTag || getLastTag()
+  log(chalk.green(`Using last tag: ${lastTag}`))
+
+  let commits = getCommits(lastTag, toRef)
+  log(chalk.green(`Found ${commits.length} commits`))
+
+  // Determine if it's a patch release
+  const isPatchRelease = currentVersion.split('.')[2] !== '0'
+
+  if (!isPatchRelease) {
+    // For main releases, remove cherry-picked commits from the previous main release
+    const [major, minor] = currentVersion.split('.')
+    const lastMainTag = `valora-v${major}.${parseInt(minor) - 1}.0`
+
+    if (lastMainTag !== lastTag) {
+      const possibleCherryPickedCommits = getCommits(lastMainTag, lastTag)
+      const possibleCherryPickedMessages = new Set(
+        possibleCherryPickedCommits.map((commit) => commit.message)
+      )
+      const cherryPickedCommits = commits.filter((commit) =>
+        possibleCherryPickedMessages.has(commit.message)
+      )
+      commits = commits.filter((commit) => !possibleCherryPickedMessages.has(commit.message))
+      log(chalk.yellow(`Possible cherry-picked commits: ${possibleCherryPickedCommits.length}`))
+      log(chalk.yellow(`Skipping ${cherryPickedCommits.length} cherry-picked commits`))
+      cherryPickedCommits.forEach((commit) => {
+        log(chalk.yellow(`  ${commit.hash} ${commit.message}`))
+      })
+    }
+  }
+
+  const releaseNotes = isPatchRelease
+    ? generatePatchReleaseNotes(commits, currentVersion)
+    : generateMainReleaseNotes(commits, currentVersion)
+
+  // Output release notes to stdout
+  console.log(releaseNotes)
+
+  log(chalk.green('Release notes generated successfully'))
+}
+
+main()


### PR DESCRIPTION
### Description

Here's an improved version of a basic script I was using locally to generate release notes.

Features:
- generate release notes for both "main" and "patch" releases
- excludes cherry-picked commits from the previous release
- detects tag prefix so it also works for Mobile Stack (i.e. no hardcoded "valora")
- verbose mode by default showing what it does (see screenshot), printed to `stderr` so we can pipe `stdout` and get just the release notes

Example usages:
- `yarn generate-release-notes` this is the recommended usage
- `yarn generate-release-notes --lastTag valora-v1.94.2`
- `yarn generate-release-notes --lastTag valora-v1.94.2 --toRef someRef`

In the future, the plan is to use it from our release workflow to create the GitHub Release automatically.

We could also update the nightly workflow to use it.

### Test plan

Successfully used it to generate the release notes for [1.95.0](https://github.com/valora-inc/wallet/releases/tag/valora-v1.95.0)

<img width="679" alt="Screenshot 2024-10-04 at 16 25 16" src="https://github.com/user-attachments/assets/c55a10d8-d5b0-4f06-81d8-575ae3677e80">

Successfully used it to generate the release for 1.95.1

<img width="633" alt="Screenshot 2024-10-04 at 17 40 19" src="https://github.com/user-attachments/assets/e155460f-cb1b-4a64-8bb2-5e2f6b97e4a4">


### Related issues

- Slack [thread](https://valora-app.slack.com/archives/C025V1D6F3J/p1724326960482299) for context.

### Backwards compatibility

Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
