### PR TITLE
fix(discover): make explore dapps card tap behavior intuitive

### DIFF
--- a/src/dappsExplorer/DappCard.tsx
+++ b/src/dappsExplorer/DappCard.tsx
@@ -74,7 +74,7 @@ function DappCard({
       <Touchable
         style={[styles.pressableCard, cardContentContainerStyle]}
         onPress={onPressDapp}
-        borderRadius={showBorder ? 8 : undefined}
+        borderRadius={8}
         testID={`Dapp/${dapp.id}`}
       >
         <>

--- a/src/dappsExplorer/DiscoverDappsCard.tsx
+++ b/src/dappsExplorer/DiscoverDappsCard.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { SectionList, StyleSheet, Text, View } from 'react-native'
 import AppAnalytics from 'src/analytics/AppAnalytics'
 import { DappExplorerEvents } from 'src/analytics/Events'
-import TextButton from 'src/components/TextButton'
+import Touchable from 'src/components/Touchable'
 import { favoriteDappsSelector, mostPopularDappsSelector } from 'src/dapps/selectors'
 import { fetchDappsList } from 'src/dapps/slice'
 import { ActiveDapp, Dapp, DappSection } from 'src/dapps/types'
@@ -86,45 +86,44 @@ function DiscoverDappsCard() {
   if (!sections.length) return null
 
   return (
-    <View testID="DiscoverDappsCard" style={styles.container}>
-      <SectionList
-        ref={sectionListRef}
-        scrollEnabled={false}
-        ListHeaderComponent={<Text style={styles.title}>{t('dappsScreen.exploreDapps')}</Text>}
-        ListFooterComponent={
-          <View>
-            <TextButton style={styles.footer} onPress={onPressExploreAll}>
-              {t('dappsScreen.exploreAll')}
-            </TextButton>
-          </View>
-        }
-        sections={sections}
-        renderItem={({ item: dapp, index, section }) => {
-          return (
-            <DappCard
-              dapp={dapp}
-              onPressDapp={() => onPressDapp({ ...dapp, openedFrom: section.dappSection }, index)}
-              disableFavoriting={true}
-              testID={`${section.testID}/DappCard`}
-              cardContentContainerStyle={styles.dappCardContentContainer}
-            />
-          )
-        }}
-        renderSectionHeader={({ section: { sectionName, testID } }) => {
-          return (
-            <Text testID={`${testID}/Title`} style={styles.sectionTitle}>
-              {sectionName}
-            </Text>
-          )
-        }}
-        keyExtractor={(dapp) => dapp.id}
-        stickySectionHeadersEnabled={false}
-        testID="DAppsExplorerScreen/DiscoverDappsCard"
-        ListFooterComponentStyle={styles.listFooterComponent}
-        keyboardShouldPersistTaps="always"
-        keyboardDismissMode="on-drag"
-      />
-    </View>
+    <Touchable onPress={onPressExploreAll} borderRadius={8} shouldRenderRippleAbove>
+      <View testID="DiscoverDappsCard" style={styles.container}>
+        <SectionList
+          ref={sectionListRef}
+          scrollEnabled={false}
+          ListHeaderComponent={<Text style={styles.title}>{t('dappsScreen.exploreDapps')}</Text>}
+          ListFooterComponent={
+            <View>
+              <Text style={styles.footer}>{t('dappsScreen.exploreAll')}</Text>
+            </View>
+          }
+          sections={sections}
+          renderItem={({ item: dapp, index, section }) => {
+            return (
+              <DappCard
+                dapp={dapp}
+                onPressDapp={() => onPressDapp({ ...dapp, openedFrom: section.dappSection }, index)}
+                disableFavoriting={true}
+                testID={`${section.testID}/DappCard`}
+              />
+            )
+          }}
+          renderSectionHeader={({ section: { sectionName, testID } }) => {
+            return (
+              <Text testID={`${testID}/Title`} style={styles.sectionTitle}>
+                {sectionName}
+              </Text>
+            )
+          }}
+          keyExtractor={(dapp) => dapp.id}
+          stickySectionHeadersEnabled={false}
+          testID="DAppsExplorerScreen/DiscoverDappsCard"
+          ListFooterComponentStyle={styles.listFooterComponent}
+          keyboardShouldPersistTaps="always"
+          keyboardDismissMode="on-drag"
+        />
+      </View>
+    </Touchable>
   )
 }
 
@@ -133,7 +132,7 @@ const styles = StyleSheet.create({
     padding: Spacing.Regular16,
     borderColor: Colors.gray2,
     borderWidth: 1,
-    borderRadius: Spacing.Smallest8,
+    borderRadius: 8,
   },
   sectionTitle: {
     ...typeScale.labelXSmall,
@@ -152,10 +151,6 @@ const styles = StyleSheet.create({
     ...typeScale.labelSemiBoldMedium,
     color: Colors.black,
     marginBottom: Spacing.Smallest8,
-  },
-  dappCardContentContainer: {
-    padding: 0,
-    marginVertical: Spacing.Regular16,
   },
 })
 


### PR DESCRIPTION
### Description

The Explore Dapps Card before this PR had some strange behavior when trying to navigate to all Dapps in that a user must tap the small 'Explore All Dapps' text at the bottom and the ripples on Android were a bit boxy. The changes in touch behavior in this PR make interacting with the card more similar to other cards on the page and more initiative in general.

#### Changes

| Android Before | Android After | 
| ----- | ----- | 
| <video src="https://github.com/user-attachments/assets/2150fa97-e1a0-4a97-8bbe-9214a0d372ed" width="100%" height="auto" /> | <video src="https://github.com/user-attachments/assets/ca2873a3-8d4f-4a2b-a9fd-3ebca3f84239"  width="100%" height="auto" />) |

### Test plan

- [x] Tested locally on iOS
- [x] Tested locally on Android

### Related issues

- N/A

### Backwards compatibility

Yes

### Network scalability

N/A