### PR TITLE
chore: use comma separated query params and only query enabled networks

### DIFF
--- a/src/tokens/saga.test.ts
+++ b/src/tokens/saga.test.ts
@@ -304,9 +304,7 @@ describe(fetchTokenBalancesForAddressByTokenId, () => {
     })
     expect(mockFetch.mock.calls.length).toEqual(1)
     expect(mockFetch.mock.calls[0][0]).toEqual(
-      encodeURI(
-        'https://api.alfajores.valora.xyz/getWalletBalances?address=some-address&networkIds[]=celo-alfajores'
-      )
+      'https://api.alfajores.valora.xyz/getWalletBalances?address=some-address&networkIds=celo-alfajores'
     )
   })
 
@@ -343,9 +341,7 @@ describe(fetchTokenBalancesForAddressByTokenId, () => {
     })
     expect(mockFetch.mock.calls.length).toEqual(1)
     expect(mockFetch.mock.calls[0][0]).toEqual(
-      encodeURI(
-        'https://api.alfajores.valora.xyz/getWalletBalances?address=some-address&networkIds[]=celo-alfajores&networkIds[]=ethereum-sepolia'
-      )
+      'https://api.alfajores.valora.xyz/getWalletBalances?address=some-address&networkIds=celo-alfajores%2Cethereum-sepolia'
     )
   })
 

--- a/src/tokens/saga.ts
+++ b/src/tokens/saga.ts
@@ -45,7 +45,7 @@ export async function fetchTokenBalancesForAddress(
 
   const url = new URL(networkConfig.getWalletBalancesUrl)
   url.searchParams.set('address', address)
-  networkIds.forEach((id) => url.searchParams.append('networkIds[]', id))
+  url.searchParams.set('networkIds', networkIds.join(','))
 
   const response = await fetchWithTimeout(url.toString())
 

--- a/src/transactions/api.ts
+++ b/src/transactions/api.ts
@@ -1,5 +1,6 @@
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
 import { type LocalCurrencyCode } from 'src/localCurrency/consts'
+import { getMultichainFeatures } from 'src/statsig'
 import { FEED_V2_INCLUDE_TYPES, type PageInfo, type TokenTransaction } from 'src/transactions/types'
 import networkConfig from 'src/web3/networkConfig'
 
@@ -25,11 +26,17 @@ export const transactionFeedV2Api = createApi({
         endCursor: PageInfo['endCursor'] | undefined
       }
     >({
-      query: ({ address, localCurrencyCode, endCursor }) => {
-        const networkIds = Object.values(networkConfig.networkToNetworkId).join('&networkIds[]=')
-        const includeTypes = FEED_V2_INCLUDE_TYPES.join('&includeTypes[]=')
-        const cursor = endCursor === undefined ? '' : `&afterCursor=${endCursor}`
-        return `?networkIds[]=${networkIds}&includeTypes[]=${includeTypes}&address=${address}&localCurrencyCode=${localCurrencyCode}${cursor}`
+      query: ({ address, localCurrencyCode, endCursor: afterCursor }) => {
+        return {
+          url: '',
+          params: {
+            address,
+            networkIds: getMultichainFeatures().showTransfers.join(','),
+            includeTypes: FEED_V2_INCLUDE_TYPES.join(','),
+            localCurrencyCode,
+            ...(afterCursor && { afterCursor }),
+          },
+        }
       },
       keepUnusedDataFor: 60, // 1 min
     }),


### PR DESCRIPTION
### Description

Updating some query params for `getWalletTransactions` and `getWalletBalances`
Following the new accepted format done in https://github.com/valora-inc/blockchain-api/pull/766 and https://github.com/valora-inc/blockchain-api/pull/769.

It's slightly less verbose when looking at logs.

Also updated `getWalletTransactions` to only request networkIds enabled in statsig.

### Test plan

- Updated tests
- Manually checked

### Related issues

- See also this Slack [thread](https://valora-app.slack.com/archives/C029Z1QMD7B/p1731057942380629?thread_ts=1731057749.819289&cid=C029Z1QMD7B)

### Backwards compatibility

Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
