### PR TITLE
feat: add enter amount percentages on swap screen

### DIFF
--- a/src/analytics/Events.tsx
+++ b/src/analytics/Events.tsx
@@ -528,7 +528,7 @@ export enum SwapEvents {
   swap_screen_open = 'swap_screen_open',
   swap_screen_select_token = 'swap_screen_select_token',
   swap_screen_confirm_token = 'swap_screen_confirm_token',
-  swap_screen_max_swap_amount = 'swap_screen_max_swap_amount',
+  swap_screen_percentage_selected = 'swap_screen_percentage_selected',
   swap_gas_fees_learn_more = 'swap_gas_fees_learn_more',
   swap_review_submit = 'swap_review_submit',
   swap_execute_success = 'swap_execute_success',

--- a/src/analytics/Properties.tsx
+++ b/src/analytics/Properties.tsx
@@ -590,7 +590,7 @@ interface SendEventsProperties {
     tokenId: string
     tokenAddress: string | null
     networkId: NetworkId | null
-    percentage: number
+    percentage: number // 0 to 100
     flow: 'send' | 'earn' | 'swap'
     mode?: EarnActiveMode
   }
@@ -1214,10 +1214,11 @@ interface SwapEventsProperties {
     areSwapTokensShuffled: boolean
     tokenPositionInList: number
   }
-  [SwapEvents.swap_screen_max_swap_amount]: {
+  [SwapEvents.swap_screen_percentage_selected]: {
     tokenSymbol?: string
     tokenId: string
     tokenNetworkId: string
+    percentage: number // 0 to 100
   }
   [SwapEvents.swap_gas_fees_learn_more]: undefined
   [SwapEvents.swap_review_submit]: SwapQuoteEvent & Web3LibraryProps & Partial<SwapTxsProperties>

--- a/src/analytics/docs.ts
+++ b/src/analytics/docs.ts
@@ -527,7 +527,7 @@ export const eventDocs: Record<AnalyticsEventType, string> = {
   [SwapEvents.swap_screen_open]: `When the screen is mounted`,
   [SwapEvents.swap_screen_select_token]: `When a user selects a token, prompting the token select bottom sheet`,
   [SwapEvents.swap_screen_confirm_token]: `When a user selects a token from the bottom sheet`,
-  [SwapEvents.swap_screen_max_swap_amount]: `when a user taps on the "max" button to swap their whole balance`,
+  [SwapEvents.swap_screen_percentage_selected]: `When the user selects a pre-defined percentage of their balance to transact with`,
   [SwapEvents.swap_review_submit]: `When a user click on the confirm swap button to proceed to next step`,
   [SwapEvents.swap_gas_fees_learn_more]: `When a user taps on the learn more text on the max swap amount warning`,
   [SwapEvents.swap_execute_success]: `When the swap is executed successfully`,

--- a/src/components/TokenBottomSheet.tsx
+++ b/src/components/TokenBottomSheet.tsx
@@ -6,7 +6,7 @@ import {
 import { debounce } from 'lodash'
 import React, { RefObject, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Keyboard, StyleSheet, Text, TextStyle, View } from 'react-native'
+import { StyleSheet, Text, TextStyle, View } from 'react-native'
 import { ScrollView } from 'react-native-gesture-handler'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import AppAnalytics from 'src/analytics/AppAnalytics'
@@ -18,6 +18,7 @@ import FilterChipsCarousel, {
   NetworkFilterChip,
   isNetworkChip,
 } from 'src/components/FilterChipsCarousel'
+import KeyboardSpacer from 'src/components/KeyboardSpacer'
 import SearchInput from 'src/components/SearchInput'
 import NetworkMultiSelectBottomSheet from 'src/components/multiSelect/NetworkMultiSelectBottomSheet'
 import InfoIcon from 'src/icons/InfoIcon'
@@ -293,10 +294,8 @@ function TokenBottomSheet({
           }
           return null
         }}
-        onScrollBeginDrag={() => {
-          Keyboard.dismiss()
-        }}
       />
+      <KeyboardSpacer />
       <View style={styles.headerContainer} onLayout={handleMeasureHeader}>
         <Text style={[styles.title, titleStyle]}>{title}</Text>
         {searchEnabled && (

--- a/src/swap/SwapAmountInput.tsx
+++ b/src/swap/SwapAmountInput.tsx
@@ -26,7 +26,6 @@ interface Props {
   onInputChange?(value: string): void
   inputValue?: string | null
   parsedInputValue?: BigNumber | null
-  onPressMax?(): void
   onSelectToken(): void
   token?: TokenBalance
   loading: boolean
@@ -42,7 +41,6 @@ const SwapAmountInput = ({
   onInputChange,
   inputValue,
   parsedInputValue,
-  onPressMax,
   onSelectToken,
   token,
   loading,
@@ -160,21 +158,6 @@ const SwapAmountInput = ({
               />
             </Text>
           )}
-          {onPressMax && (
-            <View style={styles.maxButtonWrapper}>
-              <Touchable
-                borderRadius={Spacing.Tiny4}
-                onPress={() => {
-                  onPressMax()
-                  textInputRef.current?.blur()
-                }}
-                style={styles.maxButton}
-                testID="SwapAmountInput/MaxButton"
-              >
-                <Text style={styles.maxText}>{t('max')}</Text>
-              </Touchable>
-            </View>
-          )}
         </View>
       )}
     </View>
@@ -220,22 +203,6 @@ const styles = StyleSheet.create({
   loader: {
     height: '100%',
     width: '100%',
-  },
-  maxButtonWrapper: {
-    marginLeft: Spacing.Smallest8,
-  },
-  maxButton: {
-    backgroundColor: Colors.white,
-    borderWidth: 1,
-    borderColor: Colors.gray2,
-    borderRadius: Spacing.Tiny4,
-    paddingVertical: Spacing.Tiny4,
-    paddingHorizontal: Spacing.Tiny4,
-  },
-  maxText: {
-    ...typeScale.labelXXSmall,
-    color: Colors.gray5,
-    fontSize: 10,
   },
   tokenName: {
     ...typeScale.labelSemiBoldXSmall,

--- a/src/swap/SwapScreen.test.tsx
+++ b/src/swap/SwapScreen.test.tsx
@@ -2,6 +2,7 @@ import { act, fireEvent, render, waitFor, within } from '@testing-library/react-
 import BigNumber from 'bignumber.js'
 import { FetchMock } from 'jest-fetch-mock/types'
 import React from 'react'
+import { DeviceEventEmitter } from 'react-native'
 import { Provider } from 'react-redux'
 import { ReactTestInstance } from 'react-test-renderer'
 import { showError } from 'src/alert/actions'
@@ -287,6 +288,15 @@ const selectSwapTokens = (
       i === 0 ? Field.FROM : Field.TO
     )
   }
+}
+
+const selectMaxFromAmount = async (swapScreen: ReactTestInstance) => {
+  await act(() => {
+    DeviceEventEmitter.emit('keyboardDidShow', { endCoordinates: { height: 100 } })
+  })
+
+  const amountPercentageComponent = within(swapScreen).getByTestId('SwapEnterAmount/AmountOptions')
+  fireEvent.press(within(amountPercentageComponent).getByText('maxSymbol'))
 }
 
 describe('SwapScreen', () => {
@@ -876,40 +886,72 @@ describe('SwapScreen', () => {
     expect(getByText('swapScreen.confirmSwap')).not.toBeDisabled()
   })
 
-  it('should set max from value', async () => {
-    mockFetch.mockResponse(defaultQuoteResponse)
-    const { swapFromContainer, swapToContainer, getByText, getByTestId, swapScreen } = renderScreen(
-      {}
-    )
+  it.each([
+    // mock store has 10 CELO balance
+    // mock CELO -> cUSD exchange rate is 1.2345678
+    {
+      amountLabel: 'percentage, {"percentage":25}',
+      percentage: 25,
+      expectedFromAmount: '2.5', // 25% of 10
+      expectedToAmount: '3.0864195', // expectedFromAmount * exchange rate = 2.5 * 1.2345678
+    },
+    {
+      amountLabel: 'percentage, {"percentage":50}',
+      percentage: 50,
+      expectedFromAmount: '5',
+      expectedToAmount: '6.172839',
+    },
+    {
+      amountLabel: 'percentage, {"percentage":75}',
+      percentage: 75,
+      expectedFromAmount: '7.5',
+      expectedToAmount: '9.2592585',
+    },
+    {
+      amountLabel: 'maxSymbol',
+      percentage: 100,
+      expectedFromAmount: '10',
+      expectedToAmount: '12.345678',
+    },
+  ])(
+    'sets the expected amount when the $amountLabel chip is selected',
+    async ({ amountLabel, percentage, expectedToAmount, expectedFromAmount }) => {
+      mockFetch.mockResponse(defaultQuoteResponse)
+      const { swapFromContainer, swapToContainer, getByText, getByTestId, swapScreen } =
+        renderScreen({})
 
-    selectSwapTokens('CELO', 'cUSD', swapScreen)
-    fireEvent.press(getByTestId('SwapAmountInput/MaxButton'))
+      selectSwapTokens('CELO', 'cUSD', swapScreen)
 
-    await act(() => {
-      jest.runOnlyPendingTimers()
-    })
+      await act(() => {
+        DeviceEventEmitter.emit('keyboardDidShow', { endCoordinates: { height: 100 } })
+      })
 
-    expect(getByTestId('SwapTransactionDetails/ExchangeRate')).toHaveTextContent(
-      '1 CELO ≈ 1.23456 cUSD'
-    )
-    expect(within(swapFromContainer).getByTestId('SwapAmountInput/Input').props.value).toBe(
-      '10' // matching the value inside the mocked store
-    )
-    expect(within(swapToContainer).getByTestId('SwapAmountInput/Input').props.value).toBe(
-      '12.345678'
-    )
-    expect(getByText('swapScreen.confirmSwap')).not.toBeDisabled()
-  })
+      fireEvent.press(within(getByTestId('SwapEnterAmount/AmountOptions')).getByText(amountLabel))
+
+      await waitFor(() =>
+        expect(getByTestId('SwapTransactionDetails/ExchangeRate')).toHaveTextContent(
+          '1 CELO ≈ 1.23456 cUSD'
+        )
+      )
+      expect(within(swapFromContainer).getByTestId('SwapAmountInput/Input').props.value).toBe(
+        expectedFromAmount
+      )
+      expect(within(swapToContainer).getByTestId('SwapAmountInput/Input').props.value).toBe(
+        expectedToAmount
+      )
+      expect(getByText('swapScreen.confirmSwap')).not.toBeDisabled()
+    }
+  )
 
   it('should show and hide the max warning for fee currencies', async () => {
     mockFetch.mockResponse(defaultQuoteResponse)
-    const { swapFromContainer, getByText, getByTestId, queryByTestId, swapScreen } = renderScreen({
+    const { swapFromContainer, getByText, queryByTestId, swapScreen } = renderScreen({
       celoBalance: '0',
       cUSDBalance: '10',
     }) // so that cUSD is the only feeCurrency with a balance
 
     selectSingleSwapToken(swapFromContainer, 'cUSD', swapScreen, Field.FROM)
-    fireEvent.press(getByTestId('SwapAmountInput/MaxButton'))
+    await selectMaxFromAmount(swapScreen)
     await waitFor(() =>
       expect(
         getByText('swapScreen.maxSwapAmountWarning.bodyV1_74, {"tokenSymbol":"cUSD"}')
@@ -927,13 +969,13 @@ describe('SwapScreen', () => {
 
   it("shouldn't show the max warning when there's balance for more than 1 fee currency", async () => {
     mockFetch.mockResponse(defaultQuoteResponse)
-    const { swapFromContainer, getByTestId, queryByTestId, swapScreen } = renderScreen({
+    const { swapFromContainer, queryByTestId, swapScreen } = renderScreen({
       celoBalance: '10',
       cUSDBalance: '20',
     })
 
     selectSingleSwapToken(swapFromContainer, 'CELO', swapScreen, Field.FROM)
-    fireEvent.press(getByTestId('SwapAmountInput/MaxButton'))
+    await selectMaxFromAmount(swapScreen)
     await waitFor(() => expect(queryByTestId('MaxSwapAmountWarning')).toBeFalsy())
   })
 
@@ -944,7 +986,7 @@ describe('SwapScreen', () => {
     )
 
     selectSwapTokens('CELO', 'cUSD', swapScreen)
-    fireEvent.press(getByTestId('SwapAmountInput/MaxButton'))
+    await selectMaxFromAmount(swapScreen)
 
     await act(() => {
       jest.runOnlyPendingTimers()
@@ -960,7 +1002,7 @@ describe('SwapScreen', () => {
     expect(getByText('swapScreen.confirmSwap')).toBeDisabled()
     expect(mockFetch.mock.calls.length).toEqual(1)
 
-    fireEvent.press(getByTestId('SwapAmountInput/MaxButton'))
+    await selectMaxFromAmount(swapScreen)
 
     await act(() => {
       jest.runOnlyPendingTimers()
@@ -980,15 +1022,13 @@ describe('SwapScreen', () => {
   })
 
   it('should set max value if it is zero', async () => {
-    const { swapFromContainer, swapToContainer, getByText, getByTestId, swapScreen } = renderScreen(
-      {
-        celoBalance: '0',
-        cUSDBalance: '0',
-      }
-    )
+    const { swapFromContainer, swapToContainer, getByText, swapScreen } = renderScreen({
+      celoBalance: '0',
+      cUSDBalance: '0',
+    })
 
     selectSwapTokens('CELO', 'cUSD', swapScreen)
-    fireEvent.press(getByTestId('SwapAmountInput/MaxButton'))
+    await selectMaxFromAmount(swapScreen)
 
     expect(within(swapFromContainer).getByTestId('SwapAmountInput/Input').props.value).toBe('0')
     expect(within(swapToContainer).getByTestId('SwapAmountInput/Input').props.value).toBe('')
@@ -1035,10 +1075,10 @@ describe('SwapScreen', () => {
     jest.spyOn(Date, 'now').mockReturnValue(quoteReceivedTimestamp) // quote received timestamp
 
     mockFetch.mockResponse(defaultQuoteResponse)
-    const { getByText, getByTestId, store, swapScreen } = renderScreen({})
+    const { getByText, store, swapScreen } = renderScreen({})
 
     selectSwapTokens('CELO', 'cUSD', swapScreen)
-    fireEvent.press(getByTestId('SwapAmountInput/MaxButton'))
+    await selectMaxFromAmount(swapScreen)
 
     await act(() => {
       jest.runOnlyPendingTimers()
@@ -1181,10 +1221,10 @@ describe('SwapScreen', () => {
 
   it('should have correct analytics on swap submission', async () => {
     mockFetch.mockResponse(defaultQuoteResponse)
-    const { getByText, getByTestId, swapScreen } = renderScreen({})
+    const { getByText, swapScreen } = renderScreen({})
 
     selectSwapTokens('CELO', 'cUSD', swapScreen)
-    fireEvent.press(getByTestId('SwapAmountInput/MaxButton'))
+    await selectMaxFromAmount(swapScreen)
 
     await act(() => {
       jest.runOnlyPendingTimers()
@@ -1305,7 +1345,7 @@ describe('SwapScreen', () => {
     const { update, getByText, getByTestId, swapScreen, store } = renderScreen({})
 
     selectSwapTokens('CELO', 'cUSD', swapScreen)
-    fireEvent.press(getByTestId('SwapAmountInput/MaxButton'))
+    await selectMaxFromAmount(swapScreen)
 
     await act(() => {
       jest.runOnlyPendingTimers()
@@ -1346,11 +1386,12 @@ describe('SwapScreen', () => {
 
   it('should show and hide the error warning', async () => {
     mockFetch.mockResponse(defaultQuoteResponse)
-    const { update, getByText, getByTestId, queryByText, swapFromContainer, swapScreen, store } =
-      renderScreen({})
+    const { update, getByText, queryByText, swapFromContainer, swapScreen, store } = renderScreen(
+      {}
+    )
 
     selectSwapTokens('CELO', 'cUSD', swapScreen)
-    fireEvent.press(getByTestId('SwapAmountInput/MaxButton'))
+    await selectMaxFromAmount(swapScreen)
 
     await act(() => {
       jest.runOnlyPendingTimers()
@@ -1414,7 +1455,7 @@ describe('SwapScreen', () => {
 
     // First get a quote for a network
     selectSwapTokens('CELO', 'cUSD', swapScreen)
-    fireEvent.press(getByTestId('SwapAmountInput/MaxButton'))
+    await selectMaxFromAmount(swapScreen)
 
     await act(() => {
       jest.runOnlyPendingTimers()
@@ -1471,13 +1512,13 @@ describe('SwapScreen', () => {
   it("should warn when the balances for feeCurrencies are 0 and can't cover the fee", async () => {
     // Swap from POOF to CELO, when no feeCurrency has any balance
     mockFetch.mockResponse(defaultQuoteResponse)
-    const { getByText, getByTestId, swapScreen } = renderScreen({
+    const { getByText, swapScreen } = renderScreen({
       celoBalance: '0',
       cUSDBalance: '0',
     })
 
     selectSwapTokens('POOF', 'CELO', swapScreen)
-    fireEvent.press(getByTestId('SwapAmountInput/MaxButton'))
+    await selectMaxFromAmount(swapScreen)
 
     await act(() => {
       jest.runOnlyPendingTimers()
@@ -1495,13 +1536,13 @@ describe('SwapScreen', () => {
   it('should warn when the balances for feeCurrencies are too low to cover the fee', async () => {
     // Swap from POOF to CELO, when no feeCurrency has any balance
     mockFetch.mockResponse(defaultQuoteResponse)
-    const { getByText, getByTestId, swapScreen } = renderScreen({
+    const { getByText, swapScreen } = renderScreen({
       celoBalance: '0.001',
       cUSDBalance: '0.001',
     })
 
     selectSwapTokens('POOF', 'CELO', swapScreen)
-    fireEvent.press(getByTestId('SwapAmountInput/MaxButton'))
+    await selectMaxFromAmount(swapScreen)
 
     await act(() => {
       jest.runOnlyPendingTimers()
@@ -1519,13 +1560,13 @@ describe('SwapScreen', () => {
   it('should prompt the user to decrease the swap amount when swapping the max amount of a feeCurrency, and no other feeCurrency has enough balance to pay for the fee', async () => {
     // Swap CELO to cUSD, when only CELO has balance
     mockFetch.mockResponse(defaultQuoteResponse)
-    const { getByText, getByTestId, queryByText, swapScreen, swapFromContainer } = renderScreen({
+    const { getByText, queryByText, swapScreen, swapFromContainer } = renderScreen({
       celoBalance: '1.234',
       cUSDBalance: '0',
     })
 
     selectSwapTokens('CELO', 'cUSD', swapScreen)
-    fireEvent.press(getByTestId('SwapAmountInput/MaxButton'))
+    await selectMaxFromAmount(swapScreen)
 
     await act(() => {
       jest.runOnlyPendingTimers()
@@ -1651,13 +1692,13 @@ describe('SwapScreen', () => {
   it("should allow swapping the max balance of a feeCurrency when there's another feeCurrency to pay for the fee", async () => {
     // Swap full CELO balance to cUSD
     mockFetch.mockResponse(defaultQuoteResponse)
-    const { getByText, getByTestId, queryByTestId, swapScreen, swapFromContainer } = renderScreen({
+    const { getByText, queryByTestId, swapScreen, swapFromContainer } = renderScreen({
       celoBalance: '1.234',
       cUSDBalance: '10',
     })
 
     selectSwapTokens('CELO', 'cUSD', swapScreen)
-    fireEvent.press(getByTestId('SwapAmountInput/MaxButton'))
+    await selectMaxFromAmount(swapScreen)
 
     await act(() => {
       jest.runOnlyPendingTimers()


### PR DESCRIPTION
### Description

As the title. Similar to #6240 

### Test plan


https://github.com/user-attachments/assets/8835b87b-7182-4391-b041-92ab70b1ffd1



### Related issues

- Fixes RET-1236

### Backwards compatibility

Y

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [ ] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
