### PR TITLE
feat: improve error UI in zerion homefeed

### DIFF
--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -2296,6 +2296,7 @@
     "claimRewardTitle": "Collected",
     "claimRewardSubtitle": "from {{txAppName}} Pool",
     "claimRewardSubtitle_noTxAppName": "from unknown app",
+    "allTransactionsShown": "You've reached the end of your transaction history.",
     "error": {
       "fetchError": "Oops, there was an issue refreshing your feed. Your transaction history may be incomplete for now."
     }

--- a/src/transactions/NoActivity.tsx
+++ b/src/transactions/NoActivity.tsx
@@ -7,8 +7,8 @@ import { withTranslation } from 'src/i18n'
 import colors from 'src/styles/colors'
 import { typeScale } from 'src/styles/fonts'
 interface OwnProps {
-  loading: boolean
-  error: Error | FetchBaseQueryError | SerializedError | undefined
+  loading?: boolean
+  error?: Error | FetchBaseQueryError | SerializedError | undefined
 }
 
 type Props = OwnProps & WithTranslation

--- a/src/transactions/api.ts
+++ b/src/transactions/api.ts
@@ -39,6 +39,18 @@ export const transactionFeedV2Api = createApi({
         }
       },
       keepUnusedDataFor: 60, // 1 min
+      transformErrorResponse: (error, meta) => {
+        if (meta) {
+          const params = new URL(meta.request.url).searchParams
+          return {
+            ...error,
+            // only requests for next pages have the afterCursor search param
+            hasAfterCursor: !params.get('afterCursor'),
+          }
+        }
+
+        return error
+      },
     }),
   }),
 })

--- a/src/transactions/feed/TransactionFeedV2.test.tsx
+++ b/src/transactions/feed/TransactionFeedV2.test.tsx
@@ -2,7 +2,6 @@ import { act, fireEvent, render, waitFor, within } from '@testing-library/react-
 import BigNumber from 'bignumber.js'
 import { type FetchMock } from 'jest-fetch-mock/types'
 import React from 'react'
-import Toast from 'react-native-simple-toast'
 import { Provider } from 'react-redux'
 import { type ReactTestInstance } from 'react-test-renderer'
 import AppAnalytics from 'src/analytics/AppAnalytics'
@@ -108,6 +107,7 @@ beforeEach(() => {
       ['celo-alfajores']: { contractAddress: '0x7bf3fefe9881127553d23a8cd225a2c2442c438c' },
     },
   })
+  jest.mocked(getFeatureGate).mockReturnValue(false)
 })
 
 describe('TransactionFeedV2', () => {
@@ -139,30 +139,26 @@ describe('TransactionFeedV2', () => {
     await waitFor(() => expect(tree.getAllByTestId('TransferFeedItem').length).toBe(2))
   })
 
-  it("doesn't render transfers for tokens that we don't know about", async () => {
-    mockFetch.mockResponse(typedResponse({ transactions: [mockTransaction()] }))
-    const { store, ...tree } = renderScreen()
-
-    await waitFor(() => tree.getByTestId('TransactionList'))
-    const items = tree.getAllByTestId('TransferFeedItem/title')
-    expect(items.length).toBe(1)
-  })
-
   it('renders the loading indicator while it loads', async () => {
     mockFetch.mockResponse(typedResponse({ transactions: [] }))
     const tree = renderScreen()
-    expect(tree.getByTestId('NoActivity/loading')).toBeDefined()
-    expect(tree.queryByTestId('NoActivity/error')).toBeNull()
-    expect(tree.queryByTestId('TransactionList')).toBeNull()
+
+    expect(tree.getByTestId('TransactionList/loading')).toBeTruthy()
+    expect(tree.queryByText('transactionFeed.error.fetchError')).toBeFalsy()
+    expect(tree.getByTestId('TransactionList').props.data).toHaveLength(0)
   })
 
-  it("renders an error screen if there's no cache and the query fails", async () => {
+  it("renders no transactions and an error message if there's no cache and the query fails", async () => {
     mockFetch.mockReject(new Error('Test error'))
     const tree = renderScreen()
 
-    await waitFor(() => tree.getByTestId('NoActivity/error'))
-    expect(tree.queryByTestId('NoActivity/loading')).toBeNull()
-    expect(tree.queryByTestId('TransactionList')).toBeNull()
+    expect(tree.queryByText('transactionFeed.error.fetchError')).toBeFalsy()
+    expect(tree.getByTestId('TransactionList/loading')).toBeTruthy()
+
+    await waitFor(() => expect(tree.getByText('transactionFeed.error.fetchError')).toBeTruthy())
+    expect(tree.queryByTestId('TransactionList/loading')).toBeNull()
+    expect(tree.getByText('noTransactionActivity')).toBeTruthy()
+    expect(tree.getByTestId('TransactionList').props.data).toHaveLength(0)
   })
 
   it('renders correctly when there are confirmed transactions and stand by transactions', async () => {
@@ -176,12 +172,12 @@ describe('TransactionFeedV2', () => {
       },
     })
 
-    await waitFor(() => tree.getByTestId('TransactionList'))
+    await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1))
 
-    expect(tree.queryByTestId('NoActivity/loading')).toBeNull()
-    expect(tree.queryByTestId('NoActivity/error')).toBeNull()
+    expect(tree.queryByTestId('TransactionList/loading')).toBeNull()
+    expect(tree.queryByTestId('transactionFeed.error.fetchError')).toBeNull()
 
-    const subtitles = tree.queryAllByTestId('TransferFeedItem/subtitle')
+    const subtitles = tree.getAllByTestId('TransferFeedItem/subtitle')
 
     const pendingSubtitles = subtitles.filter((node) =>
       node.children.some((ch) => ch === STAND_BY_TRANSACTION_SUBTITLE_KEY)
@@ -193,8 +189,9 @@ describe('TransactionFeedV2', () => {
     mockFetch.mockResponse(typedResponse({ transactions: [mockTransaction()] }))
     const tree = renderScreen()
 
-    await waitFor(() => tree.getByTestId('TransactionList'))
-    expect(tree.getByText('feedItemReceivedInfo, {"context":"noComment"}')).toBeTruthy()
+    await waitFor(() =>
+      expect(tree.getByText('feedItemReceivedInfo, {"context":"noComment"}')).toBeTruthy()
+    )
   })
 
   it('renders correct status for a failed transaction', async () => {
@@ -204,8 +201,7 @@ describe('TransactionFeedV2', () => {
 
     const tree = renderScreen()
 
-    await waitFor(() => tree.getByTestId('TransactionList'))
-    expect(tree.getByText('feedItemFailedTransaction')).toBeTruthy()
+    await waitFor(() => expect(tree.getByText('feedItemFailedTransaction')).toBeTruthy())
   })
 
   it('tries to fetch pages until the end is reached', async () => {
@@ -225,29 +221,42 @@ describe('TransactionFeedV2', () => {
 
     const { store, ...tree } = renderScreen()
 
-    await waitFor(() => tree.getByTestId('TransactionList'))
+    await waitFor(() => expect(mockFetch).toBeCalledTimes(1))
+    expect(tree.queryByText('transactionFeed.allTransactionsShown')).toBeFalsy()
+    expect(getNumTransactionItems(tree.getByTestId('TransactionList'))).toBe(1)
+
     fireEvent(tree.getByTestId('TransactionList'), 'onEndReached')
-    await waitFor(() => expect(mockFetch).toBeCalled())
+
     await waitFor(() => expect(tree.getByTestId('TransactionList/loading')).toBeVisible())
     await waitFor(() => expect(tree.queryByTestId('TransactionList/loading')).toBeFalsy())
 
     expect(mockFetch).toHaveBeenCalledTimes(2)
     expect(getNumTransactionItems(tree.getByTestId('TransactionList'))).toBe(2)
+    expect(tree.getByText('transactionFeed.allTransactionsShown')).toBeTruthy()
   })
 
   it('renders GetStarted if SHOW_GET_STARTED is enabled and transaction feed is empty', async () => {
-    mockFetch.mockResponse(typedResponse({ transactions: [] }))
+    mockFetch.mockResponse(
+      typedResponse({
+        transactions: [],
+        pageInfo: { hasNextPage: false, endCursor: '', hasPreviousPage: false, startCursor: '' },
+      })
+    )
     jest.mocked(getFeatureGate).mockReturnValue(true)
     const tree = renderScreen()
+
+    await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1))
     expect(tree.getByTestId('GetStarted')).toBeDefined()
+    expect(tree.queryByText('transactionFeed.allTransactionsShown')).toBeFalsy()
   })
 
-  it('renders NoActivity by default if transaction feed is empty', async () => {
-    mockFetch.mockResponse(typedResponse({ transactions: [] }))
-    jest.mocked(getFeatureGate).mockReturnValue(false)
+  it('renders GetStarted with an error if the initial fetch fails', async () => {
+    mockFetch.mockReject(new Error('test error'))
+    jest.mocked(getFeatureGate).mockReturnValue(true)
+
     const tree = renderScreen()
-    expect(tree.getByTestId('NoActivity/loading')).toBeDefined()
-    expect(tree.getByText('noTransactionActivity')).toBeTruthy()
+    expect(tree.getByTestId('GetStarted')).toBeTruthy()
+    await waitFor(() => expect(tree.getByText('transactionFeed.error.fetchError')).toBeTruthy())
   })
 
   it('useStandByTransactions properly splits pending/confirmed transactions', async () => {
@@ -314,8 +323,7 @@ describe('TransactionFeedV2', () => {
       },
     })
 
-    await waitFor(() => tree.getByTestId('TransactionList'))
-    expect(getNumTransactionItems(tree.getByTestId('TransactionList'))).toBe(7)
+    await waitFor(() => expect(getNumTransactionItems(tree.getByTestId('TransactionList'))).toBe(7))
   })
 
   it('cleanup is triggered for confirmed stand by transactions', async () => {
@@ -345,9 +353,10 @@ describe('TransactionFeedV2', () => {
     await waitFor(() => expect(tree.getByTestId('TransactionList').props.data.length).toBe(2))
     expect(tree.getByTestId('TransactionList').props.data[0].data.length).toBe(1)
     expect(tree.getByTestId('TransactionList').props.data[1].data.length).toBe(1)
+    expect(tree.queryByText('transactionFeed.allTransactionsShown')).toBeFalsy()
   })
 
-  it('should show "no transactions" toast if there is more than MIN_NUM_TRANSACTIONS transactions', async () => {
+  it('should show a message when all transactions have been loaded', async () => {
     mockFetch
       .mockResponseOnce(
         typedResponse({
@@ -364,6 +373,7 @@ describe('TransactionFeedV2', () => {
             mockTransaction({ transactionHash: '0x10' }),
             mockTransaction({ transactionHash: '0x11' }),
           ],
+          pageInfo: { hasNextPage: true, hasPreviousPage: true, startCursor: '1', endCursor: '2' },
         })
       )
       .mockResponseOnce(
@@ -375,41 +385,15 @@ describe('TransactionFeedV2', () => {
 
     const tree = renderScreen()
 
-    await waitFor(() => tree.getByTestId('TransactionList'))
+    await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1))
+    expect(tree.queryByText('transactionFeed.allTransactionsShown')).toBeFalsy()
+
     fireEvent(tree.getByTestId('TransactionList'), 'onEndReached')
-    await waitFor(() => expect(mockFetch).toBeCalled())
+
     await waitFor(() => expect(tree.getByTestId('TransactionList/loading')).toBeVisible())
     await waitFor(() => expect(tree.queryByTestId('TransactionList/loading')).toBeFalsy())
-
-    fireEvent(tree.getByTestId('TransactionList'), 'onEndReached')
-    await waitFor(() => expect(Toast.showWithGravity).toBeCalledTimes(1))
-  })
-
-  it('should not show "no transactions" toast if there is not enough transactions to trigger the toast', async () => {
-    mockFetch.mockResponse(
-      typedResponse({
-        transactions: [
-          mockTransaction({ transactionHash: '0x01', timestamp: 50 }),
-          mockTransaction({ transactionHash: '0x02', timestamp: 49 }),
-          mockTransaction({ transactionHash: '0x03', timestamp: 48 }),
-          mockTransaction({ transactionHash: '0x04', timestamp: 47 }),
-          mockTransaction({ transactionHash: '0x05', timestamp: 46 }),
-          mockTransaction({ transactionHash: '0x06', timestamp: 45 }),
-          mockTransaction({ transactionHash: '0x07', timestamp: 44 }),
-          mockTransaction({ transactionHash: '0x08', timestamp: 43 }),
-          mockTransaction({ transactionHash: '0x09', timestamp: 42 }),
-        ],
-      })
-    )
-
-    const tree = renderScreen()
-
-    await waitFor(() => tree.getByTestId('TransactionList'))
-    fireEvent(tree.getByTestId('TransactionList'), 'onEndReached')
-    await waitFor(() => expect(mockFetch).toBeCalled())
-    await waitFor(() => expect(tree.getByTestId('TransactionList/loading')).toBeVisible())
-    await waitFor(() => expect(tree.queryByTestId('TransactionList/loading')).toBeFalsy())
-    await waitFor(() => expect(Toast.showWithGravity).not.toBeCalled())
+    expect(mockFetch).toHaveBeenCalledTimes(2)
+    expect(tree.getByText('transactionFeed.allTransactionsShown')).toBeTruthy()
   })
 
   // eslint-disable-next-line jest/no-disabled-tests
@@ -621,7 +605,7 @@ describe('TransactionFeedV2', () => {
       },
     })
 
-    await waitFor(() => expect(tree.getByTestId('TransactionList')).toBeVisible())
+    await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1))
 
     const hashes = tree
       .getByTestId('TransactionList')


### PR DESCRIPTION
### Description

Context: https://valora-app.slack.com/archives/C0684TXDR3K/p1731430999696679

This PR updates the zerion transaction feed in the following ways:
1. do not show an error toast on polling errors
2. show an error toast on error to fetch next page or on fetch first page
3. include an option to retry on the error toast

Some changes worth mentioning:
- we need some way to distinguish a server error from a poll vs a server error from fetching next page. since they all go through the same hook, i added an extra property to the error returned (based on the request url) for the display layer to use.
- we should still display an error on initial fetch, which requires the toast to be available always. therefore i am now using `ListEmptyComponent` to render the empty state rather than the separate return statement before.

### Test plan

<!-- Demonstrate the change is solid, or why it doesn't need testing.
Example: add any manual testing steps or scenarios (if not obvious), screenshots / videos if the pull request changes the user interface.
-->

### Related issues

n/a

### Backwards compatibility

Y

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [ ] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
