### PR TITLE
chore(TransactionFeedV2): Cleanup stand by transactions in Transaction Feed V2

### DIFF
--- a/src/home/TabHome.tsx
+++ b/src/home/TabHome.tsx
@@ -27,7 +27,7 @@ import { phoneRecipientCacheSelector } from 'src/recipients/reducer'
 import { useDispatch, useSelector } from 'src/redux/hooks'
 import { initializeSentryUserContext } from 'src/sentry/actions'
 import colors from 'src/styles/colors'
-import TransactionFeedV2 from 'src/transactions/feed/TransactionFeedV2'
+import TransactionFeed from 'src/transactions/feed/TransactionFeed'
 import { hasGrantedContactsPermission } from 'src/utils/contacts'
 
 const AnimatedFlatList = Animated.createAnimatedComponent(FlatList)
@@ -120,7 +120,7 @@ function TabHome(_props: Props) {
       key: 'NotificationBox',
       component: <NotificationBox showOnlyHomeScreenNotifications={true} />,
     },
-    { key: 'TransactionFeed', component: <TransactionFeedV2 /> },
+    { key: 'TransactionFeed', component: <TransactionFeed /> },
   ]
 
   const renderItem = ({ item }: { item: any }) => item.component

--- a/src/home/TabHome.tsx
+++ b/src/home/TabHome.tsx
@@ -27,7 +27,7 @@ import { phoneRecipientCacheSelector } from 'src/recipients/reducer'
 import { useDispatch, useSelector } from 'src/redux/hooks'
 import { initializeSentryUserContext } from 'src/sentry/actions'
 import colors from 'src/styles/colors'
-import TransactionFeed from 'src/transactions/feed/TransactionFeed'
+import TransactionFeedV2 from 'src/transactions/feed/TransactionFeedV2'
 import { hasGrantedContactsPermission } from 'src/utils/contacts'
 
 const AnimatedFlatList = Animated.createAnimatedComponent(FlatList)
@@ -120,7 +120,7 @@ function TabHome(_props: Props) {
       key: 'NotificationBox',
       component: <NotificationBox showOnlyHomeScreenNotifications={true} />,
     },
-    { key: 'TransactionFeed', component: <TransactionFeed /> },
+    { key: 'TransactionFeed', component: <TransactionFeedV2 /> },
   ]
 
   const renderItem = ({ item }: { item: any }) => item.component

--- a/src/transactions/actions.ts
+++ b/src/transactions/actions.ts
@@ -19,6 +19,7 @@ export enum Actions {
   TRANSACTION_CONFIRMED = 'TRANSACTIONS/TRANSACTION_CONFIRMED',
   REFRESH_RECENT_TX_RECIPIENTS = 'TRANSACTIONS/REFRESH_RECENT_TX_RECIPIENTS',
   UPDATE_TRANSACTIONS = 'TRANSACTIONS/UPDATE_TRANSACTIONS',
+  REMOVE_STANDBY_TRANSACTIONS = 'TRANSACTIONS/REMOVE_STANDBY_TRANSACTIONS',
 }
 
 type BaseStandbyTransactionType<T> = Omit<PendingStandbyTransaction<T>, 'timestamp' | 'status'>
@@ -59,10 +60,16 @@ export interface UpdateTransactionsAction {
   networkId: NetworkId
 }
 
+export interface RemoveStandByTransactionsAction {
+  type: Actions.REMOVE_STANDBY_TRANSACTIONS
+  transactionHashesToRemove: string[]
+}
+
 export type ActionTypes =
   | AddStandbyTransactionAction
   | UpdateTransactionsAction
   | TransactionConfirmedAction
+  | RemoveStandByTransactionsAction
 
 export const addStandbyTransaction = (
   transaction: BaseStandbyTransaction
@@ -89,4 +96,11 @@ export const updateTransactions = (
   type: Actions.UPDATE_TRANSACTIONS,
   networkId,
   transactions,
+})
+
+export const removeStandByTransactions = (
+  transactionHashesToRemove: string[]
+): RemoveStandByTransactionsAction => ({
+  type: Actions.REMOVE_STANDBY_TRANSACTIONS,
+  transactionHashesToRemove,
 })

--- a/src/transactions/actions.ts
+++ b/src/transactions/actions.ts
@@ -19,7 +19,7 @@ export enum Actions {
   TRANSACTION_CONFIRMED = 'TRANSACTIONS/TRANSACTION_CONFIRMED',
   REFRESH_RECENT_TX_RECIPIENTS = 'TRANSACTIONS/REFRESH_RECENT_TX_RECIPIENTS',
   UPDATE_TRANSACTIONS = 'TRANSACTIONS/UPDATE_TRANSACTIONS',
-  REMOVE_STANDBY_TRANSACTIONS = 'TRANSACTIONS/REMOVE_STANDBY_TRANSACTIONS',
+  REMOVE_DUPLICATED_STANDBY_TRANSACTIONS = 'TRANSACTIONS/REMOVE_DUPLICATED_STANDBY_TRANSACTIONS',
 }
 
 type BaseStandbyTransactionType<T> = Omit<PendingStandbyTransaction<T>, 'timestamp' | 'status'>
@@ -60,16 +60,16 @@ export interface UpdateTransactionsAction {
   networkId: NetworkId
 }
 
-interface RemoveStandByTransactionsAction {
-  type: Actions.REMOVE_STANDBY_TRANSACTIONS
-  transactionHashesToRemove: string[]
+interface RemoveDuplicatedStandByTransactionsAction {
+  type: Actions.REMOVE_DUPLICATED_STANDBY_TRANSACTIONS
+  newPageTransactions: TokenTransaction[]
 }
 
 export type ActionTypes =
   | AddStandbyTransactionAction
   | UpdateTransactionsAction
   | TransactionConfirmedAction
-  | RemoveStandByTransactionsAction
+  | RemoveDuplicatedStandByTransactionsAction
 
 export const addStandbyTransaction = (
   transaction: BaseStandbyTransaction
@@ -98,9 +98,9 @@ export const updateTransactions = (
   transactions,
 })
 
-export const removeStandByTransactions = (
-  transactionHashesToRemove: string[]
-): RemoveStandByTransactionsAction => ({
-  type: Actions.REMOVE_STANDBY_TRANSACTIONS,
-  transactionHashesToRemove,
+export const removeDuplicatedStandByTransactions = (
+  newPageTransactions: TokenTransaction[]
+): RemoveDuplicatedStandByTransactionsAction => ({
+  type: Actions.REMOVE_DUPLICATED_STANDBY_TRANSACTIONS,
+  newPageTransactions,
 })

--- a/src/transactions/actions.ts
+++ b/src/transactions/actions.ts
@@ -60,7 +60,7 @@ export interface UpdateTransactionsAction {
   networkId: NetworkId
 }
 
-export interface RemoveStandByTransactionsAction {
+interface RemoveStandByTransactionsAction {
   type: Actions.REMOVE_STANDBY_TRANSACTIONS
   transactionHashesToRemove: string[]
 }

--- a/src/transactions/feed/TransactionFeedV2.test.tsx
+++ b/src/transactions/feed/TransactionFeedV2.test.tsx
@@ -299,11 +299,17 @@ describe('TransactionFeedV2', () => {
     expect(getNumTransactionItems(tree.getByTestId('TransactionList'))).toBe(7)
   })
 
-  // it('cleanup is triggered for confirmed stand by transactions', async () => {
-  //   mockFetch.mockResponse(typedResponse({ transactions: [mockTransaction()] }))
-  //   const { store, ...tree } = renderScreen({
-  //     transactions: { standbyTransactions: [mockTransaction()] },
-  //   })
+  it('cleanup is triggered for confirmed stand by transactions', async () => {
+    mockFetch.mockResponse(typedResponse({ transactions: [mockTransaction()] }))
+    const { store } = renderScreen({
+      transactions: { standbyTransactions: [mockTransaction()] },
+    })
 
-  // })
+    /**
+     * For now, there's no way to check for dispatched actions via getActions as we usually do
+     * as the current setupApiStore doesn't return it. But at least we can make sure that the
+     * transaction gets removed.
+     */
+    await waitFor(() => expect(store.getState().transactions.standbyTransactions.length).toBe(0))
+  })
 })

--- a/src/transactions/feed/TransactionFeedV2.tsx
+++ b/src/transactions/feed/TransactionFeedV2.tsx
@@ -2,12 +2,13 @@ import React, { useEffect, useMemo, useState } from 'react'
 import { ActivityIndicator, SectionList, StyleSheet, View } from 'react-native'
 import SectionHead from 'src/components/SectionHead'
 import GetStarted from 'src/home/GetStarted'
-import { useSelector } from 'src/redux/hooks'
+import { useDispatch, useSelector } from 'src/redux/hooks'
 import { getFeatureGate, getMultichainFeatures } from 'src/statsig'
 import { StatsigFeatureGates } from 'src/statsig/types'
 import colors from 'src/styles/colors'
 import { Spacing } from 'src/styles/styles'
 import NoActivity from 'src/transactions/NoActivity'
+import { removeStandByTransactions } from 'src/transactions/actions'
 import { useTransactionFeedV2Query } from 'src/transactions/api'
 import EarnFeedItem from 'src/transactions/feed/EarnFeedItem'
 import NftFeedItem from 'src/transactions/feed/NftFeedItem'
@@ -95,18 +96,32 @@ function sortTransactions(transactions: TokenTransaction[]): TokenTransaction[] 
  * Otherwise, if we merge all the stand by transactins into the page it will cause more late transactions
  * that were already merged to be removed from the top of the list and move them to the bottom.
  * This will cause the screen to "shift", which we're trying to avoid.
+ *
+ * Note: when merging the first page – stand by transactions might include some new pending transaction.
+ * In order to include them in the merged list we need to also check if the stand by transction is newer
+ * than the max timestamp from the page. But this must only happen for the first page as otherwise any
+ * following page would include stand by transactions from previous pages.
  */
-function mergeStandByTransactionsInRange(
-  transactions: TokenTransaction[],
-  standBy: TokenTransaction[]
-): TokenTransaction[] {
+function mergeStandByTransactionsInRange({
+  transactions,
+  standByTransactions,
+  currentCursor,
+}: {
+  transactions: TokenTransaction[]
+  standByTransactions: TokenTransaction[]
+  currentCursor?: number
+}): TokenTransaction[] {
   if (transactions.length === 0) return []
 
   const allowedNetworks = getAllowedNetworksForTransfers()
   const max = transactions[0].timestamp
   const min = transactions.at(-1)!.timestamp
 
-  const standByInRange = standBy.filter((tx) => tx.timestamp >= min && tx.timestamp <= max)
+  const standByInRange = standByTransactions.filter((tx) => {
+    const inRange = tx.timestamp >= min && tx.timestamp <= max
+    const newTransaction = currentCursor === FIRST_PAGE_TIMESTAMP && tx.timestamp > max
+    return inRange || newTransaction
+  })
   const deduplicatedTransactions = deduplicateTransactions([...transactions, ...standByInRange])
   const transactionsFromAllowedNetworks = deduplicatedTransactions.filter((tx) =>
     allowedNetworks.includes(tx.networkId)
@@ -116,8 +131,8 @@ function mergeStandByTransactionsInRange(
 }
 
 /**
- * Current implementation of allStandbyTransactionsSelector contains function
- * getSupportedNetworkIdsForApprovalTxsInHomefeed in its selectors list which triggers a lot of
+ * Current implementation of standbyTransactionsSelector contains function
+ * getSupportedNetworkIdsForApprovalTxsInHomefeed in its selectors which triggers a lot of
  * unnecessary re-renders. This can be avoided if we join it's result in a string and memoize it,
  * similar to how it was done with useAllowedNetworkIdsForTransfers hook from queryHelpers.ts
  *
@@ -175,6 +190,7 @@ function renderItem({ item: tx }: { item: TokenTransaction }) {
 }
 
 export default function TransactionFeedV2() {
+  const dispatch = useDispatch()
   const address = useSelector(walletAddressSelector)
   const standByTransactions = useStandByTransactions()
   const [endCursor, setEndCursor] = useState(FIRST_PAGE_TIMESTAMP)
@@ -248,10 +264,11 @@ export default function TransactionFeedV2() {
           prev[currentCursor] === undefined // data for this page wasn't stored yet
 
         if (isFirstPage || pageDataIsAbsent) {
-          const mergedTransactions = mergeStandByTransactionsInRange(
+          const mergedTransactions = mergeStandByTransactionsInRange({
             transactions,
-            standByTransactions.confirmed
-          )
+            standByTransactions: standByTransactions.confirmed,
+            currentCursor,
+          })
 
           return { ...prev, [currentCursor!]: mergedTransactions }
         }
@@ -260,6 +277,34 @@ export default function TransactionFeedV2() {
       })
     },
     [isFetching, data?.transactions, originalArgs?.endCursor, standByTransactions.confirmed]
+  )
+
+  /**
+   * In order to avoid bloating stand by transactions with confirmed transactions that are already
+   * present in the feed via pagination – we need to cleanup them up. This must run for every page
+   * as standByTransaction selector might include very old transactions. We should use the chance
+   * whenever the user managed to scroll to those old transactions and remove them from persisted
+   * storage. Maybe there is a better way to keep it clean with another saga watcher?
+   */
+  useEffect(
+    function cleanupStandByTransactions() {
+      const completeTransactionsOnFirstPage =
+        data?.transactions
+          ?.filter((tx) => tx.status !== TransactionStatus.Pending)
+          .map((tx) => tx.transactionHash) || []
+
+      const standByTransactionsToRemove: string[] = []
+      for (const tx of standByTransactions.confirmed) {
+        if (completeTransactionsOnFirstPage.includes(tx.transactionHash)) {
+          standByTransactionsToRemove.push(tx.transactionHash)
+        }
+      }
+
+      if (standByTransactionsToRemove.length) {
+        dispatch(removeStandByTransactions(standByTransactionsToRemove))
+      }
+    },
+    [data?.transactions, standByTransactions]
   )
 
   const confirmedTransactions = useMemo(() => {

--- a/src/transactions/feed/TransactionFeedV2.tsx
+++ b/src/transactions/feed/TransactionFeedV2.tsx
@@ -98,7 +98,7 @@ function sortTransactions(transactions: TokenTransaction[]): TokenTransaction[] 
  * This will cause the screen to "shift", which we're trying to avoid.
  *
  * Note: when merging the first page – stand by transactions might include some new pending transaction.
- * In order to include them in the merged list we need to also check if the stand by transction is newer
+ * In order to include them in the merged list we need to also check if the stand by transaction is newer
  * than the max timestamp from the page. But this must only happen for the first page as otherwise any
  * following page would include stand by transactions from previous pages.
  */
@@ -288,14 +288,14 @@ export default function TransactionFeedV2() {
    */
   useEffect(
     function cleanupStandByTransactions() {
-      const completeTransactionsOnFirstPage =
+      const confirmedPaginationTransactions =
         data?.transactions
           ?.filter((tx) => tx.status !== TransactionStatus.Pending)
           .map((tx) => tx.transactionHash) || []
 
       const standByTransactionsToRemove: string[] = []
       for (const tx of standByTransactions.confirmed) {
-        if (completeTransactionsOnFirstPage.includes(tx.transactionHash)) {
+        if (confirmedPaginationTransactions.includes(tx.transactionHash)) {
           standByTransactionsToRemove.push(tx.transactionHash)
         }
       }

--- a/src/transactions/feed/TransactionFeedV2.tsx
+++ b/src/transactions/feed/TransactionFeedV2.tsx
@@ -8,7 +8,7 @@ import { StatsigFeatureGates } from 'src/statsig/types'
 import colors from 'src/styles/colors'
 import { Spacing } from 'src/styles/styles'
 import NoActivity from 'src/transactions/NoActivity'
-import { removeStandByTransactions } from 'src/transactions/actions'
+import { removeDuplicatedStandByTransactions } from 'src/transactions/actions'
 import { useTransactionFeedV2Query } from 'src/transactions/api'
 import EarnFeedItem from 'src/transactions/feed/EarnFeedItem'
 import NftFeedItem from 'src/transactions/feed/NftFeedItem'
@@ -288,23 +288,11 @@ export default function TransactionFeedV2() {
    */
   useEffect(
     function cleanupStandByTransactions() {
-      const confirmedPaginationTransactions =
-        data?.transactions
-          ?.filter((tx) => tx.status !== TransactionStatus.Pending)
-          .map((tx) => tx.transactionHash) || []
-
-      const standByTransactionsToRemove: string[] = []
-      for (const tx of standByTransactions.confirmed) {
-        if (confirmedPaginationTransactions.includes(tx.transactionHash)) {
-          standByTransactionsToRemove.push(tx.transactionHash)
-        }
-      }
-
-      if (standByTransactionsToRemove.length) {
-        dispatch(removeStandByTransactions(standByTransactionsToRemove))
+      if (data?.transactions.length) {
+        dispatch(removeDuplicatedStandByTransactions(data.transactions))
       }
     },
-    [data?.transactions, standByTransactions]
+    [data?.transactions]
   )
 
   const confirmedTransactions = useMemo(() => {

--- a/src/transactions/reducer.ts
+++ b/src/transactions/reducer.ts
@@ -163,12 +163,22 @@ export const reducer = (
         standbyTransactions: updatedStandbyTransactions,
       }
 
-    case Actions.REMOVE_STANDBY_TRANSACTIONS:
+    case Actions.REMOVE_DUPLICATED_STANDBY_TRANSACTIONS:
+      const confirmedTransactionsFromNewPage = action.newPageTransactions
+        .filter((tx) => tx.status !== TransactionStatus.Pending)
+        .map((tx) => tx.transactionHash)
+
       return {
         ...state,
         standbyTransactions: state.standbyTransactions.filter((tx) => {
-          if (!tx.transactionHash) return true
-          return !action.transactionHashesToRemove.includes(tx.transactionHash)
+          /**
+           * - ignore empty hashes as there's no way to compare them
+           * - ignore pending as it should only affect confirmed transactions that are already
+           *   present in the paginated data
+           */
+          if (!tx.transactionHash || tx.status === TransactionStatus.Pending) return true
+
+          return !confirmedTransactionsFromNewPage.includes(tx.transactionHash)
         }),
       }
 

--- a/src/transactions/reducer.ts
+++ b/src/transactions/reducer.ts
@@ -216,7 +216,7 @@ export const confirmedStandbyTransactionsSelector = createSelector(
   }
 )
 
-export const transactionsByNetworkIdSelector = (state: RootState) =>
+const transactionsByNetworkIdSelector = (state: RootState) =>
   state.transactions.transactionsByNetworkId
 
 export const transactionsSelector = createSelector(

--- a/src/transactions/reducer.ts
+++ b/src/transactions/reducer.ts
@@ -162,6 +162,16 @@ export const reducer = (
         },
         standbyTransactions: updatedStandbyTransactions,
       }
+
+    case Actions.REMOVE_STANDBY_TRANSACTIONS:
+      return {
+        ...state,
+        standbyTransactions: state.standbyTransactions.filter((tx) => {
+          if (!tx.transactionHash) return true
+          return !action.transactionHashesToRemove.includes(tx.transactionHash)
+        }),
+      }
+
     default:
       return state
   }


### PR DESCRIPTION
### Description
4th PR of RET-1207. This implements the cleanup of confirmed stand by transactions that are already present in the feed. Currently, we keep confirmed transactions in `standByTransactions` even if they are present in the pagination data. This is unnecessary as it takes extra space from the persisted storage.

### Test plan
- changed the test that checks merging of pages with stand by transactions
- added test to check if the stand by transaction was correctly removed if it appeared in the pagination data

### Related issues

- Relates to RET-1207

### Backwards compatibility
Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
