### PR TITLE
fix(settings): use the custom Switch component

### DIFF
--- a/src/components/SettingsItem.tsx
+++ b/src/components/SettingsItem.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
-import { StyleSheet, Switch, Text, View } from 'react-native'
+import { StyleSheet, Text, View } from 'react-native'
 import ListItem from 'src/components/ListItem'
+import Switch from 'src/components/Switch'
 import TextInput from 'src/components/TextInput'
 import ForwardChevron from 'src/icons/ForwardChevron'
 import OpenLinkIcon from 'src/icons/OpenLinkIcon'

--- a/src/components/__snapshots__/SettingsItem.test.tsx.snap
+++ b/src/components/__snapshots__/SettingsItem.test.tsx.snap
@@ -165,6 +165,10 @@ exports[`SettingsItemSwitch renders correctly 1`] = `
         onChange={[Function]}
         onResponderTerminationRequest={[Function]}
         onStartShouldSetResponder={[Function]}
+        thumbTintColor="#E6E6E6"
+        trackColorForFalse="#757575"
+        trackColorForTrue="#1AB775"
+        trackTintColor="#1AB775"
       />
     </View>
   </View>


### PR DESCRIPTION
### Description

Ensured all switch use the custom switch component instead of the native one to be consistent.

### Test plan

| Platform | Before | After |
|--------|--------|--------|
| iOS | <video src="https://github.com/user-attachments/assets/898a3822-e006-4db5-b131-28023e87c5d7" /> | <video src="https://github.com/user-attachments/assets/52f0ba2e-5c47-4f56-96f9-e801bb535a14" /> |
| Android | <video src="https://github.com/user-attachments/assets/739bc481-dd38-4a52-8e35-2e9b7ce852b2" /> | <video src="https://github.com/user-attachments/assets/5448464a-4824-4c6d-b009-387138834305" /> | 

### Related issues

- Part of ACT-1432

### Backwards compatibility

Yes

### Network scalability

N/A