### PR TITLE
fix(earn): entry point performance and ripple

### DIFF
--- a/src/earn/EarnEntrypoint.tsx
+++ b/src/earn/EarnEntrypoint.tsx
@@ -1,7 +1,8 @@
 import BigNumber from 'bignumber.js'
 import React, { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Image, StyleSheet, Text, View } from 'react-native'
+import { StyleSheet, Text, View } from 'react-native'
+import FastImage from 'react-native-fast-image'
 import { useSelector } from 'react-redux'
 import AppAnalytics from 'src/analytics/AppAnalytics'
 import { EarnEvents } from 'src/analytics/Events'
@@ -70,7 +71,7 @@ export default function EarnEntrypoint() {
       >
         <>
           <View style={styles.row}>
-            <Image style={styles.image} source={earnCardBackground} />
+            <FastImage style={styles.image} source={earnCardBackground} />
             <View style={styles.textContainer}>
               <Text style={styles.title}>{t('earnFlow.entrypoint.title')}</Text>
               <Text style={styles.description}>

--- a/src/earn/EarnEntrypoint.tsx
+++ b/src/earn/EarnEntrypoint.tsx
@@ -66,6 +66,7 @@ export default function EarnEntrypoint() {
             : navigate(Screens.EarnInfoScreen)
         }}
         testID="EarnEntrypoint"
+        shouldRenderRippleAbove
       >
         <>
           <View style={styles.row}>


### PR DESCRIPTION
### Description

- Sets the ripple above the image on Android to be consistent with other items on the screen.
- Uses [`react-native-fast-image`](https://github.com/DylanVann/react-native-fast-image) to display the background image for better performance.

### Test plan

| Android Before | Android After |
| ----- | ----- |
| ![](https://github.com/user-attachments/assets/f3f606f6-831a-4e14-bc72-e3ac70bb377f) | ![](https://github.com/user-attachments/assets/df05ac76-7d14-47e4-bd55-55729947cf6c) |

### Related issues

N/A

### Backwards compatibility

Yes

### Network scalability

N/A
