### PR TITLE
chore(feedV2): only query non deprecated types

### DIFF
--- a/src/transactions/api.ts
+++ b/src/transactions/api.ts
@@ -1,10 +1,6 @@
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
 import { type LocalCurrencyCode } from 'src/localCurrency/consts'
-import {
-  TokenTransactionTypeV2,
-  type PageInfo,
-  type TokenTransaction,
-} from 'src/transactions/types'
+import { FEED_V2_INCLUDE_TYPES, type PageInfo, type TokenTransaction } from 'src/transactions/types'
 import networkConfig from 'src/web3/networkConfig'
 
 export type TransactionFeedV2Response = {
@@ -31,7 +27,7 @@ export const transactionFeedV2Api = createApi({
     >({
       query: ({ address, localCurrencyCode, endCursor }) => {
         const networkIds = Object.values(networkConfig.networkToNetworkId).join('&networkIds[]=')
-        const includeTypes = Object.values(TokenTransactionTypeV2).join('&includeTypes[]=')
+        const includeTypes = FEED_V2_INCLUDE_TYPES.join('&includeTypes[]=')
         const cursor = endCursor === undefined ? '' : `&afterCursor=${endCursor}`
         return `?networkIds[]=${networkIds}&includeTypes[]=${includeTypes}&address=${address}&localCurrencyCode=${localCurrencyCode}${cursor}`
       },

--- a/src/transactions/types.ts
+++ b/src/transactions/types.ts
@@ -129,6 +129,7 @@ export interface LocalAmount {
   exchangeRate: string
 }
 
+// Be sure to also update FEED_V2_INCLUDE_TYPES if you add a new type.
 export enum TokenTransactionTypeV2 {
   Exchange = 'EXCHANGE',
   Received = 'RECEIVED',
@@ -148,6 +149,20 @@ export enum TokenTransactionTypeV2 {
   EarnWithdraw = 'EARN_WITHDRAW',
   EarnClaimReward = 'EARN_CLAIM_REWARD',
 }
+
+// Because the codebase supports both the old and new feed,
+// we need this list. But we can remove it once we delete the old feed.
+export const FEED_V2_INCLUDE_TYPES = [
+  TokenTransactionTypeV2.Received,
+  TokenTransactionTypeV2.Sent,
+  TokenTransactionTypeV2.NftReceived,
+  TokenTransactionTypeV2.NftSent,
+  TokenTransactionTypeV2.SwapTransaction,
+  TokenTransactionTypeV2.CrossChainSwapTransaction,
+  TokenTransactionTypeV2.Approval,
+  TokenTransactionTypeV2.Deposit,
+  TokenTransactionTypeV2.Withdraw,
+]
 
 // Can we optional the fields `transactionHash` and `block`?
 export interface TokenTransfer {


### PR DESCRIPTION
### Description

We only want to query the non deprecated TX types for the new API.

### Test plan

- Tests pass

### Related issues

N/A

### Backwards compatibility

Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
