### PR TITLE
fix(headers): remove animations causing header shift on ios

### DIFF
--- a/src/account/AccountKeyEducation.tsx
+++ b/src/account/AccountKeyEducation.tsx
@@ -1,10 +1,9 @@
 import { NativeStackScreenProps } from '@react-navigation/native-stack'
 import React, { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Platform } from 'react-native'
 import Education, { EducationTopic } from 'src/account/Education'
-import { OnboardingEvents } from 'src/analytics/Events'
 import AppAnalytics from 'src/analytics/AppAnalytics'
+import { OnboardingEvents } from 'src/analytics/Events'
 import { BtnTypes } from 'src/components/Button'
 import { accountKey1, accountKey2, accountKey3, accountKey4 } from 'src/images/Images'
 import { noHeader } from 'src/navigator/Headers'
@@ -47,9 +46,6 @@ export default function AccountKeyEducation(props: Props) {
 
 AccountKeyEducation.navigationOptions = {
   ...noHeader,
-  ...Platform.select({
-    ios: { animation: 'slide_from_bottom' },
-  }),
 }
 
 function useSteps() {

--- a/src/account/GoldEducation.tsx
+++ b/src/account/GoldEducation.tsx
@@ -1,11 +1,10 @@
 import React, { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Platform } from 'react-native'
 import Education, { EducationTopic } from 'src/account/Education'
 import { setGoldEducationCompleted } from 'src/account/actions'
 import { celoEducationCompletedSelector } from 'src/account/selectors'
-import { OnboardingEvents } from 'src/analytics/Events'
 import AppAnalytics from 'src/analytics/AppAnalytics'
+import { OnboardingEvents } from 'src/analytics/Events'
 import { BtnTypes } from 'src/components/Button'
 import { celoEducation1, celoEducation2, celoEducation3, celoEducation4 } from 'src/images/Images'
 import { noHeader } from 'src/navigator/Headers'
@@ -49,9 +48,6 @@ export default function GoldEducation() {
 
 GoldEducation.navigationOptions = {
   ...noHeader,
-  ...Platform.select({
-    ios: { animation: 'slide_from_bottom' },
-  }),
 }
 
 function useStep() {

--- a/src/navigator/Navigator.tsx
+++ b/src/navigator/Navigator.tsx
@@ -159,7 +159,7 @@ const commonScreens = (Navigator: typeof Stack) => {
       <Navigator.Screen
         name={Screens.QRNavigator}
         component={QRNavigator}
-        options={QRNavigator.navigationOptions as NativeStackNavigationOptions}
+        options={QRNavigator.navigationOptions}
       />
     </>
   )

--- a/src/navigator/QRNavigator.tsx
+++ b/src/navigator/QRNavigator.tsx
@@ -132,9 +132,6 @@ export default function QRNavigator({ route }: Props) {
 
 QRNavigator.navigationOptions = {
   ...noHeader,
-  ...Platform.select({
-    ios: { animation: 'slide_from_bottom' },
-  }),
 }
 
 const styles = StyleSheet.create({


### PR DESCRIPTION
### Description

After upgrading to react-native-screen v4 in #6217. Some header shifts were observed on iOS for screens using the `slide_from_bottom` animations. This PR removes those animations.


### Test plan

| iOS Before | iOS After |
| ---- | ---- |
| <video src="https://github.com/user-attachments/assets/e364d86a-7ddc-4055-8405-8669ac754ad8"/> | <video src="https://github.com/user-attachments/assets/460cdd09-f982-41c2-9ed9-95700124098e" /> |

### Related issues

Part of ACT-1326

### Backwards compatibility

Yes

### Network scalability

N/A
