### PR TITLE
feat: update pull to refresh functionality on wallet and home tabs

### DIFF
--- a/src/tokens/AssetList.tsx
+++ b/src/tokens/AssetList.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import {
   NativeScrollEvent,
   NativeSyntheticEvent,
+  RefreshControl,
   SectionList,
   SectionListData,
   SectionListProps,
@@ -11,10 +12,12 @@ import {
   View,
 } from 'react-native'
 import Animated from 'react-native-reanimated'
-import { AssetsEvents } from 'src/analytics/Events'
 import AppAnalytics from 'src/analytics/AppAnalytics'
+import { AssetsEvents } from 'src/analytics/Events'
 import { hideWalletBalancesSelector } from 'src/app/selectors'
 import Touchable from 'src/components/Touchable'
+import { refreshAllBalances } from 'src/home/actions'
+import { balancesLoadingSelector } from 'src/home/selectors'
 import CircledIcon from 'src/icons/CircledIcon'
 import ImageErrorIcon from 'src/icons/ImageErrorIcon'
 import Add from 'src/icons/quick-actions/Add'
@@ -96,6 +99,7 @@ export default function AssetList({
   )
 
   const hideWalletBalances = useSelector(hideWalletBalancesSelector)
+  const isRefreshingBalances = useSelector(balancesLoadingSelector)
 
   const positions = useSelector(positionsWithBalanceSelector)
   const positionSections = useMemo(() => {
@@ -129,6 +133,10 @@ export default function AssetList({
   useEffect(() => {
     dispatch(fetchNfts())
   }, [])
+
+  const onRefresh = () => {
+    dispatch(refreshAllBalances())
+  }
 
   const sections =
     activeTab === AssetTabType.Tokens
@@ -275,6 +283,13 @@ export default function AssetList({
           nfts.length > 0 &&
           styles.nftsContentContainer,
       ]}
+      refreshControl={
+        <RefreshControl
+          refreshing={isRefreshingBalances}
+          onRefresh={onRefresh}
+          colors={[Colors.accent]}
+        />
+      }
       // ensure header is above the scrollbar on ios overscroll
       scrollIndicatorInsets={{ top: listHeaderHeight }}
       // @ts-ignore can't get the SectionList to accept a union type :(


### PR DESCRIPTION
### Description

As the title:
1. on the Wallet tab, pull to refresh refreshes balances. the loader is also displayed for any background refreshes.
2. on the Home tab, pull to refresh refreshes only the transaction items. the loader is not displayed for background refreshes.

### Test plan


https://github.com/user-attachments/assets/b0a56779-e02c-4f2f-b5e9-08b2bd6dfd9a



### Related issues

- Fixes RET-1254

### Backwards compatibility

Y

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [ ] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
