### PR TITLE
fix(analytics): Send redux_store_size event regularly

### DIFF
--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -15,10 +15,12 @@ import { rootSaga } from 'src/redux/sagas'
 import { transactionFeedV2Api } from 'src/transactions/api'
 import { resetStateOnInvalidStoredAccount } from 'src/utils/accountChecker'
 import Logger from 'src/utils/Logger'
-import { ONE_DAY_IN_MILLIS } from 'src/utils/time'
+import { ONE_MINUTE_IN_MILLIS } from 'src/utils/time'
 
-const timeBetweenStoreSizeEvents = ONE_DAY_IN_MILLIS
-let lastEventTime = Date.now()
+export const timeBetweenStoreSizeEvents = ONE_MINUTE_IN_MILLIS
+// Set this to the epoch so that a redix_store_size event will always be emitted the first time
+// the entire state is serialized in a session
+let lastEventTime = 0
 
 const persistConfig: PersistConfig<ReducersRootState> = {
   key: 'root',

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -38,7 +38,7 @@ export const formatDistanceToNow = (
 }
 
 const ONE_SECOND_IN_MILLIS = 1000
-const ONE_MINUTE_IN_MILLIS = 60 * ONE_SECOND_IN_MILLIS
+export const ONE_MINUTE_IN_MILLIS = 60 * ONE_SECOND_IN_MILLIS
 export const ONE_HOUR_IN_MILLIS = 60 * ONE_MINUTE_IN_MILLIS
 export const ONE_DAY_IN_MILLIS = 24 * ONE_HOUR_IN_MILLIS
 


### PR DESCRIPTION
### Description

Currently, we have a mechanism in place to log the user's redux store size as an analytics event, however due to a bug in the logic, it only ever gets logged if a user keeps a session open for >24 hours. This PR updates the logic to ensure that the redux store size will be logged as soon as it's first available in a new session, and then subsequently every minute, whenever the full state is serialized.

### Test plan

Unit and manual tested.

### Related issues

- Fixes #[issue number here]

### Backwards compatibility

<!-- Brief explanation of why these changes are/are not backwards compatible. -->

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
