### PR TITLE
refactor(colors): sync names with design system

### DIFF
--- a/src/account/SupportContact.tsx
+++ b/src/account/SupportContact.tsx
@@ -181,7 +181,7 @@ function SupportContact({ route }: Props) {
         </View>
         {inProgress && (
           <View style={styles.loadingSpinnerContainer} testID="ImportWalletLoadingCircle">
-            <ActivityIndicator size="large" color={colors.primary} />
+            <ActivityIndicator size="large" color={colors.accent} />
           </View>
         )}
 

--- a/src/app/AppLoading.tsx
+++ b/src/app/AppLoading.tsx
@@ -64,7 +64,7 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     flex: 1,
     width: '100%',
-    backgroundColor: colors.primary,
+    backgroundColor: colors.accent,
   },
 
   button: {

--- a/src/app/MultichainBeta.tsx
+++ b/src/app/MultichainBeta.tsx
@@ -3,8 +3,8 @@ import { useTranslation } from 'react-i18next'
 import { StyleSheet, Text, View } from 'react-native'
 import { ScrollView } from 'react-native-gesture-handler'
 import { SafeAreaView } from 'react-native-safe-area-context'
-import { AppEvents } from 'src/analytics/Events'
 import AppAnalytics from 'src/analytics/AppAnalytics'
+import { AppEvents } from 'src/analytics/Events'
 import { MultichainBetaStatus, optMultichainBeta } from 'src/app/actions'
 import { multichainBetaStatusSelector } from 'src/app/selectors'
 import BetaTag from 'src/components/BetaTag'
@@ -128,7 +128,7 @@ const styles = StyleSheet.create({
     height: 56,
   },
   supportButton: {
-    color: Colors.primary,
+    color: Colors.accent,
     ...typeScale.bodyMedium,
   },
 })

--- a/src/backup/BackupQuiz.tsx
+++ b/src/backup/BackupQuiz.tsx
@@ -7,9 +7,9 @@ import { SafeAreaView } from 'react-native-safe-area-context'
 import { connect } from 'react-redux'
 import { setBackupCompleted } from 'src/account/actions'
 import { showError } from 'src/alert/actions'
+import AppAnalytics from 'src/analytics/AppAnalytics'
 import { OnboardingEvents } from 'src/analytics/Events'
 import { BackQuizProgress } from 'src/analytics/types'
-import AppAnalytics from 'src/analytics/AppAnalytics'
 import CancelConfirm from 'src/backup/CancelConfirm'
 import { QuizzBottom } from 'src/backup/QuizzBottom'
 import { getStoredMnemonic, onGetMnemonicFail } from 'src/backup/utils'
@@ -321,7 +321,7 @@ function DeleteWord({
   }
   return (
     <Touchable borderless={true} onPress={onPressBackspace} style={styles.backWord}>
-      <Backspace color={colors.primary} />
+      <Backspace color={colors.accent} />
     </Touchable>
   )
 }
@@ -398,7 +398,7 @@ const styles = StyleSheet.create({
   mnemonicWordButtonOutterRim: {
     borderRadius: 100,
     borderWidth: 1.5,
-    borderColor: colors.primary,
+    borderColor: colors.accent,
     overflow: 'hidden',
     marginVertical: 4,
     marginHorizontal: 4,
@@ -411,7 +411,7 @@ const styles = StyleSheet.create({
   },
   mnemonicWordButonText: {
     textAlign: 'center',
-    color: colors.primary,
+    color: colors.accent,
   },
   backWord: {
     paddingRight: 24,

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -161,7 +161,7 @@ function getColors(type: BtnTypes, disabled: boolean | undefined) {
   switch (type) {
     case BtnTypes.PRIMARY:
       textColor = colors.white
-      backgroundColor = colors.black
+      backgroundColor = colors.primary
       opacity = disabled ? 0.25 : 1.0
       break
     case BtnTypes.SECONDARY:

--- a/src/components/CircleButton.tsx
+++ b/src/components/CircleButton.tsx
@@ -19,8 +19,8 @@ export default class CircleButton extends React.PureComponent<ButtonProps> {
   static defaultProps = {
     size: 50,
     disable: false,
-    activeColor: colors.primary,
-    inactiveColor: colors.primaryDisabled,
+    activeColor: colors.accent,
+    inactiveColor: colors.accentDisabled,
   }
 
   render() {

--- a/src/components/CodeInput.tsx
+++ b/src/components/CodeInput.tsx
@@ -80,7 +80,7 @@ export default function CodeInput({
       </View>
       {showStatus && (
         <View style={styles.statusContainer}>
-          {showSpinner && <ActivityIndicator size="small" color={colors.primary} />}
+          {showSpinner && <ActivityIndicator size="small" color={colors.accent} />}
           {showCheckmark && <Checkmark testID={testID ? `${testID}/CheckIcon` : undefined} />}
 
           {showError && (

--- a/src/components/CodeRow.tsx
+++ b/src/components/CodeRow.tsx
@@ -65,7 +65,7 @@ function CodeRow({
     return (
       <View style={styles.codeProcessingContainer}>
         <Text style={styles.codeValue}>{shortenedInput || t('processing')}</Text>
-        <ActivityIndicator size="small" color={colors.primary} style={styles.codeInputSpinner} />
+        <ActivityIndicator size="small" color={colors.accent} style={styles.codeInputSpinner} />
       </View>
     )
   }

--- a/src/components/CurrencyDisplay.tsx
+++ b/src/components/CurrencyDisplay.tsx
@@ -167,7 +167,7 @@ export default function CurrencyDisplay({
   const color = useColors
     ? amountCurrency === Currency.Celo
       ? colors.goldBrand
-      : colors.primary
+      : colors.accent
     : StyleSheet.flatten(style)?.color
 
   if (type === DisplayType.Big) {

--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -70,7 +70,7 @@ export default function Dialog({
           </TextButton>
         )}
         {showLoading ? (
-          <ActivityIndicator style={styles.primary} size="small" color={colors.primary} />
+          <ActivityIndicator style={styles.primary} size="small" color={colors.accent} />
         ) : (
           <>
             {!!actionText && (

--- a/src/components/Dropdown.tsx
+++ b/src/components/Dropdown.tsx
@@ -29,10 +29,10 @@ function Dropdown<T>(props: Props<T>) {
         <View style={styles.selectedOptionContainer}>
           <Text style={styles.optionText}>{labelSelected}</Text>
           {!isOpen ? (
-            <DownArrowIcon color={Colors.primary} strokeWidth={2} />
+            <DownArrowIcon color={Colors.accent} strokeWidth={2} />
           ) : (
             <DownArrowIcon
-              color={Colors.primary}
+              color={Colors.accent}
               strokeWidth={2}
               style={{ transform: [{ rotate: '180deg' }] }}
             />

--- a/src/components/LineItemRow.tsx
+++ b/src/components/LineItemRow.tsx
@@ -46,7 +46,7 @@ export default function LineItemRow({
       )}
       {isLoading && (
         <View style={styles.loadingContainer} testID="LineItemLoading">
-          <ActivityIndicator size="small" color={colors.primary} />
+          <ActivityIndicator size="small" color={colors.accent} />
         </View>
       )}
     </View>

--- a/src/components/PercentageIndicator.tsx
+++ b/src/components/PercentageIndicator.tsx
@@ -42,7 +42,7 @@ function PercentageIndicator({
   let color: Colors
 
   if (comparison > 0) {
-    color = Colors.primary
+    color = Colors.accent
     indicator = <UpIcon color={color} testID={`${testID}:UpIndicator`} />
   } else if (comparison < 0) {
     color = Colors.error

--- a/src/components/RecoveryPhraseInput.tsx
+++ b/src/components/RecoveryPhraseInput.tsx
@@ -116,7 +116,7 @@ export default function RecoveryPhraseInput({
           </View>
           {showStatus && (
             <View style={styles.statusContainer}>
-              {showStatus && <ActivityIndicator size="small" color={colors.primary} />}
+              {showStatus && <ActivityIndicator size="small" color={colors.accent} />}
             </View>
           )}
         </View>

--- a/src/components/SegmentedControl.tsx
+++ b/src/components/SegmentedControl.tsx
@@ -29,7 +29,7 @@ export default function SegmentedControl({ values, selectedIndex = 0, onChange }
     Extrapolation.CLAMP
   )
 
-  const color = interpolateColor(selectedIndex, [0.5, 1], [colors.primary, colors.white])
+  const color = interpolateColor(selectedIndex, [0.5, 1], [colors.accent, colors.white])
   const colorInverted = interpolateColor(selectedIndex, [0.5, 1], [colors.white, colors.black])
 
   const onLayout = ({
@@ -118,7 +118,7 @@ const styles = StyleSheet.create({
     height: HEIGHT,
     borderRadius: HEIGHT / 2,
     borderWidth: 1,
-    borderColor: colors.primary,
+    borderColor: colors.accent,
     overflow: 'hidden',
     marginHorizontal: 30,
   },
@@ -128,7 +128,7 @@ const styles = StyleSheet.create({
     bottom: 0,
     right: 0,
     left: 0,
-    backgroundColor: colors.primary,
+    backgroundColor: colors.accent,
   },
   maskedContainer: {
     // Transparent background because mask is based off alpha channel.
@@ -145,6 +145,6 @@ const styles = StyleSheet.create({
   },
   text: {
     ...typeScale.labelSemiBoldXSmall,
-    color: colors.primary,
+    color: colors.accent,
   },
 })

--- a/src/components/SettingsItem.tsx
+++ b/src/components/SettingsItem.tsx
@@ -3,10 +3,10 @@ import { StyleSheet, Switch, Text, View } from 'react-native'
 import ListItem from 'src/components/ListItem'
 import TextInput from 'src/components/TextInput'
 import ForwardChevron from 'src/icons/ForwardChevron'
+import OpenLinkIcon from 'src/icons/OpenLinkIcon'
 import colors from 'src/styles/colors'
 import { typeScale } from 'src/styles/fonts'
 import { Spacing } from 'src/styles/styles'
-import OpenLinkIcon from 'src/icons/OpenLinkIcon'
 
 interface WrapperProps {
   testID?: string
@@ -65,7 +65,7 @@ export function SettingsItemTextValue({
             </Text>
           )}
           {(!!value || showChevron) && (
-            <ForwardChevron height={12} color={isValueActionable ? colors.primary : colors.gray3} />
+            <ForwardChevron height={12} color={isValueActionable ? colors.accent : colors.gray3} />
           )}
           {isExternalLink && <OpenLinkIcon size={16} color={colors.black} />}
         </View>
@@ -215,7 +215,7 @@ const styles = StyleSheet.create({
   },
   valueActionable: {
     ...typeScale.bodyMedium,
-    color: colors.primary,
+    color: colors.accent,
     marginRight: 8,
   },
   details: {

--- a/src/components/SmallButton.tsx
+++ b/src/components/SmallButton.tsx
@@ -41,7 +41,7 @@ export default class SmallButton extends React.Component<ButtonProps> {
             accessibilityLabel={accessibilityLabel}
             style={[
               styles.text,
-              solid ? { color: colors.white } : { color: colors.primary },
+              solid ? { color: colors.white } : { color: colors.accent },
               children ? styles.textPadding : null,
               textStyle,
             ]}
@@ -67,14 +67,14 @@ const styles = StyleSheet.create({
     borderRadius: 2,
   },
   solid: {
-    backgroundColor: colors.primary,
+    backgroundColor: colors.accent,
     paddingVertical: PADDING_VERTICAL + 2,
     paddingHorizontal: PADDING_HORIZONTAL + 2,
   },
   hollow: {
     backgroundColor: 'transparent',
     borderWidth: 2,
-    borderColor: colors.primary,
+    borderColor: colors.accent,
   },
   text: {
     ...typeScale.labelMedium,

--- a/src/components/Switch.tsx
+++ b/src/components/Switch.tsx
@@ -15,5 +15,5 @@ export default function Switch(props: SwitchProps) {
 
 const SWITCH_TRACK = {
   false: colors.gray3,
-  true: colors.primary,
+  true: colors.accent,
 }

--- a/src/components/TextButton.tsx
+++ b/src/components/TextButton.tsx
@@ -17,6 +17,6 @@ export default function TextButton({ style, ...passThroughProps }: Props) {
 const styles = StyleSheet.create({
   text: {
     ...typeScale.labelSemiBoldMedium,
-    color: colors.primary,
+    color: colors.accent,
   },
 })

--- a/src/components/TokenBalance.tsx
+++ b/src/components/TokenBalance.tsx
@@ -210,7 +210,7 @@ export function AssetsTokenBalance({ showInfo }: { showInfo: boolean }) {
               hitSlop={variables.iconHitslop}
               testID="AssetsTokenBalance/Info"
             >
-              <InfoIcon color={Colors.primary} />
+              <InfoIcon color={Colors.accent} />
             </TouchableOpacity>
           )}
         </View>

--- a/src/dapps/DappShortcutTransactionRequest.tsx
+++ b/src/dapps/DappShortcutTransactionRequest.tsx
@@ -149,7 +149,7 @@ function Content({ rewardId }: { rewardId: string }) {
     return (
       <ActivityIndicator
         testID="DappShortcutTransactionRequest/Loading"
-        color={Colors.primary}
+        color={Colors.accent}
         style={styles.loader}
       />
     )

--- a/src/dapps/DappsScreen.tsx
+++ b/src/dapps/DappsScreen.tsx
@@ -13,8 +13,8 @@ import {
 import { ScrollView } from 'react-native-gesture-handler'
 import Animated, { useAnimatedScrollHandler, useSharedValue } from 'react-native-reanimated'
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context'
-import { DappExplorerEvents } from 'src/analytics/Events'
 import AppAnalytics from 'src/analytics/AppAnalytics'
+import { DappExplorerEvents } from 'src/analytics/Events'
 import FilterChipsCarousel, { BooleanFilterChip } from 'src/components/FilterChipsCarousel'
 import SearchInput from 'src/components/SearchInput'
 import {
@@ -204,8 +204,8 @@ function DappsScreen({ navigation }: Props) {
           <AnimatedSectionList
             refreshControl={
               <RefreshControl
-                tintColor={Colors.primary}
-                colors={[Colors.primary]}
+                tintColor={Colors.accent}
+                colors={[Colors.accent]}
                 style={styles.refreshControl}
                 refreshing={loading}
                 onRefresh={() => dispatch(fetchDappsList())}

--- a/src/dappsExplorer/DiscoverDappsCard.tsx
+++ b/src/dappsExplorer/DiscoverDappsCard.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect, useMemo, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { SectionList, StyleSheet, Text, View } from 'react-native'
-import { DappExplorerEvents } from 'src/analytics/Events'
 import AppAnalytics from 'src/analytics/AppAnalytics'
+import { DappExplorerEvents } from 'src/analytics/Events'
 import TextButton from 'src/components/TextButton'
 import { favoriteDappsSelector, mostPopularDappsSelector } from 'src/dapps/selectors'
 import { fetchDappsList } from 'src/dapps/slice'
@@ -146,7 +146,7 @@ const styles = StyleSheet.create({
   },
   footer: {
     ...typeScale.labelSemiBoldXSmall,
-    color: Colors.primary,
+    color: Colors.accent,
   },
   title: {
     ...typeScale.labelSemiBoldMedium,

--- a/src/earn/EarnCollectScreen.tsx
+++ b/src/earn/EarnCollectScreen.tsx
@@ -410,7 +410,7 @@ const styles = StyleSheet.create({
   },
   gasSubsidized: {
     ...typeScale.labelXSmall,
-    color: Colors.primary,
+    color: Colors.accent,
     marginTop: Spacing.Tiny4,
   },
 })

--- a/src/earn/EarnDepositBottomSheet.tsx
+++ b/src/earn/EarnDepositBottomSheet.tsx
@@ -359,6 +359,6 @@ const styles = StyleSheet.create({
   },
   gasSubsidized: {
     ...typeScale.labelXSmall,
-    color: Colors.primary,
+    color: Colors.accent,
   },
 })

--- a/src/earn/poolInfoScreen/SafetyCard.test.tsx
+++ b/src/earn/poolInfoScreen/SafetyCard.test.tsx
@@ -40,9 +40,9 @@ describe('SafetyCard', () => {
   })
 
   it.each([
-    { level: 'low', colors: [Colors.primary, Colors.gray2, Colors.gray2] },
-    { level: 'medium', colors: [Colors.primary, Colors.primary, Colors.gray2] },
-    { level: 'high', colors: [Colors.primary, Colors.primary, Colors.primary] },
+    { level: 'low', colors: [Colors.accent, Colors.gray2, Colors.gray2] },
+    { level: 'medium', colors: [Colors.accent, Colors.accent, Colors.gray2] },
+    { level: 'high', colors: [Colors.accent, Colors.accent, Colors.accent] },
   ] as const)('should render correct triple bars for safety level $level', ({ level, colors }) => {
     const { getAllByTestId } = render(<SafetyCard {...mockProps} safety={{ level, risks: [] }} />)
 

--- a/src/earn/poolInfoScreen/SafetyCard.tsx
+++ b/src/earn/poolInfoScreen/SafetyCard.tsx
@@ -27,7 +27,7 @@ function Risk({ risk }: { risk: SafetyRisk }) {
     <View style={styles.riskContainer} testID="SafetyCard/Risk">
       <View style={styles.icon}>
         {risk.isPositive ? (
-          <DataUp color={Colors.primary} testID="SafetyCard/RiskPositive" />
+          <DataUp color={Colors.accent} testID="SafetyCard/RiskPositive" />
         ) : (
           <DataDown color={Colors.error} testID="SafetyCard/RiskNegative" />
         )}
@@ -119,7 +119,7 @@ const styles = StyleSheet.create({
     backgroundColor: Colors.gray2,
   },
   barHighlighted: {
-    backgroundColor: Colors.primary,
+    backgroundColor: Colors.accent,
   },
   viewDetailsText: {
     ...typeScale.labelSemiBoldSmall,

--- a/src/fiatExchanges/BidaliScreen.tsx
+++ b/src/fiatExchanges/BidaliScreen.tsx
@@ -163,7 +163,7 @@ BidaliScreen.navigationOptions = () => {
       <ActivityIndicator
         style={styles.headerActivityIndicator}
         size="small"
-        color={colors.primary}
+        color={colors.accent}
       />
     ),
   }

--- a/src/fiatExchanges/FiatExchangeAmount.tsx
+++ b/src/fiatExchanges/FiatExchangeAmount.tsx
@@ -296,7 +296,7 @@ const styles = StyleSheet.create({
     minHeight: 48, // setting height manually b.c. of bug causing text to jump on Android
   },
   fiatCurrencyColor: {
-    color: colors.primary,
+    color: colors.accent,
   },
   reviewBtn: {
     padding: variables.contentPadding,

--- a/src/fiatExchanges/PaymentMethodSection.tsx
+++ b/src/fiatExchanges/PaymentMethodSection.tsx
@@ -229,7 +229,7 @@ export function PaymentMethodSection({
       >
         <View>
           <Expandable
-            arrowColor={colors.primary}
+            arrowColor={colors.accent}
             containerStyle={{
               ...styles.expandableContainer,
               paddingVertical: isExpandable ? (expanded ? 22 : 27) : 16,
@@ -372,7 +372,7 @@ const styles = StyleSheet.create({
   },
   expandedTag: {
     ...typeScale.labelSemiBoldSmall,
-    color: colors.primary,
+    color: colors.accent,
     fontSize: 12,
     marginTop: 2,
   },

--- a/src/fiatExchanges/ReviewFees.tsx
+++ b/src/fiatExchanges/ReviewFees.tsx
@@ -84,7 +84,7 @@ export default function ReviewFees({
         <Text style={typeScale.labelSemiBoldLarge}>{t('providerFeesDialog.title')}</Text>
         {'\n\n'}
         <Text style={[typeScale.bodyMedium]}>{t('providerFeesDialog.body1')}</Text>
-        <Text style={{ color: colors.primary }} onPress={openProviderFeeUrl}>
+        <Text style={{ color: colors.accent }} onPress={openProviderFeeUrl}>
           {t('providerFeesDialog.body2', { providerName: provider })}
         </Text>
       </Dialog>
@@ -180,7 +180,7 @@ const styles = StyleSheet.create({
   },
   feeWaivedText: {
     ...typeScale.bodyMedium,
-    color: colors.primary,
+    color: colors.accent,
   },
   reviewLineTextAlt: {
     color: colors.gray4,

--- a/src/fiatExchanges/SelectProvider.tsx
+++ b/src/fiatExchanges/SelectProvider.tsx
@@ -256,7 +256,7 @@ export default function SelectProviderScreen({ route, navigation }: Props) {
   if (quotesLoading) {
     return (
       <View style={styles.activityIndicatorContainer}>
-        <ActivityIndicator testID="QuotesLoading" size="large" color={colors.primary} />
+        <ActivityIndicator testID="QuotesLoading" size="large" color={colors.accent} />
       </View>
     )
   }
@@ -603,7 +603,7 @@ const styles = StyleSheet.create({
   },
   switchCurrency: {
     ...typeScale.labelLarge,
-    color: colors.primary,
+    color: colors.accent,
     padding: Spacing.Smallest8,
   },
   noPaymentMethodsContainer: {

--- a/src/fiatExchanges/SimplexScreen.tsx
+++ b/src/fiatExchanges/SimplexScreen.tsx
@@ -110,7 +110,7 @@ function SimplexScreen({ route, navigation }: Props) {
     <View style={styles.container}>
       {loadSimplexCheckout && simplexPaymentRequest && !redirected && (
         <View style={[styles.container, styles.indicator]}>
-          <ActivityIndicator size="large" color={colors.primary} />
+          <ActivityIndicator size="large" color={colors.accent} />
         </View>
       )}
       {!loadSimplexCheckout || !simplexPaymentRequest ? (

--- a/src/fiatconnect/FiatDetailsScreen.tsx
+++ b/src/fiatconnect/FiatDetailsScreen.tsx
@@ -204,13 +204,13 @@ const FiatDetailsScreen = ({ route, navigation }: Props) => {
     case SendingFiatAccountStatus.Sending:
       return (
         <View testID="spinner" style={styles.activityIndicatorContainer}>
-          <ActivityIndicator size="large" color={colors.primary} />
+          <ActivityIndicator size="large" color={colors.accent} />
         </View>
       )
     case SendingFiatAccountStatus.KycApproved:
       return (
         <View testID="checkmark" style={styles.activityIndicatorContainer}>
-          <Checkmark color={colors.primary} />
+          <Checkmark color={colors.accent} />
         </View>
       )
     case SendingFiatAccountStatus.NotSending:

--- a/src/fiatconnect/KycLanding.tsx
+++ b/src/fiatconnect/KycLanding.tsx
@@ -54,7 +54,7 @@ export default function KycLanding(
   if (personaInProgress) {
     return (
       <View style={styles.activityIndicatorContainer}>
-        <ActivityIndicator testID="personaInProgress" size="large" color={Colors.primary} />
+        <ActivityIndicator testID="personaInProgress" size="large" color={Colors.accent} />
       </View>
     )
   }

--- a/src/fiatconnect/RefetchQuoteScreen.tsx
+++ b/src/fiatconnect/RefetchQuoteScreen.tsx
@@ -53,7 +53,7 @@ export default function FiatConnectRefetchQuoteScreen({ route }: Props) {
 
   return (
     <View style={styles.activityIndicatorContainer}>
-      <ActivityIndicator size="large" color={colors.primary} />
+      <ActivityIndicator size="large" color={colors.accent} />
     </View>
   )
 }

--- a/src/fiatconnect/ReviewScreen.tsx
+++ b/src/fiatconnect/ReviewScreen.tsx
@@ -245,7 +245,7 @@ export default function FiatConnectReviewScreen({ route, navigation }: Props) {
   if (fiatConnectQuotesLoading) {
     return (
       <View style={styles.activityIndicatorContainer}>
-        <ActivityIndicator size="large" color={colors.primary} />
+        <ActivityIndicator size="large" color={colors.accent} />
       </View>
     )
   }

--- a/src/fiatconnect/TransferStatusScreen.tsx
+++ b/src/fiatconnect/TransferStatusScreen.tsx
@@ -241,7 +241,7 @@ export default function FiatConnectTransferStatusScreen({ route, navigation }: P
     case SendingTransferStatus.Sending:
       return (
         <View style={styles.activityIndicatorContainer}>
-          <ActivityIndicator testID="loadingTransferStatus" size="large" color={colors.primary} />
+          <ActivityIndicator testID="loadingTransferStatus" size="large" color={colors.accent} />
           <Text
             style={{ ...styles.loadingDescription, color: loadingDescriptionColor }}
             testID="loadingDescription"

--- a/src/fiatconnect/kyc/KycDenied.tsx
+++ b/src/fiatconnect/kyc/KycDenied.tsx
@@ -60,7 +60,7 @@ function KycDenied({ route, navigation }: Props) {
   if (tryAgainLoading) {
     return (
       <View testID="spinnerContainer" style={styles.activityIndicatorContainer}>
-        <ActivityIndicator size="large" color={colors.primary} />
+        <ActivityIndicator size="large" color={colors.accent} />
       </View>
     )
   }

--- a/src/fiatconnect/kyc/KycExpired.tsx
+++ b/src/fiatconnect/kyc/KycExpired.tsx
@@ -61,7 +61,7 @@ function KycExpired({ route, navigation }: Props) {
   if (tryAgainLoading) {
     return (
       <View testID="spinnerContainer" style={styles.activityIndicatorContainer}>
-        <ActivityIndicator size="large" color={colors.primary} />
+        <ActivityIndicator size="large" color={colors.accent} />
       </View>
     )
   }

--- a/src/home/NotificationBell.tsx
+++ b/src/home/NotificationBell.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { StyleProp, ViewStyle } from 'react-native'
-import { HomeEvents } from 'src/analytics/Events'
 import AppAnalytics from 'src/analytics/AppAnalytics'
+import { HomeEvents } from 'src/analytics/Events'
 import { useNotifications } from 'src/home/NotificationCenter'
 import NotificationBellIcon from 'src/icons/NotificationBellIcon'
 import { navigate } from 'src/navigator/NavigationService'
@@ -19,7 +19,7 @@ export default function NotificationBell({ testID, size, style }: Props) {
   const notifications = useNotifications()
 
   const hasNotifications = notifications.length > 0
-  const notificationMark = hasNotifications ? colors.primary : undefined
+  const notificationMark = hasNotifications ? colors.accent : undefined
 
   const onPress = () => {
     AppAnalytics.track(HomeEvents.notification_bell_pressed, { hasNotifications })

--- a/src/home/TabHome.tsx
+++ b/src/home/TabHome.tsx
@@ -113,7 +113,7 @@ function TabHome(_props: Props) {
   }
 
   const refresh: React.ReactElement<RefreshControlProps> = (
-    <RefreshControl refreshing={isLoading} onRefresh={onRefresh} colors={[colors.primary]} />
+    <RefreshControl refreshing={isLoading} onRefresh={onRefresh} colors={[colors.accent]} />
   ) as React.ReactElement<RefreshControlProps>
 
   const flatListSections = [

--- a/src/icons/BankIcon.tsx
+++ b/src/icons/BankIcon.tsx
@@ -12,7 +12,7 @@ export default class BankIcon extends React.PureComponent<Props> {
   static defaultProps = {
     height: 32,
     width: 32,
-    color: colors.primary,
+    color: colors.accent,
   }
 
   render() {

--- a/src/icons/CheckBox.tsx
+++ b/src/icons/CheckBox.tsx
@@ -12,7 +12,7 @@ type Props = {
 const CheckBox = ({
   checked,
   testID,
-  checkedColor = Colors.primary,
+  checkedColor = Colors.accent,
   uncheckedColor = Colors.gray3,
 }: Props) => {
   if (checked)

--- a/src/icons/Checkmark.tsx
+++ b/src/icons/Checkmark.tsx
@@ -14,7 +14,7 @@ export default class Checkmark extends React.PureComponent<Props> {
   static defaultProps = {
     height: 32,
     width: 32,
-    color: colors.primary,
+    color: colors.accent,
     stroke: false,
     testID: undefined,
   }

--- a/src/icons/CircledIcon.tsx
+++ b/src/icons/CircledIcon.tsx
@@ -11,7 +11,7 @@ interface Props {
 }
 
 export default function CircledIcon({
-  backgroundColor = colors.primary,
+  backgroundColor = colors.accent,
   radius = 50,
   borderColor,
   style,

--- a/src/icons/ClockIcon.tsx
+++ b/src/icons/ClockIcon.tsx
@@ -12,7 +12,7 @@ export default class ClockIcon extends React.PureComponent<Props> {
   static defaultProps = {
     height: 32,
     width: 32,
-    color: colors.primary,
+    color: colors.accent,
   }
 
   render() {

--- a/src/icons/CloudCheck.tsx
+++ b/src/icons/CloudCheck.tsx
@@ -8,7 +8,7 @@ interface Props {
   height?: number
 }
 
-const CloudCheck = ({ color = colors.primary, width = 20, height = 14 }: Props) => (
+const CloudCheck = ({ color = colors.accent, width = 20, height = 14 }: Props) => (
   <Svg width={width} height={height} fill="none" viewBox="0 0 20 14">
     <Path
       fill={color}

--- a/src/icons/CopyIcon.tsx
+++ b/src/icons/CopyIcon.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import Svg, { Path } from 'react-native-svg'
 import Colors from 'src/styles/colors'
 
-const CopyIcon = ({ color = Colors.primary }) => (
+const CopyIcon = ({ color = Colors.accent }) => (
   <Svg width={16} height={18} fill="none">
     <Path
       d="M11.655 0H1.835C.936 0 .2.736.2 1.636v11.455h1.636V1.636h9.819V0Zm2.454 3.273h-9c-.9 0-1.636.736-1.636 1.636v11.455c0 .9.736 1.636 1.636 1.636h9c.9 0 1.636-.736 1.636-1.636V4.909c0-.9-.736-1.636-1.636-1.636Zm0 13.09h-9V4.91h9v11.455Z"

--- a/src/icons/DataUp.tsx
+++ b/src/icons/DataUp.tsx
@@ -7,7 +7,7 @@ interface Props {
   testID?: string
 }
 
-const DataUp = ({ color = colors.primary, testID }: Props) => (
+const DataUp = ({ color = colors.accent, testID }: Props) => (
   <Svg width={10} height={6} viewBox="0 0 10 6" fill="none" testID={testID}>
     <Path d="M5 0L0 6H10L5 0Z" fill={color} />
   </Svg>

--- a/src/icons/DefaultAvatar.tsx
+++ b/src/icons/DefaultAvatar.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import Svg, { Circle } from 'react-native-svg'
-import Colors from 'src/styles/colors'
 import User from 'src/icons/User'
+import Colors from 'src/styles/colors'
 
 interface Props {
   foregroundColor: Colors
@@ -10,7 +10,7 @@ interface Props {
 
 export default function DefaultAvatar({
   foregroundColor = Colors.white,
-  backgroundColor = Colors.primary,
+  backgroundColor = Colors.accent,
 }: Props) {
   return (
     <Svg width="40" height="40" viewBox="0 0 40 40" fill="none">

--- a/src/icons/EarnCoins.tsx
+++ b/src/icons/EarnCoins.tsx
@@ -8,7 +8,7 @@ interface Props {
   size?: number
 }
 
-function EarnCoins({ color = colors.primary, testID = 'EarnCoins', size = 24 }: Props) {
+function EarnCoins({ color = colors.accent, testID = 'EarnCoins', size = 24 }: Props) {
   return (
     <Svg width={size} height={size} viewBox="0 0 24 24" fill="none" testID={testID}>
       <Path

--- a/src/icons/Lock.tsx
+++ b/src/icons/Lock.tsx
@@ -8,7 +8,7 @@ interface Props {
   height?: number
 }
 
-const Lock = ({ color = colors.primary, width = 20, height = 20 }: Props) => (
+const Lock = ({ color = colors.accent, width = 20, height = 20 }: Props) => (
   <Svg width={width} height={height} fill="none" viewBox="0 0 20 20">
     <Path
       fill={color}

--- a/src/icons/Manage.tsx
+++ b/src/icons/Manage.tsx
@@ -8,7 +8,7 @@ interface Props {
   size?: number
 }
 
-function Manage({ color = colors.primary, testID = 'Manage', size = 20 }: Props) {
+function Manage({ color = colors.accent, testID = 'Manage', size = 20 }: Props) {
   return (
     <Svg width={size} height={size} viewBox="0 0 20 20" fill="none" testID={testID}>
       <Path

--- a/src/icons/RadioButton.tsx
+++ b/src/icons/RadioButton.tsx
@@ -13,7 +13,7 @@ export default class RadioButton extends React.PureComponent<Props> {
   static defaultProps = {
     width: 20,
     height: 20,
-    color: colors.primary,
+    color: colors.accent,
     selected: true,
     disabled: false,
   }

--- a/src/icons/Share.tsx
+++ b/src/icons/Share.tsx
@@ -7,7 +7,7 @@ export interface Props {
   color?: string
 }
 
-function Share({ color = colors.primary, size = 32 }: Props) {
+function Share({ color = colors.accent, size = 32 }: Props) {
   return (
     <Svg width={size} height={size} viewBox="0 0 32 32" fill="none">
       <Path

--- a/src/icons/ThumbsUpIllustration.tsx
+++ b/src/icons/ThumbsUpIllustration.tsx
@@ -9,7 +9,7 @@ export interface Props {
 const ThumbsUpIllustration = ({ size = 72 }: Props) => (
   <Svg width={size} height={size} fill="none" viewBox="0 0 72 72">
     <Path
-      fill={Colors.primaryDisabled}
+      fill={Colors.accentDisabled}
       fill-rule="evenodd"
       d="M22.95 36.138c3.475-7.578-.332-20.911 13.982-18.603 14.466 2.332 18.973 15.283 24.031 24.732 3.496 6.532 4.065 12.679-2.324 15.822-12.112 5.958-27.096 16.644-43.348 6.647-16.057-9.875 3.113-18.682 7.66-28.598Z"
       clip-rule="evenodd"

--- a/src/icons/Wallet.tsx
+++ b/src/icons/Wallet.tsx
@@ -5,7 +5,7 @@ import Colors from 'src/styles/colors'
 const Wallet = () => (
   <Svg width={40} height={40} fill="none">
     <Path
-      fill={Colors.primaryDisabled}
+      fill={Colors.accentDisabled}
       fillRule="evenodd"
       d="M2.438 21.197c.941-3.634 7.045-4.151 11.427-5.68 3.816-1.332 7.451-3.395 11.691-2.387 4.699 1.117 8.11 4.187 10.202 7.591 2.477 4.032 4.614 8.63 2.018 12.293-2.794 3.944-8.794 6.328-14.94 5.948-5.58-.346-9.248-4.366-13.054-7.68-3.524-3.07-8.317-6.326-7.344-10.085Z"
       clipRule="evenodd"

--- a/src/keylessBackup/KeylessBackupPhoneCodeInput.tsx
+++ b/src/keylessBackup/KeylessBackupPhoneCodeInput.tsx
@@ -217,7 +217,7 @@ const styles = StyleSheet.create({
     marginBottom: Spacing.Regular16,
   },
   help: {
-    color: colors.primary,
+    color: colors.accent,
     ...typeScale.labelSemiBoldMedium,
   },
   bottomSheetTitle: {
@@ -240,7 +240,7 @@ const styles = StyleSheet.create({
     marginHorizontal: Spacing.Smallest8,
   },
   primaryCta: {
-    color: colors.primary,
+    color: colors.accent,
     textAlign: 'center',
   },
   secondaryCta: {

--- a/src/keylessBackup/KeylessBackupProgress.tsx
+++ b/src/keylessBackup/KeylessBackupProgress.tsx
@@ -483,7 +483,7 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
   help: {
-    color: colors.primary,
+    color: colors.accent,
     ...typeScale.labelSemiBoldMedium,
   },
 })

--- a/src/keylessBackup/SignInWithEmail.tsx
+++ b/src/keylessBackup/SignInWithEmail.tsx
@@ -28,13 +28,12 @@ import {
 import { useDispatch, useSelector } from 'src/redux/hooks'
 import { getFeatureGate } from 'src/statsig'
 import { StatsigFeatureGates } from 'src/statsig/types'
-import Colors from 'src/styles/colors'
+import { default as Colors, default as colors } from 'src/styles/colors'
 import { typeScale } from 'src/styles/fonts'
 import { Spacing } from 'src/styles/styles'
 import variables from 'src/styles/variables'
 import Logger from 'src/utils/Logger'
 import { walletAddressSelector } from 'src/web3/selectors'
-import colors from 'src/styles/colors'
 
 const TAG = 'keylessBackup/SignInWithEmail'
 
@@ -180,7 +179,7 @@ function SignInWithEmail({ route }: Props) {
     return (
       <SafeAreaView style={styles.container}>
         <View style={styles.activityIndicatorContainer}>
-          <ActivityIndicator testID="loadingTransferStatus" size="large" color={colors.primary} />
+          <ActivityIndicator testID="loadingTransferStatus" size="large" color={colors.accent} />
         </View>
       </SafeAreaView>
     )

--- a/src/navigator/TopBarButton.tsx
+++ b/src/navigator/TopBarButton.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { StyleProp, StyleSheet, Text, TextStyle, ViewStyle } from 'react-native'
-import { AnalyticsEventType, AnalyticsPropertiesList } from 'src/analytics/Properties'
 import AppAnalytics from 'src/analytics/AppAnalytics'
+import { AnalyticsEventType, AnalyticsPropertiesList } from 'src/analytics/Properties'
 import Touchable from 'src/components/Touchable'
 import colors from 'src/styles/colors'
 import { typeScale } from 'src/styles/fonts'
@@ -81,6 +81,6 @@ export function TopBarTextButton(props: TopBarTextButtonProps) {
 const styles = StyleSheet.create({
   text: {
     ...typeScale.bodyMedium,
-    color: colors.primary,
+    color: colors.accent,
   },
 })

--- a/src/onboarding/registration/ProtectWallet.tsx
+++ b/src/onboarding/registration/ProtectWallet.tsx
@@ -75,7 +75,7 @@ function ProtectWallet({ navigation }: Props) {
     return (
       <SafeAreaView style={styles.container}>
         <View style={styles.activityIndicatorContainer}>
-          <ActivityIndicator testID="loadingTransferStatus" size="large" color={colors.primary} />
+          <ActivityIndicator testID="loadingTransferStatus" size="large" color={colors.accent} />
         </View>
       </SafeAreaView>
     )

--- a/src/points/PointsHistoryBottomSheet.tsx
+++ b/src/points/PointsHistoryBottomSheet.tsx
@@ -114,7 +114,7 @@ function PointsHistoryBottomSheet({ forwardedRef }: Props) {
         testID={'PointsHistoryBottomSheet/Loading'}
         style={styles.loadingIcon}
         size="large"
-        color={colors.primary}
+        color={colors.accent}
       />
     ) : null
 

--- a/src/points/PointsHome.tsx
+++ b/src/points/PointsHome.tsx
@@ -107,8 +107,8 @@ export default function PointsHome({ route, navigation }: Props) {
         contentContainerStyle={styles.contentContainer}
         refreshControl={
           <RefreshControl
-            tintColor={Colors.primary}
-            colors={[Colors.primary]}
+            tintColor={Colors.accent}
+            colors={[Colors.accent]}
             refreshing={pointsBalanceStatus === 'loading'}
             onRefresh={onRefreshHistoryAndBalance}
           />

--- a/src/positions/HooksPreviewModeBanner.tsx
+++ b/src/positions/HooksPreviewModeBanner.tsx
@@ -17,7 +17,7 @@ const AnimatedSafeAreaView = Animated.createAnimatedComponent(SafeAreaView)
 const STATUS_COLORS = {
   idle: colors.gray2,
   loading: colors.gray2,
-  success: colors.primary,
+  success: colors.accent,
   error: colors.errorDark,
 }
 

--- a/src/qrcode/QRCode.tsx
+++ b/src/qrcode/QRCode.tsx
@@ -162,7 +162,7 @@ const styles = StyleSheet.create({
   link: {
     ...typeScale.labelSemiBoldMedium,
     textDecorationLine: 'underline',
-    color: colors.primary,
+    color: colors.accent,
     flexWrap: 'wrap',
   },
   qrContainer: {

--- a/src/recipients/RecipientItemV2.tsx
+++ b/src/recipients/RecipientItemV2.tsx
@@ -79,7 +79,7 @@ function RecipientItem({ recipient, onSelectRecipient, loading, selected }: Prop
           <View style={styles.rightIconContainer}>
             <ActivityIndicator
               size="small"
-              color={colors.primary}
+              color={colors.accent}
               testID="RecipientItem/ActivityIndicator"
             />
           </View>
@@ -118,7 +118,7 @@ const styles = StyleSheet.create({
     position: 'absolute',
     top: 22,
     left: 22,
-    backgroundColor: Colors.primary,
+    backgroundColor: Colors.accent,
     padding: 4,
     borderRadius: 100,
     // To override the default shadow props on the logo

--- a/src/styles/colors.tsx
+++ b/src/styles/colors.tsx
@@ -1,29 +1,44 @@
 // Designer Created Figma Colors
+// from https://www.figma.com/design/erFfzHvSTm5g1sjK6jWyEH/Working-Design-System?node-id=2100-4881&node-type=frame&t=vKGGXrs3Torz7kFE-0
 export enum Colors {
-  error = '#EA6042',
-  primary = '#1AB775',
-  primaryDisabled = `${primary}80`, // 50% opacity
-  white = '#FFFFFF',
-  ivory = '#F9F6F0',
+  // black & white
   black = '#2E3338',
+  white = '#FFFFFF',
+
+  // grays
   gray5 = '#505050',
   gray4 = '#666666',
   gray3 = '#757575',
   gray2 = '#E6E6E6',
   gray1 = '#F8F9F9',
+
+  // primary
+  primary = '#2E3338',
+  primaryDisabled = '#2E333840',
+  accent = '#1AB775',
+
+  // other
   successDark = '#137211',
   successLight = '#F1FDF1',
-  infoDark = '#0768AE',
-  infoLight = '#E8F8FF',
   warningDark = '#9C6E00',
   warningLight = '#FFF9EA',
+  error = '#EA6042',
   errorDark = '#C93717',
   errorLight = '#FBF2F0',
 
+  // shadows
   softShadow = 'rgba(156, 164, 169, 0.4)',
   lightShadow = 'rgba(48, 46, 37, 0.15)',
   barShadow = 'rgba(129, 134, 139, 0.5)',
 
+  /** @deprecated */
+  infoDark = '#0768AE',
+  /** @deprecated */
+  infoLight = '#E8F8FF',
+  /** @deprecated */
+  ivory = '#F9F6F0',
+  /** @deprecated */
+  accentDisabled = `${accent}80`, // 50% opacity
   /** @deprecated */
   goldBrand = '#FBCC5C',
   /** @deprecated */

--- a/src/tokens/PasteButton.tsx
+++ b/src/tokens/PasteButton.tsx
@@ -29,6 +29,6 @@ export const PasteButton = ({ onPress }: Props) => {
 const styles = StyleSheet.create({
   text: {
     ...typeScale.labelSemiBoldSmall,
-    color: Colors.primary,
+    color: Colors.accent,
   },
 })

--- a/src/tokens/SegmentedControl.tsx
+++ b/src/tokens/SegmentedControl.tsx
@@ -25,7 +25,7 @@ function SegmentedControl({ values, selectedIndex, onChange }: Props) {
           key={value}
           style={[
             styles.button,
-            { backgroundColor: index === selectedIndex ? Colors.primary : Colors.gray1 },
+            { backgroundColor: index === selectedIndex ? Colors.accent : Colors.gray1 },
             // Round the left and right sides of the first and last buttons respectively
             index === 0 && { borderBottomEndRadius: 0, borderTopEndRadius: 0 },
             index === values.length - 1 && { borderBottomStartRadius: 0, borderTopStartRadius: 0 },

--- a/src/transactions/NoActivity.tsx
+++ b/src/transactions/NoActivity.tsx
@@ -32,7 +32,7 @@ export class NoActivity extends React.PureComponent<Props> {
           <ActivityIndicator
             style={styles.icon}
             size="large"
-            color={colors.primary}
+            color={colors.accent}
             testID="NoActivity/loading"
           />
         )}

--- a/src/transactions/feed/EarnFeedItem.tsx
+++ b/src/transactions/feed/EarnFeedItem.tsx
@@ -93,7 +93,7 @@ function AmountDisplay({ transaction, isLocal }: AmountDisplayProps) {
     : [
         styles.amountTitle,
         transaction.__typename !== 'EarnDeposit' &&
-          transaction.__typename !== 'EarnSwapDeposit' && { color: Colors.primary },
+          transaction.__typename !== 'EarnSwapDeposit' && { color: Colors.accent },
       ]
 
   return (

--- a/src/transactions/feed/SwapFeedItem.tsx
+++ b/src/transactions/feed/SwapFeedItem.tsx
@@ -2,8 +2,8 @@ import BigNumber from 'bignumber.js'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 import { StyleSheet, Text, View } from 'react-native'
-import { HomeEvents } from 'src/analytics/Events'
 import AppAnalytics from 'src/analytics/AppAnalytics'
+import { HomeEvents } from 'src/analytics/Events'
 import TokenDisplay from 'src/components/TokenDisplay'
 import Touchable from 'src/components/Touchable'
 import { navigate } from 'src/navigator/NavigationService'
@@ -111,7 +111,7 @@ const styles = StyleSheet.create({
   },
   amount: {
     ...typeScale.labelMedium,
-    color: colors.primary,
+    color: colors.accent,
     flexWrap: 'wrap',
     textAlign: 'right',
   },

--- a/src/transactions/feed/TransactionFeed.tsx
+++ b/src/transactions/feed/TransactionFeed.tsx
@@ -128,7 +128,7 @@ function TransactionFeed() {
       />
       {fetchingMoreTransactions && (
         <View style={styles.centerContainer}>
-          <ActivityIndicator style={styles.loadingIcon} size="large" color={colors.primary} />
+          <ActivityIndicator style={styles.loadingIcon} size="large" color={colors.accent} />
         </View>
       )}
     </>

--- a/src/transactions/feed/TransactionFeedV2.tsx
+++ b/src/transactions/feed/TransactionFeedV2.tsx
@@ -472,7 +472,7 @@ export default function TransactionFeedV2() {
       />
       {isFetching && (
         <View style={styles.centerContainer} testID="TransactionList/loading">
-          <ActivityIndicator style={styles.loadingIcon} size="large" color={colors.primary} />
+          <ActivityIndicator style={styles.loadingIcon} size="large" color={colors.accent} />
         </View>
       )}
     </>

--- a/src/transactions/feed/TransferFeedItem.tsx
+++ b/src/transactions/feed/TransferFeedItem.tsx
@@ -1,8 +1,8 @@
 import BigNumber from 'bignumber.js'
 import React from 'react'
 import { StyleSheet, Text, View } from 'react-native'
-import { HomeEvents } from 'src/analytics/Events'
 import AppAnalytics from 'src/analytics/AppAnalytics'
+import { HomeEvents } from 'src/analytics/Events'
 import TokenDisplay from 'src/components/TokenDisplay'
 import Touchable from 'src/components/Touchable'
 import { jumpstartReclaimFlowStarted } from 'src/jumpstart/slice'
@@ -49,7 +49,7 @@ function TransferFeedItem({ transfer }: Props) {
     isJumpstart
   )
 
-  const colorStyle = new BigNumber(amount.value).isPositive() ? { color: colors.primary } : {}
+  const colorStyle = new BigNumber(amount.value).isPositive() ? { color: colors.accent } : {}
 
   return (
     <Touchable testID="TransferFeedItem" onPress={openTransferDetails}>

--- a/src/verify/VerificationStartScreen.tsx
+++ b/src/verify/VerificationStartScreen.tsx
@@ -205,7 +205,7 @@ function VerificationStartScreen({
   if (!account) {
     return (
       <SafeAreaView style={styles.container}>
-        <ActivityIndicator size="large" color={colors.primary} />
+        <ActivityIndicator size="large" color={colors.accent} />
       </SafeAreaView>
     )
   }

--- a/src/walletConnect/screens/WalletConnectRequest.tsx
+++ b/src/walletConnect/screens/WalletConnectRequest.tsx
@@ -30,7 +30,7 @@ function WalletConnectRequest({ route: { params } }: Props) {
     >
       {params.type === WalletConnectRequestType.Loading && (
         <>
-          <ActivityIndicator color={colors.primary} />
+          <ActivityIndicator color={colors.accent} />
           <Text style={styles.connecting}>
             {params.origin === WalletConnectPairingOrigin.Scan
               ? t('loadingFromScan')


### PR DESCRIPTION
### Description

Sync colors with design system. Changes include:
- Rename `primary` to `accent` (called `appGreen` in design system, but using `accent` to be independent of actual color after talking to Kayla)
- Add `primary` color and set to `black` and use it for Button
- Marked colors no longer in design system as deprecated 

Will make follow ups to update some inconsistencies in using colors

### Test plan

Manually ensured primary button looks the same and no other changes

### Related issues

- Part of ACT-1432

### Backwards compatibility

Yes

### Network scalability

N/A