### PR TITLE
chore: reduce logging and update error UI for homefeed

### DIFF
--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -2291,7 +2291,10 @@
     "withdrawSubtitle_noTxAppName": "from unknown app",
     "claimRewardTitle": "Collected",
     "claimRewardSubtitle": "from {{txAppName}} Pool",
-    "claimRewardSubtitle_noTxAppName": "from unknown app"
+    "claimRewardSubtitle_noTxAppName": "from unknown app",
+    "error": {
+      "fetchError": "Oops, there was an issue refreshing your feed. Your transaction history may be incomplete for now."
+    }
   },
   "transactionDetails": {
     "descriptionLabel": "Details",

--- a/src/alert/AlertBanner.tsx
+++ b/src/alert/AlertBanner.tsx
@@ -63,6 +63,10 @@ function AlertBanner() {
         description={toastAlert?.message || ''}
         ctaLabel={toastAlert?.buttonMessage || ''}
         onPressCta={toastAlert?.isActive ? onPressToast : noop}
+        swipeable
+        onDismiss={() => {
+          dispatch(hideAlert())
+        }}
       />
     </>
   )

--- a/src/redux/sagas.ts
+++ b/src/redux/sagas.ts
@@ -71,6 +71,7 @@ const loggerPayloadBlocklist = [
   fetchPositionsSuccess.type,
   fetchShortcutsSuccess.type,
   AppActions.UPDATE_REMOTE_CONFIG_VALUES,
+  'transactionFeedV2Api/executeQuery/fulfilled',
 ]
 
 function* loggerSaga() {

--- a/src/transactions/feed/TransactionFeedV2.tsx
+++ b/src/transactions/feed/TransactionFeedV2.tsx
@@ -3,10 +3,9 @@ import React, { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ActivityIndicator, SectionList, StyleSheet, View } from 'react-native'
 import Toast from 'react-native-simple-toast'
-import { showError } from 'src/alert/actions'
+import { showToast } from 'src/alert/actions'
 import AppAnalytics from 'src/analytics/AppAnalytics'
 import { SwapEvents } from 'src/analytics/Events'
-import { ErrorMessages } from 'src/app/ErrorMessages'
 import SectionHead from 'src/components/SectionHead'
 import GetStarted from 'src/home/GetStarted'
 import { getLocalCurrencyCode } from 'src/localCurrency/selectors'
@@ -399,8 +398,8 @@ export default function TransactionFeedV2() {
     function handleError() {
       if (error === undefined) return
 
-      Logger.error(TAG, 'Error while fetching transactions', error)
-      dispatch(showError(ErrorMessages.FETCH_FAILED))
+      Logger.warn(TAG, 'Error while fetching transactions', error)
+      dispatch(showToast(t('transactionFeed.error.fetchError'), null, null, null))
     },
     [error]
   )


### PR DESCRIPTION
### Description

This PR updates 2 small things related to the transaction feed:
1. update the error state for failure to fetch transactions from banner to toast. we switched from banner to toast in the balances fetch because the banner blocks the navigation buttons at the top and is not dismissable. i also updated the error message because "server connection failed" doesn't fit the voice of the app.
2. omit logging the payload of the transaction feed, this adds extra noise to the logs and the payload (example below) is unhelpful.
`DEBUG  [15:14:33.829Z] iPhone 15 Pro redux/saga@logger {"meta": {"RTK_autoBatch": true, "arg": {"endpointName": "transactionFeedV2", "forceRefetch": true, "originalArgs": [Object], "queryCacheKey": "transactionFeedV2({\"address\":\"0x1d21ee8eb9607f2484d814d83cd3b4714c44d105\",\"localCurrencyCode\":\"EUR\"})", "subscribe": false, "subscriptionOptions": undefined, "type": "query", Symbol(forceQueryFn): undefined}, "baseQueryMeta": {"request": [Request], "response": [Response]}, "fulfilledTimeStamp": 1730387673797, "requestId": "mS2XSIkVCYZI4e1fU7IbV", "requestStatus": "fulfilled"}, "payload": {"pageInfo": {"endCursor": "aHR0cHM6Ly9hcGkuemVyaW9uLmlvL3YxL3dhbGxldHMvMHgxZDIxZWU4ZWI5NjA3ZjI0ODRkODE0ZDgzY2QzYjQ3MTRjNDRkMTA1L3RyYW5zYWN0aW9ucy8/Y3VycmVuY3k9dXNkJmZpbHRlciU1QmNoYWluX2lkcyU1RD1hcmJpdHJ1bSUyQ2Jhc2UlMkNjZWxvJTJDZXRoZXJldW0lMkNvcHRpbWlzbSUyQ3BvbHlnb24mZmlsdGVyJTVCb3BlcmF0aW9uX3R5cGVzJTVEPWFwcHJvdmUlMkNkZXBvc2l0JTJDZXhlY3V0ZSUyQ21pbnQlMkNyZWNlaXZlJTJDc2VuZCUyQ3RyYWRlJTJDd2l0aGRyYXcmZmlsdGVyJTVCdHJhc2glNUQ9bm9fZmlsdGVyJnBhZ2UlNUJhZnRlciU1RD1XeUl5TURJMExUQTRMVEEzVkRFME9qRTNPalE1V2lJc0lqWXdOVEJtWlRVek9XWTFOVFV6T0RaaVpHRTJNRGRrWlRJMU1XTTJNMk5oSWwwJTNEJnBhZ2UlNUJzaXplJTVEPTEwMA==", "hasNextPage": true, "hasPreviousPage": false, "startCursor": "aHR0cHM6Ly9hcGkuemVyaW9uLmlvL3YxL3dhbGxldHMvMHgxZDIxZWU4ZWI5NjA3ZjI0ODRkODE0ZDgzY2QzYjQ3MTRjNDRkMTA1L3RyYW5zYWN0aW9ucy8/Y3VycmVuY3k9dXNkJmZpbHRlciU1QmNoYWluX2lkcyU1RD1hcmJpdHJ1bSUyQ2Jhc2UlMkNjZWxvJTJDZXRoZXJldW0lMkNvcHRpbWlzbSUyQ3BvbHlnb24mZmlsdGVyJTVCb3BlcmF0aW9uX3R5cGVzJTVEPWFwcHJvdmUlMkNkZXBvc2l0JTJDZXhlY3V0ZSUyQ21pbnQlMkNyZWNlaXZlJTJDc2VuZCUyQ3RyYWRlJTJDd2l0aGRyYXcmZmlsdGVyJTVCdHJhc2glNUQ9bm9fZmlsdGVyJnBhZ2UlNUJhZnRlciU1RD1XeUlpTENJaVhRJTNEJTNEJnBhZ2UlNUJzaXplJTVEPTEwMA=="}, "transactions": [[Object], [Object], [Object], [Object], [Object], [Object], [Object], [Object], [Object], [Object], [Object], [Object], [Object], [Object], [Object], [Object], [Object], [Object], [Object], [Object], [Object], [Object], [Object], [Object], [Object], [Object], [Object], [Object], [Object], [Object], [Object], [Object], [Object], [Object], [Object], [Object], [Object], [Object], [Object], [Object], [Object], [Object], [Object], [Object], [Object], [Object], [Object], [Object], [Object], [Object]]}, "type": "transactionFeedV2Api/executeQuery/fulfilled"}`

### Test plan

https://github.com/user-attachments/assets/9676aefd-9917-4bb2-9b67-14f839670487


### Related issues

- n/a

### Backwards compatibility

Y

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [ ] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
