### PR TITLE
fix: some pending stand by transaction not getting cleaned up

### DIFF
--- a/src/transactions/slice.ts
+++ b/src/transactions/slice.ts
@@ -246,7 +246,7 @@ const slice = createSlice({
              * - ignore pending as it should only affect confirmed transactions that are already
              *   present in the paginated data
              */
-            if (!tx.transactionHash || tx.status === TransactionStatus.Pending) return true
+            if (!tx.transactionHash) return true
             return !confirmedTransactionsFromNewPage.includes(tx.transactionHash)
           }),
         }


### PR DESCRIPTION
### Description
Saga that is watching for pending transactions to turn into completed are not reporting certain transactions' status correctly. It was tested that when swapping from USDC(Optimism) to USDC(Celo):
- cross-chain swap transaction was hanging in a forever "Pending" state
- approval has never appeared in a saga's list

This PR fixes this by doing more thorough cleanup of stand by transactions, once they appear in Zerion's response. Previously, we didn't clean pending transactions up and this PR fixes that.

### Test plan
Existing tests pass.

### Related issues
N/A

### Backwards compatibility
Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
