### PR TITLE
feat: add feature gate for zerion transaction feed

### DIFF
--- a/src/home/TabHome.tsx
+++ b/src/home/TabHome.tsx
@@ -26,8 +26,11 @@ import { StackParamList } from 'src/navigator/types'
 import { phoneRecipientCacheSelector } from 'src/recipients/reducer'
 import { useDispatch, useSelector } from 'src/redux/hooks'
 import { initializeSentryUserContext } from 'src/sentry/actions'
+import { getFeatureGate } from 'src/statsig'
+import { StatsigFeatureGates } from 'src/statsig/types'
 import colors from 'src/styles/colors'
 import TransactionFeed from 'src/transactions/feed/TransactionFeed'
+import TransactionFeedV2 from 'src/transactions/feed/TransactionFeedV2'
 import { hasGrantedContactsPermission } from 'src/utils/contacts'
 
 const AnimatedFlatList = Animated.createAnimatedComponent(FlatList)
@@ -52,6 +55,8 @@ function TabHome(_props: Props) {
   const showNftCelebration = canShowNftCelebration && isFocused && !showNotificationSpotlight
   const canShowNftReward = useSelector(showNftRewardSelector)
   const showNftReward = canShowNftReward && isFocused && !showNotificationSpotlight
+
+  const showZerionTransactionFeed = getFeatureGate(StatsigFeatureGates.SHOW_ZERION_TRANSACTION_FEED)
 
   useEffect(() => {
     dispatch(visitHome())
@@ -120,7 +125,10 @@ function TabHome(_props: Props) {
       key: 'NotificationBox',
       component: <NotificationBox showOnlyHomeScreenNotifications={true} />,
     },
-    { key: 'TransactionFeed', component: <TransactionFeed /> },
+    {
+      key: 'TransactionFeed',
+      component: showZerionTransactionFeed ? <TransactionFeedV2 /> : <TransactionFeed />,
+    },
   ]
 
   const renderItem = ({ item }: { item: any }) => item.component

--- a/src/statsig/types.ts
+++ b/src/statsig/types.ts
@@ -40,6 +40,7 @@ export enum StatsigFeatureGates {
   SHOW_SWAP_AND_DEPOSIT = 'show_swap_and_deposit',
   SHOW_UK_COMPLIANT_VARIANT = 'show_uk_compliant_variant',
   ALLOW_EARN_PARTIAL_WITHDRAWAL = 'allow_earn_partial_withdrawal',
+  SHOW_ZERION_TRANSACTION_FEED = 'show_zerion_transaction_feed',
 }
 
 export enum StatsigExperiments {


### PR DESCRIPTION
### Description

As the title.

While updating the TabHome tests, I noticed every test was throwing an act warning (below) so this PR also updates the tests to remove the errors.
```
Warning: An update to TransactionFeed inside a test was not wrapped in act(...).
    
    When testing, code that causes React state updates should be wrapped into act(...):
    
    act(() => {
      /* fire events that update state */
    });
    /* assert on the output */
```

### Test plan

Tested via unit tests and manually.

### Related issues

n/a

### Backwards compatibility

Y

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [ ] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
