### PR TITLE
chore: add `itemType` to `transaction_feed_item_select` event

### DIFF
--- a/src/analytics/Properties.tsx
+++ b/src/analytics/Properties.tsx
@@ -179,7 +179,7 @@ interface HomeEventsProperties {
     notificationPositionInList?: number
   }
   [HomeEvents.notification_center_spotlight_dismiss]: undefined
-  [HomeEvents.transaction_feed_item_select]: undefined
+  [HomeEvents.transaction_feed_item_select]: { itemType: TokenTransactionTypeV2 }
   [HomeEvents.transaction_feed_address_copy]: undefined
   [HomeEvents.view_token_balances]: { totalBalance?: string }
   [HomeEvents.home_action_pressed]: { action: HomeActionName }

--- a/src/transactions/feed/ClaimRewardFeedItem.test.tsx
+++ b/src/transactions/feed/ClaimRewardFeedItem.test.tsx
@@ -157,6 +157,8 @@ describe('ClaimRewardFeedItem', () => {
     fireEvent.press(
       getByTestId(`ClaimRewardFeedItem/${mockClaimRewardTransaction.transactionHash}`)
     )
-    expect(AppAnalytics.track).toHaveBeenCalledWith(HomeEvents.transaction_feed_item_select)
+    expect(AppAnalytics.track).toHaveBeenCalledWith(HomeEvents.transaction_feed_item_select, {
+      itemType: mockClaimRewardTransaction.type,
+    })
   })
 })

--- a/src/transactions/feed/ClaimRewardFeedItem.tsx
+++ b/src/transactions/feed/ClaimRewardFeedItem.tsx
@@ -88,8 +88,9 @@ export default function ClaimRewardFeedItem({ transaction }: Props) {
     <Touchable
       testID={`ClaimRewardFeedItem/${transaction.transactionHash}`}
       onPress={() => {
-        // TODO: we'll add the type in a subsequent PR
-        AppAnalytics.track(HomeEvents.transaction_feed_item_select)
+        AppAnalytics.track(HomeEvents.transaction_feed_item_select, {
+          itemType: transaction.type,
+        })
         navigate(Screens.TransactionDetailsScreen, { transaction })
       }}
     >

--- a/src/transactions/feed/DepositOrWithdrawFeedItem.test.tsx
+++ b/src/transactions/feed/DepositOrWithdrawFeedItem.test.tsx
@@ -1,6 +1,8 @@
-import { render } from '@testing-library/react-native'
+import { fireEvent, render } from '@testing-library/react-native'
 import * as React from 'react'
 import { Provider } from 'react-redux'
+import AppAnalytics from 'src/analytics/AppAnalytics'
+import { HomeEvents } from 'src/analytics/Events'
 import DepositOrWithdrawFeedItem from 'src/transactions/feed/DepositOrWithdrawFeedItem'
 import { NetworkId, TokenTransactionTypeV2, TransactionStatus } from 'src/transactions/types'
 import { createMockStore } from 'test/utils'
@@ -82,5 +84,18 @@ describe('DepositOrWithdrawFeedItem', () => {
     )
 
     expect(queryByText('transactionFeed.depositSubtitle, {"txAppName":"Some Dapp"}')).toBeNull()
+  })
+
+  it('should fire analytic event on tap', () => {
+    const { getByTestId } = render(
+      <Provider store={store}>
+        <DepositOrWithdrawFeedItem transaction={depositTransaction} />
+      </Provider>
+    )
+
+    fireEvent.press(getByTestId(`DepositOrWithdrawFeedItem/${depositTransaction.transactionHash}`))
+    expect(AppAnalytics.track).toHaveBeenCalledWith(HomeEvents.transaction_feed_item_select, {
+      itemType: depositTransaction.type,
+    })
   })
 })

--- a/src/transactions/feed/DepositOrWithdrawFeedItem.tsx
+++ b/src/transactions/feed/DepositOrWithdrawFeedItem.tsx
@@ -123,8 +123,9 @@ export default function DepositOrWithdrawFeedItem({ transaction }: Props) {
     <Touchable
       testID={`DepositOrWithdrawFeedItem/${transaction.transactionHash}`}
       onPress={() => {
-        // TODO: we'll add the type in a subsequent PR
-        AppAnalytics.track(HomeEvents.transaction_feed_item_select)
+        AppAnalytics.track(HomeEvents.transaction_feed_item_select, {
+          itemType: transaction.type,
+        })
         navigate(Screens.TransactionDetailsScreen, { transaction })
       }}
     >

--- a/src/transactions/feed/NftFeedItem.tsx
+++ b/src/transactions/feed/NftFeedItem.tsx
@@ -28,7 +28,9 @@ function NftFeedItem({ transaction }: Props) {
 
   const openNftTransactionDetails = () => {
     navigate(Screens.NftsInfoCarousel, { nfts, networkId: transaction.networkId })
-    AppAnalytics.track(HomeEvents.transaction_feed_item_select)
+    AppAnalytics.track(HomeEvents.transaction_feed_item_select, {
+      itemType: transaction.type,
+    })
   }
 
   return (

--- a/src/transactions/feed/SwapFeedItem.tsx
+++ b/src/transactions/feed/SwapFeedItem.tsx
@@ -27,7 +27,9 @@ function SwapFeedItem({ transaction }: Props) {
 
   const handleOpenTransactionDetails = () => {
     navigate(Screens.TransactionDetailsScreen, { transaction: transaction })
-    AppAnalytics.track(HomeEvents.transaction_feed_item_select)
+    AppAnalytics.track(HomeEvents.transaction_feed_item_select, {
+      itemType: transaction.type,
+    })
   }
 
   const isCrossChainSwap = transaction.type === TokenTransactionTypeV2.CrossChainSwapTransaction

--- a/src/transactions/feed/TokenApprovalFeedItem.tsx
+++ b/src/transactions/feed/TokenApprovalFeedItem.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 import { StyleSheet, Text, View } from 'react-native'
-import { HomeEvents } from 'src/analytics/Events'
 import AppAnalytics from 'src/analytics/AppAnalytics'
+import { HomeEvents } from 'src/analytics/Events'
 import Touchable from 'src/components/Touchable'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
@@ -21,7 +21,9 @@ function TokenApprovalFeedItem({ transaction }: Props) {
 
   const handleOpenTransactionDetails = () => {
     navigate(Screens.TransactionDetailsScreen, { transaction })
-    AppAnalytics.track(HomeEvents.transaction_feed_item_select)
+    AppAnalytics.track(HomeEvents.transaction_feed_item_select, {
+      itemType: transaction.type,
+    })
   }
 
   return (

--- a/src/transactions/feed/TransferFeedItem.tsx
+++ b/src/transactions/feed/TransferFeedItem.tsx
@@ -38,7 +38,9 @@ function TransferFeedItem({ transfer }: Props) {
       navigate(Screens.TransactionDetailsScreen, { transaction: transfer })
     }
 
-    AppAnalytics.track(HomeEvents.transaction_feed_item_select)
+    AppAnalytics.track(HomeEvents.transaction_feed_item_select, {
+      itemType: transfer.type,
+    })
   }
 
   const tokenInfo = useTokenInfo(amount.tokenId)


### PR DESCRIPTION
### Description

As the title says.

### Test plan

- Tests pass

### Related issues

See Slack [thread](https://valora-app.slack.com/archives/C02DY3RK79T/p1729846095107579).

### Backwards compatibility

Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
