### PR TITLE
chore(cleanup): Remove onboarding_terms_and_conditions experiment

### DIFF
--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -729,17 +729,6 @@
     "goldDisclaimer": "When you create an \"account\" with {{appName}} you are creating a digital wallet to which only you hold the keys. No other person or entity, including {{appName}}, can recover your key, change or undo transactions, or recover lost funds. Be aware that digital assets are part of a new asset class and present a risk of financial loss. Carefully consider your financial circumstances and tolerance for financial risk before purchasing any digital asset.",
     "goldDisclaimerWithPoints": "When you create an \"account\" with {{appName}} you are creating a digital wallet to which only you hold the keys. No other person or entity, including {{appName}}, can recover your key, change or undo transactions, or recover lost funds. {{appName}} grants tokenized loyalty rewards (\"Points\") to Users for engaging in certain in-app activities. Points are on-chain, non-transferable, and non-redeemable collectibles. No guarantees are made about Points availability or value. Be aware that digital assets are part of a new asset class and present a risk of financial loss. Carefully consider your financial circumstances and tolerance for financial risk before purchasing any digital asset."
   },
-  "termsColloquial": {
-    "title": "Let’s start by creating your wallet",
-    "privacyHeading": "Your Info & Privacy:",
-    "privacy1": "We gather usage data which helps us improve the app and security. The type of information we collect, how we use it and your rights related to that information can all be seen in our <0>Privacy Policy</0>.",
-    "privacy2": "If you decide to link your phone number, we will store an encrypted copy of it.",
-    "privacy3": "If you decide to connect your contacts, we use their names, numbers, and profile pictures to make it easier to find them.",
-    "walletHeading": "Your Digital Wallet with {{appName}}:",
-    "wallet1": "You’re about to create a digital wallet. Only you have the key to your wallet. We cannot recover your key or your assets if you lose your key. We also cannot reverse actions taken through {{appName}} on blockchains.",
-    "wallet2": "Digital assets, the assets with which you will interact with {{appName}}, come with unique risks. By using {{appName}}, you accept these risks and take responsibility for them. Please consider your finances and risk tolerance before making choices.",
-    "fullTerms": "Read our full <0>Terms & Conditions</0>"
-  },
   "fullNameOrPsuedonym": "Full name or pseudonym",
   "namePlaceholder": "ex. name",
   "nameAndPicGuideCopyTitle": "What’s your name?",
@@ -848,8 +837,7 @@
     "hasWallet": "I already have a wallet",
     "hasWalletV1_88": "I have a wallet",
     "header": "Welcome to {{appName}}! Let's create your crypto wallet.",
-    "getStarted": "Get Started",
-    "agreeToTerms": "By creating a wallet you agree to our <0>Terms and Conditions</0>"
+    "getStarted": "Get Started"
   },
   "accessContacts": {
     "disclosure": {

--- a/src/onboarding/registration/RegulatoryTerms.test.tsx
+++ b/src/onboarding/registration/RegulatoryTerms.test.tsx
@@ -6,7 +6,7 @@ import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import { RegulatoryTerms as RegulatoryTermsClass } from 'src/onboarding/registration/RegulatoryTerms'
 import { firstOnboardingScreen } from 'src/onboarding/steps'
-import { getDynamicConfigParams, getExperimentParams } from 'src/statsig'
+import { getDynamicConfigParams } from 'src/statsig'
 import { createMockStore, getMockI18nProps } from 'test/utils'
 
 jest.mock('src/onboarding/steps')
@@ -23,8 +23,7 @@ describe('RegulatoryTermsScreen', () => {
       },
     })
   })
-  it('renders correct components for control', () => {
-    jest.mocked(getExperimentParams).mockReturnValue({ variant: 'control' })
+  it('renders correct components', () => {
     const store = createMockStore({})
     const { getByTestId, queryByTestId } = render(
       <Provider store={store}>
@@ -40,60 +39,37 @@ describe('RegulatoryTermsScreen', () => {
     expect(queryByTestId('colloquialTermsSectionList')).toBeFalsy()
   })
 
-  it('renders correct components for colloquial_terms', () => {
-    jest.mocked(getExperimentParams).mockReturnValue({ variant: 'colloquial_terms' })
-    const store = createMockStore({})
-    const { getByTestId, queryByTestId } = render(
-      <Provider store={store}>
-        <RegulatoryTermsClass
-          {...getMockI18nProps()}
-          acceptTerms={acceptTerms}
-          recoveringFromStoreWipe={false}
-        />
-      </Provider>
-    )
+  describe('when accept button is pressed', () => {
+    it('stores that info', async () => {
+      const store = createMockStore({})
+      const wrapper = render(
+        <Provider store={store}>
+          <RegulatoryTermsClass
+            {...getMockI18nProps()}
+            acceptTerms={acceptTerms}
+            recoveringFromStoreWipe={false}
+          />
+        </Provider>
+      )
+      fireEvent.press(wrapper.getByTestId('AcceptTermsButton'))
+      expect(acceptTerms).toHaveBeenCalled()
+    })
+    it('navigates to PincodeSet', () => {
+      const store = createMockStore({})
+      jest.mocked(firstOnboardingScreen).mockReturnValue(Screens.PincodeSet)
 
-    expect(getByTestId('colloquialTermsSectionList')).toBeTruthy()
-    expect(queryByTestId('scrollView')).toBeFalsy()
+      const wrapper = render(
+        <Provider store={store}>
+          <RegulatoryTermsClass
+            {...getMockI18nProps()}
+            acceptTerms={acceptTerms}
+            recoveringFromStoreWipe={false}
+          />
+        </Provider>
+      )
+      fireEvent.press(wrapper.getByTestId('AcceptTermsButton'))
+      expect(firstOnboardingScreen).toHaveBeenCalled()
+      expect(navigate).toHaveBeenCalledWith(Screens.PincodeSet)
+    })
   })
-
-  describe.each([{ variant: 'control' }, { variant: 'colloquial_terms' }])(
-    'when accept button is pressed ($variant)',
-    ({ variant }) => {
-      beforeAll(() => {
-        jest.mocked(getExperimentParams).mockReturnValue({ variant })
-      })
-      it('stores that info', async () => {
-        const store = createMockStore({})
-        const wrapper = render(
-          <Provider store={store}>
-            <RegulatoryTermsClass
-              {...getMockI18nProps()}
-              acceptTerms={acceptTerms}
-              recoveringFromStoreWipe={false}
-            />
-          </Provider>
-        )
-        fireEvent.press(wrapper.getByTestId('AcceptTermsButton'))
-        expect(acceptTerms).toHaveBeenCalled()
-      })
-      it('navigates to PincodeSet', () => {
-        const store = createMockStore({})
-        jest.mocked(firstOnboardingScreen).mockReturnValue(Screens.PincodeSet)
-
-        const wrapper = render(
-          <Provider store={store}>
-            <RegulatoryTermsClass
-              {...getMockI18nProps()}
-              acceptTerms={acceptTerms}
-              recoveringFromStoreWipe={false}
-            />
-          </Provider>
-        )
-        fireEvent.press(wrapper.getByTestId('AcceptTermsButton'))
-        expect(firstOnboardingScreen).toHaveBeenCalled()
-        expect(navigate).toHaveBeenCalledWith(Screens.PincodeSet)
-      })
-    }
-  )
 })

--- a/src/onboarding/registration/RegulatoryTerms.tsx
+++ b/src/onboarding/registration/RegulatoryTerms.tsx
@@ -16,9 +16,9 @@ import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import { firstOnboardingScreen } from 'src/onboarding/steps'
 import { RootState } from 'src/redux/reducers'
-import { getDynamicConfigParams, getExperimentParams, getFeatureGate } from 'src/statsig'
-import { DynamicConfigs, ExperimentConfigs } from 'src/statsig/constants'
-import { StatsigDynamicConfigs, StatsigExperiments, StatsigFeatureGates } from 'src/statsig/types'
+import { getDynamicConfigParams, getFeatureGate } from 'src/statsig'
+import { DynamicConfigs } from 'src/statsig/constants'
+import { StatsigDynamicConfigs, StatsigFeatureGates } from 'src/statsig/types'
 import Colors from 'src/styles/colors'
 import { typeScale } from 'src/styles/fonts'
 import { Spacing } from 'src/styles/styles'
@@ -168,10 +168,6 @@ export class RegulatoryTerms extends React.Component<Props> {
   render() {
     const { t } = this.props
 
-    const { variant } = getExperimentParams(
-      ExperimentConfigs[StatsigExperiments.ONBOARDING_TERMS_AND_CONDITIONS]
-    )
-
     return (
       <SafeAreaView
         style={styles.container}
@@ -180,7 +176,7 @@ export class RegulatoryTerms extends React.Component<Props> {
         edges={Platform.select({ ios: ['bottom', 'left', 'right'] })}
       >
         <DevSkipButton nextScreen={Screens.PincodeSet} />
-        {variant === 'colloquial_terms' ? this.renderColloquialTerms() : this.renderTerms()}
+        {this.renderTerms()}
         <SafeAreaInsetsContext.Consumer>
           {(insets) => (
             <Button

--- a/src/onboarding/registration/RegulatoryTerms.tsx
+++ b/src/onboarding/registration/RegulatoryTerms.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { Trans, WithTranslation } from 'react-i18next'
-import { Platform, ScrollView, SectionList, StyleSheet, Text, View } from 'react-native'
+import { Platform, ScrollView, StyleSheet, Text } from 'react-native'
 import { SafeAreaInsetsContext, SafeAreaView } from 'react-native-safe-area-context'
 import { connect } from 'react-redux'
 import { acceptTerms } from 'src/account/actions'
@@ -21,7 +21,6 @@ import { DynamicConfigs } from 'src/statsig/constants'
 import { StatsigDynamicConfigs, StatsigFeatureGates } from 'src/statsig/types'
 import Colors from 'src/styles/colors'
 import { typeScale } from 'src/styles/fonts'
-import { Spacing } from 'src/styles/styles'
 import { navigateToURI } from 'src/utils/linking'
 
 const MARGIN = 24
@@ -107,64 +106,6 @@ export class RegulatoryTerms extends React.Component<Props> {
     )
   }
 
-  renderColloquialTerms() {
-    const { t } = this.props
-
-    return (
-      <SectionList
-        style={styles.scrollView}
-        contentContainerStyle={styles.scrollContent}
-        testID="colloquialTermsSectionList"
-        sections={[
-          {
-            title: t('termsColloquial.privacyHeading'),
-            data: [
-              { text: 'termsColloquial.privacy1', onPress: this.onPressGoToPrivacyPolicy },
-              { text: 'termsColloquial.privacy2' },
-              { text: 'termsColloquial.privacy3' },
-            ],
-          },
-          {
-            title: t('termsColloquial.walletHeading'),
-            data: [{ text: 'termsColloquial.wallet1' }, { text: 'termsColloquial.wallet2' }],
-          },
-        ]}
-        renderItem={({ item }) => {
-          return (
-            <View style={styles.itemContainer}>
-              <Text style={styles.item}>{'\u2022'}</Text>
-              {item.onPress ? (
-                <Text style={styles.item}>
-                  <Trans i18nKey={item.text}>
-                    <Text onPress={item.onPress} style={styles.link} />
-                  </Trans>
-                </Text>
-              ) : (
-                <Text style={styles.item}>
-                  <Trans i18nKey={item.text} />
-                </Text>
-              )}
-            </View>
-          )
-        }}
-        renderSectionHeader={({ section: { title } }) => (
-          <Text style={styles.sectionHeader}>{title}</Text>
-        )}
-        ListHeaderComponent={
-          <Text style={styles.titleColloquial}>{t('termsColloquial.title')}</Text>
-        }
-        ListFooterComponent={
-          <Text style={styles.fullTerms}>
-            <Trans i18nKey="termsColloquial.fullTerms">
-              <Text onPress={this.onPressGoToTerms} style={styles.link} />
-            </Trans>
-          </Text>
-        }
-        stickySectionHeadersEnabled={false}
-      />
-    )
-  }
-
   render() {
     const { t } = this.props
 
@@ -229,26 +170,5 @@ const styles = StyleSheet.create({
   button: {
     marginTop: MARGIN,
     marginHorizontal: MARGIN,
-  },
-  titleColloquial: {
-    ...typeScale.titleSmall,
-    marginBottom: Spacing.Small12,
-  },
-  sectionHeader: {
-    ...typeScale.labelSemiBoldSmall,
-    marginVertical: Spacing.Small12,
-  },
-  itemContainer: {
-    flexDirection: 'row',
-    gap: Spacing.Smallest8,
-  },
-  item: {
-    ...typeScale.bodySmall,
-    flexShrink: 1,
-  },
-  fullTerms: {
-    ...typeScale.labelSemiBoldSmall,
-    marginVertical: Spacing.Small12,
-    color: Colors.infoDark,
   },
 })

--- a/src/onboarding/welcome/Welcome.test.tsx
+++ b/src/onboarding/welcome/Welcome.test.tsx
@@ -1,19 +1,18 @@
 import { fireEvent, render, waitFor } from '@testing-library/react-native'
 import * as React from 'react'
 import { Provider } from 'react-redux'
-import { acceptTerms, chooseCreateAccount, chooseRestoreAccount } from 'src/account/actions'
-import { OnboardingEvents } from 'src/analytics/Events'
+import { chooseCreateAccount, chooseRestoreAccount } from 'src/account/actions'
 import AppAnalytics from 'src/analytics/AppAnalytics'
+import { OnboardingEvents } from 'src/analytics/Events'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import { firstOnboardingScreen } from 'src/onboarding/steps'
 import Welcome from 'src/onboarding/welcome/Welcome'
-import { getExperimentParams, patchUpdateStatsigUser } from 'src/statsig'
+import { patchUpdateStatsigUser } from 'src/statsig'
 import { createMockStore } from 'test/utils'
 
 jest.mock('src/onboarding/steps')
 jest.mock('src/statsig', () => ({
-  getExperimentParams: jest.fn(),
   patchUpdateStatsigUser: jest.fn(),
 }))
 
@@ -27,123 +26,8 @@ describe('Welcome', () => {
     jest.clearAllMocks()
   })
 
-  describe.each([{ variant: 'control' }, { variant: 'colloquial_terms' }])(
-    '$variant',
-    ({ variant }) => {
-      beforeAll(() => {
-        jest.mocked(getExperimentParams).mockReturnValue({ variant })
-      })
-      it('renders components', async () => {
-        const store = createMockStore()
-        const { getByTestId, queryByTestId } = render(
-          <Provider store={store}>
-            <Welcome />
-          </Provider>
-        )
-        expect(getByTestId('CreateAccountButton')).toBeTruthy()
-        expect(getByTestId('RestoreAccountButton')).toBeTruthy()
-        expect(queryByTestId('TermsCheckbox/unchecked')).toBeFalsy()
-        expect(queryByTestId('TermsCheckbox/checked')).toBeFalsy()
-      })
-      it('create updates statsig, fires action and navigates to terms screen for first time onboarding', async () => {
-        const store = createMockStore()
-        const { getByTestId } = render(
-          <Provider store={store}>
-            <Welcome />
-          </Provider>
-        )
-
-        fireEvent.press(getByTestId('CreateAccountButton'))
-        await waitFor(() =>
-          expect(patchUpdateStatsigUser).toHaveBeenCalledWith({
-            custom: { startOnboardingTime: 123 },
-          })
-        )
-        expect(store.getActions()).toEqual([chooseCreateAccount(123)])
-        expect(navigate).toHaveBeenCalledTimes(1)
-        expect(navigate).toHaveBeenCalledWith(Screens.RegulatoryTerms)
-        expect(AppAnalytics.track).toHaveBeenCalledTimes(1)
-        expect(AppAnalytics.track).toHaveBeenCalledWith(OnboardingEvents.create_account_start)
-      })
-      it('create skips statsig update if not onboarding the first time', () => {
-        const store = createMockStore({
-          account: {
-            startOnboardingTime: 111,
-          },
-        })
-        const { getByTestId } = render(
-          <Provider store={store}>
-            <Welcome />
-          </Provider>
-        )
-
-        fireEvent.press(getByTestId('CreateAccountButton'))
-        expect(store.getActions()).toEqual([chooseCreateAccount(123)])
-        expect(navigate).toHaveBeenCalledTimes(1)
-        expect(navigate).toHaveBeenCalledWith(Screens.RegulatoryTerms)
-        expect(patchUpdateStatsigUser).not.toHaveBeenCalled()
-        expect(AppAnalytics.track).toHaveBeenCalledTimes(1)
-        expect(AppAnalytics.track).toHaveBeenCalledWith(OnboardingEvents.create_account_start)
-      })
-      it('restore fires action and navigates to terms screen', () => {
-        const store = createMockStore()
-        const { getByTestId } = render(
-          <Provider store={store}>
-            <Welcome />
-          </Provider>
-        )
-
-        fireEvent.press(getByTestId('RestoreAccountButton'))
-        expect(navigate).toHaveBeenCalledTimes(1)
-        expect(navigate).toHaveBeenCalledWith(Screens.RegulatoryTerms)
-        expect(store.getActions()).toEqual([chooseRestoreAccount()])
-        expect(AppAnalytics.track).toHaveBeenCalledTimes(1)
-        expect(AppAnalytics.track).toHaveBeenCalledWith(OnboardingEvents.restore_account_start)
-      })
-      it.each([
-        {
-          buttonId: 'CreateAccountButton',
-          action: chooseCreateAccount(123),
-          event: OnboardingEvents.create_account_start,
-        },
-        {
-          buttonId: 'RestoreAccountButton',
-          action: chooseRestoreAccount(),
-          event: OnboardingEvents.restore_account_start,
-        },
-      ])(
-        '$buttonId goes to the onboarding screen if terms already accepted',
-        ({ buttonId, action, event }) => {
-          const store = createMockStore({
-            account: {
-              acceptedTerms: true,
-              startOnboardingTime: 111,
-            },
-          })
-          const { getByTestId } = render(
-            <Provider store={store}>
-              <Welcome />
-            </Provider>
-          )
-
-          fireEvent.press(getByTestId(buttonId))
-          expect(firstOnboardingScreen).toHaveBeenCalled()
-          expect(navigate).toHaveBeenCalledTimes(1)
-          expect(navigate).toHaveBeenCalledWith(Screens.PincodeSet)
-          expect(store.getActions()).toEqual([action])
-          expect(AppAnalytics.track).toHaveBeenCalledTimes(1)
-          expect(AppAnalytics.track).toHaveBeenCalledWith(event)
-        }
-      )
-    }
-  )
-
-  describe('checkbox', () => {
-    beforeAll(() => {
-      jest.mocked(getExperimentParams).mockReturnValue({ variant: 'checkbox' })
-    })
-
-    it('renders correctly', async () => {
+  describe('Welcome', () => {
+    it('renders components', async () => {
       const store = createMockStore()
       const { getByTestId, queryByTestId } = render(
         <Provider store={store}>
@@ -152,62 +36,30 @@ describe('Welcome', () => {
       )
       expect(getByTestId('CreateAccountButton')).toBeTruthy()
       expect(getByTestId('RestoreAccountButton')).toBeTruthy()
-      expect(getByTestId('TermsCheckbox/unchecked')).toBeTruthy()
-      expect(queryByTestId('TermsCheckbox/checked')).toBeFalsy()
-    })
-
-    it('checkbox toggles buttons', async () => {
-      const store = createMockStore()
-      const { getByTestId, queryByTestId } = render(
-        <Provider store={store}>
-          <Welcome />
-        </Provider>
-      )
-      expect(getByTestId('TermsCheckbox/unchecked')).toBeTruthy()
-      expect(queryByTestId('TermsCheckbox/checked')).toBeFalsy()
-      expect(getByTestId('CreateAccountButton')).toBeDisabled()
-      expect(getByTestId('RestoreAccountButton')).toBeDisabled()
-
-      fireEvent.press(getByTestId('TermsCheckbox/unchecked'))
-
-      expect(getByTestId('TermsCheckbox/checked')).toBeTruthy()
       expect(queryByTestId('TermsCheckbox/unchecked')).toBeFalsy()
-      expect(getByTestId('CreateAccountButton')).toBeEnabled()
-      expect(getByTestId('RestoreAccountButton')).toBeEnabled()
-
-      fireEvent.press(getByTestId('TermsCheckbox/checked'))
-
-      expect(getByTestId('TermsCheckbox/unchecked')).toBeTruthy()
       expect(queryByTestId('TermsCheckbox/checked')).toBeFalsy()
-      expect(getByTestId('CreateAccountButton')).toBeDisabled()
-      expect(getByTestId('RestoreAccountButton')).toBeDisabled()
     })
-
-    it('create updates statsig, fires actions and navigates to onboarding screen for first time onboarding', async () => {
+    it('create updates statsig, fires action and navigates to terms screen for first time onboarding', async () => {
       const store = createMockStore()
       const { getByTestId } = render(
         <Provider store={store}>
           <Welcome />
         </Provider>
       )
-      fireEvent.press(getByTestId('TermsCheckbox/unchecked'))
+
       fireEvent.press(getByTestId('CreateAccountButton'))
       await waitFor(() =>
         expect(patchUpdateStatsigUser).toHaveBeenCalledWith({
           custom: { startOnboardingTime: 123 },
         })
       )
-      expect(store.getActions()).toEqual([chooseCreateAccount(123), acceptTerms()])
+      expect(store.getActions()).toEqual([chooseCreateAccount(123)])
       expect(navigate).toHaveBeenCalledTimes(1)
-      expect(navigate).toHaveBeenCalledWith(Screens.PincodeSet)
-      expect(AppAnalytics.track).toHaveBeenCalledTimes(2)
+      expect(navigate).toHaveBeenCalledWith(Screens.RegulatoryTerms)
+      expect(AppAnalytics.track).toHaveBeenCalledTimes(1)
       expect(AppAnalytics.track).toHaveBeenCalledWith(OnboardingEvents.create_account_start)
-      expect(AppAnalytics.track).toHaveBeenCalledWith(
-        OnboardingEvents.terms_and_conditions_accepted
-      )
     })
-
-    it('create skips statsig if not first time onboarding', async () => {
+    it('create skips statsig update if not onboarding the first time', () => {
       const store = createMockStore({
         account: {
           startOnboardingTime: 111,
@@ -218,38 +70,30 @@ describe('Welcome', () => {
           <Welcome />
         </Provider>
       )
-      fireEvent.press(getByTestId('TermsCheckbox/unchecked'))
-      fireEvent.press(getByTestId('CreateAccountButton'))
-      expect(store.getActions()).toEqual([chooseCreateAccount(123), acceptTerms()])
-      expect(navigate).toHaveBeenCalledTimes(1)
-      expect(navigate).toHaveBeenCalledWith(Screens.PincodeSet)
-      expect(patchUpdateStatsigUser).not.toHaveBeenCalled()
-      expect(AppAnalytics.track).toHaveBeenCalledTimes(2)
-      expect(AppAnalytics.track).toHaveBeenCalledWith(OnboardingEvents.create_account_start)
-      expect(AppAnalytics.track).toHaveBeenCalledWith(
-        OnboardingEvents.terms_and_conditions_accepted
-      )
-    })
 
-    it('restore fires actions and navigates to onboarding screen', () => {
+      fireEvent.press(getByTestId('CreateAccountButton'))
+      expect(store.getActions()).toEqual([chooseCreateAccount(123)])
+      expect(navigate).toHaveBeenCalledTimes(1)
+      expect(navigate).toHaveBeenCalledWith(Screens.RegulatoryTerms)
+      expect(patchUpdateStatsigUser).not.toHaveBeenCalled()
+      expect(AppAnalytics.track).toHaveBeenCalledTimes(1)
+      expect(AppAnalytics.track).toHaveBeenCalledWith(OnboardingEvents.create_account_start)
+    })
+    it('restore fires action and navigates to terms screen', () => {
       const store = createMockStore()
       const { getByTestId } = render(
         <Provider store={store}>
           <Welcome />
         </Provider>
       )
-      fireEvent.press(getByTestId('TermsCheckbox/unchecked'))
-      fireEvent.press(getByTestId('RestoreAccountButton'))
-      expect(store.getActions()).toEqual([chooseRestoreAccount(), acceptTerms()])
-      expect(navigate).toHaveBeenCalledTimes(1)
-      expect(navigate).toHaveBeenCalledWith(Screens.PincodeSet)
-      expect(AppAnalytics.track).toHaveBeenCalledTimes(2)
-      expect(AppAnalytics.track).toHaveBeenCalledWith(OnboardingEvents.restore_account_start)
-      expect(AppAnalytics.track).toHaveBeenCalledWith(
-        OnboardingEvents.terms_and_conditions_accepted
-      )
-    })
 
+      fireEvent.press(getByTestId('RestoreAccountButton'))
+      expect(navigate).toHaveBeenCalledTimes(1)
+      expect(navigate).toHaveBeenCalledWith(Screens.RegulatoryTerms)
+      expect(store.getActions()).toEqual([chooseRestoreAccount()])
+      expect(AppAnalytics.track).toHaveBeenCalledTimes(1)
+      expect(AppAnalytics.track).toHaveBeenCalledWith(OnboardingEvents.restore_account_start)
+    })
     it.each([
       {
         buttonId: 'CreateAccountButton',
@@ -262,7 +106,7 @@ describe('Welcome', () => {
         event: OnboardingEvents.restore_account_start,
       },
     ])(
-      '$buttonId skips accept terms action and analytics event when terms already accepted',
+      '$buttonId goes to the onboarding screen if terms already accepted',
       ({ buttonId, action, event }) => {
         const store = createMockStore({
           account: {
@@ -280,12 +124,9 @@ describe('Welcome', () => {
         expect(firstOnboardingScreen).toHaveBeenCalled()
         expect(navigate).toHaveBeenCalledTimes(1)
         expect(navigate).toHaveBeenCalledWith(Screens.PincodeSet)
+        expect(store.getActions()).toEqual([action])
         expect(AppAnalytics.track).toHaveBeenCalledTimes(1)
         expect(AppAnalytics.track).toHaveBeenCalledWith(event)
-        expect(AppAnalytics.track).not.toHaveBeenCalledWith(
-          OnboardingEvents.terms_and_conditions_accepted
-        )
-        expect(store.getActions()).toEqual([action])
       }
     )
   })

--- a/src/onboarding/welcome/Welcome.tsx
+++ b/src/onboarding/welcome/Welcome.tsx
@@ -1,28 +1,22 @@
-import React, { useState } from 'react'
-import { Trans, useTranslation } from 'react-i18next'
-import { ImageBackground, StyleSheet, Text, TouchableOpacity, View } from 'react-native'
+import React from 'react'
+import { useTranslation } from 'react-i18next'
+import { ImageBackground, StyleSheet, View } from 'react-native'
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context'
-import { acceptTerms, chooseCreateAccount, chooseRestoreAccount } from 'src/account/actions'
-import { recoveringFromStoreWipeSelector } from 'src/account/selectors'
+import { chooseCreateAccount, chooseRestoreAccount } from 'src/account/actions'
 import AppAnalytics from 'src/analytics/AppAnalytics'
 import { OnboardingEvents } from 'src/analytics/Events'
 import Button, { BtnSizes, BtnTypes } from 'src/components/Button'
-import CheckBox from 'src/icons/CheckBox'
 import { welcomeBackground } from 'src/images/Images'
 import WelcomeLogo from 'src/images/WelcomeLogo'
 import { nuxNavigationOptions } from 'src/navigator/Headers'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import LanguageButton from 'src/onboarding/LanguageButton'
-import { firstOnboardingScreen } from 'src/onboarding/steps'
 import { useDispatch, useSelector } from 'src/redux/hooks'
-import { getDynamicConfigParams, getExperimentParams, patchUpdateStatsigUser } from 'src/statsig'
-import { DynamicConfigs, ExperimentConfigs } from 'src/statsig/constants'
-import { StatsigDynamicConfigs, StatsigExperiments } from 'src/statsig/types'
+import { patchUpdateStatsigUser } from 'src/statsig'
 import colors from 'src/styles/colors'
 import { typeScale } from 'src/styles/fonts'
 import { Spacing } from 'src/styles/styles'
-import { navigateToURI } from 'src/utils/linking'
 
 export default function Welcome() {
   const { t } = useTranslation()
@@ -30,35 +24,10 @@ export default function Welcome() {
   const acceptedTerms = useSelector((state) => state.account.acceptedTerms)
   const startOnboardingTime = useSelector((state) => state.account.startOnboardingTime)
   const insets = useSafeAreaInsets()
-  const recoveringFromStoreWipe = useSelector(recoveringFromStoreWipeSelector)
-  const [termsCheckbox, toggleTermsCheckBox] = useState(acceptedTerms)
-
-  const { variant } = getExperimentParams(
-    ExperimentConfigs[StatsigExperiments.ONBOARDING_TERMS_AND_CONDITIONS]
-  )
-
-  const showTermsCheckbox = variant === 'checkbox'
-  const buttonsDisabled = showTermsCheckbox && !termsCheckbox
-
-  const startOnboarding = () => {
-    navigate(
-      firstOnboardingScreen({
-        recoveringFromStoreWipe,
-      })
-    )
-  }
 
   const navigateNext = () => {
-    if (!acceptedTerms && !showTermsCheckbox) {
+    if (!acceptedTerms) {
       navigate(Screens.RegulatoryTerms)
-    } else {
-      if (showTermsCheckbox && !acceptedTerms) {
-        // if terms have not already been accepted, fire the analytics event
-        // and dispatch the action to accept the terms
-        AppAnalytics.track(OnboardingEvents.terms_and_conditions_accepted)
-        dispatch(acceptTerms())
-      }
-      startOnboarding()
     }
   }
 
@@ -81,11 +50,6 @@ export default function Welcome() {
     navigateNext()
   }
 
-  const onPressTerms = () => {
-    const { links } = getDynamicConfigParams(DynamicConfigs[StatsigDynamicConfigs.APP_CONFIG])
-    navigateToURI(links.tos)
-  }
-
   return (
     <SafeAreaView style={styles.container}>
       <ImageBackground source={welcomeBackground} resizeMode="stretch" style={styles.image}>
@@ -93,24 +57,6 @@ export default function Welcome() {
           <WelcomeLogo />
         </View>
         <View style={{ ...styles.buttonView, marginBottom: Math.max(0, 40 - insets.bottom) }}>
-          {showTermsCheckbox && (
-            <View style={styles.termsContainer}>
-              <TouchableOpacity onPress={() => toggleTermsCheckBox((prev) => !prev)}>
-                <CheckBox
-                  testID="TermsCheckbox"
-                  checked={termsCheckbox}
-                  checkedColor={colors.black}
-                  uncheckedColor={colors.black}
-                />
-              </TouchableOpacity>
-              <Text style={styles.termsText}>
-                <Trans i18nKey="welcome.agreeToTerms">
-                  <Text onPress={onPressTerms} style={styles.termsTextLink} />
-                </Trans>
-              </Text>
-            </View>
-          )}
-
           <Button
             onPress={onPressCreateAccount}
             text={t('welcome.createNewWallet')}
@@ -118,7 +64,7 @@ export default function Welcome() {
             type={BtnTypes.PRIMARY}
             style={styles.createAccountButton}
             testID={'CreateAccountButton'}
-            disabled={buttonsDisabled}
+            disabled={false}
           />
           <Button
             onPress={onPressRestoreAccount}
@@ -126,7 +72,7 @@ export default function Welcome() {
             size={BtnSizes.FULL}
             type={BtnTypes.SECONDARY}
             testID={'RestoreAccountButton'}
-            disabled={buttonsDisabled}
+            disabled={false}
           />
         </View>
       </ImageBackground>

--- a/src/onboarding/welcome/Welcome.tsx
+++ b/src/onboarding/welcome/Welcome.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { ImageBackground, StyleSheet, View } from 'react-native'
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context'
 import { chooseCreateAccount, chooseRestoreAccount } from 'src/account/actions'
+import { recoveringFromStoreWipeSelector } from 'src/account/selectors'
 import AppAnalytics from 'src/analytics/AppAnalytics'
 import { OnboardingEvents } from 'src/analytics/Events'
 import Button, { BtnSizes, BtnTypes } from 'src/components/Button'
@@ -12,6 +13,7 @@ import { nuxNavigationOptions } from 'src/navigator/Headers'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import LanguageButton from 'src/onboarding/LanguageButton'
+import { firstOnboardingScreen } from 'src/onboarding/steps'
 import { useDispatch, useSelector } from 'src/redux/hooks'
 import { patchUpdateStatsigUser } from 'src/statsig'
 import { Spacing } from 'src/styles/styles'
@@ -22,10 +24,21 @@ export default function Welcome() {
   const acceptedTerms = useSelector((state) => state.account.acceptedTerms)
   const startOnboardingTime = useSelector((state) => state.account.startOnboardingTime)
   const insets = useSafeAreaInsets()
+  const recoveringFromStoreWipe = useSelector(recoveringFromStoreWipeSelector)
+
+  const startOnboarding = () => {
+    navigate(
+      firstOnboardingScreen({
+        recoveringFromStoreWipe,
+      })
+    )
+  }
 
   const navigateNext = () => {
     if (!acceptedTerms) {
       navigate(Screens.RegulatoryTerms)
+    } else {
+      startOnboarding()
     }
   }
 

--- a/src/onboarding/welcome/Welcome.tsx
+++ b/src/onboarding/welcome/Welcome.tsx
@@ -75,7 +75,6 @@ export default function Welcome() {
             type={BtnTypes.PRIMARY}
             style={styles.createAccountButton}
             testID={'CreateAccountButton'}
-            disabled={false}
           />
           <Button
             onPress={onPressRestoreAccount}
@@ -83,7 +82,6 @@ export default function Welcome() {
             size={BtnSizes.FULL}
             type={BtnTypes.SECONDARY}
             testID={'RestoreAccountButton'}
-            disabled={false}
           />
         </View>
       </ImageBackground>

--- a/src/onboarding/welcome/Welcome.tsx
+++ b/src/onboarding/welcome/Welcome.tsx
@@ -14,8 +14,6 @@ import { Screens } from 'src/navigator/Screens'
 import LanguageButton from 'src/onboarding/LanguageButton'
 import { useDispatch, useSelector } from 'src/redux/hooks'
 import { patchUpdateStatsigUser } from 'src/statsig'
-import colors from 'src/styles/colors'
-import { typeScale } from 'src/styles/fonts'
 import { Spacing } from 'src/styles/styles'
 
 export default function Welcome() {
@@ -96,21 +94,6 @@ const styles = StyleSheet.create({
   },
   createAccountButton: {
     marginBottom: Spacing.Smallest8,
-  },
-  termsContainer: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    marginBottom: Spacing.Regular16,
-    paddingHorizontal: Spacing.Smallest8,
-    gap: Spacing.Smallest8,
-  },
-  termsText: {
-    color: colors.black,
-    flexShrink: 1,
-    ...typeScale.bodySmall,
-  },
-  termsTextLink: {
-    textDecorationLine: 'underline',
   },
   buttonView: {
     paddingHorizontal: Spacing.Thick24,

--- a/src/statsig/constants.ts
+++ b/src/statsig/constants.ts
@@ -9,12 +9,6 @@ import networkConfig from 'src/web3/networkConfig'
 
 export const ExperimentConfigs = {
   // NOTE: the keys of defaultValues MUST be parameter names
-  [StatsigExperiments.ONBOARDING_TERMS_AND_CONDITIONS]: {
-    experimentName: StatsigExperiments.ONBOARDING_TERMS_AND_CONDITIONS,
-    defaultValues: {
-      variant: 'control' as 'control' | 'colloquial_terms' | 'checkbox',
-    },
-  },
 } satisfies {
   [key in StatsigExperiments]: {
     experimentName: key

--- a/src/statsig/constants.ts
+++ b/src/statsig/constants.ts
@@ -10,10 +10,10 @@ import networkConfig from 'src/web3/networkConfig'
 export const ExperimentConfigs = {
   // NOTE: the keys of defaultValues MUST be parameter names
   // Needed for CI, remove if there are actual experiments
-  [StatsigExperiments.TEST]: {
-    experimentName: StatsigExperiments.TEST,
+  [StatsigExperiments.SAMPLE]: {
+    experimentName: StatsigExperiments.SAMPLE,
     defaultValues: {
-      testParam: 'test-param-1',
+      testParam: 'sample-param-1',
     },
   },
 } satisfies {

--- a/src/statsig/constants.ts
+++ b/src/statsig/constants.ts
@@ -9,6 +9,13 @@ import networkConfig from 'src/web3/networkConfig'
 
 export const ExperimentConfigs = {
   // NOTE: the keys of defaultValues MUST be parameter names
+  // Needed for CI, remove if there are actual experiments
+  [StatsigExperiments.TEST]: {
+    experimentName: StatsigExperiments.TEST,
+    defaultValues: {
+      testParam: 'test-param-1',
+    },
+  },
 } satisfies {
   [key in StatsigExperiments]: {
     experimentName: key

--- a/src/statsig/types.ts
+++ b/src/statsig/types.ts
@@ -42,7 +42,9 @@ export enum StatsigFeatureGates {
   SHOW_ZERION_TRANSACTION_FEED = 'show_zerion_transaction_feed',
 }
 
-export enum StatsigExperiments {}
+export enum StatsigExperiments {
+  TEST = 'test', // Needed for CI, remove if there are actual experiments
+}
 
 export type StatsigParameter =
   | string

--- a/src/statsig/types.ts
+++ b/src/statsig/types.ts
@@ -42,9 +42,7 @@ export enum StatsigFeatureGates {
   SHOW_ZERION_TRANSACTION_FEED = 'show_zerion_transaction_feed',
 }
 
-export enum StatsigExperiments {
-  ONBOARDING_TERMS_AND_CONDITIONS = 'onboarding_terms_and_conditions',
-}
+export enum StatsigExperiments {}
 
 export type StatsigParameter =
   | string

--- a/src/statsig/types.ts
+++ b/src/statsig/types.ts
@@ -43,7 +43,7 @@ export enum StatsigFeatureGates {
 }
 
 export enum StatsigExperiments {
-  TEST = 'test', // Needed for CI, remove if there are actual experiments
+  SAMPLE = 'sample', // Needed for CI, remove if there are actual experiments
 }
 
 export type StatsigParameter =


### PR DESCRIPTION
### Description

Test experiment added to enum/constants so that CI can pass. With those being empty tests would fail, and looking at git history could not find a time when it was empty. This seemed like the easiest solution, and added a comment explaining.

### Test plan

CI

### Related issues

- Part of ACT-1443

### Backwards compatibility

Yes
### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- N/A