### PR TITLE
fix: remove whitespace at bottom of web-view after keyboard dismiss

### DIFF
--- a/src/webview/WebViewScreen.tsx
+++ b/src/webview/WebViewScreen.tsx
@@ -15,6 +15,7 @@ import { ShouldStartLoadRequest } from 'react-native-webview/lib/WebViewTypes'
 import AppAnalytics from 'src/analytics/AppAnalytics'
 import { DappExplorerEvents, WebViewEvents } from 'src/analytics/Events'
 import { openDeepLink } from 'src/app/actions'
+import KeyboardSpacer from 'src/components/KeyboardSpacer'
 import Touchable from 'src/components/Touchable'
 import WebView, { WebViewRef } from 'src/components/WebView'
 import { DEEP_LINK_URL_SCHEME } from 'src/config'
@@ -218,6 +219,7 @@ function WebViewScreen({ route, navigation }: Props) {
           mediaPlaybackRequiresUserAction={mediaPlaybackRequiresUserAction}
           testID={activeDapp ? `WebViewScreen/${activeDapp.name}` : 'RNWebView'}
         />
+        <KeyboardSpacer />
       </KeyboardAvoidingView>
       {Platform.OS === 'android' && (
         <WebViewAndroidBottomSheet
@@ -264,7 +266,7 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   keyboardView: {
-    flex: 1,
+    flexGrow: 1,
   },
   loading: {
     position: 'absolute',


### PR DESCRIPTION
### Description

After merging #6217, there is a residual whitespace after dismissing the keyboard in web views;  this PR removes that whitespace.


| Android Before | Android After | 
| ----- | ----- | 
| <video src="https://github.com/user-attachments/assets/ff6a2386-f8c6-4c17-bc52-4ac1d83620d9" />  | <video src="https://github.com/user-attachments/assets/ba1358fc-63f0-4b34-8cac-ccf7a9edbb95" /> |

### Test plan
- [ ] Tested locally on iOS
- [x] Tested locally on Android

### Related issues

N/A

### Backwards compatibility

Yes

### Network scalability

N/A
