### PR TITLE
feat(earn): Show daily yield rate on the pool info screen if available

### DIFF
--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -2695,6 +2695,7 @@
       "chainName": "Chain: <0>{{networkName}}</0>",
       "protocolName": "Protocol: <0>{{providerName}}</0>",
       "yieldRate": "Yield Rate",
+      "dailyRate": "Daily Rate",
       "ratePercent": "{{rate}}%",
       "rewards": "Rewards",
       "noRewards": "No rewards",
@@ -2716,7 +2717,10 @@
         "ageTitle": "Age of Pool",
         "ageDescription": "Older liquidity pools can indicate a solid track record and a history of building community trust. Because of this, some may consider these pools to be safer.\n\nThere is no perfect way to determine risk, so use this info as part of your overall research to make the decision that is best for you.",
         "yieldRateTitle": "Yield Rate",
-        "yieldRateDescription": "While most pools offer earnings in the form of a liquidity pool token, some give additional token(s) as a reward or added incentive.\n\nSince {{appName}} aggregates pools across multiple protocols, we have combined all the earning and reward rates into a single, overall yield rate to help easily evaluate your earning potential. This number is an estimate since the earning and reward values fluctuate constantly.\n\nFor further information about earning breakdowns you can visit <0>{{providerName}}</0>."
+        "yieldRateDescription": "While most pools offer earnings in the form of a liquidity pool token, some give additional token(s) as a reward or added incentive.\n\nSince {{appName}} aggregates pools across multiple protocols, we have combined all the earning and reward rates into a single, overall yield rate to help easily evaluate your earning potential. This number is an estimate since the earning and reward values fluctuate constantly.\n\nFor further information about earning breakdowns you can visit <0>{{providerName}}</0>.",
+        "dailyYieldRateTitle": "Daily Rate",
+        "dailyYieldRateDescription": "The daily rate displayed reflects the daily rate provided by {{providerName}}.",
+        "dailyYieldRateLink": "View More Daily Rate Details On {{providerName}}"
       }
     },
     "beforeDepositBottomSheet": {

--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -2695,7 +2695,7 @@
       "chainName": "Chain: <0>{{networkName}}</0>",
       "protocolName": "Protocol: <0>{{providerName}}</0>",
       "yieldRate": "Yield Rate",
-      "dailyRate": "Daily Rate",
+      "dailyYieldRate": "Daily Rate",
       "ratePercent": "{{rate}}%",
       "rewards": "Rewards",
       "noRewards": "No rewards",

--- a/src/analytics/Properties.tsx
+++ b/src/analytics/Properties.tsx
@@ -1621,7 +1621,7 @@ interface EarnEventsProperties {
   [EarnEvents.earn_home_error_try_again]: undefined
   [EarnEvents.earn_pool_info_view_pool]: EarnCommonProperties
   [EarnEvents.earn_pool_info_tap_info_icon]: {
-    type: 'tvl' | 'age' | 'yieldRate' | 'deposit'
+    type: 'tvl' | 'age' | 'yieldRate' | 'deposit' | 'dailyYieldRate'
   } & EarnCommonProperties
   [EarnEvents.earn_pool_info_tap_withdraw]: {
     poolAmount: string

--- a/src/earn/EarnPoolInfoScreen.test.tsx
+++ b/src/earn/EarnPoolInfoScreen.test.tsx
@@ -623,4 +623,28 @@ describe('EarnPoolInfoScreen', () => {
     })
     // TODO (ACT-1343): check that navigate is called with correct params
   })
+  it('shows the daily yield rate when it is available', () => {
+    const { getByTestId } = renderEarnPoolInfoScreen({
+      ...mockEarnPositions[0],
+      dataProps: {
+        ...mockEarnPositions[0].dataProps,
+        dailyYieldRatePercentage: 0.0452483,
+      },
+    })
+    expect(
+      within(getByTestId('DailyYieldRateCard')).getAllByText(
+        'earnFlow.poolInfoScreen.ratePercent, {"rate":"0.0452"}'
+      )
+    ).toBeTruthy()
+  })
+  it.each([0, undefined])('does not show the daily yield rate when it is %s', (dailyYieldRate) => {
+    const { queryByTestId } = renderEarnPoolInfoScreen({
+      ...mockEarnPositions[0],
+      dataProps: {
+        ...mockEarnPositions[0].dataProps,
+        dailyYieldRatePercentage: dailyYieldRate,
+      },
+    })
+    expect(queryByTestId('DailyYieldRateCard')).toBeFalsy()
+  })
 })

--- a/src/earn/EarnPoolInfoScreen.tsx
+++ b/src/earn/EarnPoolInfoScreen.tsx
@@ -320,29 +320,27 @@ function YieldCard({
   )
 }
 
-function DailyYieldCard({
-  dailyYield,
+function DailyYieldRateCard({
+  dailyYieldRate,
   onInfoIconPress,
 }: {
-  dailyYield: number
+  dailyYieldRate: number
   onInfoIconPress: () => void
 }) {
   const { t } = useTranslation()
   return (
-    <View style={styles.card} testID="DailyYieldCard">
+    <View style={styles.card} testID="DailyYieldRateCard">
       <View style={styles.cardLineContainer}>
         <View style={styles.cardLineLabel}>
           <LabelWithInfo
             onPress={onInfoIconPress}
-            label={t('earnFlow.poolInfoScreen.dailyRate')}
+            label={t('earnFlow.poolInfoScreen.dailyYieldRate')}
             labelStyle={styles.cardTitleText}
-            testID="DailyRateInfoIcon"
+            testID="DailyYieldRateInfoIcon"
           />
         </View>
         <Text style={styles.cardTitleText}>
-          {dailyYield > 0
-            ? t('earnFlow.poolInfoScreen.ratePercent', { rate: dailyYield.toFixed(4) })
-            : '--'}
+          {t('earnFlow.poolInfoScreen.ratePercent', { rate: dailyYieldRate.toFixed(4) })}
         </Text>
       </View>
     </View>
@@ -604,8 +602,8 @@ export default function EarnPoolInfoScreen({ route, navigation }: Props) {
             earnPosition={pool}
           />
           {!!dataProps.dailyYieldRatePercentage && dataProps.dailyYieldRatePercentage > 0 && (
-            <DailyYieldCard
-              dailyYield={dataProps.dailyYieldRatePercentage}
+            <DailyYieldRateCard
+              dailyYieldRate={dataProps.dailyYieldRatePercentage}
               onInfoIconPress={() => {
                 AppAnalytics.track(EarnEvents.earn_pool_info_tap_info_icon, {
                   providerId: appId,
@@ -756,7 +754,7 @@ function InfoBottomSheet({
       {descriptionUrl ? (
         <Text style={styles.infoBottomSheetText}>
           <Trans i18nKey={descriptionKey} tOptions={{ providerName }}>
-            <Text onPress={onPressUrl} style={styles.descriptionLinkText} />
+            <Text onPress={onPressUrl} style={styles.linkText} />
           </Trans>
         </Text>
       ) : (
@@ -938,7 +936,7 @@ const styles = StyleSheet.create({
     marginBottom: Spacing.Thick24,
     color: Colors.black,
   },
-  descriptionLinkText: {
+  linkText: {
     textDecorationLine: 'underline',
   },
 })

--- a/src/earn/EarnPoolInfoScreen.tsx
+++ b/src/earn/EarnPoolInfoScreen.tsx
@@ -770,11 +770,8 @@ function InfoBottomSheet({
           >
             <View style={styles.learnMoreView}>
               <Text style={styles.learnMoreText}>
-                <Trans i18nKey={linkKey} tOptions={{ providerName }}>
-                  <Text />
-                </Trans>
+                <Trans i18nKey={linkKey} tOptions={{ providerName }} />
               </Text>
-
               <OpenLinkIcon color={Colors.black} size={16} />
             </View>
           </Touchable>

--- a/src/earn/EarnPoolInfoScreen.tsx
+++ b/src/earn/EarnPoolInfoScreen.tsx
@@ -286,7 +286,7 @@ function YieldCard({
           />
         </View>
         <Text style={styles.cardTitleText}>
-          {yieldRateSum > 0
+          {yieldRateSum > 0.00005
             ? t('earnFlow.poolInfoScreen.ratePercent', { rate: yieldRateSum.toFixed(2) })
             : '--'}
         </Text>

--- a/src/positions/types.ts
+++ b/src/positions/types.ts
@@ -36,6 +36,7 @@ interface EarnDataProps {
   depositTokenId: string
   withdrawTokenId: string
   rewardsPositionIds?: string[]
+  dailyYieldRatePercentage?: number // The daily yield rate percentage
   // We'll add more fields here as needed
 }
 

--- a/src/positions/types.ts
+++ b/src/positions/types.ts
@@ -36,7 +36,7 @@ interface EarnDataProps {
   depositTokenId: string
   withdrawTokenId: string
   rewardsPositionIds?: string[]
-  dailyYieldRatePercentage?: number // The daily yield rate percentage
+  dailyYieldRatePercentage?: number
   // We'll add more fields here as needed
 }
 

--- a/test/RootStateSchema.json
+++ b/test/RootStateSchema.json
@@ -1245,6 +1245,9 @@
                 "contractCreatedAt": {
                     "type": "string"
                 },
+                "dailyYieldRatePercentage": {
+                    "type": "number"
+                },
                 "depositTokenId": {
                     "type": "string"
                 },


### PR DESCRIPTION
### Description

https://www.figma.com/design/E1rC3MG74qEg5V4tvbeUnU/Stablecoin-Enablement?node-id=7514-85993&node-type=instance&m=dev
https://linear.app/valora/issue/ACT-1406/daily-rate

* Daily yield rate in pool info screen when available
* small style fix to learn more link 

#### Daily Yield Rate


https://github.com/user-attachments/assets/9ad04f6c-a06c-4e49-9af5-a9d8c6a2d1f7

#### Link Style

https://www.figma.com/design/E1rC3MG74qEg5V4tvbeUnU/Stablecoin-Enablement?node-id=7514-85993&node-type=instance&m=dev
| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/1a9e19cd-48c2-4eb9-ba67-23a864232343" width="250px"> | <img src="https://github.com/user-attachments/assets/05afb6d8-59c3-4786-b4f7-368828b1f667" width="250px"> |

### Test plan

Unit tests and manually verified

### Related issues

https://linear.app/valora/issue/ACT-1406/daily-rate