### PR TITLE
fix: jumpstart intro should only be seen once

### DIFF
--- a/src/jumpstart/slice.ts
+++ b/src/jumpstart/slice.ts
@@ -1,4 +1,6 @@
 import { PayloadAction, createSlice } from '@reduxjs/toolkit'
+import { REHYDRATE, RehydrateAction } from 'redux-persist'
+import { getRehydratePayload } from 'src/redux/persist-helper'
 import { TokenBalance } from 'src/tokens/slice'
 import { NetworkId, TokenAmount } from 'src/transactions/types'
 import { SerializableTransactionRequest } from 'src/viem/preparedTransactionSerialization'
@@ -118,6 +120,15 @@ const slice = createSlice({
       ...state,
       introHasBeenSeen: true,
     }),
+  },
+  extraReducers: (builder) => {
+    builder.addCase(REHYDRATE, (state, action: RehydrateAction) => ({
+      ...state,
+      ...getRehydratePayload(action, 'jumpstart'),
+      claimStatus: 'idle',
+      depositStatus: 'idle',
+      reclaimStatus: 'idle',
+    }))
   },
 })
 

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -27,14 +27,7 @@ const persistConfig: PersistConfig<ReducersRootState> = {
   version: 237,
   keyPrefix: `reduxStore-`, // the redux-persist default is `persist:` which doesn't work with some file systems.
   storage: FSStorage(),
-  blacklist: [
-    'networkInfo',
-    'alert',
-    'imports',
-    'keylessBackup',
-    'jumpstart',
-    transactionFeedV2Api.reducerPath,
-  ],
+  blacklist: ['networkInfo', 'alert', 'imports', 'keylessBackup', transactionFeedV2Api.reducerPath],
   stateReconciler: autoMergeLevel2,
   migrate: async (...args) => {
     const migrate = createMigrate(migrations)


### PR DESCRIPTION
### Description

This PR fixes the jumpstart intro seen screen from being shown more than once. The jumpstart slice was part of the redux persist blacklist, now it is removed and the relevant state variables reset on rehydrate.

### Test plan

n/a

### Related issues

n/a

### Backwards compatibility

Y

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [ ] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
