### PR TITLE
chore(e2e): re-enable home feed e2e test

### DIFF
--- a/e2e/src/HomeFeed.spec.js
+++ b/e2e/src/HomeFeed.spec.js
@@ -6,10 +6,7 @@ beforeAll(async () => {
   await quickOnboarding()
 })
 
-// TODO: Disabled to unlock the CI
-// To enable once the home feed issue on Alfajores is fixed
-// Context: https://valora-app.slack.com/archives/C025V1D6F3J/p1727427797940139
-xdescribe('Home Feed', () => {
+describe('Home Feed', () => {
   it('should show correct information on tap of feed item', async () => {
     // Load Wallet Home
     await waitForElementId('WalletHome')


### PR DESCRIPTION
### Description

Reverts #6101 as the GraphQL endpoint for Alfajores has been fixed.

Context: https://valora-app.slack.com/archives/C01AEKH9XGX/p1728460043801219?thread_ts=1727801385.833739&cid=C01AEKH9XGX

### Test plan

CI succeeds

### Related issues

NA

### Backwards compatibility

NA

### Network scalability

NA