### PR TITLE
refactor: remove usage of `__typename` for the tx feed

### DIFF
--- a/src/analytics/Properties.tsx
+++ b/src/analytics/Properties.tsx
@@ -1614,7 +1614,11 @@ interface EarnEventsProperties {
   } & EarnCommonProperties
   [EarnEvents.earn_deposit_add_gas_press]: EarnCommonProperties & { gasTokenId: string }
   [EarnEvents.earn_feed_item_select]: {
-    origin: 'EarnDeposit' | 'EarnWithdraw' | 'EarnClaimReward' | 'EarnSwapDeposit'
+    origin:
+      | TokenTransactionTypeV2.EarnDeposit
+      | TokenTransactionTypeV2.EarnWithdraw
+      | TokenTransactionTypeV2.EarnClaimReward
+      | TokenTransactionTypeV2.EarnSwapDeposit
   }
   [EarnEvents.earn_collect_earnings_press]: EarnWithdrawProperties
   [EarnEvents.earn_withdraw_submit_start]: EarnWithdrawProperties

--- a/src/earn/saga.test.ts
+++ b/src/earn/saga.test.ts
@@ -147,7 +147,6 @@ describe('depositSubmitSaga', () => {
   }
 
   const expectedApproveStandbyTx = {
-    __typename: 'TokenApproval',
     context: {
       id: 'id-earn/saga-Earn/Approve',
       tag: 'earn/saga',
@@ -162,7 +161,6 @@ describe('depositSubmitSaga', () => {
   }
 
   const expectedDepositStandbyTx = {
-    __typename: 'EarnDeposit',
     context: {
       id: 'id-earn/saga-Earn/Deposit',
       tag: 'earn/saga',
@@ -184,7 +182,6 @@ describe('depositSubmitSaga', () => {
   }
 
   const expectedSwapDepositStandbyTx = {
-    __typename: 'EarnSwapDeposit',
     context: {
       id: 'id-earn/saga-Earn/SwapDeposit',
       tag: 'earn/saga',
@@ -734,7 +731,6 @@ describe('withdrawSubmitSaga', () => {
   }
 
   const expectedWithdrawStandbyTx = {
-    __typename: 'EarnWithdraw',
     context: {
       id: 'id-earn/saga-Earn/Withdraw',
       tag: 'earn/saga',
@@ -757,7 +753,6 @@ describe('withdrawSubmitSaga', () => {
 
   // TODO: replace with EarnClaimReward type
   const expectedClaimRewardTx = {
-    __typename: 'EarnClaimReward',
     context: {
       id: 'id-earn/saga-Earn/ClaimReward-1',
       tag: 'earn/saga',

--- a/src/earn/saga.ts
+++ b/src/earn/saga.ts
@@ -152,7 +152,6 @@ export function* depositSubmitSaga(action: PayloadAction<DepositInfo>) {
           ): BaseStandbyTransaction => {
             return {
               context: newTransactionContext(TAG, 'Earn/Approve'),
-              __typename: 'TokenApproval',
               networkId,
               type: TokenTransactionTypeV2.Approval,
               transactionHash,
@@ -177,7 +176,6 @@ export function* depositSubmitSaga(action: PayloadAction<DepositInfo>) {
       ): BaseStandbyTransaction => {
         return {
           context: newTransactionContext(TAG, 'Earn/Deposit'),
-          __typename: 'EarnDeposit',
           networkId,
           type: TokenTransactionTypeV2.EarnDeposit,
           inAmount: {
@@ -199,7 +197,6 @@ export function* depositSubmitSaga(action: PayloadAction<DepositInfo>) {
       ): BaseStandbyTransaction => {
         return {
           context: newTransactionContext(TAG, 'Earn/SwapDeposit'),
-          __typename: 'EarnSwapDeposit',
           networkId,
           type: TokenTransactionTypeV2.EarnSwapDeposit,
           swap: {
@@ -352,7 +349,6 @@ export function* withdrawSubmitSaga(action: PayloadAction<WithdrawInfo>) {
     ): BaseStandbyTransaction => {
       return {
         context: newTransactionContext(TAG, 'Earn/Withdraw'),
-        __typename: 'EarnWithdraw',
         networkId,
         type: TokenTransactionTypeV2.EarnWithdraw,
         inAmount: {
@@ -378,7 +374,6 @@ export function* withdrawSubmitSaga(action: PayloadAction<WithdrawInfo>) {
       ): BaseStandbyTransaction => {
         return {
           context: newTransactionContext(TAG, `Earn/ClaimReward-${index + 1}`),
-          __typename: 'EarnClaimReward',
           networkId,
           amount: {
             value: balance,

--- a/src/fiatExchanges/saga.test.ts
+++ b/src/fiatExchanges/saga.test.ts
@@ -225,7 +225,6 @@ describe(tagTxsWithProviderInfo, () => {
   const mockProviderAccount = '0x30d5ca2a263e0c0d11e7a668ccf30b38f1482251'
 
   const mockTransactionDetails = {
-    __typename: 'TokenTransferV3' as const,
     amount: mockAmount,
     timestamp: 1578530602,
     address: mockAccount,

--- a/src/fiatExchanges/saga.ts
+++ b/src/fiatExchanges/saga.ts
@@ -142,7 +142,7 @@ export function* tagTxsWithProviderInfo(action: UpdateTransactionsPayload) {
     const txHashesToProvider = yield* call(fetchTxHashesToProviderMapping)
 
     for (const tx of transactions) {
-      if (tx.__typename !== 'TokenTransferV3' || tx.type !== TokenTransactionTypeV2.Received) {
+      if (tx.type !== TokenTransactionTypeV2.Received) {
         continue
       }
 

--- a/src/fiatconnect/saga.ts
+++ b/src/fiatconnect/saga.ts
@@ -965,7 +965,6 @@ export function* _initiateSendTxToProvider({
     transactionHash: string,
     feeCurrencyId?: string
   ): BaseStandbyTransaction => ({
-    __typename: 'TokenTransferV3',
     type: TokenTransactionTypeV2.Sent,
     context,
     networkId: tokenInfo.networkId,

--- a/src/firebase/notifications.test.ts
+++ b/src/firebase/notifications.test.ts
@@ -124,7 +124,6 @@ describe(handleNotification, () => {
 
       expect(navigate).toHaveBeenCalledWith(Screens.TransactionDetailsScreen, {
         transaction: {
-          __typename: 'TokenTransferV3',
           networkId: NetworkId['celo-alfajores'],
           type: 'RECEIVED',
           transactionHash: '0xTXHASH',

--- a/src/firebase/notifications.ts
+++ b/src/firebase/notifications.ts
@@ -25,7 +25,6 @@ function handlePaymentReceived(transferNotification: TransferNotificationData) {
 
   navigate(Screens.TransactionDetailsScreen, {
     transaction: {
-      __typename: 'TokenTransferV3',
       networkId: networkConfig.defaultNetworkId,
       type: TokenTransactionTypeV2.Received,
       transactionHash: transferNotification.txHash,

--- a/src/jumpstart/JumpstartTransactionDetailsScreen.test.tsx
+++ b/src/jumpstart/JumpstartTransactionDetailsScreen.test.tsx
@@ -109,7 +109,7 @@ describe('JumpstartTransactionDetailsScreen', () => {
     fees = [],
     status = TransactionStatus.Complete,
   }: {
-    type: TokenTransactionTypeV2
+    type: TokenTransactionTypeV2.Sent | TokenTransactionTypeV2.Received
     address?: string
     amount?: TokenAmount
     metadata?: TokenTransferMetadata
@@ -117,7 +117,6 @@ describe('JumpstartTransactionDetailsScreen', () => {
     status?: TransactionStatus
   }): TokenTransfer {
     return {
-      __typename: 'TokenTransferV3',
       networkId: NetworkId['celo-alfajores'],
       type,
       transactionHash: mockTransactionHash,

--- a/src/jumpstart/saga.test.ts
+++ b/src/jumpstart/saga.test.ts
@@ -244,7 +244,6 @@ describe('dispatchPendingERC20Transactions', () => {
       )
       .put(
         addStandbyTransaction({
-          __typename: 'TokenTransferV3',
           type: TokenTransactionTypeV2.Received,
           context: { id: mockTransactionHash },
           transactionHash: mockTransactionHash,
@@ -305,7 +304,6 @@ describe('dispatchPendingERC721Transactions', () => {
       ])
       .put(
         addStandbyTransaction({
-          __typename: 'NftTransferV3',
           type: TokenTransactionTypeV2.NftReceived,
           context: { id: mockTransactionHash },
           transactionHash: mockTransactionHash,

--- a/src/jumpstart/saga.ts
+++ b/src/jumpstart/saga.ts
@@ -121,7 +121,6 @@ export function* dispatchPendingERC20Transactions(
 
       yield* put(
         addStandbyTransaction({
-          __typename: 'TokenTransferV3',
           type: TokenTransactionTypeV2.Received,
           context: {
             id: transactionHash,
@@ -175,7 +174,6 @@ export function* dispatchPendingERC721Transactions(
 
         yield* put(
           addStandbyTransaction({
-            __typename: 'NftTransferV3',
             type: TokenTransactionTypeV2.NftReceived,
             context: {
               id: transactionHash,
@@ -261,7 +259,6 @@ export function* sendJumpstartTransactions(
       ): BaseStandbyTransaction => {
         return {
           context: newTransactionContext(TAG, 'Approve jumpstart transaction'),
-          __typename: 'TokenApproval',
           networkId,
           type: TokenTransactionTypeV2.Approval,
           transactionHash: txHash,
@@ -277,7 +274,6 @@ export function* sendJumpstartTransactions(
       hash: string,
       feeCurrencyId?: string
     ): BaseStandbyTransaction => ({
-      __typename: 'TokenTransferV3',
       type: TokenTransactionTypeV2.Sent,
       context: newTransactionContext(TAG, 'Send jumpstart transaction'),
       networkId,
@@ -369,7 +365,6 @@ export function* jumpstartReclaim(action: PayloadAction<JumpstarReclaimAction>) 
     ): BaseStandbyTransaction => {
       return {
         context: newTransactionContext(TAG, 'Reclaim transaction'),
-        __typename: 'TokenTransferV3',
         networkId,
         type: TokenTransactionTypeV2.Received,
         transactionHash: transactionHash,

--- a/src/redux/migrations.ts
+++ b/src/redux/migrations.ts
@@ -1924,4 +1924,5 @@ export const migrations = {
       feedFirstPage: [],
     },
   }),
+  235: (state: any) => state,
 }

--- a/src/redux/store.test.ts
+++ b/src/redux/store.test.ts
@@ -115,7 +115,7 @@ describe('store state', () => {
       {
         "_persist": {
           "rehydrated": true,
-          "version": 234,
+          "version": 235,
         },
         "account": {
           "acceptedTerms": false,

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -24,7 +24,7 @@ const persistConfig: PersistConfig<ReducersRootState> = {
   key: 'root',
   // default is -1, increment as we make migrations
   // See https://github.com/valora-inc/wallet/tree/main/WALLET.md#redux-state-migration
-  version: 234,
+  version: 235,
   keyPrefix: `reduxStore-`, // the redux-persist default is `persist:` which doesn't work with some file systems.
   storage: FSStorage(),
   blacklist: [

--- a/src/send/saga.test.ts
+++ b/src/send/saga.test.ts
@@ -135,7 +135,6 @@ describe(sendPaymentSaga, () => {
         .call(getViemWallet, networkConfig.viemChain.celo, false)
         .put(
           addStandbyTransaction({
-            __typename: 'TokenTransferV3',
             context: { id: 'mock' },
             type: TokenTransactionTypeV2.Sent,
             networkId: NetworkId['celo-alfajores'],
@@ -176,7 +175,6 @@ describe(sendPaymentSaga, () => {
       .call(getViemWallet, networkConfig.viemChain.celo, false)
       .put(
         addStandbyTransaction({
-          __typename: 'TokenTransferV3',
           context: { id: 'mock' },
           type: TokenTransactionTypeV2.Sent,
           networkId: NetworkId['celo-alfajores'],

--- a/src/send/saga.ts
+++ b/src/send/saga.ts
@@ -67,7 +67,6 @@ export function* sendPaymentSaga({
       transactionHash: string,
       feeCurrencyId?: string
     ): BaseStandbyTransaction => ({
-      __typename: 'TokenTransferV3',
       type: TokenTransactionTypeV2.Sent,
       context,
       networkId: tokenInfo.networkId,

--- a/src/swap/saga.test.ts
+++ b/src/swap/saga.test.ts
@@ -403,7 +403,6 @@ describe(swapSubmitSaga, () => {
               tag: 'swap/saga',
               description: 'Swap/Approve',
             },
-            __typename: 'TokenApproval',
             networkId,
             type: TokenTransactionTypeV2.Approval,
             transactionHash: mockApproveTxReceipt.transactionHash,
@@ -419,7 +418,6 @@ describe(swapSubmitSaga, () => {
               tag: 'swap/saga',
               description: 'Swap/Execute',
             },
-            __typename: 'TokenExchangeV3',
             networkId,
             type: TokenTransactionTypeV2.SwapTransaction,
             inAmount: {
@@ -558,7 +556,6 @@ describe(swapSubmitSaga, () => {
             tag: 'swap/saga',
             description: 'Swap/Execute',
           },
-          __typename: 'TokenExchangeV3',
           networkId: NetworkId['celo-alfajores'],
           type: TokenTransactionTypeV2.SwapTransaction,
           inAmount: {
@@ -577,7 +574,7 @@ describe(swapSubmitSaga, () => {
         action: {
           type: actions.addStandbyTransaction.type,
           transaction: {
-            __typename: 'TokenApproval',
+            type: TokenTransactionTypeV2.Approval,
           },
         },
       })
@@ -601,7 +598,6 @@ describe(swapSubmitSaga, () => {
             tag: 'swap/saga',
             description: 'Swap/Approve',
           },
-          __typename: 'TokenApproval',
           networkId: NetworkId['celo-alfajores'],
           type: TokenTransactionTypeV2.Approval,
           transactionHash: mockApproveTxReceipt.transactionHash,
@@ -617,7 +613,6 @@ describe(swapSubmitSaga, () => {
             tag: 'swap/saga',
             description: 'Swap/Execute',
           },
-          __typename: 'TokenExchangeV3',
           networkId: NetworkId['celo-alfajores'],
           type: TokenTransactionTypeV2.SwapTransaction,
           inAmount: {
@@ -646,7 +641,6 @@ describe(swapSubmitSaga, () => {
             tag: 'swap/saga',
             description: 'Swap/Approve',
           },
-          __typename: 'TokenApproval',
           networkId: NetworkId['celo-alfajores'],
           type: TokenTransactionTypeV2.Approval,
           transactionHash: mockApproveTxReceipt.transactionHash,
@@ -662,7 +656,6 @@ describe(swapSubmitSaga, () => {
             tag: 'swap/saga',
             description: 'Swap/Execute',
           },
-          __typename: 'CrossChainTokenExchange',
           networkId: NetworkId['celo-alfajores'],
           type: TokenTransactionTypeV2.CrossChainSwapTransaction,
           inAmount: {

--- a/src/swap/saga.ts
+++ b/src/swap/saga.ts
@@ -207,7 +207,6 @@ export function* swapSubmitSaga(action: PayloadAction<SwapInfo>) {
         ): BaseStandbyTransaction => {
           return {
             context: swapApproveContext,
-            __typename: 'TokenApproval',
             networkId,
             type: TokenTransactionTypeV2.Approval,
             transactionHash,
@@ -225,7 +224,6 @@ export function* swapSubmitSaga(action: PayloadAction<SwapInfo>) {
       feeCurrencyId?: string
     ): BaseStandbyTransaction => ({
       context: swapExecuteContext,
-      __typename: swapType === 'same-chain' ? 'TokenExchangeV3' : 'CrossChainTokenExchange',
       networkId,
       type:
         swapType === 'same-chain'

--- a/src/transactions/feed/EarnFeedItem.test.tsx
+++ b/src/transactions/feed/EarnFeedItem.test.tsx
@@ -8,7 +8,7 @@ import { Screens } from 'src/navigator/Screens'
 import { getFeatureGate } from 'src/statsig'
 import { StatsigFeatureGates } from 'src/statsig/types'
 import EarnFeedItem from 'src/transactions/feed/EarnFeedItem'
-import { NetworkId } from 'src/transactions/types'
+import { NetworkId, TokenTransactionTypeV2 } from 'src/transactions/types'
 import { createMockStore } from 'test/utils'
 import {
   mockAaveArbUsdcAddress,
@@ -107,7 +107,7 @@ const store = createMockStore({
 
 describe.each([
   {
-    type: 'EarnWithdraw',
+    type: TokenTransactionTypeV2.EarnWithdraw,
     transaction: mockEarnWithdrawTransaction,
     expectedTitle: 'earnFlow.transactionFeed.earnWithdrawTitle',
     expectedSubTitle: 'earnFlow.transactionFeed.earnWithdrawSubtitle, {"providerName":"Aave"}',
@@ -115,7 +115,7 @@ describe.each([
     expectedTotalLocal: '₱1.33',
   },
   {
-    type: 'EarnDeposit',
+    type: TokenTransactionTypeV2.EarnDeposit,
     transaction: mockEarnDepositTransaction,
     expectedTitle: 'earnFlow.transactionFeed.earnDepositTitle',
     expectedSubTitle: 'earnFlow.transactionFeed.earnDepositSubtitle, {"providerName":"Aave"}',
@@ -123,7 +123,7 @@ describe.each([
     expectedTotalLocal: '₱13.30',
   },
   {
-    type: 'EarnSwapDeposit',
+    type: TokenTransactionTypeV2.EarnSwapDeposit,
     transaction: mockEarnSwapDeposit,
     expectedTitle: 'earnFlow.transactionFeed.earnDepositTitle',
     expectedSubTitle: 'earnFlow.transactionFeed.earnDepositSubtitle, {"providerName":"Aave"}',
@@ -131,7 +131,7 @@ describe.each([
     expectedTotalLocal: '₱13.30',
   },
   {
-    type: 'EarnClaimReward',
+    type: TokenTransactionTypeV2.EarnClaimReward,
     transaction: mockEarnClaimRewardTransaction,
     expectedTitle: 'earnFlow.transactionFeed.earnClaimTitle',
     expectedSubTitle: 'earnFlow.transactionFeed.earnClaimSubtitle, {"providerName":"Aave"}',

--- a/src/transactions/feed/EarnFeedItem.tsx
+++ b/src/transactions/feed/EarnFeedItem.tsx
@@ -14,7 +14,13 @@ import { typeScale } from 'src/styles/fonts'
 import { Spacing } from 'src/styles/styles'
 import variables from 'src/styles/variables'
 import TransactionFeedItemImage from 'src/transactions/feed/TransactionFeedItemImage'
-import { EarnClaimReward, EarnDeposit, EarnSwapDeposit, EarnWithdraw } from 'src/transactions/types'
+import {
+  EarnClaimReward,
+  EarnDeposit,
+  EarnSwapDeposit,
+  EarnWithdraw,
+  TokenTransactionTypeV2,
+} from 'src/transactions/types'
 
 interface DescriptionProps {
   transaction: EarnWithdraw | EarnDeposit | EarnClaimReward | EarnSwapDeposit
@@ -23,24 +29,24 @@ interface DescriptionProps {
 function Description({ transaction }: DescriptionProps) {
   const { t } = useTranslation()
   const providerName = useEarnPositionProviderName(
-    transaction.__typename === 'EarnSwapDeposit'
+    transaction.type === TokenTransactionTypeV2.EarnSwapDeposit
       ? transaction.deposit.providerId
       : transaction.providerId
   )
   let title
   let subtitle
 
-  switch (transaction.__typename) {
-    case 'EarnSwapDeposit':
-    case 'EarnDeposit':
+  switch (transaction.type) {
+    case TokenTransactionTypeV2.EarnSwapDeposit:
+    case TokenTransactionTypeV2.EarnDeposit:
       title = t('earnFlow.transactionFeed.earnDepositTitle')
       subtitle = t('earnFlow.transactionFeed.earnDepositSubtitle', { providerName })
       break
-    case 'EarnWithdraw':
+    case TokenTransactionTypeV2.EarnWithdraw:
       title = t('earnFlow.transactionFeed.earnWithdrawTitle')
       subtitle = t('earnFlow.transactionFeed.earnWithdrawSubtitle', { providerName })
       break
-    case 'EarnClaimReward':
+    case TokenTransactionTypeV2.EarnClaimReward:
       title = t('earnFlow.transactionFeed.earnClaimTitle')
       subtitle = t('earnFlow.transactionFeed.earnClaimSubtitle', { providerName })
       break
@@ -69,20 +75,20 @@ function AmountDisplay({ transaction, isLocal }: AmountDisplayProps) {
   let amountValue
   let tokenId
 
-  switch (transaction.__typename) {
-    case 'EarnDeposit':
+  switch (transaction.type) {
+    case TokenTransactionTypeV2.EarnDeposit:
       amountValue = new BigNumber(-transaction.outAmount.value)
       tokenId = transaction.outAmount.tokenId
       break
-    case 'EarnSwapDeposit':
+    case TokenTransactionTypeV2.EarnSwapDeposit:
       amountValue = new BigNumber(-transaction.deposit.outAmount.value)
       tokenId = transaction.deposit.outAmount.tokenId
       break
-    case 'EarnWithdraw':
+    case TokenTransactionTypeV2.EarnWithdraw:
       amountValue = new BigNumber(transaction.inAmount.value)
       tokenId = transaction.inAmount.tokenId
       break
-    case 'EarnClaimReward':
+    case TokenTransactionTypeV2.EarnClaimReward:
       amountValue = new BigNumber(transaction.amount.value)
       tokenId = transaction.amount.tokenId
       break
@@ -92,8 +98,8 @@ function AmountDisplay({ transaction, isLocal }: AmountDisplayProps) {
     ? styles.amountSubtitle
     : [
         styles.amountTitle,
-        transaction.__typename !== 'EarnDeposit' &&
-          transaction.__typename !== 'EarnSwapDeposit' && { color: Colors.primary },
+        transaction.type !== TokenTransactionTypeV2.EarnDeposit &&
+          transaction.type !== TokenTransactionTypeV2.EarnSwapDeposit && { color: Colors.primary },
       ]
 
   return (
@@ -105,7 +111,7 @@ function AmountDisplay({ transaction, isLocal }: AmountDisplayProps) {
       showExplicitPositiveSign={!isLocal}
       hideSign={!!isLocal}
       style={textStyle}
-      testID={`EarnFeedItem/${transaction.__typename}-amount-${isLocal ? 'local' : 'crypto'}`}
+      testID={`EarnFeedItem/${transaction.type}-amount-${isLocal ? 'local' : 'crypto'}`}
     />
   )
 }
@@ -132,14 +138,14 @@ export default function EarnFeedItem({ transaction }: Props) {
     <Touchable
       testID={`EarnFeedItem/${transaction.transactionHash}`}
       onPress={() => {
-        AppAnalytics.track(EarnEvents.earn_feed_item_select, { origin: transaction.__typename })
+        AppAnalytics.track(EarnEvents.earn_feed_item_select, { origin: transaction.type })
         navigate(Screens.TransactionDetailsScreen, { transaction })
       }}
     >
       <View style={styles.container}>
         <TransactionFeedItemImage
           status={transaction.status}
-          transactionType={transaction.__typename}
+          transactionType={transaction.type}
           networkId={transaction.networkId}
         />
         <Description transaction={transaction} />

--- a/src/transactions/feed/NftFeedItem.test.tsx
+++ b/src/transactions/feed/NftFeedItem.test.tsx
@@ -36,7 +36,7 @@ describe('NftFeedItem', () => {
     type = TokenTransactionTypeV2.NftReceived,
     fees = [],
   }: {
-    type?: TokenTransactionTypeV2
+    type?: TokenTransactionTypeV2.NftReceived | TokenTransactionTypeV2.NftSent
     fees?: Fee[]
     storeOverrides?: RecursivePartial<RootState>
   }) {
@@ -50,7 +50,6 @@ describe('NftFeedItem', () => {
       <Provider store={store}>
         <NftFeedItem
           transaction={{
-            __typename: 'NftTransferV3',
             networkId: NetworkId['celo-alfajores'],
             type,
             transactionHash: MOCK_TX_HASH,

--- a/src/transactions/feed/SwapFeedItem.test.tsx
+++ b/src/transactions/feed/SwapFeedItem.test.tsx
@@ -16,7 +16,6 @@ import { mockCeurTokenId, mockCusdTokenId, mockEthTokenId, mockTokenBalances } f
 const MOCK_TX_HASH = '0x006b866d20452a24d1d90c7514422188cc7c5d873e2f1ed661ec3f810ad5331c'
 
 const swapTransaction: TokenExchange = {
-  __typename: 'TokenExchangeV3',
   networkId: NetworkId['celo-alfajores'],
   type: TokenTransactionTypeV2.SwapTransaction,
   transactionHash: MOCK_TX_HASH,
@@ -36,7 +35,6 @@ const swapTransaction: TokenExchange = {
 
 const crossChainSwapTransaction: TokenExchange = {
   ...swapTransaction,
-  __typename: 'CrossChainTokenExchange',
   type: TokenTransactionTypeV2.CrossChainSwapTransaction,
   inAmount: {
     tokenId: mockEthTokenId,

--- a/src/transactions/feed/SwapFeedItem.tsx
+++ b/src/transactions/feed/SwapFeedItem.tsx
@@ -37,7 +37,7 @@ function SwapFeedItem({ transaction }: Props) {
       <View style={styles.container}>
         <TransactionFeedItemImage
           status={transaction.status}
-          transactionType={transaction.__typename}
+          transactionType={transaction.type}
           networkId={transaction.networkId}
           hideNetworkIcon={isCrossChainSwap}
         />

--- a/src/transactions/feed/TokenApprovalFeedItem.tsx
+++ b/src/transactions/feed/TokenApprovalFeedItem.tsx
@@ -32,7 +32,7 @@ function TokenApprovalFeedItem({ transaction }: Props) {
       <View style={styles.container}>
         <TransactionFeedItemImage
           status={transaction.status}
-          transactionType={transaction.__typename}
+          transactionType={transaction.type}
           networkId={transaction.networkId}
         />
         <Text style={styles.title}>{t('transactionFeed.approvalTransactionTitle')}</Text>

--- a/src/transactions/feed/TransactionDetails.tsx
+++ b/src/transactions/feed/TransactionDetails.tsx
@@ -2,8 +2,8 @@ import React from 'react'
 import { useTranslation } from 'react-i18next'
 import { ScrollView, StyleSheet, Text, View } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
-import { TransactionDetailsEvents } from 'src/analytics/Events'
 import AppAnalytics from 'src/analytics/AppAnalytics'
+import { TransactionDetailsEvents } from 'src/analytics/Events'
 import RowDivider from 'src/components/RowDivider'
 import Touchable from 'src/components/Touchable'
 import i18n from 'src/i18n'
@@ -15,7 +15,12 @@ import { typeScale } from 'src/styles/fonts'
 import { Spacing } from 'src/styles/styles'
 import TransactionPrimaryAction from 'src/transactions/feed/TransactionPrimaryAction'
 import TransactionStatusIndicator from 'src/transactions/feed/TransactionStatusIndicator'
-import { NetworkId, TokenTransaction, TransactionStatus } from 'src/transactions/types'
+import {
+  NetworkId,
+  TokenTransaction,
+  TokenTransactionTypeV2,
+  TransactionStatus,
+} from 'src/transactions/types'
 import { getDatetimeDisplayString } from 'src/utils/time'
 import networkConfig, { blockExplorerUrls } from 'src/web3/networkConfig'
 
@@ -36,7 +41,7 @@ function TransactionDetails({ transaction, title, subtitle, children, retryHandl
   // been initiated. Therefore for failed cross chain swaps, we should show the
   // transaction in the default network explorer.
   const showCrossChainSwapExplorer =
-    transaction.__typename === 'CrossChainTokenExchange' &&
+    transaction.type === TokenTransactionTypeV2.CrossChainSwapTransaction &&
     transaction.status !== TransactionStatus.Failed
 
   const openBlockExplorerHandler =

--- a/src/transactions/feed/TransactionDetailsScreen.test.tsx
+++ b/src/transactions/feed/TransactionDetailsScreen.test.tsx
@@ -112,7 +112,7 @@ describe('TransactionDetailsScreen', () => {
     fees = [],
     status = TransactionStatus.Complete,
   }: {
-    type: TokenTransactionTypeV2
+    type: TokenTransactionTypeV2.Sent | TokenTransactionTypeV2.Received
     address?: string
     amount?: TokenAmount
     metadata?: TokenTransferMetadata
@@ -120,7 +120,6 @@ describe('TransactionDetailsScreen', () => {
     status?: TransactionStatus
   }): TokenTransfer {
     return {
-      __typename: 'TokenTransferV3',
       networkId: NetworkId['celo-alfajores'],
       type,
       transactionHash: '0x544367eaf2b01622dd1c7b75a6b19bf278d72127aecfb2e5106424c40c268e8b',
@@ -167,7 +166,6 @@ describe('TransactionDetailsScreen', () => {
     networkId?: NetworkId
   }): TokenExchange {
     return {
-      __typename: 'TokenExchangeV3',
       networkId,
       type: TokenTransactionTypeV2.SwapTransaction,
       transactionHash: '0xf5J440sML02q2z8q92Vyt3psStjBACc3825KmFGB2Zk1zMil6wrI306097C1Rps2',
@@ -231,7 +229,6 @@ describe('TransactionDetailsScreen', () => {
       networkId: NetworkId['celo-mainnet'],
       type: TokenTransactionTypeV2.CrossChainSwapTransaction,
       timestamp: 1722345417000,
-      __typename: 'CrossChainTokenExchange',
     }
   }
 
@@ -377,7 +374,7 @@ describe('TransactionDetailsScreen', () => {
     expect(getByTestId('TransactionDetails/FeeRowItem')).toHaveTextContent('₱0.13')
   })
 
-  it.each([TokenTransactionTypeV2.Sent, TokenTransactionTypeV2.Received])(
+  it.each([TokenTransactionTypeV2.Sent, TokenTransactionTypeV2.Received] as const)(
     'renders details action for complete %s transaction',
     (type) => {
       const { getByText } = renderScreen({
@@ -401,7 +398,7 @@ describe('TransactionDetailsScreen', () => {
     expect(getByText('transactionDetailsActions.showCompletedTransactionDetails')).toBeTruthy()
   })
 
-  it.each([TokenTransactionTypeV2.Sent, TokenTransactionTypeV2.Received])(
+  it.each([TokenTransactionTypeV2.Sent, TokenTransactionTypeV2.Received] as const)(
     'renders check status action for pending %s transaction',
     (type) => {
       const { getByText } = renderScreen({

--- a/src/transactions/feed/TransactionDetailsScreen.tsx
+++ b/src/transactions/feed/TransactionDetailsScreen.tsx
@@ -16,17 +16,7 @@ import {
 } from 'src/transactions/feed/detailContent/EarnContent'
 import TokenApprovalDetails from 'src/transactions/feed/detailContent/TokenApprovalDetails'
 import TransferSentContent from 'src/transactions/feed/detailContent/TransferSentContent'
-import {
-  EarnClaimReward,
-  EarnDeposit,
-  EarnSwapDeposit,
-  EarnWithdraw,
-  TokenApproval,
-  TokenExchange,
-  TokenTransaction,
-  TokenTransactionTypeV2,
-  TokenTransfer,
-} from 'src/transactions/types'
+import { TokenTransaction, TokenTransactionTypeV2 } from 'src/transactions/types'
 import { Currency } from 'src/utils/currencies'
 import networkConfig from 'src/web3/networkConfig'
 import RewardReceivedContent from './detailContent/RewardReceivedContent'
@@ -45,13 +35,13 @@ function useHeaderTitle(transaction: TokenTransaction) {
   switch (transaction.type) {
     case TokenTransactionTypeV2.Exchange:
       // TODO: Change this to show any exchanges, not just CELO sell/purchase.
-      const isCeloSell = (transaction as TokenExchange).inAmount.tokenId === celoTokenId
+      const isCeloSell = transaction.inAmount.tokenId === celoTokenId
       return isCeloSell ? t('soldGold') : t('purchasedGold')
     case TokenTransactionTypeV2.Sent:
-      const isCeloSend = (transaction as TokenTransfer).amount.tokenId === celoTokenId
+      const isCeloSend = transaction.amount.tokenId === celoTokenId
       return isCeloSend ? t('transactionHeaderWithdrewCelo') : t('transactionHeaderSent')
     case TokenTransactionTypeV2.Received:
-      const transfer = transaction as TokenTransfer
+      const transfer = transaction
       const isCeloReception = transfer.amount.tokenId === celoTokenId
       const isCoinbasePaySenders = coinbasePaySenders.includes(transfer.address)
       if (
@@ -100,12 +90,12 @@ function TransactionDetailsScreen({ route }: Props) {
 
   switch (transaction.type) {
     case TokenTransactionTypeV2.Sent:
-      const sentTransfer = transaction as TokenTransfer
+      const sentTransfer = transaction
       retryHandler = () => navigate(Screens.SendSelectRecipient)
       content = <TransferSentContent transfer={sentTransfer} />
       break
     case TokenTransactionTypeV2.Received:
-      const receivedTransfer = transaction as TokenTransfer
+      const receivedTransfer = transaction
       const isRewardSender =
         rewardsSenders.includes(receivedTransfer.address) ||
         addressToDisplayName[receivedTransfer.address]?.isCeloRewardSender
@@ -117,23 +107,23 @@ function TransactionDetailsScreen({ route }: Props) {
       break
     case TokenTransactionTypeV2.CrossChainSwapTransaction:
     case TokenTransactionTypeV2.SwapTransaction:
-      content = <SwapContent transaction={transaction as TokenExchange} />
+      content = <SwapContent transaction={transaction} />
       retryHandler = () => navigate(Screens.SwapScreenWithBack)
       break
     case TokenTransactionTypeV2.EarnClaimReward:
-      content = <EarnClaimContent transaction={transaction as EarnClaimReward} />
+      content = <EarnClaimContent transaction={transaction} />
       break
     case TokenTransactionTypeV2.EarnWithdraw:
-      content = <EarnWithdrawContent transaction={transaction as EarnWithdraw} />
+      content = <EarnWithdrawContent transaction={transaction} />
       break
     case TokenTransactionTypeV2.EarnDeposit:
-      content = <EarnDepositContent transaction={transaction as EarnDeposit} />
+      content = <EarnDepositContent transaction={transaction} />
       break
     case TokenTransactionTypeV2.EarnSwapDeposit:
-      content = <EarnDepositContent transaction={transaction as EarnSwapDeposit} />
+      content = <EarnDepositContent transaction={transaction} />
       break
     case TokenTransactionTypeV2.Approval:
-      content = <TokenApprovalDetails transaction={transaction as TokenApproval} />
+      content = <TokenApprovalDetails transaction={transaction} />
       break
   }
 

--- a/src/transactions/feed/TransactionFeed.test.tsx
+++ b/src/transactions/feed/TransactionFeed.test.tsx
@@ -25,7 +25,6 @@ const mockTransaction = (
   status = TransactionStatus.Complete
 ): TokenTransaction => {
   return {
-    __typename: 'TokenTransferV3',
     networkId: NetworkId['celo-alfajores'],
     address: '0xd68360cce1f1ff696d898f58f03e0f1252f2ea33',
     amount: {
@@ -46,7 +45,6 @@ const mockTransaction = (
 const STAND_BY_TRANSACTION_SUBTITLE_KEY = 'confirmingTransaction'
 
 const MOCK_STANDBY_TRANSACTION: StandbyTransaction = {
-  __typename: 'TokenTransferV3',
   context: { id: 'test' },
   networkId: NetworkId['celo-alfajores'],
   type: TokenTransactionTypeV2.Sent,

--- a/src/transactions/feed/TransactionFeed.tsx
+++ b/src/transactions/feed/TransactionFeed.tsx
@@ -22,7 +22,7 @@ import {
   confirmedStandbyTransactionsSelector,
   pendingStandbyTransactionsSelector,
 } from 'src/transactions/selectors'
-import { TokenTransaction, TransactionStatus } from 'src/transactions/types'
+import { TokenTransaction, TokenTransactionTypeV2, TransactionStatus } from 'src/transactions/types'
 import { groupFeedItemsInSections } from 'src/transactions/utils'
 
 function TransactionFeed() {
@@ -55,7 +55,11 @@ function TransactionFeed() {
       if (diff === 0) {
         // if the timestamps are the same, most likely one of the transactions
         // is an approval. on the feed we want to show the approval first.
-        return a.__typename === 'TokenApproval' ? 1 : b.__typename === 'TokenApproval' ? -1 : 0
+        return a.type === TokenTransactionTypeV2.Approval
+          ? 1
+          : b.type === TokenTransactionTypeV2.Approval
+            ? -1
+            : 0
       }
       return diff
     })
@@ -97,20 +101,23 @@ function TransactionFeed() {
   }
 
   function renderItem({ item: tx }: { item: TokenTransaction; index: number }) {
-    switch (tx.__typename) {
-      case 'TokenExchangeV3':
-      case 'CrossChainTokenExchange':
+    switch (tx.type) {
+      case TokenTransactionTypeV2.Exchange:
+      case TokenTransactionTypeV2.SwapTransaction:
+      case TokenTransactionTypeV2.CrossChainSwapTransaction:
         return <SwapFeedItem key={tx.transactionHash} transaction={tx} />
-      case 'TokenTransferV3':
+      case TokenTransactionTypeV2.Sent:
+      case TokenTransactionTypeV2.Received:
         return <TransferFeedItem key={tx.transactionHash} transfer={tx} />
-      case 'NftTransferV3':
+      case TokenTransactionTypeV2.NftSent:
+      case TokenTransactionTypeV2.NftReceived:
         return <NftFeedItem key={tx.transactionHash} transaction={tx} />
-      case 'TokenApproval':
+      case TokenTransactionTypeV2.Approval:
         return <TokenApprovalFeedItem key={tx.transactionHash} transaction={tx} />
-      case 'EarnDeposit':
-      case 'EarnSwapDeposit':
-      case 'EarnWithdraw':
-      case 'EarnClaimReward':
+      case TokenTransactionTypeV2.EarnDeposit:
+      case TokenTransactionTypeV2.EarnSwapDeposit:
+      case TokenTransactionTypeV2.EarnWithdraw:
+      case TokenTransactionTypeV2.EarnClaimReward:
         return <EarnFeedItem key={tx.transactionHash} transaction={tx} />
     }
   }

--- a/src/transactions/feed/TransactionFeedItemImage.tsx
+++ b/src/transactions/feed/TransactionFeedItemImage.tsx
@@ -10,7 +10,7 @@ import MagicWand from 'src/icons/MagicWand'
 import SwapArrows from 'src/icons/SwapArrows'
 import { Recipient } from 'src/recipients/recipient'
 import Colors from 'src/styles/colors'
-import { NetworkId, TransactionStatus } from 'src/transactions/types'
+import { NetworkId, TokenTransactionTypeV2, TransactionStatus } from 'src/transactions/types'
 import Logger from 'src/utils/Logger'
 
 const AVATAR_SIZE = 40
@@ -18,16 +18,17 @@ const AVATAR_SIZE = 40
 type Props = { networkId: NetworkId; status: TransactionStatus; hideNetworkIcon?: boolean } & (
   | {
       transactionType:
-        | 'TokenExchangeV3'
-        | 'CrossChainTokenExchange'
-        | 'TokenApproval'
-        | 'EarnDeposit'
-        | 'EarnSwapDeposit'
-        | 'EarnWithdraw'
-        | 'EarnClaimReward'
+        | TokenTransactionTypeV2.Exchange
+        | TokenTransactionTypeV2.SwapTransaction
+        | TokenTransactionTypeV2.CrossChainSwapTransaction
+        | TokenTransactionTypeV2.Approval
+        | TokenTransactionTypeV2.EarnDeposit
+        | TokenTransactionTypeV2.EarnSwapDeposit
+        | TokenTransactionTypeV2.EarnWithdraw
+        | TokenTransactionTypeV2.EarnClaimReward
     }
   | {
-      transactionType: 'TokenTransferV3'
+      transactionType: TokenTransactionTypeV2.Sent | TokenTransactionTypeV2.Received
       recipient: Recipient
       isJumpstart: boolean
     }
@@ -46,14 +47,17 @@ function TransactionFeedItemBaseImage(props: Props) {
   if (status === TransactionStatus.Pending) {
     return <GreenLoadingSpinner height={AVATAR_SIZE} />
   }
-  if (transactionType === 'TokenExchangeV3' || transactionType === 'CrossChainTokenExchange') {
+  if (
+    transactionType === TokenTransactionTypeV2.SwapTransaction ||
+    transactionType === TokenTransactionTypeV2.CrossChainSwapTransaction
+  ) {
     return (
       <CircledIcon backgroundColor={Colors.successLight} radius={AVATAR_SIZE}>
         <SwapArrows color={Colors.successDark} />
       </CircledIcon>
     )
   }
-  if (transactionType === 'TokenApproval') {
+  if (transactionType === TokenTransactionTypeV2.Approval) {
     return (
       <CircledIcon backgroundColor={Colors.successLight} radius={AVATAR_SIZE}>
         <Activity />
@@ -61,7 +65,10 @@ function TransactionFeedItemBaseImage(props: Props) {
     )
   }
 
-  if (transactionType === 'TokenTransferV3') {
+  if (
+    transactionType === TokenTransactionTypeV2.Sent ||
+    transactionType === TokenTransactionTypeV2.Received
+  ) {
     if (props.isJumpstart) {
       return (
         <CircledIcon backgroundColor={Colors.successLight} radius={AVATAR_SIZE}>
@@ -74,7 +81,10 @@ function TransactionFeedItemBaseImage(props: Props) {
   }
 
   if (
-    ['EarnWithdraw', 'EarnDeposit', 'EarnClaimReward', 'EarnSwapDeposit'].includes(transactionType)
+    transactionType === TokenTransactionTypeV2.EarnWithdraw ||
+    transactionType === TokenTransactionTypeV2.EarnDeposit ||
+    transactionType === TokenTransactionTypeV2.EarnClaimReward ||
+    transactionType === TokenTransactionTypeV2.EarnSwapDeposit
   ) {
     return (
       <CircledIcon backgroundColor={Colors.successLight} radius={AVATAR_SIZE}>

--- a/src/transactions/feed/TransactionFeedV2.test.tsx
+++ b/src/transactions/feed/TransactionFeedV2.test.tsx
@@ -38,7 +38,6 @@ const mockFetch = fetch as FetchMock
 
 function mockTransaction(data?: Partial<TokenTransaction | StandbyTransaction>): TokenTransaction {
   return {
-    __typename: 'TokenTransferV3',
     networkId: NetworkId['celo-alfajores'],
     address: '0xd68360cce1f1ff696d898f58f03e0f1252f2ea33',
     amount: {
@@ -495,7 +494,6 @@ describe('TransactionFeedV2', () => {
 
     await act(() => {
       const newPendingTransaction = addStandbyTransaction({
-        __typename: 'TokenTransferV3',
         context: { id: pendingStandByTransactionHash2 },
         type: TokenTransactionTypeV2.Sent,
         networkId: NetworkId['celo-alfajores'],
@@ -528,7 +526,6 @@ describe('TransactionFeedV2', () => {
     const hash = '0x01' as string
     const mockedTransaction = {
       context: { id: hash },
-      __typename: 'CrossChainTokenExchange',
       transactionHash: hash,
       type: TokenTransactionTypeV2.CrossChainSwapTransaction,
       status: TransactionStatus.Pending,

--- a/src/transactions/feed/TransactionFeedV2.tsx
+++ b/src/transactions/feed/TransactionFeedV2.tsx
@@ -32,12 +32,8 @@ import {
   TokenTransactionTypeV2,
   TransactionStatus,
   type NetworkId,
-  type NftTransfer,
-  type TokenApproval,
-  type TokenEarn,
   type TokenExchange,
   type TokenTransaction,
-  type TokenTransfer,
 } from 'src/transactions/types'
 import {
   groupFeedItemsInSections,
@@ -295,20 +291,20 @@ function renderItem({ item: tx }: { item: TokenTransaction }) {
     case TokenTransactionTypeV2.Exchange:
     case TokenTransactionTypeV2.SwapTransaction:
     case TokenTransactionTypeV2.CrossChainSwapTransaction:
-      return <SwapFeedItem key={tx.transactionHash} transaction={tx as TokenExchange} />
+      return <SwapFeedItem key={tx.transactionHash} transaction={tx} />
     case TokenTransactionTypeV2.Sent:
     case TokenTransactionTypeV2.Received:
-      return <TransferFeedItem key={tx.transactionHash} transfer={tx as TokenTransfer} />
+      return <TransferFeedItem key={tx.transactionHash} transfer={tx} />
     case TokenTransactionTypeV2.NftSent:
     case TokenTransactionTypeV2.NftReceived:
-      return <NftFeedItem key={tx.transactionHash} transaction={tx as NftTransfer} />
+      return <NftFeedItem key={tx.transactionHash} transaction={tx} />
     case TokenTransactionTypeV2.Approval:
-      return <TokenApprovalFeedItem key={tx.transactionHash} transaction={tx as TokenApproval} />
+      return <TokenApprovalFeedItem key={tx.transactionHash} transaction={tx} />
     case TokenTransactionTypeV2.EarnDeposit:
     case TokenTransactionTypeV2.EarnSwapDeposit:
     case TokenTransactionTypeV2.EarnWithdraw:
     case TokenTransactionTypeV2.EarnClaimReward:
-      return <EarnFeedItem key={tx.transactionHash} transaction={tx as TokenEarn} />
+      return <EarnFeedItem key={tx.transactionHash} transaction={tx} />
   }
 }
 

--- a/src/transactions/feed/TransferFeedItem.test.tsx
+++ b/src/transactions/feed/TransferFeedItem.test.tsx
@@ -88,7 +88,7 @@ describe('TransferFeedItem', () => {
     status = TransactionStatus.Complete,
     address = MOCK_ADDRESS,
   }: {
-    type?: TokenTransactionTypeV2
+    type?: TokenTransactionTypeV2.Sent | TokenTransactionTypeV2.Received
     amount?: TokenAmount
     metadata?: TokenTransferMetadata
     fees?: Fee[]
@@ -104,7 +104,6 @@ describe('TransferFeedItem', () => {
       <Provider store={store}>
         <TransferFeedItem
           transfer={{
-            __typename: 'TokenTransferV3',
             networkId: NetworkId['celo-alfajores'],
             type,
             status,

--- a/src/transactions/feed/TransferFeedItem.tsx
+++ b/src/transactions/feed/TransferFeedItem.tsx
@@ -57,7 +57,7 @@ function TransferFeedItem({ transfer }: Props) {
         <TransactionFeedItemImage
           recipient={recipient}
           status={transfer.status}
-          transactionType={transfer.__typename}
+          transactionType={transfer.type}
           isJumpstart={isJumpstart}
           networkId={transfer.networkId}
         />

--- a/src/transactions/feed/detailContent/EarnContent.tsx
+++ b/src/transactions/feed/detailContent/EarnContent.tsx
@@ -17,6 +17,7 @@ import {
   EarnSwapDeposit,
   EarnWithdraw,
   FeeType,
+  TokenTransactionTypeV2,
 } from 'src/transactions/types'
 
 interface EarnClaimRewardProps {
@@ -74,12 +75,14 @@ interface EarnDepositProps {
 export function EarnDepositContent({ transaction }: EarnDepositProps) {
   const { t } = useTranslation()
   const providerName = useEarnPositionProviderName(
-    transaction.__typename === 'EarnSwapDeposit'
+    transaction.type === TokenTransactionTypeV2.EarnSwapDeposit
       ? transaction.deposit.providerId
       : transaction.providerId
   )
   const depositAmount =
-    transaction.__typename === 'EarnDeposit' ? transaction.outAmount : transaction.deposit.outAmount
+    transaction.type === TokenTransactionTypeV2.EarnDeposit
+      ? transaction.outAmount
+      : transaction.deposit.outAmount
   const depositTokenInfo = useTokenInfo(depositAmount.tokenId)
   const depositTokenSymbol = depositTokenInfo?.symbol ?? ''
 
@@ -115,7 +118,7 @@ export function EarnDepositContent({ transaction }: EarnDepositProps) {
             style={styles.amountSubtitle}
           />
         </View>
-        {transaction.__typename === 'EarnSwapDeposit' && (
+        {transaction.type === TokenTransactionTypeV2.EarnSwapDeposit && (
           <View style={styles.row}>
             <Text style={styles.bodyText}>{t('earnFlow.transactionDetails.swap')}</Text>
             <View style={styles.swapValueContainer}>
@@ -137,7 +140,7 @@ export function EarnDepositContent({ transaction }: EarnDepositProps) {
             </View>
           </View>
         )}
-        {transaction.__typename === 'EarnSwapDeposit' && (
+        {transaction.type === TokenTransactionTypeV2.EarnSwapDeposit && (
           <View style={styles.row}>
             <Text style={styles.bodyText}>{t('earnFlow.transactionDetails.network')}</Text>
             <Text style={styles.bodyTextValue}>{NETWORK_NAMES[transaction.networkId]}</Text>
@@ -152,7 +155,7 @@ export function EarnDepositContent({ transaction }: EarnDepositProps) {
           feeType={FeeType.SecurityFee}
           transactionStatus={transaction.status}
         />
-        {transaction.__typename === 'EarnSwapDeposit' && (
+        {transaction.type === TokenTransactionTypeV2.EarnSwapDeposit && (
           <FeeRowItem
             fees={transaction.fees}
             feeType={FeeType.AppFee}

--- a/src/transactions/feed/detailContent/SwapContent.tsx
+++ b/src/transactions/feed/detailContent/SwapContent.tsx
@@ -10,7 +10,12 @@ import { typeScale } from 'src/styles/fonts'
 import { Spacing } from 'src/styles/styles'
 import { useTokensList } from 'src/tokens/hooks'
 import FeeRowItem from 'src/transactions/feed/detailContent/FeeRowItem'
-import { FeeType, TokenExchange, TransactionStatus } from 'src/transactions/types'
+import {
+  FeeType,
+  TokenExchange,
+  TokenTransactionTypeV2,
+  TransactionStatus,
+} from 'src/transactions/types'
 export interface Props {
   transaction: TokenExchange
 }
@@ -22,7 +27,7 @@ export default function SwapContent({ transaction }: Props) {
 
   const fromToken = tokensList.find((token) => token.tokenId === transaction.outAmount.tokenId)
   const toToken = tokensList.find((token) => token.tokenId === transaction.inAmount.tokenId)
-  const isCrossChainSwap = transaction.__typename === 'CrossChainTokenExchange'
+  const isCrossChainSwap = transaction.type === TokenTransactionTypeV2.CrossChainSwapTransaction
 
   const showExchangeRate =
     transaction.status === TransactionStatus.Complete &&

--- a/src/transactions/feed/queryHelper.test.ts
+++ b/src/transactions/feed/queryHelper.test.ts
@@ -6,7 +6,12 @@ import * as TokenSelectors from 'src/tokens/selectors'
 import { TokenBalance } from 'src/tokens/slice'
 import { QueryResponse, handlePollResponse } from 'src/transactions/feed/queryHelper'
 import { updateTransactions } from 'src/transactions/slice'
-import { NetworkId, TokenTransaction, TransactionStatus } from 'src/transactions/types'
+import {
+  NetworkId,
+  TokenTransaction,
+  TokenTransactionTypeV2,
+  TransactionStatus,
+} from 'src/transactions/types'
 
 jest.mock('src/styles/hapticFeedback')
 
@@ -24,13 +29,13 @@ describe('handlePollResponse', () => {
   } as TokenTransaction
 
   const mockPendingCrossChainTransaction = {
-    __typename: 'CrossChainTokenExchange',
+    type: TokenTransactionTypeV2.CrossChainSwapTransaction,
     transactionHash: '0xabc',
     status: TransactionStatus.Pending,
   } as TokenTransaction
 
   const mockCompletedCrossChainTransaction = {
-    __typename: 'CrossChainTokenExchange',
+    type: TokenTransactionTypeV2.CrossChainSwapTransaction,
     transactionHash: '0xabc',
     status: TransactionStatus.Complete,
     inAmount: {

--- a/src/transactions/feed/queryHelper.ts
+++ b/src/transactions/feed/queryHelper.ts
@@ -27,6 +27,7 @@ import {
   NetworkId,
   TokenExchange,
   TokenTransaction,
+  TokenTransactionTypeV2,
   TransactionStatus,
 } from 'src/transactions/types'
 import Logger from 'src/utils/Logger'
@@ -376,7 +377,7 @@ export function handlePollResponse({
 
           if (
             // Track cross-chain swap transaction status change to `Complete`
-            tx.__typename === 'CrossChainTokenExchange' &&
+            tx.type === TokenTransactionTypeV2.CrossChainSwapTransaction &&
             (pendingStandbyTransactionHashes?.has(tx.transactionHash) ||
               knownPendingTransactionHashes?.has(tx.transactionHash))
           ) {
@@ -582,7 +583,6 @@ export const TRANSACTIONS_QUERY = gql`
   }
 
   fragment TokenTransferItemV3 on TokenTransferV3 {
-    __typename
     type
     transactionHash
     timestamp
@@ -620,7 +620,6 @@ export const TRANSACTIONS_QUERY = gql`
   }
 
   fragment NftTransferItemV3 on NftTransferV3 {
-    __typename
     type
     transactionHash
     status
@@ -651,7 +650,6 @@ export const TRANSACTIONS_QUERY = gql`
   }
 
   fragment TokenExchangeItemV3 on TokenExchangeV3 {
-    __typename
     type
     transactionHash
     status
@@ -697,7 +695,6 @@ export const TRANSACTIONS_QUERY = gql`
   }
 
   fragment CrossChainTokenExchangeItem on CrossChainTokenExchange {
-    __typename
     type
     transactionHash
     status
@@ -739,7 +736,6 @@ export const TRANSACTIONS_QUERY = gql`
   }
 
   fragment EarnSwapDepositItem on EarnSwapDeposit {
-    __typename
     type
     transactionHash
     status
@@ -806,7 +802,6 @@ export const TRANSACTIONS_QUERY = gql`
   }
 
   fragment EarnDepositItem on EarnDeposit {
-    __typename
     type
     transactionHash
     status
@@ -849,7 +844,6 @@ export const TRANSACTIONS_QUERY = gql`
   }
 
   fragment EarnWithdrawItem on EarnWithdraw {
-    __typename
     type
     transactionHash
     status
@@ -892,7 +886,6 @@ export const TRANSACTIONS_QUERY = gql`
   }
 
   fragment EarnClaimRewardItem on EarnClaimReward {
-    __typename
     type
     transactionHash
     status
@@ -925,7 +918,6 @@ export const TRANSACTIONS_QUERY = gql`
   }
 
   fragment TokenApprovalItem on TokenApproval {
-    __typename
     type
     timestamp
     block

--- a/src/transactions/saga.test.ts
+++ b/src/transactions/saga.test.ts
@@ -35,7 +35,6 @@ describe('watchPendingTransactions', () => {
   const transactionHash = '0x123'
 
   const pendingTransaction: StandbyTransaction = {
-    __typename: 'TokenTransferV3',
     context: { id: transactionId },
     networkId: NetworkId['celo-alfajores'],
     type: TokenTransactionTypeV2.Sent,
@@ -116,7 +115,6 @@ describe('watchPendingTransactions', () => {
 
   it('updates and tracks the pending swap transaction', async () => {
     const standbySwaptransaction: StandbyTransaction = {
-      __typename: 'TokenExchangeV3',
       context: {
         id: transactionId,
       },

--- a/src/transactions/saga.ts
+++ b/src/transactions/saga.ts
@@ -10,6 +10,7 @@ import {
   Network,
   NetworkId,
   StandbyTransaction,
+  TokenTransactionTypeV2,
   TransactionStatus,
 } from 'src/transactions/types'
 import Logger from 'src/utils/Logger'
@@ -37,7 +38,7 @@ export function* getTransactionReceipt(
   network: Network
 ) {
   if (
-    transaction.__typename === 'CrossChainTokenExchange' &&
+    transaction.type === TokenTransactionTypeV2.CrossChainSwapTransaction &&
     'isSourceNetworkTxConfirmed' in transaction &&
     transaction.isSourceNetworkTxConfirmed
   ) {
@@ -48,10 +49,10 @@ export function* getTransactionReceipt(
     return
   }
 
-  const { feeCurrencyId, transactionHash, __typename } = transaction
+  const { feeCurrencyId, transactionHash, type } = transaction
   const networkId = networkConfig.networkToNetworkId[network]
-  const isCrossChainSwapTransaction = __typename === 'CrossChainTokenExchange'
-  const isSwapTransaction = __typename === 'TokenExchangeV3'
+  const isCrossChainSwapTransaction = type === TokenTransactionTypeV2.CrossChainSwapTransaction
+  const isSwapTransaction = type === TokenTransactionTypeV2.SwapTransaction
 
   try {
     const receipt = yield* call([publicClient[network], 'waitForTransactionReceipt'], {

--- a/src/transactions/selectors.ts
+++ b/src/transactions/selectors.ts
@@ -4,6 +4,7 @@ import { getSupportedNetworkIdsForApprovalTxsInHomefeed } from 'src/tokens/utils
 import {
   type ConfirmedStandbyTransaction,
   type NetworkId,
+  TokenTransactionTypeV2,
   TransactionStatus,
 } from 'src/transactions/types'
 
@@ -13,7 +14,7 @@ const standbyTransactionsSelector = createSelector(
   [allStandbyTransactionsSelector, getSupportedNetworkIdsForApprovalTxsInHomefeed],
   (standbyTransactions, supportedNetworkIdsForApprovalTxs) => {
     return standbyTransactions.filter((tx) => {
-      if (tx.__typename === 'TokenApproval') {
+      if (tx.type === TokenTransactionTypeV2.Approval) {
         return supportedNetworkIdsForApprovalTxs.includes(tx.networkId)
       }
       return true
@@ -56,7 +57,7 @@ export const transactionsSelector = createSelector(
     return transactionsForAllNetworks
       .sort((a, b) => b.timestamp - a.timestamp)
       .filter((tx) => {
-        if (tx.__typename === 'TokenApproval') {
+        if (tx.type === TokenTransactionTypeV2.Approval) {
           return supportedNetworkIdsForApprovalTxs.includes(tx.networkId)
         }
         return true

--- a/src/transactions/slice.test.ts
+++ b/src/transactions/slice.test.ts
@@ -15,7 +15,6 @@ import { getMockStoreData } from 'test/utils'
 jest.mock('src/statsig')
 
 const standbyCrossChainSwap: StandbyTransaction = {
-  __typename: 'CrossChainTokenExchange',
   timestamp: 1721978699901,
   feeCurrencyId: 'celo-mainnet:native',
   inAmount: {
@@ -79,7 +78,6 @@ const incomingCrossChainSwap: TokenExchange = {
   type: TokenTransactionTypeV2.CrossChainSwapTransaction,
   networkId: NetworkId['celo-mainnet'],
   timestamp: 1721978706000,
-  __typename: 'CrossChainTokenExchange',
 }
 
 describe('transactions reducer', () => {
@@ -316,13 +314,11 @@ describe('selector', () => {
         transactionHash: '0x60b169b86f7b54413f50e5dc77283ce2d4842119fa313658c23607eade1e41b9',
         block: '26987429',
         networkId: NetworkId['celo-mainnet'],
-        type: TokenTransactionTypeV2.CrossChainSwapTransaction,
+        type: TokenTransactionTypeV2.CrossChainSwapTransaction as const,
         timestamp: 1722609137000,
-        __typename: 'CrossChainTokenExchange' as const,
       }
       const standbyApproval = {
         status: TransactionStatus.Pending,
-        __typename: 'TokenApproval' as const,
         networkId: NetworkId['celo-mainnet'],
         tokenId: 'celo-mainnet:0x765de816845861e75a25fca122bb6898b8b1282a',
         approvedAmount: '0.1',
@@ -334,7 +330,7 @@ describe('selector', () => {
           description: 'Swap/Approve',
         },
         timestamp: 1722588482000,
-        type: TokenTransactionTypeV2.Approval,
+        type: TokenTransactionTypeV2.Approval as const,
       }
 
       const state: RootState = getMockStoreData({

--- a/src/transactions/slice.ts
+++ b/src/transactions/slice.ts
@@ -3,6 +3,7 @@ import { REHYDRATE, type RehydrateAction } from 'redux-persist'
 import { getRehydratePayload } from 'src/redux/persist-helper'
 import { transactionFeedV2Api } from 'src/transactions/api'
 import {
+  TokenTransactionTypeV2,
   TransactionStatus,
   type EarnClaimReward,
   type EarnDeposit,
@@ -118,7 +119,8 @@ const slice = createSlice({
                 block,
                 timestamp: action.payload.blockTimestampInMs,
                 fees: fees || [],
-                ...(standbyTransaction.__typename === 'CrossChainTokenExchange' && {
+                ...(standbyTransaction.type ===
+                  TokenTransactionTypeV2.CrossChainSwapTransaction && {
                   isSourceNetworkTxConfirmed: true,
                 }),
               }
@@ -149,7 +151,7 @@ const slice = createSlice({
       action.payload.transactions.forEach((tx) => {
         if (
           tx.status === TransactionStatus.Pending &&
-          tx.__typename === 'CrossChainTokenExchange' &&
+          tx.type === TokenTransactionTypeV2.CrossChainSwapTransaction &&
           standbyTransactionHashes.has(tx.transactionHash)
         ) {
           pendingCrossChainTxsWithStandby.push(tx)
@@ -171,7 +173,10 @@ const slice = createSlice({
           // augment existing standby cross chain swap transactions with
           // received tx information from blockchain-api, but keep the estimated
           // inAmount value from the original standby transaction
-          if (standbyTx.transactionHash && standbyTx.__typename === 'CrossChainTokenExchange') {
+          if (
+            standbyTx.transactionHash &&
+            standbyTx.type === TokenTransactionTypeV2.CrossChainSwapTransaction
+          ) {
             const receivedCrossChainTx = pendingCrossChainTxsWithStandby.find(
               (tx) => tx.transactionHash === standbyTx.transactionHash
             )

--- a/src/transactions/types.ts
+++ b/src/transactions/types.ts
@@ -281,5 +281,3 @@ export interface TrackedTx {
   txHash: Hash | undefined
   txReceipt: TransactionReceipt | undefined
 }
-
-export type TokenEarn = EarnWithdraw | EarnDeposit | EarnClaimReward | EarnSwapDeposit

--- a/src/transactions/types.ts
+++ b/src/transactions/types.ts
@@ -62,9 +62,10 @@ export type StandbyTransaction =
   | ConfirmedStandbyTransaction
 
 type PendingTokenExchange =
-  | (Omit<TokenExchange, '__typename'> & { __typename: 'TokenExchangeV3' })
-  | (Omit<TokenExchange, '__typename'> & {
-      __typename: 'CrossChainTokenExchange'
+  | (Omit<TokenExchange, 'type'> & { type: TokenTransactionTypeV2.Exchange })
+  | (Omit<TokenExchange, 'type'> & { type: TokenTransactionTypeV2.SwapTransaction })
+  | (Omit<TokenExchange, 'type'> & {
+      type: TokenTransactionTypeV2.CrossChainSwapTransaction
       isSourceNetworkTxConfirmed?: boolean
     })
 
@@ -142,9 +143,8 @@ export enum TokenTransactionTypeV2 {
 
 // Can we optional the fields `transactionHash` and `block`?
 export interface TokenTransfer {
-  __typename: 'TokenTransferV3'
   networkId: NetworkId
-  type: TokenTransactionTypeV2
+  type: TokenTransactionTypeV2.Sent | TokenTransactionTypeV2.Received
   transactionHash: string
   timestamp: number
   block: string
@@ -162,9 +162,8 @@ export interface TokenTransferMetadata {
 }
 
 export interface NftTransfer {
-  __typename: 'NftTransferV3'
   networkId: NetworkId
-  type: TokenTransactionTypeV2
+  type: TokenTransactionTypeV2.NftReceived | TokenTransactionTypeV2.NftSent
   transactionHash: string
   timestamp: number
   block: string
@@ -175,9 +174,11 @@ export interface NftTransfer {
 
 // Can we optional the fields `transactionHash` and `block`?
 export interface TokenExchange {
-  __typename: 'TokenExchangeV3' | 'CrossChainTokenExchange'
   networkId: NetworkId
-  type: TokenTransactionTypeV2
+  type:
+    | TokenTransactionTypeV2.Exchange
+    | TokenTransactionTypeV2.SwapTransaction
+    | TokenTransactionTypeV2.CrossChainSwapTransaction
   transactionHash: string
   timestamp: number
   block: string
@@ -207,9 +208,8 @@ export interface Fee {
 }
 
 export interface TokenApproval {
-  __typename: 'TokenApproval'
   networkId: NetworkId
-  type: TokenTransactionTypeV2
+  type: TokenTransactionTypeV2.Approval
   timestamp: number
   block: string
   transactionHash: string
@@ -220,9 +220,8 @@ export interface TokenApproval {
 }
 
 export interface EarnDeposit {
-  __typename: 'EarnDeposit'
   networkId: NetworkId
-  type: TokenTransactionTypeV2
+  type: TokenTransactionTypeV2.EarnDeposit
   transactionHash: string
   timestamp: number
   block: string
@@ -234,9 +233,8 @@ export interface EarnDeposit {
 }
 
 export interface EarnSwapDeposit {
-  __typename: 'EarnSwapDeposit'
   networkId: NetworkId
-  type: TokenTransactionTypeV2
+  type: TokenTransactionTypeV2.EarnSwapDeposit
   transactionHash: string
   timestamp: number
   block: string
@@ -254,9 +252,8 @@ export interface EarnSwapDeposit {
 }
 
 export interface EarnWithdraw {
-  __typename: 'EarnWithdraw'
   networkId: NetworkId
-  type: TokenTransactionTypeV2
+  type: TokenTransactionTypeV2.EarnWithdraw
   transactionHash: string
   timestamp: number
   block: string
@@ -268,10 +265,9 @@ export interface EarnWithdraw {
 }
 
 export interface EarnClaimReward {
-  __typename: 'EarnClaimReward'
   networkId: NetworkId
   amount: TokenAmount
-  type: TokenTransactionTypeV2
+  type: TokenTransactionTypeV2.EarnClaimReward
   transactionHash: string
   timestamp: number
   block: string

--- a/src/transactions/utils.test.ts
+++ b/src/transactions/utils.test.ts
@@ -9,7 +9,6 @@ import { mockCusdAddress, mockCusdTokenId } from 'test/values'
 
 const mockFeedItem = (timestamp: number, status = TransactionStatus.Complete): TokenTransaction => {
   return {
-    __typename: 'TokenTransferV3',
     networkId: NetworkId['celo-alfajores'],
     type: TokenTransactionTypeV2.Sent,
     block: '8648978',

--- a/src/viem/saga.test.ts
+++ b/src/viem/saga.test.ts
@@ -46,14 +46,12 @@ const serializablePreparedTransactions = getSerializablePreparedTransactions(pre
 const mockStandbyTransactions: BaseStandbyTransaction[] = [
   {
     context: { id: 'mockContext1' },
-    __typename: 'TokenApproval',
     networkId: NetworkId['celo-alfajores'],
     type: TokenTransactionTypeV2.Approval,
     tokenId: mockCusdTokenId,
     approvedAmount: '1',
   },
   {
-    __typename: 'TokenTransferV3',
     context: { id: 'mockContext2' },
     type: TokenTransactionTypeV2.Sent,
     networkId: NetworkId['celo-alfajores'],

--- a/test/RootStateSchema.json
+++ b/test/RootStateSchema.json
@@ -1187,10 +1187,6 @@
         "EarnClaimReward": {
             "additionalProperties": false,
             "properties": {
-                "__typename": {
-                    "const": "EarnClaimReward",
-                    "type": "string"
-                },
                 "amount": {
                     "$ref": "#/definitions/TokenAmount"
                 },
@@ -1219,11 +1215,11 @@
                     "type": "string"
                 },
                 "type": {
-                    "$ref": "#/definitions/TokenTransactionTypeV2"
+                    "const": "EARN_CLAIM_REWARD",
+                    "type": "string"
                 }
             },
             "required": [
-                "__typename",
                 "amount",
                 "block",
                 "fees",
@@ -1306,10 +1302,6 @@
         "EarnDeposit": {
             "additionalProperties": false,
             "properties": {
-                "__typename": {
-                    "const": "EarnDeposit",
-                    "type": "string"
-                },
                 "block": {
                     "type": "string"
                 },
@@ -1341,11 +1333,11 @@
                     "type": "string"
                 },
                 "type": {
-                    "$ref": "#/definitions/TokenTransactionTypeV2"
+                    "const": "EARN_DEPOSIT",
+                    "type": "string"
                 }
             },
             "required": [
-                "__typename",
                 "block",
                 "fees",
                 "inAmount",
@@ -1362,10 +1354,6 @@
         "EarnSwapDeposit": {
             "additionalProperties": false,
             "properties": {
-                "__typename": {
-                    "const": "EarnSwapDeposit",
-                    "type": "string"
-                },
                 "block": {
                     "type": "string"
                 },
@@ -1424,11 +1412,11 @@
                     "type": "string"
                 },
                 "type": {
-                    "$ref": "#/definitions/TokenTransactionTypeV2"
+                    "const": "EARN_SWAP_DEPOSIT",
+                    "type": "string"
                 }
             },
             "required": [
-                "__typename",
                 "block",
                 "deposit",
                 "fees",
@@ -1444,10 +1432,6 @@
         "EarnWithdraw": {
             "additionalProperties": false,
             "properties": {
-                "__typename": {
-                    "const": "EarnWithdraw",
-                    "type": "string"
-                },
                 "block": {
                     "type": "string"
                 },
@@ -1479,11 +1463,11 @@
                     "type": "string"
                 },
                 "type": {
-                    "$ref": "#/definitions/TokenTransactionTypeV2"
+                    "const": "EARN_WITHDRAW",
+                    "type": "string"
                 }
             },
             "required": [
-                "__typename",
                 "block",
                 "fees",
                 "inAmount",
@@ -2185,10 +2169,6 @@
         "NftTransfer": {
             "additionalProperties": false,
             "properties": {
-                "__typename": {
-                    "const": "NftTransferV3",
-                    "type": "string"
-                },
                 "block": {
                     "type": "string"
                 },
@@ -2217,11 +2197,14 @@
                     "type": "string"
                 },
                 "type": {
-                    "$ref": "#/definitions/TokenTransactionTypeV2"
+                    "enum": [
+                        "NFT_RECEIVED",
+                        "NFT_SENT"
+                    ],
+                    "type": "string"
                 }
             },
             "required": [
-                "__typename",
                 "block",
                 "networkId",
                 "status",
@@ -2552,10 +2535,6 @@
         "PendingStandbyTransaction<EarnClaimReward>": {
             "additionalProperties": false,
             "properties": {
-                "__typename": {
-                    "const": "EarnClaimReward",
-                    "type": "string"
-                },
                 "amount": {
                     "$ref": "#/definitions/TokenAmount"
                 },
@@ -2582,11 +2561,11 @@
                     "type": "string"
                 },
                 "type": {
-                    "$ref": "#/definitions/TokenTransactionTypeV2"
+                    "const": "EARN_CLAIM_REWARD",
+                    "type": "string"
                 }
             },
             "required": [
-                "__typename",
                 "amount",
                 "context",
                 "networkId",
@@ -2600,10 +2579,6 @@
         "PendingStandbyTransaction<EarnDeposit>": {
             "additionalProperties": false,
             "properties": {
-                "__typename": {
-                    "const": "EarnDeposit",
-                    "type": "string"
-                },
                 "context": {
                     "$ref": "#/definitions/TransactionContext"
                 },
@@ -2633,11 +2608,11 @@
                     "type": "string"
                 },
                 "type": {
-                    "$ref": "#/definitions/TokenTransactionTypeV2"
+                    "const": "EARN_DEPOSIT",
+                    "type": "string"
                 }
             },
             "required": [
-                "__typename",
                 "context",
                 "inAmount",
                 "networkId",
@@ -2652,10 +2627,6 @@
         "PendingStandbyTransaction<EarnSwapDeposit>": {
             "additionalProperties": false,
             "properties": {
-                "__typename": {
-                    "const": "EarnSwapDeposit",
-                    "type": "string"
-                },
                 "context": {
                     "$ref": "#/definitions/TransactionContext"
                 },
@@ -2712,11 +2683,11 @@
                     "type": "string"
                 },
                 "type": {
-                    "$ref": "#/definitions/TokenTransactionTypeV2"
+                    "const": "EARN_SWAP_DEPOSIT",
+                    "type": "string"
                 }
             },
             "required": [
-                "__typename",
                 "context",
                 "deposit",
                 "networkId",
@@ -2730,10 +2701,6 @@
         "PendingStandbyTransaction<EarnWithdraw>": {
             "additionalProperties": false,
             "properties": {
-                "__typename": {
-                    "const": "EarnWithdraw",
-                    "type": "string"
-                },
                 "context": {
                     "$ref": "#/definitions/TransactionContext"
                 },
@@ -2763,11 +2730,11 @@
                     "type": "string"
                 },
                 "type": {
-                    "$ref": "#/definitions/TokenTransactionTypeV2"
+                    "const": "EARN_WITHDRAW",
+                    "type": "string"
                 }
             },
             "required": [
-                "__typename",
                 "context",
                 "inAmount",
                 "networkId",
@@ -2782,10 +2749,6 @@
         "PendingStandbyTransaction<NftTransfer>": {
             "additionalProperties": false,
             "properties": {
-                "__typename": {
-                    "const": "NftTransferV3",
-                    "type": "string"
-                },
                 "context": {
                     "$ref": "#/definitions/TransactionContext"
                 },
@@ -2812,11 +2775,14 @@
                     "type": "string"
                 },
                 "type": {
-                    "$ref": "#/definitions/TokenTransactionTypeV2"
+                    "enum": [
+                        "NFT_RECEIVED",
+                        "NFT_SENT"
+                    ],
+                    "type": "string"
                 }
             },
             "required": [
-                "__typename",
                 "context",
                 "networkId",
                 "status",
@@ -2828,13 +2794,6 @@
         "PendingStandbyTransaction<PendingTokenExchange>": {
             "additionalProperties": false,
             "properties": {
-                "__typename": {
-                    "enum": [
-                        "CrossChainTokenExchange",
-                        "TokenExchangeV3"
-                    ],
-                    "type": "string"
-                },
                 "context": {
                     "$ref": "#/definitions/TransactionContext"
                 },
@@ -2864,11 +2823,10 @@
                     "type": "string"
                 },
                 "type": {
-                    "$ref": "#/definitions/TokenTransactionTypeV2"
+                    "$ref": "#/definitions/TokenTransactionTypeV2.Exchange"
                 }
             },
             "required": [
-                "__typename",
                 "context",
                 "inAmount",
                 "networkId",
@@ -2882,10 +2840,6 @@
         "PendingStandbyTransaction<TokenApproval>": {
             "additionalProperties": false,
             "properties": {
-                "__typename": {
-                    "const": "TokenApproval",
-                    "type": "string"
-                },
                 "approvedAmount": {
                     "type": [
                         "null",
@@ -2915,11 +2869,11 @@
                     "type": "string"
                 },
                 "type": {
-                    "$ref": "#/definitions/TokenTransactionTypeV2"
+                    "const": "APPROVAL",
+                    "type": "string"
                 }
             },
             "required": [
-                "__typename",
                 "approvedAmount",
                 "context",
                 "networkId",
@@ -2933,10 +2887,6 @@
         "PendingStandbyTransaction<TokenTransfer>": {
             "additionalProperties": false,
             "properties": {
-                "__typename": {
-                    "const": "TokenTransferV3",
-                    "type": "string"
-                },
                 "address": {
                     "type": "string"
                 },
@@ -2966,11 +2916,14 @@
                     "type": "string"
                 },
                 "type": {
-                    "$ref": "#/definitions/TokenTransactionTypeV2"
+                    "enum": [
+                        "RECEIVED",
+                        "SENT"
+                    ],
+                    "type": "string"
                 }
             },
             "required": [
-                "__typename",
                 "address",
                 "amount",
                 "context",
@@ -3841,13 +3794,6 @@
                 {
                     "additionalProperties": false,
                     "properties": {
-                        "__typename": {
-                            "enum": [
-                                "CrossChainTokenExchange",
-                                "TokenExchangeV3"
-                            ],
-                            "type": "string"
-                        },
                         "block": {
                             "type": "string"
                         },
@@ -3889,11 +3835,15 @@
                             "type": "string"
                         },
                         "type": {
-                            "$ref": "#/definitions/TokenTransactionTypeV2"
+                            "enum": [
+                                "CROSS_CHAIN_SWAP_TRANSACTION",
+                                "EXCHANGE",
+                                "SWAP_TRANSACTION"
+                            ],
+                            "type": "string"
                         }
                     },
                     "required": [
-                        "__typename",
                         "block",
                         "context",
                         "fees",
@@ -3910,10 +3860,6 @@
                 {
                     "additionalProperties": false,
                     "properties": {
-                        "__typename": {
-                            "const": "TokenTransferV3",
-                            "type": "string"
-                        },
                         "address": {
                             "type": "string"
                         },
@@ -3955,11 +3901,14 @@
                             "type": "string"
                         },
                         "type": {
-                            "$ref": "#/definitions/TokenTransactionTypeV2"
+                            "enum": [
+                                "RECEIVED",
+                                "SENT"
+                            ],
+                            "type": "string"
                         }
                     },
                     "required": [
-                        "__typename",
                         "address",
                         "amount",
                         "block",
@@ -3977,10 +3926,6 @@
                 {
                     "additionalProperties": false,
                     "properties": {
-                        "__typename": {
-                            "const": "TokenApproval",
-                            "type": "string"
-                        },
                         "approvedAmount": {
                             "type": [
                                 "null",
@@ -4022,11 +3967,11 @@
                             "type": "string"
                         },
                         "type": {
-                            "$ref": "#/definitions/TokenTransactionTypeV2"
+                            "const": "APPROVAL",
+                            "type": "string"
                         }
                     },
                     "required": [
-                        "__typename",
                         "approvedAmount",
                         "block",
                         "context",
@@ -4043,10 +3988,6 @@
                 {
                     "additionalProperties": false,
                     "properties": {
-                        "__typename": {
-                            "const": "NftTransferV3",
-                            "type": "string"
-                        },
                         "block": {
                             "type": "string"
                         },
@@ -4085,11 +4026,14 @@
                             "type": "string"
                         },
                         "type": {
-                            "$ref": "#/definitions/TokenTransactionTypeV2"
+                            "enum": [
+                                "NFT_RECEIVED",
+                                "NFT_SENT"
+                            ],
+                            "type": "string"
                         }
                     },
                     "required": [
-                        "__typename",
                         "block",
                         "context",
                         "networkId",
@@ -4103,10 +4047,6 @@
                 {
                     "additionalProperties": false,
                     "properties": {
-                        "__typename": {
-                            "const": "EarnDeposit",
-                            "type": "string"
-                        },
                         "block": {
                             "type": "string"
                         },
@@ -4148,11 +4088,11 @@
                             "type": "string"
                         },
                         "type": {
-                            "$ref": "#/definitions/TokenTransactionTypeV2"
+                            "const": "EARN_DEPOSIT",
+                            "type": "string"
                         }
                     },
                     "required": [
-                        "__typename",
                         "block",
                         "context",
                         "fees",
@@ -4170,10 +4110,6 @@
                 {
                     "additionalProperties": false,
                     "properties": {
-                        "__typename": {
-                            "const": "EarnSwapDeposit",
-                            "type": "string"
-                        },
                         "block": {
                             "type": "string"
                         },
@@ -4242,11 +4178,11 @@
                             "type": "string"
                         },
                         "type": {
-                            "$ref": "#/definitions/TokenTransactionTypeV2"
+                            "const": "EARN_SWAP_DEPOSIT",
+                            "type": "string"
                         }
                     },
                     "required": [
-                        "__typename",
                         "block",
                         "context",
                         "deposit",
@@ -4263,10 +4199,6 @@
                 {
                     "additionalProperties": false,
                     "properties": {
-                        "__typename": {
-                            "const": "EarnWithdraw",
-                            "type": "string"
-                        },
                         "block": {
                             "type": "string"
                         },
@@ -4308,11 +4240,11 @@
                             "type": "string"
                         },
                         "type": {
-                            "$ref": "#/definitions/TokenTransactionTypeV2"
+                            "const": "EARN_WITHDRAW",
+                            "type": "string"
                         }
                     },
                     "required": [
-                        "__typename",
                         "block",
                         "context",
                         "fees",
@@ -4330,10 +4262,6 @@
                 {
                     "additionalProperties": false,
                     "properties": {
-                        "__typename": {
-                            "const": "EarnClaimReward",
-                            "type": "string"
-                        },
                         "amount": {
                             "$ref": "#/definitions/TokenAmount"
                         },
@@ -4372,11 +4300,11 @@
                             "type": "string"
                         },
                         "type": {
-                            "$ref": "#/definitions/TokenTransactionTypeV2"
+                            "const": "EARN_CLAIM_REWARD",
+                            "type": "string"
                         }
                     },
                     "required": [
-                        "__typename",
                         "amount",
                         "block",
                         "context",
@@ -5989,10 +5917,6 @@
         "TokenApproval": {
             "additionalProperties": false,
             "properties": {
-                "__typename": {
-                    "const": "TokenApproval",
-                    "type": "string"
-                },
                 "approvedAmount": {
                     "type": [
                         "null",
@@ -6024,11 +5948,11 @@
                     "type": "string"
                 },
                 "type": {
-                    "$ref": "#/definitions/TokenTransactionTypeV2"
+                    "const": "APPROVAL",
+                    "type": "string"
                 }
             },
             "required": [
-                "__typename",
                 "approvedAmount",
                 "block",
                 "fees",
@@ -6044,13 +5968,6 @@
         "TokenExchange": {
             "additionalProperties": false,
             "properties": {
-                "__typename": {
-                    "enum": [
-                        "CrossChainTokenExchange",
-                        "TokenExchangeV3"
-                    ],
-                    "type": "string"
-                },
                 "block": {
                     "type": "string"
                 },
@@ -6082,11 +5999,15 @@
                     "type": "string"
                 },
                 "type": {
-                    "$ref": "#/definitions/TokenTransactionTypeV2"
+                    "enum": [
+                        "CROSS_CHAIN_SWAP_TRANSACTION",
+                        "EXCHANGE",
+                        "SWAP_TRANSACTION"
+                    ],
+                    "type": "string"
                 }
             },
             "required": [
-                "__typename",
                 "block",
                 "fees",
                 "inAmount",
@@ -6139,19 +6060,10 @@
                 }
             ]
         },
-        "TokenTransactionTypeV2": {
+        "TokenTransactionTypeV2.Exchange": {
             "enum": [
-                "APPROVAL",
                 "CROSS_CHAIN_SWAP_TRANSACTION",
-                "EARN_CLAIM_REWARD",
-                "EARN_DEPOSIT",
-                "EARN_SWAP_DEPOSIT",
-                "EARN_WITHDRAW",
                 "EXCHANGE",
-                "NFT_RECEIVED",
-                "NFT_SENT",
-                "RECEIVED",
-                "SENT",
                 "SWAP_TRANSACTION"
             ],
             "type": "string"
@@ -6159,10 +6071,6 @@
         "TokenTransfer": {
             "additionalProperties": false,
             "properties": {
-                "__typename": {
-                    "const": "TokenTransferV3",
-                    "type": "string"
-                },
                 "address": {
                     "type": "string"
                 },
@@ -6194,11 +6102,14 @@
                     "type": "string"
                 },
                 "type": {
-                    "$ref": "#/definitions/TokenTransactionTypeV2"
+                    "enum": [
+                        "RECEIVED",
+                        "SENT"
+                    ],
+                    "type": "string"
                 }
             },
             "required": [
-                "__typename",
                 "address",
                 "amount",
                 "block",

--- a/test/schemas.ts
+++ b/test/schemas.ts
@@ -3553,6 +3553,14 @@ export const v234Schema = {
   },
 }
 
+export const v235Schema = {
+  ...v234Schema,
+  _persist: {
+    ...v234Schema._persist,
+    version: 235,
+  },
+}
+
 export function getLatestSchema(): Partial<RootState> {
-  return v234Schema as Partial<RootState>
+  return v235Schema as Partial<RootState>
 }

--- a/test/values.ts
+++ b/test/values.ts
@@ -2016,7 +2016,6 @@ export const mockTypedData = {
 
 export const mockApprovalTransaction: TokenApproval = {
   tokenId: 'ethereum-sepolia:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
-  __typename: 'TokenApproval',
   timestamp: 1695389027000,
   type: TokenTransactionTypeV2.Approval,
   networkId: NetworkId['ethereum-sepolia'],
@@ -2037,7 +2036,6 @@ export const mockApprovalTransaction: TokenApproval = {
 
 export const mockEarnClaimRewardTransaction: EarnClaimReward = {
   type: TokenTransactionTypeV2.EarnClaimReward,
-  __typename: 'EarnClaimReward',
   amount: {
     localAmount: undefined,
     tokenAddress: mockArbArbAddress,
@@ -2064,7 +2062,6 @@ export const mockEarnClaimRewardTransaction: EarnClaimReward = {
 }
 
 export const mockEarnDepositTransaction: EarnDeposit = {
-  __typename: 'EarnDeposit',
   inAmount: {
     localAmount: undefined,
     tokenAddress: mockAaveArbUsdcAddress,
@@ -2098,7 +2095,6 @@ export const mockEarnDepositTransaction: EarnDeposit = {
 }
 
 export const mockEarnSwapDeposit: EarnSwapDeposit = {
-  __typename: 'EarnSwapDeposit',
   deposit: {
     inAmount: {
       localAmount: undefined,
@@ -2148,7 +2144,6 @@ export const mockEarnSwapDeposit: EarnSwapDeposit = {
 }
 
 export const mockEarnWithdrawTransaction: EarnWithdraw = {
-  __typename: 'EarnWithdraw',
   inAmount: {
     localAmount: undefined,
     tokenAddress: '0xdef',


### PR DESCRIPTION
### Description

`__typename` was inherited from GraphQL and is not needed anymore.
It was duplicating the `type` property and making it a bit difficult to see which one should be used now.

### Test plan

- Tests pass

### Related issues

N/A

### Backwards compatibility

Almost, but the analytics event `earn_feed_item_select` will now return the `type` value instead of `__typename` for the `origin` property.

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
