### PR TITLE
fix(discover): misc android ripple bounds

### DIFF
--- a/src/dappsExplorer/DappFeaturedActions.tsx
+++ b/src/dappsExplorer/DappFeaturedActions.tsx
@@ -85,11 +85,12 @@ export function DappFeaturedActions() {
 const styles = StyleSheet.create({
   container: {
     marginHorizontal: -Spacing.Thick24,
-    marginTop: Spacing.Smallest8,
-    marginBottom: Spacing.Thick24,
+    paddingTop: Spacing.Smallest8,
+    paddingBottom: Spacing.Thick24,
   },
   contentContainer: {
     paddingHorizontal: Spacing.Thick24,
+    gap: Spacing.Regular16,
   },
   pressableCard: {
     padding: Spacing.Regular16,
@@ -108,7 +109,6 @@ const styles = StyleSheet.create({
   },
   reducedWidthCard: {
     width: variables.width - Spacing.Thick24 * 4,
-    marginRight: Spacing.Regular16,
   },
   title: {
     ...typeScale.labelSemiBoldMedium,

--- a/src/dappsExplorer/DappFeaturedActions.tsx
+++ b/src/dappsExplorer/DappFeaturedActions.tsx
@@ -25,7 +25,12 @@ interface Props {
 
 function FeaturedAction({ title, description, Image, style, onPress }: Props) {
   return (
-    <Touchable style={[styles.pressableCard, style]} onPress={onPress} testID="DappFeaturedAction">
+    <Touchable
+      style={[styles.pressableCard, style]}
+      onPress={onPress}
+      testID="DappFeaturedAction"
+      borderRadius={8}
+    >
       <View style={styles.cardContainer}>
         {Image}
         <View style={styles.cardContentContainer}>
@@ -80,6 +85,8 @@ export function DappFeaturedActions() {
 const styles = StyleSheet.create({
   container: {
     marginHorizontal: -Spacing.Thick24,
+    marginTop: Spacing.Smallest8,
+    marginBottom: Spacing.Thick24,
   },
   contentContainer: {
     paddingHorizontal: Spacing.Thick24,
@@ -87,8 +94,6 @@ const styles = StyleSheet.create({
   pressableCard: {
     padding: Spacing.Regular16,
     borderRadius: 8,
-    marginTop: Spacing.Smallest8,
-    marginBottom: Spacing.Thick24,
     borderWidth: 1,
     borderColor: Colors.gray2,
     width: variables.width - Spacing.Thick24 * 2,

--- a/src/earn/EarnActivePools.tsx
+++ b/src/earn/EarnActivePools.tsx
@@ -52,6 +52,7 @@ export default function EarnActivePools() {
 
   return (
     <Touchable
+      shouldRenderRippleAbove
       style={styles.card}
       borderRadius={Spacing.Smallest8}
       testID="EarnActivePools"
@@ -81,6 +82,7 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderRadius: Spacing.Smallest8,
     marginBottom: Spacing.Thick24,
+    overflow: 'hidden',
   },
   title: {
     ...typeScale.labelSemiBoldMedium,

--- a/src/earn/poolInfoScreen/EarnPoolInfoScreen.tsx
+++ b/src/earn/poolInfoScreen/EarnPoolInfoScreen.tsx
@@ -546,7 +546,7 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'center',
-    marginBottom: Spacing.Thick24,
+    padding: variables.contentPadding,
   },
   learnMoreText: {
     ...typeScale.labelSemiBoldSmall,

--- a/src/earn/poolInfoScreen/EarnPoolInfoScreen.tsx
+++ b/src/earn/poolInfoScreen/EarnPoolInfoScreen.tsx
@@ -546,7 +546,7 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'center',
-    padding: variables.contentPadding,
+    padding: Spacing.Thick24,
   },
   learnMoreText: {
     ...typeScale.labelSemiBoldSmall,


### PR DESCRIPTION
### Description

Adjust the ripple for three components on Android:
- Learn more Link in Earn Pool Info Screen
- Reward Card on Discover
- Active Pools Card on Discover

#### Learn More

| Learn More Before (Android) | Learn More After (Android) |
| ----- | ----- |
| ![](https://github.com/user-attachments/assets/a186e0ea-277a-43d4-a658-2cc69522519e) | ![](https://github.com/user-attachments/assets/bf376070-3430-4017-8561-10e6b6dc8034) | 

#### Reward Card
| Reward Card Before (Android) | Reward Card After (Android) |
| ----- | ----- |
| ![](https://github.com/user-attachments/assets/ad22fca5-5957-44e2-a669-c992afe35589) | ![](https://github.com/user-attachments/assets/24d54390-6942-4068-b8b9-71302d683cd9) |

#### Active Pools Card
| Active Pools Before (Android) | Active Pools After (Android) | 
| ----- | ----- |
| ![Screenshot 2024-10-21 at 12 04 00 PM](https://github.com/user-attachments/assets/4b5fe574-801e-478e-ae35-27301447afa4) | ![](https://github.com/user-attachments/assets/b97160d2-a89c-4a1d-8303-257e68fc66ff) |

### Test plan

- [x] Tested locally on Android
- [x] Tested locally on iOS

### Related issues

N/A

### Backwards compatibility

Yes

### Network scalability

N/A
