### PR TITLE
feat(fiatExchanges): support url params on external quotes

### DIFF
--- a/src/fiatExchanges/quotes/ExternalQuote.test.ts
+++ b/src/fiatExchanges/quotes/ExternalQuote.test.ts
@@ -233,7 +233,20 @@ describe('ExternalQuote', () => {
         tokenId: mockCusdTokenId,
       })
       quote.navigate()
-      expect(navigateToURI).toHaveBeenCalled()
+      expect(navigateToURI).toHaveBeenCalledWith('https://www.moonpay.com/')
+    })
+    it('calls navigateToURI with quote specific url', () => {
+      const quote = new ExternalQuote({
+        quote: {
+          ...(mockProviders[1].quote as RawProviderQuote[])[0],
+          url: 'https://example.com',
+        },
+        provider: mockProviders[1],
+        flow: CICOFlow.CashIn,
+        tokenId: mockCusdTokenId,
+      })
+      quote.navigate()
+      expect(navigateToURI).toHaveBeenCalledWith('https://example.com')
     })
   })
 

--- a/src/fiatExchanges/quotes/ExternalQuote.ts
+++ b/src/fiatExchanges/quotes/ExternalQuote.ts
@@ -127,7 +127,8 @@ export default class ExternalQuote extends NormalizedQuote {
         tokenId: this.tokenId,
       })
     } else {
-      navigateToURI(this.provider.url!)
+      const url = this.quote.url ?? this.provider.url
+      navigateToURI(url!)
     }
   }
 

--- a/src/fiatExchanges/utils.tsx
+++ b/src/fiatExchanges/utils.tsx
@@ -81,6 +81,7 @@ export interface RawProviderQuote {
   returnedAmount?: number
   fiatFee?: number
   extraReqs?: { mobileCarrier: 'Safaricom' | 'MTN' }
+  url?: string
 }
 
 export interface LegacyMobileMoneyProvider {


### PR DESCRIPTION
### Description

Relates to this change https://github.com/valora-inc/cloud-functions/commit/fa45ba6cf4855da36109e92f0d5bdaa44eef16e1

### Test plan

unit tests updated