### PR TITLE
fix: use historical local amount in sent transaction details

### DIFF
--- a/src/transactions/feed/detailContent/TransferSentContent.tsx
+++ b/src/transactions/feed/detailContent/TransferSentContent.tsx
@@ -21,16 +21,19 @@ import networkConfig from 'src/web3/networkConfig'
 
 // Note that this is tested from TransactionDetailsScreen.test.tsx
 function TransferSentContent({ transfer }: { transfer: TokenTransfer }) {
-  const { amount, metadata, address } = transfer
-
   const { t } = useTranslation()
   const info = useSelector(recipientInfoSelector)
 
   const celoTokenId = useTokenInfo(networkConfig.currencyToTokenId[Currency.Celo])?.tokenId
   const transferTokenInfo = useTokenInfo(transfer.amount.tokenId)
 
-  const isCeloWithdrawal = amount.tokenId === celoTokenId
-  const recipient = getRecipientFromAddress(address, info, metadata.title, metadata.image)
+  const isCeloWithdrawal = transfer.amount.tokenId === celoTokenId
+  const recipient = getRecipientFromAddress(
+    transfer.address,
+    info,
+    transfer.metadata.title,
+    transfer.metadata.image
+  )
 
   return (
     <>
@@ -78,6 +81,7 @@ function TransferSentContent({ transfer }: { transfer: TokenTransfer }) {
           <TokenDisplay
             amount={transfer.amount.value}
             tokenId={transfer.amount.tokenId}
+            localAmount={transfer.amount.localAmount}
             showLocalAmount={true}
             hideSign={true}
             testID="TransferSent/AmountSentValueFiat"


### PR DESCRIPTION
### Description

As the title - we should use historical prices returned by the backend rather than letting TokenDisplay default to using the current price.

### Test plan

n/a

### Related issues

- Fixes RET-1260

### Backwards compatibility

Y

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [ ] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
