### PR TITLE
feat(feedV2): generic claim reward type

### DIFF
--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -2288,7 +2288,10 @@
     "depositSubtitle_noTxAppName": "to unknown pool",
     "withdrawTitle": "Withdrew",
     "withdrawSubtitle": "from {{txAppName}} Pool",
-    "withdrawSubtitle_noTxAppName": "from unknown app"
+    "withdrawSubtitle_noTxAppName": "from unknown app",
+    "claimRewardTitle": "Collected",
+    "claimRewardSubtitle": "from {{txAppName}} Pool",
+    "claimRewardSubtitle_noTxAppName": "from unknown app"
   },
   "transactionDetails": {
     "descriptionLabel": "Details",
@@ -2300,6 +2303,10 @@
     "withdrawSubtitle": "Withdrew {{tokenSymbol}} from {{txAppName}} Pool",
     "withdrawSubtitle_noTxAppName": "Withdrew {{tokenSymbol}} from unknown app",
     "withdrawDetails": "Amount Withdrawn",
+    "claimRewardTitle": "Collected",
+    "claimRewardSubtitle": "Collected {{tokenSymbol}} from {{txAppName}} Pool",
+    "claimRewardSubtitle_noTxAppName": "Collected {{tokenSymbol}} from unknown app",
+    "claimRewardDetails": "Amount Collected",
     "swap": "Swap",
     "network": "Network",
     "fees": "Fees"

--- a/src/transactions/feed/ClaimRewardFeedItem.test.tsx
+++ b/src/transactions/feed/ClaimRewardFeedItem.test.tsx
@@ -1,0 +1,162 @@
+import { fireEvent, render, within } from '@testing-library/react-native'
+import React from 'react'
+import { Provider } from 'react-redux'
+import AppAnalytics from 'src/analytics/AppAnalytics'
+import { HomeEvents } from 'src/analytics/Events'
+import { navigate } from 'src/navigator/NavigationService'
+import { Screens } from 'src/navigator/Screens'
+import { getFeatureGate } from 'src/statsig'
+import { StatsigFeatureGates } from 'src/statsig/types'
+import ClaimRewardFeedItem from 'src/transactions/feed/ClaimRewardFeedItem'
+import { NetworkId } from 'src/transactions/types'
+import { createMockStore } from 'test/utils'
+import {
+  mockAaveArbUsdcAddress,
+  mockAaveArbUsdcTokenId,
+  mockArbArbTokenId,
+  mockArbUsdcTokenId,
+  mockClaimRewardTransaction,
+} from 'test/values'
+
+jest.mock('src/statsig')
+jest
+  .mocked(getFeatureGate)
+  .mockImplementation((featureGateName) => featureGateName === StatsigFeatureGates.SHOW_POSITIONS)
+
+const store = createMockStore({
+  tokens: {
+    tokenBalances: {
+      [mockArbUsdcTokenId]: {
+        tokenId: mockArbUsdcTokenId,
+        symbol: 'USDC',
+        priceUsd: '1',
+        priceFetchedAt: Date.now(),
+        networkId: NetworkId['arbitrum-sepolia'],
+      },
+      [mockArbArbTokenId]: {
+        tokenId: mockArbArbTokenId,
+        symbol: 'ARB',
+        priceUsd: '0.9898',
+        priceFetchedAt: Date.now(),
+        networkId: NetworkId['arbitrum-sepolia'],
+      },
+      [mockAaveArbUsdcTokenId]: {
+        networkId: NetworkId['arbitrum-sepolia'],
+        address: mockAaveArbUsdcAddress,
+        tokenId: mockAaveArbUsdcTokenId,
+        symbol: 'aArbSepUSDC',
+        priceUsd: '1',
+        priceFetchedAt: Date.now(),
+      },
+    },
+  },
+  positions: {
+    positions: [
+      {
+        type: 'app-token',
+        networkId: NetworkId['arbitrum-sepolia'],
+        address: '0x460b97bd498e1157530aeb3086301d5225b91216',
+        tokenId: 'arbitrum-sepolia:0x460b97bd498e1157530aeb3086301d5225b91216',
+        positionId: 'arbitrum-sepolia:0x460b97bd498e1157530aeb3086301d5225b91216',
+        appId: 'aave',
+        appName: 'Aave',
+        symbol: 'aArbSepUSDC',
+        decimals: 6,
+        displayProps: {
+          title: 'USDC',
+          description: 'Supplied (APY: 1.92%)',
+          imageUrl: 'https://raw.githubusercontent.com/valora-inc/dapp-list/main/assets/aave.png',
+        },
+        dataProps: {
+          yieldRates: [
+            {
+              percentage: 1.9194202601763743,
+              label: 'Earnings APY',
+              tokenId: 'arbitrum-sepolia:0x75faf114eafb1bdbe2f0316df893fd58ce46aa4d',
+            },
+          ],
+          earningItems: [],
+          depositTokenId: 'arbitrum-sepolia:0x75faf114eafb1bdbe2f0316df893fd58ce46aa4d',
+          withdrawTokenId: 'arbitrum-sepolia:0x460b97bd498e1157530aeb3086301d5225b91216',
+        },
+        tokens: [
+          {
+            tokenId: 'arbitrum-sepolia:0x75faf114eafb1bdbe2f0316df893fd58ce46aa4d',
+            networkId: NetworkId['arbitrum-sepolia'],
+            address: '0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d',
+            symbol: 'USDC',
+            decimals: 6,
+            priceUsd: '0',
+            type: 'base-token',
+            balance: '0',
+          },
+        ],
+        pricePerShare: ['1'],
+        priceUsd: '0.999',
+        balance: '10',
+        supply: '190288.768509',
+        availableShortcutIds: ['deposit', 'withdraw'],
+      },
+    ],
+    earnPositionIds: ['arbitrum-sepolia:0x460b97bd498e1157530aeb3086301d5225b91216'],
+  },
+})
+
+describe('ClaimRewardFeedItem', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should render correctly', () => {
+    const { getByText, getByTestId } = render(
+      <Provider store={store}>
+        <ClaimRewardFeedItem transaction={mockClaimRewardTransaction} />
+      </Provider>
+    )
+
+    expect(getByText('transactionFeed.claimRewardTitle')).toBeTruthy()
+    expect(getByText('transactionFeed.claimRewardSubtitle, {"txAppName":"Aave"}')).toBeTruthy()
+    expect(
+      within(getByTestId('ClaimRewardFeedItem/amount-crypto')).getByText('+1.50 ARB')
+    ).toBeTruthy()
+    expect(within(getByTestId('ClaimRewardFeedItem/amount-local')).getByText('₱1.97')).toBeTruthy()
+  })
+
+  it('should display when app name is not available', () => {
+    const { getByText } = render(
+      <Provider store={store}>
+        <ClaimRewardFeedItem transaction={{ ...mockClaimRewardTransaction, appName: undefined }} />
+      </Provider>
+    )
+
+    expect(getByText('transactionFeed.claimRewardSubtitle, {"context":"noTxAppName"}')).toBeTruthy()
+  })
+
+  it('should navigate correctly on tap', () => {
+    const { getByTestId } = render(
+      <Provider store={store}>
+        <ClaimRewardFeedItem transaction={mockClaimRewardTransaction} />
+      </Provider>
+    )
+
+    fireEvent.press(
+      getByTestId(`ClaimRewardFeedItem/${mockClaimRewardTransaction.transactionHash}`)
+    )
+    expect(navigate).toHaveBeenCalledWith(Screens.TransactionDetailsScreen, {
+      transaction: mockClaimRewardTransaction,
+    })
+  })
+
+  it('should fire analytic event on tap', () => {
+    const { getByTestId } = render(
+      <Provider store={store}>
+        <ClaimRewardFeedItem transaction={mockClaimRewardTransaction} />
+      </Provider>
+    )
+
+    fireEvent.press(
+      getByTestId(`ClaimRewardFeedItem/${mockClaimRewardTransaction.transactionHash}`)
+    )
+    expect(AppAnalytics.track).toHaveBeenCalledWith(HomeEvents.transaction_feed_item_select)
+  })
+})

--- a/src/transactions/feed/ClaimRewardFeedItem.tsx
+++ b/src/transactions/feed/ClaimRewardFeedItem.tsx
@@ -54,6 +54,7 @@ function AmountDisplay({ transaction, isLocal }: AmountDisplayProps) {
   return (
     <TokenDisplay
       amount={amountValue}
+      localAmount={transaction.amount.localAmount}
       tokenId={tokenId}
       showLocalAmount={isLocal}
       showSymbol={true}

--- a/src/transactions/feed/ClaimRewardFeedItem.tsx
+++ b/src/transactions/feed/ClaimRewardFeedItem.tsx
@@ -1,0 +1,142 @@
+import BigNumber from 'bignumber.js'
+import React from 'react'
+import { useTranslation } from 'react-i18next'
+import { StyleSheet, Text, View } from 'react-native'
+import AppAnalytics from 'src/analytics/AppAnalytics'
+import { HomeEvents } from 'src/analytics/Events'
+import TokenDisplay from 'src/components/TokenDisplay'
+import Touchable from 'src/components/Touchable'
+import { navigate } from 'src/navigator/NavigationService'
+import { Screens } from 'src/navigator/Screens'
+import Colors from 'src/styles/colors'
+import { typeScale } from 'src/styles/fonts'
+import { Spacing } from 'src/styles/styles'
+import variables from 'src/styles/variables'
+import TransactionFeedItemImage from 'src/transactions/feed/TransactionFeedItemImage'
+import { ClaimReward } from 'src/transactions/types'
+
+interface DescriptionProps {
+  transaction: ClaimReward
+}
+
+function Description({ transaction }: DescriptionProps) {
+  const { t } = useTranslation()
+  const txAppName = transaction.appName
+  const title = t('transactionFeed.claimRewardTitle')
+  const subtitle = t('transactionFeed.claimRewardSubtitle', {
+    context: !txAppName ? 'noTxAppName' : undefined,
+    txAppName,
+  })
+
+  return (
+    <View style={styles.contentContainer}>
+      <Text style={styles.title} testID={'ClaimRewardFeedItem/title'} numberOfLines={1}>
+        {title}
+      </Text>
+      <Text style={styles.subtitle} testID={'ClaimRewardFeedItem/subtitle'} numberOfLines={1}>
+        {subtitle}
+      </Text>
+    </View>
+  )
+}
+
+interface AmountDisplayProps {
+  transaction: ClaimReward
+  isLocal: boolean
+}
+
+function AmountDisplay({ transaction, isLocal }: AmountDisplayProps) {
+  const amountValue = new BigNumber(transaction.amount.value)
+  const tokenId = transaction.amount.tokenId
+
+  const textStyle = isLocal ? styles.amountSubtitle : [styles.amountTitle, { color: Colors.accent }]
+
+  return (
+    <TokenDisplay
+      amount={amountValue}
+      tokenId={tokenId}
+      showLocalAmount={isLocal}
+      showSymbol={true}
+      showExplicitPositiveSign={!isLocal}
+      hideSign={!!isLocal}
+      style={textStyle}
+      testID={`ClaimRewardFeedItem/amount-${isLocal ? 'local' : 'crypto'}`}
+    />
+  )
+}
+
+interface AmountProps {
+  transaction: ClaimReward
+}
+
+function Amount({ transaction }: AmountProps) {
+  return (
+    <View style={styles.amountContainer}>
+      <AmountDisplay transaction={transaction} isLocal={false} />
+      <AmountDisplay transaction={transaction} isLocal={true} />
+    </View>
+  )
+}
+
+interface Props {
+  transaction: ClaimReward
+}
+
+export default function ClaimRewardFeedItem({ transaction }: Props) {
+  return (
+    <Touchable
+      testID={`ClaimRewardFeedItem/${transaction.transactionHash}`}
+      onPress={() => {
+        // TODO: we'll add the type in a subsequent PR
+        AppAnalytics.track(HomeEvents.transaction_feed_item_select)
+        navigate(Screens.TransactionDetailsScreen, { transaction })
+      }}
+    >
+      <View style={styles.container}>
+        <TransactionFeedItemImage
+          status={transaction.status}
+          transactionType={transaction.type}
+          networkId={transaction.networkId}
+        />
+        <Description transaction={transaction} />
+        <Amount transaction={transaction} />
+      </View>
+    </Touchable>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    paddingVertical: Spacing.Small12,
+    paddingHorizontal: variables.contentPadding,
+    alignItems: 'center',
+  },
+  contentContainer: {
+    flex: 1,
+    paddingHorizontal: variables.contentPadding,
+  },
+  title: {
+    ...typeScale.labelMedium,
+    color: Colors.black,
+  },
+  subtitle: {
+    ...typeScale.bodySmall,
+    color: Colors.gray4,
+  },
+  amountContainer: {
+    maxWidth: '50%',
+  },
+  amountTitle: {
+    ...typeScale.labelMedium,
+    color: Colors.black,
+    flexWrap: 'wrap',
+    textAlign: 'right',
+  },
+  amountSubtitle: {
+    ...typeScale.bodySmall,
+    color: Colors.gray4,
+    flexWrap: 'wrap',
+    textAlign: 'right',
+  },
+})

--- a/src/transactions/feed/TransactionDetailsScreen.test.tsx
+++ b/src/transactions/feed/TransactionDetailsScreen.test.tsx
@@ -11,6 +11,7 @@ import { getDynamicConfigParams } from 'src/statsig'
 import { StatsigDynamicConfigs } from 'src/statsig/types'
 import TransactionDetailsScreen from 'src/transactions/feed/TransactionDetailsScreen'
 import {
+  ClaimReward,
   DepositOrWithdraw,
   EarnClaimReward,
   EarnDeposit,
@@ -44,6 +45,7 @@ import {
   mockCeloTokenId,
   mockCeurAddress,
   mockCeurTokenId,
+  mockClaimRewardTransaction,
   mockCusdAddress,
   mockCusdTokenId,
   mockDisplayNumber2,
@@ -240,6 +242,17 @@ describe('TransactionDetailsScreen', () => {
     return {
       ...mockApprovalTransaction,
       status,
+    }
+  }
+
+  function claimRewardTransaction({
+    status = TransactionStatus.Complete,
+    ...rest
+  }: Partial<ClaimReward>): ClaimReward {
+    return {
+      ...mockClaimRewardTransaction,
+      status,
+      ...rest,
     }
   }
 
@@ -689,6 +702,71 @@ describe('TransactionDetailsScreen', () => {
       })
 
       expect(getByTestId('TransactionDetails/FeeRowItem')).toHaveTextContent('0.10 CELO')
+    })
+  })
+
+  describe('Claim Reward', () => {
+    beforeEach(() => {
+      jest.clearAllMocks()
+    })
+
+    it('renders check status action for pending ClaimReward transaction', () => {
+      const { getByText } = renderScreen({
+        transaction: claimRewardTransaction({
+          status: TransactionStatus.Pending,
+        }),
+      })
+
+      expect(getByText('transactionDetailsActions.checkPendingTransactionStatus')).toBeTruthy()
+    })
+
+    it('renders details action for complete ClaimReward transaction', () => {
+      const { getByText } = renderScreen({
+        transaction: claimRewardTransaction({
+          status: TransactionStatus.Complete,
+        }),
+        storeOverrides: {
+          tokens: {
+            tokenBalances: mockTokenBalances,
+          },
+        },
+      })
+
+      expect(getByText('transactionDetailsActions.showCompletedTransactionDetails')).toBeTruthy()
+    })
+
+    it('should display app name', () => {
+      const { getByText } = renderScreen({
+        transaction: claimRewardTransaction({ appName: 'Aave' }),
+        storeOverrides: {
+          tokens: {
+            tokenBalances: mockTokenBalances,
+          },
+        },
+      })
+
+      expect(
+        getByText(
+          'transactionDetails.claimRewardSubtitle, {"txAppName":"Aave","tokenSymbol":"ARB"}'
+        )
+      ).toBeTruthy()
+    })
+
+    it('should display when app name is not available', () => {
+      const { getByText } = renderScreen({
+        transaction: claimRewardTransaction({ appName: undefined }),
+        storeOverrides: {
+          tokens: {
+            tokenBalances: mockTokenBalances,
+          },
+        },
+      })
+
+      expect(
+        getByText(
+          'transactionDetails.claimRewardSubtitle, {"context":"noTxAppName","tokenSymbol":"ARB"}'
+        )
+      ).toBeTruthy()
     })
   })
 

--- a/src/transactions/feed/TransactionDetailsScreen.tsx
+++ b/src/transactions/feed/TransactionDetailsScreen.tsx
@@ -9,6 +9,7 @@ import { coinbasePaySendersSelector, rewardsSendersSelector } from 'src/recipien
 import { useSelector } from 'src/redux/hooks'
 import { useTokenInfo } from 'src/tokens/hooks'
 import TransactionDetails from 'src/transactions/feed/TransactionDetails'
+import { ClaimRewardContent } from 'src/transactions/feed/detailContent/ClaimRewardContent'
 import {
   EarnClaimContent,
   EarnDepositContent,
@@ -64,6 +65,8 @@ function useHeaderTitle(transaction: TokenTransaction) {
       return t('swapScreen.title')
     case TokenTransactionTypeV2.Approval:
       return t('transactionFeed.approvalTransactionTitle')
+    case TokenTransactionTypeV2.ClaimReward:
+      return t('transactionFeed.claimRewardTitle')
     case TokenTransactionTypeV2.EarnWithdraw:
       return t('earnFlow.transactionFeed.earnWithdrawTitle')
     case TokenTransactionTypeV2.EarnClaimReward:
@@ -114,6 +117,9 @@ function TransactionDetailsScreen({ route }: Props) {
     case TokenTransactionTypeV2.Deposit:
     case TokenTransactionTypeV2.Withdraw:
       content = <DepositOrWithdrawContent transaction={transaction} />
+      break
+    case TokenTransactionTypeV2.ClaimReward:
+      content = <ClaimRewardContent transaction={transaction} />
       break
     case TokenTransactionTypeV2.EarnClaimReward:
       content = <EarnClaimContent transaction={transaction} />

--- a/src/transactions/feed/TransactionFeed.tsx
+++ b/src/transactions/feed/TransactionFeed.tsx
@@ -116,6 +116,7 @@ function TransactionFeed() {
         return <TokenApprovalFeedItem key={tx.transactionHash} transaction={tx} />
       case TokenTransactionTypeV2.Deposit:
       case TokenTransactionTypeV2.Withdraw:
+      case TokenTransactionTypeV2.ClaimReward:
         // These are handled by the FeedV2 only
         return null
       case TokenTransactionTypeV2.EarnDeposit:

--- a/src/transactions/feed/TransactionFeedItemImage.tsx
+++ b/src/transactions/feed/TransactionFeedItemImage.tsx
@@ -24,6 +24,7 @@ type Props = { networkId: NetworkId; status: TransactionStatus; hideNetworkIcon?
         | TokenTransactionTypeV2.Approval
         | TokenTransactionTypeV2.Deposit
         | TokenTransactionTypeV2.Withdraw
+        | TokenTransactionTypeV2.ClaimReward
         | TokenTransactionTypeV2.EarnDeposit
         | TokenTransactionTypeV2.EarnSwapDeposit
         | TokenTransactionTypeV2.EarnWithdraw
@@ -85,6 +86,7 @@ function TransactionFeedItemBaseImage(props: Props) {
   if (
     transactionType === TokenTransactionTypeV2.Deposit ||
     transactionType === TokenTransactionTypeV2.Withdraw ||
+    transactionType === TokenTransactionTypeV2.ClaimReward ||
     transactionType === TokenTransactionTypeV2.EarnWithdraw ||
     transactionType === TokenTransactionTypeV2.EarnDeposit ||
     transactionType === TokenTransactionTypeV2.EarnClaimReward ||

--- a/src/transactions/feed/TransactionFeedV2.tsx
+++ b/src/transactions/feed/TransactionFeedV2.tsx
@@ -20,6 +20,7 @@ import { Spacing } from 'src/styles/styles'
 import { tokensByIdSelector } from 'src/tokens/selectors'
 import { getSupportedNetworkIdsForSwap } from 'src/tokens/utils'
 import { useTransactionFeedV2Query } from 'src/transactions/api'
+import ClaimRewardFeedItem from 'src/transactions/feed/ClaimRewardFeedItem'
 import DepositOrWithdrawFeedItem from 'src/transactions/feed/DepositOrWithdrawFeedItem'
 import EarnFeedItem from 'src/transactions/feed/EarnFeedItem'
 import NftFeedItem from 'src/transactions/feed/NftFeedItem'
@@ -307,6 +308,8 @@ function renderItem({ item: tx }: { item: TokenTransaction }) {
     case TokenTransactionTypeV2.Deposit:
     case TokenTransactionTypeV2.Withdraw:
       return <DepositOrWithdrawFeedItem key={tx.transactionHash} transaction={tx} />
+    case TokenTransactionTypeV2.ClaimReward:
+      return <ClaimRewardFeedItem key={tx.transactionHash} transaction={tx} />
     case TokenTransactionTypeV2.EarnDeposit:
     case TokenTransactionTypeV2.EarnSwapDeposit:
     case TokenTransactionTypeV2.EarnWithdraw:

--- a/src/transactions/feed/detailContent/ClaimRewardContent.tsx
+++ b/src/transactions/feed/detailContent/ClaimRewardContent.tsx
@@ -1,0 +1,86 @@
+import React from 'react'
+import { useTranslation } from 'react-i18next'
+import { StyleSheet, Text, View } from 'react-native'
+import RowDivider from 'src/components/RowDivider'
+import TokenDisplay from 'src/components/TokenDisplay'
+import Colors from 'src/styles/colors'
+import { typeScale } from 'src/styles/fonts'
+import { useTokenInfo } from 'src/tokens/hooks'
+import FeeRowItem from 'src/transactions/feed/detailContent/FeeRowItem'
+import { ClaimReward, FeeType } from 'src/transactions/types'
+
+interface ClaimRewardProps {
+  transaction: ClaimReward
+}
+
+export function ClaimRewardContent({ transaction }: ClaimRewardProps) {
+  const { t } = useTranslation()
+  const txAppName = transaction.appName
+  const tokenInfo = useTokenInfo(transaction.amount.tokenId)
+  const tokenSymbol = tokenInfo?.symbol ?? ''
+
+  return (
+    <>
+      <Text style={styles.detailsTitle}>{t('transactionDetails.descriptionLabel')}</Text>
+      <Text style={styles.detailsSubtitle}>
+        {t('transactionDetails.claimRewardSubtitle', {
+          context: !txAppName ? 'noTxAppName' : undefined,
+          txAppName,
+          tokenSymbol,
+        })}
+      </Text>
+      <RowDivider />
+      <View>
+        <View style={styles.row}>
+          <Text style={styles.amountTitle} testID={'ClaimRewardContent/title'}>
+            {t('transactionDetails.claimRewardDetails')}
+          </Text>
+          <TokenDisplay
+            amount={transaction.amount.value}
+            tokenId={transaction.amount.tokenId}
+            showSymbol={true}
+            showLocalAmount={false}
+            style={styles.amountTitle}
+          />
+        </View>
+        <TokenDisplay
+          amount={transaction.amount.value}
+          tokenId={transaction.amount.tokenId}
+          style={styles.amountSubtitle}
+        />
+      </View>
+      <RowDivider />
+      <FeeRowItem
+        fees={transaction.fees}
+        feeType={FeeType.SecurityFee}
+        transactionStatus={transaction.status}
+      />
+    </>
+  )
+}
+
+const styles = StyleSheet.create({
+  detailsTitle: {
+    ...typeScale.labelSmall,
+    color: Colors.black,
+  },
+  detailsSubtitle: {
+    ...typeScale.bodyMedium,
+    color: Colors.black,
+  },
+  row: {
+    flex: 1,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    flexWrap: 'wrap',
+  },
+  amountTitle: {
+    ...typeScale.labelSemiBoldMedium,
+    color: Colors.black,
+  },
+  amountSubtitle: {
+    ...typeScale.bodySmall,
+    color: Colors.gray4,
+    marginLeft: 'auto',
+  },
+})

--- a/src/transactions/feed/detailContent/ClaimRewardContent.tsx
+++ b/src/transactions/feed/detailContent/ClaimRewardContent.tsx
@@ -45,6 +45,7 @@ export function ClaimRewardContent({ transaction }: ClaimRewardProps) {
         </View>
         <TokenDisplay
           amount={transaction.amount.value}
+          localAmount={transaction.amount.localAmount}
           tokenId={transaction.amount.tokenId}
           style={styles.amountSubtitle}
         />

--- a/src/transactions/types.ts
+++ b/src/transactions/types.ts
@@ -41,6 +41,7 @@ export type ConfirmedStandbyTransaction = (
   | Omit<TokenApproval, 'status'>
   | Omit<NftTransfer, 'status'>
   | Omit<DepositOrWithdraw, 'status'>
+  | Omit<ClaimReward, 'status'>
   | Omit<EarnDeposit, 'status'>
   | Omit<EarnSwapDeposit, 'status'>
   | Omit<EarnWithdraw, 'status'>
@@ -57,6 +58,7 @@ export type StandbyTransaction =
   | PendingStandbyTransaction<TokenApproval>
   | PendingStandbyTransaction<NftTransfer>
   | PendingStandbyTransaction<DepositOrWithdraw>
+  | PendingStandbyTransaction<ClaimReward>
   | PendingStandbyTransaction<EarnDeposit>
   | PendingStandbyTransaction<EarnSwapDeposit>
   | PendingStandbyTransaction<EarnWithdraw>
@@ -111,6 +113,7 @@ export type TokenTransaction =
   | NftTransfer
   | TokenApproval
   | DepositOrWithdraw
+  | ClaimReward
   | EarnDeposit
   | EarnSwapDeposit
   | EarnWithdraw
@@ -141,12 +144,14 @@ export enum TokenTransactionTypeV2 {
   Approval = 'APPROVAL',
   Deposit = 'DEPOSIT',
   Withdraw = 'WITHDRAW',
+  ClaimReward = 'CLAIM_REWARD',
   /** @deprecated Use Deposit instead */
   EarnDeposit = 'EARN_DEPOSIT',
   /** @deprecated Use Deposit instead */
   EarnSwapDeposit = 'EARN_SWAP_DEPOSIT',
   /** @deprecated Use Withdraw instead */
   EarnWithdraw = 'EARN_WITHDRAW',
+  /** @deprecated Use ClaimReward instead */
   EarnClaimReward = 'EARN_CLAIM_REWARD',
 }
 
@@ -162,6 +167,7 @@ export const FEED_V2_INCLUDE_TYPES = [
   TokenTransactionTypeV2.Approval,
   TokenTransactionTypeV2.Deposit,
   TokenTransactionTypeV2.Withdraw,
+  TokenTransactionTypeV2.ClaimReward,
 ]
 
 // Can we optional the fields `transactionHash` and `block`?
@@ -308,7 +314,7 @@ export interface EarnWithdraw {
   status: TransactionStatus
 }
 
-/** @deprecated Use TokenTransfer instead */
+/** @deprecated Use ClaimReward instead */
 export interface EarnClaimReward {
   networkId: NetworkId
   amount: TokenAmount
@@ -318,6 +324,18 @@ export interface EarnClaimReward {
   block: string
   fees: Fee[]
   providerId: string
+  status: TransactionStatus
+}
+
+export interface ClaimReward {
+  networkId: NetworkId
+  amount: TokenAmount
+  type: TokenTransactionTypeV2.ClaimReward
+  transactionHash: string
+  timestamp: number
+  block: string
+  fees: Fee[]
+  appName: string | undefined
   status: TransactionStatus
 }
 

--- a/test/RootStateSchema.json
+++ b/test/RootStateSchema.json
@@ -813,6 +813,54 @@
                 }
             ]
         },
+        "ClaimReward": {
+            "additionalProperties": false,
+            "properties": {
+                "amount": {
+                    "$ref": "#/definitions/TokenAmount"
+                },
+                "appName": {
+                    "type": "string"
+                },
+                "block": {
+                    "type": "string"
+                },
+                "fees": {
+                    "items": {
+                        "$ref": "#/definitions/Fee"
+                    },
+                    "type": "array"
+                },
+                "networkId": {
+                    "$ref": "#/definitions/NetworkId"
+                },
+                "status": {
+                    "$ref": "#/definitions/TransactionStatus"
+                },
+                "timestamp": {
+                    "type": "number"
+                },
+                "transactionHash": {
+                    "type": "string"
+                },
+                "type": {
+                    "const": "CLAIM_REWARD",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "amount",
+                "appName",
+                "block",
+                "fees",
+                "networkId",
+                "status",
+                "timestamp",
+                "transactionHash",
+                "type"
+            ],
+            "type": "object"
+        },
         "CleverTapInboxMessage": {
             "additionalProperties": false,
             "properties": {
@@ -2603,6 +2651,49 @@
             ],
             "type": "object"
         },
+        "PendingStandbyTransaction<ClaimReward>": {
+            "additionalProperties": false,
+            "properties": {
+                "amount": {
+                    "$ref": "#/definitions/TokenAmount"
+                },
+                "appName": {
+                    "type": "string"
+                },
+                "context": {
+                    "$ref": "#/definitions/TransactionContext"
+                },
+                "feeCurrencyId": {
+                    "type": "string"
+                },
+                "networkId": {
+                    "$ref": "#/definitions/NetworkId"
+                },
+                "status": {
+                    "const": "Pending",
+                    "type": "string"
+                },
+                "timestamp": {
+                    "type": "number"
+                },
+                "transactionHash": {
+                    "type": "string"
+                },
+                "type": {
+                    "const": "CLAIM_REWARD",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "amount",
+                "context",
+                "networkId",
+                "status",
+                "timestamp",
+                "type"
+            ],
+            "type": "object"
+        },
         "PendingStandbyTransaction<DepositOrWithdraw>": {
             "additionalProperties": false,
             "properties": {
@@ -3932,6 +4023,9 @@
                     "$ref": "#/definitions/PendingStandbyTransaction<DepositOrWithdraw>"
                 },
                 {
+                    "$ref": "#/definitions/PendingStandbyTransaction<ClaimReward>"
+                },
+                {
                     "additionalProperties": false,
                     "properties": {
                         "block": {
@@ -4258,6 +4352,64 @@
                         "inAmount",
                         "networkId",
                         "outAmount",
+                        "status",
+                        "timestamp",
+                        "transactionHash",
+                        "type"
+                    ],
+                    "type": "object"
+                },
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "amount": {
+                            "$ref": "#/definitions/TokenAmount"
+                        },
+                        "appName": {
+                            "type": "string"
+                        },
+                        "block": {
+                            "type": "string"
+                        },
+                        "context": {
+                            "$ref": "#/definitions/TransactionContext"
+                        },
+                        "feeCurrencyId": {
+                            "type": "string"
+                        },
+                        "fees": {
+                            "items": {
+                                "$ref": "#/definitions/Fee"
+                            },
+                            "type": "array"
+                        },
+                        "networkId": {
+                            "$ref": "#/definitions/NetworkId"
+                        },
+                        "status": {
+                            "enum": [
+                                "Complete",
+                                "Failed"
+                            ],
+                            "type": "string"
+                        },
+                        "timestamp": {
+                            "type": "number"
+                        },
+                        "transactionHash": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "const": "CLAIM_REWARD",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "amount",
+                        "block",
+                        "context",
+                        "fees",
+                        "networkId",
                         "status",
                         "timestamp",
                         "transactionHash",
@@ -6281,6 +6433,9 @@
                 },
                 {
                     "$ref": "#/definitions/DepositOrWithdraw"
+                },
+                {
+                    "$ref": "#/definitions/ClaimReward"
                 }
             ]
         },

--- a/test/values.ts
+++ b/test/values.ts
@@ -48,6 +48,7 @@ import {
 import { TransactionDataInput } from 'src/send/types'
 import { NativeTokenBalance, StoredTokenBalance, TokenBalance } from 'src/tokens/slice'
 import {
+  ClaimReward,
   EarnClaimReward,
   EarnDeposit,
   EarnSwapDeposit,
@@ -2032,6 +2033,33 @@ export const mockApprovalTransaction: TokenApproval = {
       },
     },
   ],
+  status: TransactionStatus.Complete,
+}
+
+export const mockClaimRewardTransaction: ClaimReward = {
+  type: TokenTransactionTypeV2.ClaimReward,
+  amount: {
+    localAmount: undefined,
+    tokenAddress: mockArbArbAddress,
+    tokenId: mockArbArbTokenId,
+    value: '1.5',
+  },
+  block: '211278852',
+  fees: [
+    {
+      amount: {
+        localAmount: undefined,
+        tokenAddress: mockArbArbAddress,
+        tokenId: mockArbArbTokenId,
+        value: '0.00000146037',
+      },
+      type: 'SECURITY_FEE',
+    },
+  ],
+  networkId: NetworkId['arbitrum-sepolia'],
+  appName: 'Aave',
+  timestamp: Date.now(),
+  transactionHash: '0xHASH2',
   status: TransactionStatus.Complete,
 }
 


### PR DESCRIPTION
### Description

Introduce new generic type for the TX feed for claim reward.

`CLAIM_REWARD` replaces `EARN_CLAIM_REWARD`

Why?

1. This allows directly supporting more claim reward TXs, not only for Earn but also GoodDollar, etc.
2. We can do this now without too much effort and keep a "simple" backend implementation for the new `getWalletTransactions`

Similar to what was done in https://github.com/valora-inc/wallet/pull/6189

This is just for the new feed API with Zerion. 

### Test plan

- Tests pass

### Related issues

- Related to RET-1204
- Also see this Slack [thread](https://valora-app.slack.com/archives/C029Z1QMD7B/p1729847488933829) for context

### Backwards compatibility

Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
