### PR TITLE
chore(TransactionFeedV2): Merge old stand by transactions that are out of scope of pagination

### DIFF
--- a/src/transactions/feed/TransactionFeedV2.test.tsx
+++ b/src/transactions/feed/TransactionFeedV2.test.tsx
@@ -592,4 +592,53 @@ describe('TransactionFeedV2', () => {
     expect(tree.getByTestId('TransactionList').props.data[0].data.length).toBe(1)
     expect(mockFetch).not.toBeCalled()
   })
+
+  it('should merge the rest of stand by transactions after the last page', async () => {
+    mockFetch.mockResponse(
+      typedResponse({
+        transactions: [
+          mockTransaction({ transactionHash: '0x100', timestamp: 100 }),
+          mockTransaction({ transactionHash: '0x90', timestamp: 90 }),
+          mockTransaction({ transactionHash: '0x80', timestamp: 80 }),
+        ],
+        pageInfo: {
+          startCursor: '1',
+          endCursor: '',
+          hasPreviousPage: false,
+          hasNextPage: false,
+        },
+      })
+    )
+
+    const tree = renderScreen({
+      transactions: {
+        standbyTransactions: [
+          mockTransaction({ transactionHash: '0x95', timestamp: 95 }),
+          mockTransaction({ transactionHash: '0x85', timestamp: 85 }),
+          mockTransaction({ transactionHash: '0x30', timestamp: 30 }),
+          mockTransaction({ transactionHash: '0x20', timestamp: 20 }),
+          mockTransaction({ transactionHash: '0x10', timestamp: 10 }),
+        ],
+      },
+    })
+
+    await waitFor(() => {
+      expect(tree.getByTestId('TransactionList')).toBeVisible()
+
+      const hashes = tree
+        .getByTestId('TransactionList')
+        .props.data[0].data.map((item: TokenTransaction) => item.transactionHash)
+
+      expect(hashes).toStrictEqual([
+        '0x100',
+        '0x95',
+        '0x90',
+        '0x85',
+        '0x80',
+        '0x30',
+        '0x20',
+        '0x10',
+      ])
+    })
+  })
 })

--- a/src/transactions/feed/TransactionFeedV2.test.tsx
+++ b/src/transactions/feed/TransactionFeedV2.test.tsx
@@ -622,23 +622,11 @@ describe('TransactionFeedV2', () => {
       },
     })
 
-    await waitFor(() => {
-      expect(tree.getByTestId('TransactionList')).toBeVisible()
+    await waitFor(() => expect(tree.getByTestId('TransactionList')).toBeVisible())
 
-      const hashes = tree
-        .getByTestId('TransactionList')
-        .props.data[0].data.map((item: TokenTransaction) => item.transactionHash)
-
-      expect(hashes).toStrictEqual([
-        '0x100',
-        '0x95',
-        '0x90',
-        '0x85',
-        '0x80',
-        '0x30',
-        '0x20',
-        '0x10',
-      ])
-    })
+    const hashes = tree
+      .getByTestId('TransactionList')
+      .props.data[0].data.map((item: TokenTransaction) => item.transactionHash)
+    expect(hashes).toStrictEqual(['0x100', '0x95', '0x90', '0x85', '0x80', '0x30', '0x20', '0x10'])
   })
 })

--- a/src/transactions/feed/TransactionFeedV2.tsx
+++ b/src/transactions/feed/TransactionFeedV2.tsx
@@ -171,10 +171,12 @@ function mergeStandByTransactionsInRange({
   transactions,
   standByTransactions,
   currentCursor,
+  isLastPage,
 }: {
   transactions: TokenTransaction[]
   standByTransactions: TokenTransaction[]
-  currentCursor?: keyof PaginatedData
+  currentCursor: keyof PaginatedData
+  isLastPage: boolean
 }): TokenTransaction[] {
   /**
    * If the data from the first page is empty - there's no successful transactions in the wallet.
@@ -199,7 +201,8 @@ function mergeStandByTransactionsInRange({
   const standByInRange = standByTransactions.filter((tx) => {
     const inRange = tx.timestamp >= min && tx.timestamp <= max
     const newTransaction = isFirstPage && tx.timestamp > max
-    return inRange || newTransaction
+    const veryOldTransaction = isLastPage && tx.timestamp < min
+    return inRange || newTransaction || veryOldTransaction
   })
   const deduplicatedTransactions = deduplicateTransactions([...transactions, ...standByInRange])
   const transactionsFromAllowedNetworks = deduplicatedTransactions.filter((tx) =>
@@ -360,7 +363,8 @@ export default function TransactionFeedV2() {
     function updatePaginatedData() {
       if (isFetching || !data) return
 
-      const currentCursor = data?.pageInfo.hasPreviousPage
+      const isLastPage = !data.pageInfo.hasNextPage
+      const currentCursor = data.pageInfo.hasPreviousPage
         ? data.pageInfo.startCursor
         : FIRST_PAGE_CURSOR
 
@@ -373,9 +377,10 @@ export default function TransactionFeedV2() {
 
         if (isFirstPage || pageDataIsAbsent) {
           const mergedTransactions = mergeStandByTransactionsInRange({
-            transactions: data?.transactions || [],
+            transactions: data.transactions,
             standByTransactions: standByTransactions.confirmed,
             currentCursor,
+            isLastPage,
           })
 
           return { ...prev, [currentCursor!]: mergedTransactions }


### PR DESCRIPTION
### Description
This PR fixes the merging process of pagination data with stand by transactions. Previously, there were still some stand by transactions that didn't get merged, specifically those that are older than the last transaction from pagination. This PR fixes that by merging all the stand by transactions that are "out of scope" of pagination at the very end of the feed.

### Test plan
Added test that checks proper merging for old stand by transactions

### Related issues

- Relates to RET-1207

### Backwards compatibility
Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
