### PR TITLE
feat(earn): show risks in safety card on pool info screen

### DIFF
--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -2723,7 +2723,8 @@
         "dailyYieldRateDescription": "The daily rate displayed reflects the daily rate provided by {{providerName}}.",
         "dailyYieldRateLink": "View More Daily Rate Details On {{providerName}}"
       },
-      "viewMoreDetails": "View More Details"
+      "viewMoreDetails": "View More Details",
+      "viewLessDetails": "View Less Details"
     },
     "beforeDepositBottomSheet": {
       "youNeedTitle": "You Need {{tokenSymbol}} on {{tokenNetwork}} to Deposit",

--- a/src/analytics/Events.tsx
+++ b/src/analytics/Events.tsx
@@ -682,5 +682,5 @@ export enum EarnEvents {
   earn_pool_info_tap_info_icon = 'earn_pool_info_tap_info_icon',
   earn_pool_info_tap_withdraw = 'earn_pool_info_tap_withdraw',
   earn_pool_info_tap_deposit = 'earn_pool_info_tap_deposit',
-  earn_pool_info_safety_details = 'earn_pool_info_safety_details',
+  earn_pool_info_tap_safety_details = 'earn_pool_info_tap_safety_details',
 }

--- a/src/analytics/Events.tsx
+++ b/src/analytics/Events.tsx
@@ -682,4 +682,5 @@ export enum EarnEvents {
   earn_pool_info_tap_info_icon = 'earn_pool_info_tap_info_icon',
   earn_pool_info_tap_withdraw = 'earn_pool_info_tap_withdraw',
   earn_pool_info_tap_deposit = 'earn_pool_info_tap_deposit',
+  earn_pool_info_safety_details = 'earn_pool_info_safety_details',
 }

--- a/src/analytics/Properties.tsx
+++ b/src/analytics/Properties.tsx
@@ -1631,6 +1631,9 @@ interface EarnEventsProperties {
     hasTokensOnSameNetwork: boolean
     hasTokensOnOtherNetworks: boolean
   }
+  [EarnEvents.earn_pool_info_safety_details]: EarnCommonProperties & {
+    action: 'expand' | 'collapse'
+  }
 }
 
 export type AnalyticsPropertiesList = AppEventsProperties &

--- a/src/analytics/Properties.tsx
+++ b/src/analytics/Properties.tsx
@@ -1631,7 +1631,7 @@ interface EarnEventsProperties {
     hasTokensOnSameNetwork: boolean
     hasTokensOnOtherNetworks: boolean
   }
-  [EarnEvents.earn_pool_info_safety_details]: EarnCommonProperties & {
+  [EarnEvents.earn_pool_info_tap_safety_details]: EarnCommonProperties & {
     action: 'expand' | 'collapse'
   }
 }

--- a/src/analytics/docs.ts
+++ b/src/analytics/docs.ts
@@ -609,6 +609,7 @@ export const eventDocs: Record<AnalyticsEventType, string> = {
   [EarnEvents.earn_pool_info_tap_info_icon]: `When the user taps an info icon on the earn pool info screen`,
   [EarnEvents.earn_pool_info_tap_withdraw]: `When the user taps the withdraw button on the pool info screen`,
   [EarnEvents.earn_pool_info_tap_deposit]: `When the user taps the deposit button on the pool info screen`,
+  [EarnEvents.earn_pool_info_safety_details]: `When the user taps the view more/less details on the safety card on the pool info screen`,
 
   // Legacy event docs
   //  The below events had docs, but are no longer produced by the latest app version.

--- a/src/analytics/docs.ts
+++ b/src/analytics/docs.ts
@@ -609,7 +609,7 @@ export const eventDocs: Record<AnalyticsEventType, string> = {
   [EarnEvents.earn_pool_info_tap_info_icon]: `When the user taps an info icon on the earn pool info screen`,
   [EarnEvents.earn_pool_info_tap_withdraw]: `When the user taps the withdraw button on the pool info screen`,
   [EarnEvents.earn_pool_info_tap_deposit]: `When the user taps the deposit button on the pool info screen`,
-  [EarnEvents.earn_pool_info_safety_details]: `When the user taps the view more/less details on the safety card on the pool info screen`,
+  [EarnEvents.earn_pool_info_tap_safety_details]: `When the user taps the view more/less details on the safety card on the pool info screen`,
 
   // Legacy event docs
   //  The below events had docs, but are no longer produced by the latest app version.

--- a/src/earn/EarnPoolInfoScreen.tsx
+++ b/src/earn/EarnPoolInfoScreen.tsx
@@ -8,6 +8,7 @@ import Animated, { useAnimatedScrollHandler, useSharedValue } from 'react-native
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context'
 import AppAnalytics from 'src/analytics/AppAnalytics'
 import { EarnEvents } from 'src/analytics/Events'
+import { EarnCommonProperties } from 'src/analytics/Properties'
 import { openUrl } from 'src/app/actions'
 import BottomSheet, { BottomSheetModalRefType } from 'src/components/BottomSheet'
 import Button, { BtnSizes, BtnTypes } from 'src/components/Button'
@@ -36,7 +37,6 @@ import variables from 'src/styles/variables'
 import { useTokenInfo, useTokensInfo } from 'src/tokens/hooks'
 import { tokensByIdSelector } from 'src/tokens/selectors'
 import { TokenBalance } from 'src/tokens/slice'
-import { NetworkId } from 'src/transactions/types'
 import { navigateToURI } from 'src/utils/linking'
 import { formattedDuration } from 'src/utils/time'
 
@@ -407,17 +407,11 @@ function AgeCard({ ageOfPool, onInfoIconPress }: { ageOfPool: Date; onInfoIconPr
 function LearnMoreTouchable({
   url,
   providerName,
-  appId,
-  positionId,
-  networkId,
-  depositTokenId,
+  commonAnalyticsProps,
 }: {
   url: string
   providerName: string
-  appId: string
-  positionId: string
-  networkId: NetworkId
-  depositTokenId: string
+  commonAnalyticsProps: EarnCommonProperties
 }) {
   const { t } = useTranslation()
   return (
@@ -425,12 +419,7 @@ function LearnMoreTouchable({
       <Touchable
         borderRadius={8}
         onPress={() => {
-          AppAnalytics.track(EarnEvents.earn_pool_info_view_pool, {
-            providerId: appId,
-            poolId: positionId,
-            networkId,
-            depositTokenId,
-          })
+          AppAnalytics.track(EarnEvents.earn_pool_info_view_pool, commonAnalyticsProps)
           navigateToURI(url)
         }}
       >
@@ -512,6 +501,13 @@ export default function EarnPoolInfoScreen({ route, navigation }: Props) {
     throw new Error(`Token ${dataProps.depositTokenId} not found`)
   }
 
+  const commonAnalyticsProps: EarnCommonProperties = {
+    providerId: appId,
+    poolId: positionId,
+    networkId,
+    depositTokenId: dataProps.depositTokenId,
+  }
+
   const {
     hasDepositToken,
     hasTokensOnSameNetwork,
@@ -522,10 +518,7 @@ export default function EarnPoolInfoScreen({ route, navigation }: Props) {
 
   const onPressDeposit = () => {
     AppAnalytics.track(EarnEvents.earn_pool_info_tap_deposit, {
-      poolId: positionId,
-      providerId: appId,
-      networkId: networkId,
-      depositTokenId: dataProps.depositTokenId,
+      ...commonAnalyticsProps,
       hasDepositToken,
       hasTokensOnSameNetwork,
       hasTokensOnOtherNetworks,
@@ -578,11 +571,8 @@ export default function EarnPoolInfoScreen({ route, navigation }: Props) {
               earnPosition={pool}
               onInfoIconPress={() => {
                 AppAnalytics.track(EarnEvents.earn_pool_info_tap_info_icon, {
-                  providerId: appId,
-                  poolId: positionId,
                   type: 'deposit',
-                  networkId,
-                  depositTokenId: dataProps.depositTokenId,
+                  ...commonAnalyticsProps,
                 })
                 depositInfoBottomSheetRef.current?.snapToIndex(0)
               }}
@@ -591,11 +581,8 @@ export default function EarnPoolInfoScreen({ route, navigation }: Props) {
           <YieldCard
             onInfoIconPress={() => {
               AppAnalytics.track(EarnEvents.earn_pool_info_tap_info_icon, {
-                providerId: appId,
-                poolId: positionId,
                 type: 'yieldRate',
-                networkId,
-                depositTokenId: dataProps.depositTokenId,
+                ...commonAnalyticsProps,
               })
               yieldRateInfoBottomSheetRef.current?.snapToIndex(0)
             }}
@@ -607,26 +594,22 @@ export default function EarnPoolInfoScreen({ route, navigation }: Props) {
               dailyYieldRate={dataProps.dailyYieldRatePercentage}
               onInfoIconPress={() => {
                 AppAnalytics.track(EarnEvents.earn_pool_info_tap_info_icon, {
-                  providerId: appId,
-                  poolId: positionId,
                   type: 'dailyYieldRate',
-                  networkId,
-                  depositTokenId: dataProps.depositTokenId,
+                  ...commonAnalyticsProps,
                 })
                 dailyYieldRateInfoBottomSheetRef.current?.snapToIndex(0)
               }}
             />
           )}
-          {!!dataProps.safety && <SafetyCard safety={dataProps.safety} />}
+          {!!dataProps.safety && (
+            <SafetyCard safety={dataProps.safety} commonAnalyticsProps={commonAnalyticsProps} />
+          )}
           <TvlCard
             earnPosition={pool}
             onInfoIconPress={() => {
               AppAnalytics.track(EarnEvents.earn_pool_info_tap_info_icon, {
-                providerId: appId,
-                poolId: positionId,
                 type: 'tvl',
-                networkId,
-                depositTokenId: dataProps.depositTokenId,
+                ...commonAnalyticsProps,
               })
               tvlInfoBottomSheetRef.current?.snapToIndex(0)
             }}
@@ -636,11 +619,8 @@ export default function EarnPoolInfoScreen({ route, navigation }: Props) {
               ageOfPool={new Date(dataProps.contractCreatedAt)}
               onInfoIconPress={() => {
                 AppAnalytics.track(EarnEvents.earn_pool_info_tap_info_icon, {
-                  providerId: appId,
-                  poolId: positionId,
                   type: 'age',
-                  networkId,
-                  depositTokenId: dataProps.depositTokenId,
+                  ...commonAnalyticsProps,
                 })
                 ageInfoBottomSheetRef.current?.snapToIndex(0)
               }}
@@ -650,10 +630,7 @@ export default function EarnPoolInfoScreen({ route, navigation }: Props) {
             <LearnMoreTouchable
               url={dataProps.manageUrl}
               providerName={appName}
-              appId={appId}
-              positionId={positionId}
-              networkId={networkId}
-              depositTokenId={dataProps.depositTokenId}
+              commonAnalyticsProps={commonAnalyticsProps}
             />
           ) : null}
         </View>

--- a/src/earn/SafetyCard.test.tsx
+++ b/src/earn/SafetyCard.test.tsx
@@ -83,7 +83,7 @@ describe('SafetyCard', () => {
     )
     expect(getAllByTestId('SafetyCard/Risk')[1]).toHaveTextContent('Risk 2')
     expect(getAllByTestId('SafetyCard/Risk')[1]).toHaveTextContent('Category 2')
-    expect(AppAnalytics.track).toHaveBeenCalledWith(EarnEvents.earn_pool_info_safety_details, {
+    expect(AppAnalytics.track).toHaveBeenCalledWith(EarnEvents.earn_pool_info_tap_safety_details, {
       action: 'expand',
       ...mockAnalyticsProps,
     })
@@ -95,7 +95,7 @@ describe('SafetyCard', () => {
     expect(getByTestId('SafetyCard/ViewDetails')).toHaveTextContent(
       'earnFlow.poolInfoScreen.viewMoreDetails'
     )
-    expect(AppAnalytics.track).toHaveBeenCalledWith(EarnEvents.earn_pool_info_safety_details, {
+    expect(AppAnalytics.track).toHaveBeenCalledWith(EarnEvents.earn_pool_info_tap_safety_details, {
       action: 'collapse',
       ...mockAnalyticsProps,
     })

--- a/src/earn/SafetyCard.test.tsx
+++ b/src/earn/SafetyCard.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react-native'
+import { fireEvent, render } from '@testing-library/react-native'
 import React from 'react'
 import { SafetyCard } from 'src/earn/SafetyCard'
 import Colors from 'src/styles/colors'
@@ -9,10 +9,13 @@ describe('SafetyCard', () => {
       <SafetyCard safety={{ level: 'low', risks: [] }} />
     )
 
-    expect(getByTestId('SafetyCard')).toBeDefined()
-    expect(getByTestId('SafetyCardInfoIcon')).toBeDefined()
+    expect(getByTestId('SafetyCard')).toBeTruthy()
+    expect(getByTestId('SafetyCardInfoIcon')).toBeTruthy()
     expect(getAllByTestId('SafetyCard/Bar')).toHaveLength(3)
-    expect(getByTestId('SafetyCard/ViewDetails')).toBeDefined()
+    expect(getByTestId('SafetyCard/ViewDetails')).toBeTruthy()
+    expect(getByTestId('SafetyCard/ViewDetails')).toHaveTextContent(
+      'earnFlow.poolInfoScreen.viewMoreDetails'
+    )
   })
 
   it.each([
@@ -23,9 +26,52 @@ describe('SafetyCard', () => {
     const { getAllByTestId } = render(<SafetyCard safety={{ level, risks: [] }} />)
 
     const bars = getAllByTestId('SafetyCard/Bar')
-    expect(bars.length).toBe(3)
+    expect(bars).toHaveLength(3)
     expect(bars[0]).toHaveStyle({ backgroundColor: colors[0] })
     expect(bars[1]).toHaveStyle({ backgroundColor: colors[1] })
     expect(bars[2]).toHaveStyle({ backgroundColor: colors[2] })
+  })
+
+  it('expands and collapses card and displays risks when View More/Less Details is pressed', () => {
+    const { getByTestId, getAllByTestId, queryByTestId } = render(
+      <SafetyCard
+        safety={{
+          level: 'low',
+          risks: [
+            { title: 'Risk 1', category: 'Category 1', isPositive: true },
+            { title: 'Risk 2', category: 'Category 2', isPositive: false },
+          ],
+        }}
+      />
+    )
+
+    expect(queryByTestId('SafetyCard/Risk')).toBeFalsy()
+    expect(getByTestId('SafetyCard/ViewDetails')).toHaveTextContent(
+      'earnFlow.poolInfoScreen.viewMoreDetails'
+    )
+
+    // expand
+    fireEvent.press(getByTestId('SafetyCard/ViewDetails'))
+    expect(getAllByTestId('SafetyCard/Risk')).toHaveLength(2)
+    expect(getByTestId('SafetyCard/ViewDetails')).toHaveTextContent(
+      'earnFlow.poolInfoScreen.viewLessDetails'
+    )
+    expect(getAllByTestId('SafetyCard/Risk')[0].children[0]).toContainElement(
+      getByTestId('SafetyCard/RiskPositive')
+    )
+    expect(getAllByTestId('SafetyCard/Risk')[0]).toHaveTextContent('Risk 1')
+    expect(getAllByTestId('SafetyCard/Risk')[0]).toHaveTextContent('Category 1')
+    expect(getAllByTestId('SafetyCard/Risk')[1].children[0]).toContainElement(
+      getByTestId('SafetyCard/RiskNegative')
+    )
+    expect(getAllByTestId('SafetyCard/Risk')[1]).toHaveTextContent('Risk 2')
+    expect(getAllByTestId('SafetyCard/Risk')[1]).toHaveTextContent('Category 2')
+
+    // collapse
+    fireEvent.press(getByTestId('SafetyCard/ViewDetails'))
+    expect(queryByTestId('SafetyCard/Risk')).toBeFalsy()
+    expect(getByTestId('SafetyCard/ViewDetails')).toHaveTextContent(
+      'earnFlow.poolInfoScreen.viewMoreDetails'
+    )
   })
 })

--- a/src/earn/SafetyCard.tsx
+++ b/src/earn/SafetyCard.tsx
@@ -1,6 +1,9 @@
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 import { StyleSheet, Text, View } from 'react-native'
+import AppAnalytics from 'src/analytics/AppAnalytics'
+import { EarnEvents } from 'src/analytics/Events'
+import { EarnCommonProperties } from 'src/analytics/Properties'
 import { LabelWithInfo } from 'src/components/LabelWithInfo'
 import Touchable from 'src/components/Touchable'
 import DataDown from 'src/icons/DataDown'
@@ -36,7 +39,13 @@ function Risk({ risk }: { risk: SafetyRisk }) {
   )
 }
 
-export function SafetyCard({ safety }: { safety: Safety }) {
+export function SafetyCard({
+  safety,
+  commonAnalyticsProps,
+}: {
+  safety: Safety
+  commonAnalyticsProps: EarnCommonProperties
+}) {
   const { t } = useTranslation()
   const [expanded, setExpanded] = React.useState(false)
   return (
@@ -78,6 +87,10 @@ export function SafetyCard({ safety }: { safety: Safety }) {
         style={styles.cardLineContainer}
         onPress={() => {
           setExpanded((prev) => !prev)
+          AppAnalytics.track(EarnEvents.earn_pool_info_safety_details, {
+            action: expanded ? 'collapse' : 'expand',
+            ...commonAnalyticsProps,
+          })
         }}
       >
         <Text style={styles.viewDetailsText}>

--- a/src/earn/SafetyCard.tsx
+++ b/src/earn/SafetyCard.tsx
@@ -31,7 +31,7 @@ function Risk({ risk }: { risk: SafetyRisk }) {
           <DataDown color={Colors.error} testID="SafetyCard/RiskNegative" />
         )}
       </View>
-      <View>
+      <View style={styles.riskTextContainer}>
         <Text style={styles.riskTitle}>{risk.title}</Text>
         <Text style={styles.riskCategory}>{risk.category}</Text>
       </View>
@@ -87,7 +87,7 @@ export function SafetyCard({
         style={styles.cardLineContainer}
         onPress={() => {
           setExpanded((prev) => !prev)
-          AppAnalytics.track(EarnEvents.earn_pool_info_safety_details, {
+          AppAnalytics.track(EarnEvents.earn_pool_info_tap_safety_details, {
             action: expanded ? 'collapse' : 'expand',
             ...commonAnalyticsProps,
           })
@@ -150,6 +150,9 @@ const styles = StyleSheet.create({
   riskContainer: {
     flexDirection: 'row',
     gap: Spacing.Smallest8,
+  },
+  riskTextContainer: {
+    flex: 1,
   },
   icon: {
     width: 24,

--- a/src/earn/SafetyCard.tsx
+++ b/src/earn/SafetyCard.tsx
@@ -3,7 +3,9 @@ import { useTranslation } from 'react-i18next'
 import { StyleSheet, Text, View } from 'react-native'
 import { LabelWithInfo } from 'src/components/LabelWithInfo'
 import Touchable from 'src/components/Touchable'
-import { Safety } from 'src/positions/types'
+import DataDown from 'src/icons/DataDown'
+import DataUp from 'src/icons/DataUp'
+import { Safety, SafetyRisk } from 'src/positions/types'
 import Colors from 'src/styles/colors'
 import { typeScale } from 'src/styles/fonts'
 import { Spacing } from 'src/styles/styles'
@@ -16,8 +18,27 @@ const LEVEL_TO_MAX_HIGHLIGHTED_BAR: Record<Safety['level'], 1 | 2 | 3> = {
   high: 3,
 }
 
+function Risk({ risk }: { risk: SafetyRisk }) {
+  return (
+    <View style={styles.riskContainer} testID="SafetyCard/Risk">
+      <View style={styles.icon}>
+        {risk.isPositive ? (
+          <DataUp color={Colors.primary} testID="SafetyCard/RiskPositive" />
+        ) : (
+          <DataDown color={Colors.error} testID="SafetyCard/RiskNegative" />
+        )}
+      </View>
+      <View>
+        <Text style={styles.riskTitle}>{risk.title}</Text>
+        <Text style={styles.riskCategory}>{risk.category}</Text>
+      </View>
+    </View>
+  )
+}
+
 export function SafetyCard({ safety }: { safety: Safety }) {
   const { t } = useTranslation()
+  const [expanded, setExpanded] = React.useState(false)
   return (
     <View style={styles.card} testID="SafetyCard">
       <View style={styles.cardLineContainer}>
@@ -45,14 +66,25 @@ export function SafetyCard({ safety }: { safety: Safety }) {
           ))}
         </View>
       </View>
+      {expanded && (
+        <View style={styles.risksContainer}>
+          {safety.risks.map((risk, index) => (
+            <Risk key={`risk-${index}`} risk={risk} />
+          ))}
+        </View>
+      )}
       <Touchable
         testID="SafetyCard/ViewDetails"
         style={styles.cardLineContainer}
         onPress={() => {
-          // todo(act-1405): expand and display risks
+          setExpanded((prev) => !prev)
         }}
       >
-        <Text style={styles.viewDetailsText}>{t('earnFlow.poolInfoScreen.viewMoreDetails')}</Text>
+        <Text style={styles.viewDetailsText}>
+          {expanded
+            ? t('earnFlow.poolInfoScreen.viewLessDetails')
+            : t('earnFlow.poolInfoScreen.viewMoreDetails')}
+        </Text>
       </Touchable>
     </View>
   )
@@ -98,5 +130,26 @@ const styles = StyleSheet.create({
     color: Colors.gray3,
     textAlign: 'center',
     flex: 1,
+  },
+  risksContainer: {
+    gap: Spacing.Thick24,
+  },
+  riskContainer: {
+    flexDirection: 'row',
+    gap: Spacing.Smallest8,
+  },
+  icon: {
+    width: 24,
+    height: 24,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  riskTitle: {
+    ...typeScale.labelMedium,
+    color: Colors.black,
+  },
+  riskCategory: {
+    ...typeScale.bodySmall,
+    color: Colors.gray3,
   },
 })

--- a/src/positions/types.ts
+++ b/src/positions/types.ts
@@ -25,7 +25,7 @@ export interface EarningItem {
   includedInPoolBalance?: boolean
 }
 
-interface SafetyRisk {
+export interface SafetyRisk {
   isPositive: boolean
   title: string
   category: string


### PR DESCRIPTION
### Description

Implement expandable container to show / hide risks in safety card

### Test plan


https://github.com/user-attachments/assets/97c55657-9980-4150-83a2-ab1ff2b4a334



### Related issues

- Part of ACT-1405

### Backwards compatibility

Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
