### PR TITLE
chore(e2e): upload artifacts if an Android workflow was cancelled

### DIFF
--- a/.github/workflows/e2e-android.yml
+++ b/.github/workflows/e2e-android.yml
@@ -101,7 +101,7 @@ jobs:
           check_name: Android (${{ inputs.android-api-level }}) e2e Test Report
           report_paths: 'e2e/test-results/junit.xml'
       - name: 'Upload Android E2E Artifacts'
-        if: failure()
+        if: failure() || cancelled()
         uses: actions/upload-artifact@v4
         with:
           name: android-${{ inputs.android-api-level }}-e2e-artifact


### PR DESCRIPTION
### Description

Upload E2E test artifacts if an Android test was cancelled (e.g. due to timeout) for better visibility for debugging

### Test plan

CI

### Related issues

NA

### Backwards compatibility

NA

### Network scalability

NA