### PR TITLE
fix: incorrect withdraw percentage amount

### DIFF
--- a/src/earn/EarnEnterAmount.test.tsx
+++ b/src/earn/EarnEnterAmount.test.tsx
@@ -187,6 +187,20 @@ describe('EarnEnterAmount', () => {
       expect(queryByTestId('downArrowIcon')).toBeFalsy()
     })
 
+    it('should apply the maximum amount if the user selects the max option', async () => {
+      const { getByTestId } = render(
+        <Provider store={store}>
+          <MockedNavigator component={EarnEnterAmount} params={depositParams} />
+        </Provider>
+      )
+      await act(() => {
+        DeviceEventEmitter.emit('keyboardDidShow', { endCoordinates: { height: 100 } })
+      })
+
+      fireEvent.press(within(getByTestId('EarnEnterAmount/AmountOptions')).getByText('maxSymbol'))
+      expect(getByTestId('EarnEnterAmount/TokenAmountInput').props.value).toBe('10') // balance
+    })
+
     it('should prepare transactions with the expected inputs', async () => {
       const { getByTestId } = render(
         <Provider store={store}>
@@ -411,6 +425,20 @@ describe('EarnEnterAmount', () => {
       expect(getByTestId('EarnEnterAmount/TokenSelect')).toHaveTextContent('USDC')
       expect(getByTestId('EarnEnterAmount/TokenSelect')).toBeDisabled()
       expect(queryByTestId('downArrowIcon')).toBeFalsy()
+    })
+
+    it('should apply the maximum amount if the user selects the max option', async () => {
+      const { getByTestId } = render(
+        <Provider store={store}>
+          <MockedNavigator component={EarnEnterAmount} params={withdrawParams} />
+        </Provider>
+      )
+      await act(() => {
+        DeviceEventEmitter.emit('keyboardDidShow', { endCoordinates: { height: 100 } })
+      })
+
+      fireEvent.press(within(getByTestId('EarnEnterAmount/AmountOptions')).getByText('maxSymbol'))
+      expect(getByTestId('EarnEnterAmount/TokenAmountInput').props.value).toBe('11') // balance * pool price per share
     })
 
     it('should prepare transactions with the expected inputs', async () => {
@@ -660,8 +688,7 @@ describe('EarnEnterAmount', () => {
       },
     })
 
-    // eslint-disable-next-line jest/no-disabled-tests
-    it.skip('selecting max token amount applies correct decimal separator', async () => {
+    it('selecting max token amount applies correct decimal separator', async () => {
       const { getByTestId } = render(
         <Provider store={mockStore}>
           <MockedNavigator component={EarnEnterAmount} params={params} />

--- a/src/earn/EarnEnterAmount.tsx
+++ b/src/earn/EarnEnterAmount.tsx
@@ -343,7 +343,7 @@ function EarnEnterAmount({ route }: Props) {
   }
 
   const onSelectPercentageAmount = (percentage: number) => {
-    setTokenAmountInput(inputToken.balance.multipliedBy(percentage).toFormat({ decimalSeparator }))
+    setTokenAmountInput(balanceInInputToken.multipliedBy(percentage).toFormat({ decimalSeparator }))
     setEnteredIn('token')
     setSelectedPercentage(percentage)
 


### PR DESCRIPTION
### Description

As the title - this was a copy paste error, restoring it to the [previous logic](https://github.com/valora-inc/wallet/blob/7714ddffef3b08d252fa6e6595b4b4114eb7e28c/src/earn/EarnEnterAmount.tsx#L348).

### Test plan

Applying the max amount now matches the max amount displayed in the withdraw details.

https://github.com/user-attachments/assets/540854a7-9020-4208-930b-e0042c92a025


### Related issues

n/a

### Backwards compatibility

Y

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [ ] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
