### PR TITLE
fetch exchange rate

### DIFF
--- a/src/localCurrency/saga.test.ts
+++ b/src/localCurrency/saga.test.ts
@@ -34,7 +34,7 @@ describe(watchFetchCurrentRate, () => {
     await expectSaga(watchFetchCurrentRate)
       .provide([
         [select(getLocalCurrencyCode), LocalCurrencyCode.PHP],
-        [call(fetchExchangeRate, LocalCurrencyCode.USD, LocalCurrencyCode.PHP), '1.33'],
+        [call(fetchExchangeRate, LocalCurrencyCode.PHP), '1.33'],
       ])
       .put(fetchCurrentRateSuccess(LocalCurrencyCode.PHP, '1.33', now))
       .dispatch(fetchCurrentRate())
@@ -72,13 +72,13 @@ describe(watchSelectPreferredCurrency, () => {
 
 describe(fetchExchangeRate, () => {
   it('does not fetch when the local currency code is the same as source currency code', async () => {
-    await fetchExchangeRate(LocalCurrencyCode.USD, LocalCurrencyCode.USD)
+    await fetchExchangeRate(LocalCurrencyCode.USD)
     expect(mockFetch).not.toHaveBeenCalled()
   })
 
   it('fetches the exchange rate and returns it', async () => {
-    mockFetch.mockResponseOnce(JSON.stringify({ data: { currencyConversion: { rate: 1.33 } } }))
-    await fetchExchangeRate(LocalCurrencyCode.PHP, LocalCurrencyCode.USD)
+    mockFetch.mockResponseOnce(JSON.stringify({ rate: 1.33 }))
+    await fetchExchangeRate(LocalCurrencyCode.PHP)
     expect(mockFetch).toHaveBeenCalled()
   })
 })

--- a/src/localCurrency/saga.ts
+++ b/src/localCurrency/saga.ts
@@ -10,69 +10,35 @@ import {
 import { LocalCurrencyCode } from 'src/localCurrency/consts'
 import { getLocalCurrencyCode } from 'src/localCurrency/selectors'
 import Logger from 'src/utils/Logger'
-import { gql } from 'src/utils/gql'
+import { fetchWithTimeout } from 'src/utils/fetchWithTimeout'
 import { safely } from 'src/utils/safely'
 import networkConfig from 'src/web3/networkConfig'
 import { call, put, select, spawn, take, takeLatest } from 'typed-redux-saga'
 
 const TAG = 'localCurrency/saga'
 
-interface ExchangeRateQueryVariables {
-  currencyCode: string
-  sourceCurrencyCode?: string | null
-}
-
-interface ExchangeRateQuery {
-  currencyConversion: { rate: BigNumber.Value } | null
-}
-
-export async function fetchExchangeRate(
-  sourceCurrency: string,
-  localCurrencyCode: string
-): Promise<string> {
-  if (sourceCurrency === localCurrencyCode) {
-    // If the source currency is the same as the local currency, the exchange rate is always 1
+export async function fetchExchangeRate(localCurrencyCode: string): Promise<string> {
+  if (localCurrencyCode === LocalCurrencyCode.USD) {
+    // The exchange rate is returned against USD, so for USD it is always 1
     return '1'
   }
 
-  const response = await fetch(`${networkConfig.blockchainApiUrl}/graphql`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Accept: 'application/json',
-    },
-    body: JSON.stringify({
-      query: gql`
-        query ExchangeRate($currencyCode: String!, $sourceCurrencyCode: String) {
-          currencyConversion(currencyCode: $currencyCode, sourceCurrencyCode: $sourceCurrencyCode) {
-            rate
-          }
-        }
-      `,
-      variables: {
-        currencyCode: localCurrencyCode,
-        sourceCurrencyCode: sourceCurrency,
-      } satisfies ExchangeRateQueryVariables,
-    }),
-  })
+  const url = new URL(networkConfig.getExchangeRateUrl)
+  url.searchParams.set('localCurrencyCode', localCurrencyCode)
+  const response = await fetchWithTimeout(url.toString())
 
   if (!response.ok) {
     throw new Error(`Failed to fetch exchange rate: ${response.status} ${response.statusText}`)
   }
 
-  const body = (await response.json()) as { data: ExchangeRateQuery | undefined }
+  const body = (await response.json()) as { rate?: string }
 
-  const rate = body.data?.currencyConversion?.rate
-  if (typeof rate !== 'number' && typeof rate !== 'string') {
-    throw new Error(`Invalid response data ${body.data}`)
+  if (body.rate === undefined || new BigNumber(body.rate).isNaN()) {
+    throw new Error(`Invalid response data ${JSON.stringify(body)}`)
   }
 
-  const fetchedExchangeRate = new BigNumber(rate).toString()
-  Logger.info(
-    TAG,
-    `Fetched exchange rate for ${sourceCurrency} -> ${localCurrencyCode}: ${fetchedExchangeRate}`
-  )
-  return fetchedExchangeRate
+  Logger.info(TAG, `Fetched exchange rate for ${localCurrencyCode}: ${body.rate}`)
+  return body.rate
 }
 
 export function* fetchLocalCurrencyRateSaga() {
@@ -81,7 +47,7 @@ export function* fetchLocalCurrencyRateSaga() {
     if (!localCurrencyCode) {
       throw new Error("Can't fetch local currency rate without a currency code")
     }
-    const usdToLocalRate = yield* call(fetchExchangeRate, LocalCurrencyCode.USD, localCurrencyCode)
+    const usdToLocalRate = yield* call(fetchExchangeRate, localCurrencyCode)
     yield* put(fetchCurrentRateSuccess(localCurrencyCode, usdToLocalRate, Date.now()))
   } catch (error) {
     Logger.error(`${TAG}@fetchLocalCurrencyRateSaga`, 'Failed to fetch local currency rate', error)

--- a/src/send/utils.ts
+++ b/src/send/utils.ts
@@ -63,7 +63,7 @@ export function* handleSendPaymentData(
     const currency: LocalCurrencyCode = data.currencyCode
       ? (data.currencyCode as LocalCurrencyCode)
       : yield* select(getLocalCurrencyCode)
-    const exchangeRate = yield* call(fetchExchangeRate, LocalCurrencyCode.USD, currency)
+    const exchangeRate = yield* call(fetchExchangeRate, currency)
     const dollarAmount = convertLocalAmountToDollars(data.amount, exchangeRate)
     const usdToLocalRate = yield* select(usdToLocalCurrencyRateSelector)
     const localAmount = convertDollarsToLocalAmount(dollarAmount, usdToLocalRate)

--- a/src/web3/networkConfig.ts
+++ b/src/web3/networkConfig.ts
@@ -101,6 +101,7 @@ interface NetworkConfig {
   web3AuthVerifier: string
   crossChainExplorerUrl: string
   getWalletTransactionsUrl: string
+  getExchangeRateUrl: string
 }
 
 const ALCHEMY_ETHEREUM_RPC_URL_STAGING = 'https://eth-sepolia.g.alchemy.com/v2/'
@@ -278,6 +279,9 @@ const INTERNAL_ARBITRUM_RPC_URL_MAINNET = `${CLOUD_FUNCTIONS_MAINNET}/rpc/${Netw
 const GET_WALLET_TRANSACTIONS_ALFAJORES = `${CLOUD_FUNCTIONS_STAGING}/getWalletTransactions`
 const GET_WALLET_TRANSACTIONS_MAINNET = `${CLOUD_FUNCTIONS_MAINNET}/getWalletTransactions`
 
+const GET_EXCHANGE_RATE_ALFAJORES = `${CLOUD_FUNCTIONS_STAGING}/getExchangeRate`
+const GET_EXCHANGE_RATE_MAINNET = `${CLOUD_FUNCTIONS_MAINNET}/getExchangeRate`
+
 const WEB3_AUTH_VERIFIER = 'valora-cab-auth0'
 
 const BASE_SET_REGISTRATION_PROPERTIES_AUTH = {
@@ -416,6 +420,7 @@ const networkConfigs: { [testnet: string]: NetworkConfig } = {
     web3AuthVerifier: WEB3_AUTH_VERIFIER,
     crossChainExplorerUrl: CROSS_CHAIN_EXPLORER_URL,
     getWalletTransactionsUrl: GET_WALLET_TRANSACTIONS_ALFAJORES,
+    getExchangeRateUrl: GET_EXCHANGE_RATE_ALFAJORES,
   },
   [Testnets.mainnet]: {
     networkId: '42220',
@@ -516,6 +521,7 @@ const networkConfigs: { [testnet: string]: NetworkConfig } = {
     web3AuthVerifier: WEB3_AUTH_VERIFIER,
     crossChainExplorerUrl: CROSS_CHAIN_EXPLORER_URL,
     getWalletTransactionsUrl: GET_WALLET_TRANSACTIONS_MAINNET,
+    getExchangeRateUrl: GET_EXCHANGE_RATE_MAINNET,
   },
 }
 


### PR DESCRIPTION
### Description

Use cloud function `getExchangeRate` instead of the GraphQL endpoint of the blockchain-api.

Not hiding it behind the feature flag since the risk of failure seems low, and it can be handled by the backend update.

### Test plan

- Updated unit test

### Related issues

- Fixes RET-1224

### Backwards compatibility

Y

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
