### PR TITLE
fix(feedV2): inverted swap from/to for deposits with swap

### DIFF
--- a/src/transactions/feed/detailContent/DepositOrWithdrawContent.tsx
+++ b/src/transactions/feed/detailContent/DepositOrWithdrawContent.tsx
@@ -76,16 +76,16 @@ export function DepositOrWithdrawContent({ transaction }: DepositOrWithdrawConte
             <View style={styles.swapValueContainer}>
               <TokenDisplay
                 testID="DepositOrWithdraw/Swap/From"
-                tokenId={transaction.swap.inAmount.tokenId}
-                amount={transaction.swap.inAmount.value}
+                tokenId={transaction.swap.outAmount.tokenId}
+                amount={transaction.swap.outAmount.value}
                 showLocalAmount={false}
                 style={styles.bodyText}
               />
               <ArrowRightThick size={20} color={Colors.black} />
               <TokenDisplay
                 testID="DepositOrWithdraw/Swap/To"
-                tokenId={transaction.swap.outAmount.tokenId}
-                amount={transaction.swap.outAmount.value}
+                tokenId={transaction.swap.inAmount.tokenId}
+                amount={transaction.swap.inAmount.value}
                 showLocalAmount={false}
                 style={styles.bodyText}
               />


### PR DESCRIPTION
### Description

Oops, I inverted from/to in #6189

### Test plan

- Manually checked from/to are now as expected for swap and deposit.

### Related issues

Part of RET-1204

### Backwards compatibility

Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
