### PR TITLE
feat: add build number to settings screen

### DIFF
--- a/src/navigator/SettingsMenu.tsx
+++ b/src/navigator/SettingsMenu.tsx
@@ -122,6 +122,7 @@ export default function SettingsMenu({ route }: Props) {
   const account = useSelector(walletAddressSelector)
 
   const appVersion = deviceInfoModule.getVersion()
+  const buildNumber = deviceInfoModule.getBuildNumber()
 
   const { v2 } = useSelector(walletConnectEnabledSelector)
   const { sessions } = useSelector(selectSessions)
@@ -261,7 +262,7 @@ export default function SettingsMenu({ route }: Props) {
         <TouchableWithoutFeedback onPress={onDevSettingsTriggerPress}>
           <View style={styles.appVersionContainer} testID="SettingsMenu/Version">
             <Text style={styles.appVersionText}>{t('appVersion')}</Text>
-            <Text style={styles.appVersionText}>{appVersion}</Text>
+            <Text style={styles.appVersionText}>{`${appVersion} (${buildNumber})`}</Text>
           </View>
         </TouchableWithoutFeedback>
         {getDevSettingsComp()}


### PR DESCRIPTION
### Description

As the title. This will be helpful to identify which version of the nightly build you're on.

### Test plan

![Simulator Screenshot - iPhone 15 Pro - 2024-11-15 at 10 19 38](https://github.com/user-attachments/assets/e7d1714e-c2c1-4bc3-95e0-cd18ed7e3675)


### Related issues

n/a

### Backwards compatibility

Y

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [ ] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
