### PR TITLE
feat(fiatExchanges): use getCicoQuotes endpoint

### DIFF
--- a/src/fiatExchanges/PaymentMethodSection.test.tsx
+++ b/src/fiatExchanges/PaymentMethodSection.test.tsx
@@ -13,11 +13,11 @@ import { getFeatureGate } from 'src/statsig'
 import { NetworkId } from 'src/transactions/types'
 import { createMockStore } from 'test/utils'
 import {
+  mockCicoQuotes,
   mockCusdAddress,
   mockCusdTokenId,
   mockFiatConnectQuotes,
   mockProviderSelectionAnalyticsData,
-  mockProviders,
 } from 'test/values'
 
 const mockStore = createMockStore({
@@ -61,14 +61,12 @@ describe('PaymentMethodSection', () => {
   beforeEach(() => {
     props = {
       paymentMethod: PaymentMethod.Card,
-      // the below creates 4 quotes - 1 Ramp (card), 2 Moonpay (bank, card), 1 Simplex (card)
-      normalizedQuotes: normalizeQuotes(
-        CICOFlow.CashIn,
-        [],
-        mockProviders,
-        mockCusdTokenId,
-        'cUSD'
-      ),
+      normalizedQuotes: normalizeQuotes({
+        flow: CICOFlow.CashIn,
+        fiatConnectQuotes: [],
+        cicoQuotes: mockCicoQuotes,
+        tokenId: mockCusdTokenId,
+      }),
       flow: CICOFlow.CashIn,
       tokenId: mockCusdTokenId,
       analyticsData: mockProviderSelectionAnalyticsData,
@@ -90,13 +88,12 @@ describe('PaymentMethodSection', () => {
 
   it('shows a non-expandable view with receive amount if there is one provider available', async () => {
     jest.mocked(getFeatureGate).mockReturnValue(true)
-    props.normalizedQuotes = normalizeQuotes(
-      CICOFlow.CashIn,
-      [],
-      [mockProviders[2]],
-      mockCusdTokenId,
-      'cUSD'
-    )
+    props.normalizedQuotes = normalizeQuotes({
+      flow: CICOFlow.CashIn,
+      fiatConnectQuotes: [],
+      cicoQuotes: [mockCicoQuotes[3]],
+      tokenId: mockCusdTokenId,
+    })
     const { queryByText, queryByTestId } = render(
       <Provider store={mockStore}>
         <PaymentMethodSection {...props} />
@@ -111,13 +108,12 @@ describe('PaymentMethodSection', () => {
   })
 
   it('shows new info dialog in non expandable section', async () => {
-    props.normalizedQuotes = normalizeQuotes(
-      CICOFlow.CashIn,
-      [],
-      [mockProviders[2]],
-      mockCusdTokenId,
-      'cUSD'
-    )
+    props.normalizedQuotes = normalizeQuotes({
+      flow: CICOFlow.CashIn,
+      fiatConnectQuotes: [],
+      cicoQuotes: [mockCicoQuotes[3]],
+      tokenId: mockCusdTokenId,
+    })
     jest.spyOn(props.normalizedQuotes[0], 'isProviderNew').mockReturnValue(true)
     const { getByText, getByTestId } = render(
       <Provider store={mockStore}>
@@ -173,13 +169,12 @@ describe('PaymentMethodSection', () => {
   })
 
   it('shows "ID required" when KYC is required', async () => {
-    props.normalizedQuotes = normalizeQuotes(
-      CICOFlow.CashIn,
-      [mockFiatConnectQuotes[3]] as FiatConnectQuoteSuccess[],
-      [],
-      mockCusdTokenId,
-      'cUSD'
-    )
+    props.normalizedQuotes = normalizeQuotes({
+      flow: CICOFlow.CashIn,
+      fiatConnectQuotes: [mockFiatConnectQuotes[3]] as FiatConnectQuoteSuccess[],
+      cicoQuotes: [],
+      tokenId: mockCusdTokenId,
+    })
     props.paymentMethod = PaymentMethod.Bank
     const { queryByTestId } = render(
       <Provider store={mockStore}>
@@ -194,13 +189,12 @@ describe('PaymentMethodSection', () => {
   })
 
   it('shows no ID requirement when KYC not required', async () => {
-    props.normalizedQuotes = normalizeQuotes(
-      CICOFlow.CashIn,
-      [mockFiatConnectQuotes[1]] as FiatConnectQuoteSuccess[],
-      [],
-      mockCusdTokenId,
-      'cUSD'
-    )
+    props.normalizedQuotes = normalizeQuotes({
+      flow: CICOFlow.CashIn,
+      fiatConnectQuotes: [mockFiatConnectQuotes[1]] as FiatConnectQuoteSuccess[],
+      cicoQuotes: [],
+      tokenId: mockCusdTokenId,
+    })
     props.paymentMethod = PaymentMethod.Bank
     const { queryByTestId } = render(
       <Provider store={mockStore}>
@@ -218,31 +212,34 @@ describe('PaymentMethodSection', () => {
   it.each([
     [
       PaymentMethod.Card as const,
-      normalizeQuotes(CICOFlow.CashIn, [], [mockProviders[2]], mockCusdTokenId, 'cUSD'),
+      normalizeQuotes({
+        flow: CICOFlow.CashIn,
+        fiatConnectQuotes: [],
+        cicoQuotes: [mockCicoQuotes[3]],
+        tokenId: mockCusdTokenId,
+      }),
       'card',
       'oneHour',
     ],
     [
       PaymentMethod.Bank as const,
-      normalizeQuotes(
-        CICOFlow.CashIn,
-        [mockFiatConnectQuotes[1]] as FiatConnectQuoteSuccess[],
-        [],
-        mockCusdTokenId,
-        'cUSD'
-      ),
+      normalizeQuotes({
+        flow: CICOFlow.CashIn,
+        fiatConnectQuotes: [mockFiatConnectQuotes[1]] as FiatConnectQuoteSuccess[],
+        cicoQuotes: [],
+        tokenId: mockCusdTokenId,
+      }),
       'bank',
       'xToYHours',
     ],
     [
       PaymentMethod.FiatConnectMobileMoney as const,
-      normalizeQuotes(
-        CICOFlow.CashIn,
-        [mockFiatConnectQuotes[4]] as FiatConnectQuoteSuccess[],
-        [],
-        mockCusdTokenId,
-        'cUSD'
-      ),
+      normalizeQuotes({
+        flow: CICOFlow.CashIn,
+        fiatConnectQuotes: [mockFiatConnectQuotes[4]] as FiatConnectQuoteSuccess[],
+        cicoQuotes: [],
+        tokenId: mockCusdTokenId,
+      }),
       'mobileMoney',
       'xHours',
     ],

--- a/src/fiatExchanges/quotes/ExternalQuote.test.ts
+++ b/src/fiatExchanges/quotes/ExternalQuote.test.ts
@@ -2,17 +2,16 @@ import BigNumber from 'bignumber.js'
 import AppAnalytics from 'src/analytics/AppAnalytics'
 import ExternalQuote from 'src/fiatExchanges/quotes/ExternalQuote'
 import { SettlementTime } from 'src/fiatExchanges/quotes/constants'
-import { CICOFlow, PaymentMethod, SimplexQuote } from 'src/fiatExchanges/types'
-import { RawProviderQuote } from 'src/fiatExchanges/utils'
+import { CICOFlow, PaymentMethod } from 'src/fiatExchanges/types'
 import { navigate } from 'src/navigator/NavigationService'
 import { NetworkId } from 'src/transactions/types'
 import { navigateToURI } from 'src/utils/linking'
 import { createMockStore } from 'test/utils'
 import {
+  mockCicoQuotes,
   mockCusdAddress,
   mockCusdTokenId,
   mockProviderSelectionAnalyticsData,
-  mockProviders,
 } from 'test/values'
 
 jest.mock('src/analytics/AppAnalytics')
@@ -36,148 +35,45 @@ const mockTokenInfo = {
 }
 
 describe('ExternalQuote', () => {
-  describe('constructor', () => {
-    it('throws an error if provider is unavailable', () => {
-      expect(
-        () =>
-          new ExternalQuote({
-            quote: (mockProviders[4].quote as RawProviderQuote[])[0],
-            provider: mockProviders[4],
-            flow: CICOFlow.CashIn,
-            tokenId: mockCusdTokenId,
-          })
-      ).toThrow()
-    })
-    it('throws an error if provider is restricted', () => {
-      expect(
-        () =>
-          new ExternalQuote({
-            quote: (mockProviders[3].quote as RawProviderQuote[])[0],
-            provider: mockProviders[3],
-            flow: CICOFlow.CashIn,
-            tokenId: mockCusdTokenId,
-          })
-      ).toThrow()
-    })
-    it('throws an error if the provider does not suport the flow', () => {
-      expect(
-        () =>
-          new ExternalQuote({
-            quote: (mockProviders[1].quote as RawProviderQuote[])[0],
-            provider: mockProviders[1],
-            flow: CICOFlow.CashOut,
-            tokenId: mockCusdTokenId,
-          })
-      ).toThrow()
-    })
-  })
   describe('.getPaymentMethod', () => {
-    it('returns PaymentMethod for simplex', () => {
-      const quote = new ExternalQuote({
-        quote: mockProviders[0].quote as SimplexQuote,
-        provider: mockProviders[0],
-        flow: CICOFlow.CashIn,
-        tokenId: mockCusdTokenId,
-      })
-      expect(quote.getPaymentMethod()).toEqual(PaymentMethod.Card)
-    })
-    it('returns PaymentMethod for other', () => {
-      const quote = new ExternalQuote({
-        quote: (mockProviders[1].quote as RawProviderQuote[])[0],
-        provider: mockProviders[1],
-        flow: CICOFlow.CashIn,
-        tokenId: mockCusdTokenId,
-      })
+    it('returns PaymentMethod', () => {
+      const quote = new ExternalQuote(mockCicoQuotes[1])
       expect(quote.getPaymentMethod()).toEqual(PaymentMethod.Bank)
     })
   })
 
   describe('.getFeeInCrypto', () => {
-    it('returns converted fee for simplex', () => {
-      const quote = new ExternalQuote({
-        quote: mockProviders[0].quote as SimplexQuote,
-        provider: mockProviders[0],
-        flow: CICOFlow.CashIn,
-        tokenId: mockCusdTokenId,
-      })
-      expect(quote.getFeeInCrypto(mockUsdToLocalRate, mockTokenInfo)).toEqual(new BigNumber(3))
-    })
-    it('returns converted fee for other', () => {
-      const quote = new ExternalQuote({
-        quote: (mockProviders[1].quote as RawProviderQuote[])[0],
-        provider: mockProviders[1],
-        flow: CICOFlow.CashIn,
-        tokenId: mockCusdTokenId,
-      })
+    it('returns converted fee', () => {
+      const quote = new ExternalQuote(mockCicoQuotes[1])
       expect(quote.getFeeInCrypto(mockUsdToLocalRate, mockTokenInfo)).toEqual(new BigNumber(2.5))
     })
     it('returns null when fee is unspecified', () => {
-      const quote = new ExternalQuote({
-        quote: {
-          paymentMethod: PaymentMethod.Card,
-          digitalAsset: 'cUSD',
-        },
-        provider: mockProviders[1],
-        flow: CICOFlow.CashIn,
-        tokenId: mockCusdTokenId,
-      })
+      const quote = new ExternalQuote({ ...mockCicoQuotes[1], fiatFee: undefined })
       expect(quote.getFeeInCrypto(mockUsdToLocalRate, mockTokenInfo)).toEqual(null)
     })
   })
 
   describe('.getFeeInFiat', () => {
-    it('returns fee for simplex', () => {
-      const quote = new ExternalQuote({
-        quote: mockProviders[0].quote as SimplexQuote,
-        provider: mockProviders[0],
-        flow: CICOFlow.CashIn,
-        tokenId: mockCusdTokenId,
-      })
-      expect(quote.getFeeInFiat(mockUsdToLocalRate, mockTokenInfo)).toEqual(new BigNumber(6))
-    })
     it('returns fee for other', () => {
-      const quote = new ExternalQuote({
-        quote: (mockProviders[1].quote as RawProviderQuote[])[0],
-        provider: mockProviders[1],
-        flow: CICOFlow.CashIn,
-        tokenId: mockCusdTokenId,
-      })
+      const quote = new ExternalQuote(mockCicoQuotes[1])
       expect(quote.getFeeInFiat(mockUsdToLocalRate, mockTokenInfo)).toEqual(new BigNumber(5))
     })
     it('returns null when fee is unspecified', () => {
-      const quote = new ExternalQuote({
-        quote: {
-          paymentMethod: PaymentMethod.Card,
-          digitalAsset: 'cUSD',
-        },
-        provider: mockProviders[1],
-        flow: CICOFlow.CashIn,
-        tokenId: mockCusdTokenId,
-      })
+      const quote = new ExternalQuote({ ...mockCicoQuotes[1], fiatFee: undefined })
       expect(quote.getFeeInFiat(mockUsdToLocalRate, mockTokenInfo)).toEqual(null)
     })
   })
 
   describe('.getKycInfo', () => {
     it('returns idRequired', () => {
-      const quote = new ExternalQuote({
-        quote: (mockProviders[1].quote as RawProviderQuote[])[0],
-        provider: mockProviders[1],
-        flow: CICOFlow.CashIn,
-        tokenId: mockCusdTokenId,
-      })
+      const quote = new ExternalQuote(mockCicoQuotes[1])
       expect(quote.getKycInfo()).toEqual('selectProviderScreen.idRequired')
     })
   })
 
   describe('.getTimeEstimation', () => {
     it('returns 1-3 days for Bank', () => {
-      const quote = new ExternalQuote({
-        quote: (mockProviders[1].quote as RawProviderQuote[])[0],
-        provider: mockProviders[1],
-        flow: CICOFlow.CashIn,
-        tokenId: mockCusdTokenId,
-      })
+      const quote = new ExternalQuote(mockCicoQuotes[1])
       expect(quote.getTimeEstimation()).toEqual({
         settlementTime: SettlementTime.X_TO_Y_DAYS,
         lowerBound: 1,
@@ -185,12 +81,7 @@ describe('ExternalQuote', () => {
       })
     })
     it('returns oneHour for Card', () => {
-      const quote = new ExternalQuote({
-        quote: mockProviders[0].quote as SimplexQuote,
-        provider: mockProviders[0],
-        flow: CICOFlow.CashIn,
-        tokenId: mockCusdTokenId,
-      })
+      const quote = new ExternalQuote(mockCicoQuotes[0])
       expect(quote.getTimeEstimation()).toEqual({
         settlementTime: SettlementTime.LESS_THAN_ONE_HOUR,
       })
@@ -199,12 +90,7 @@ describe('ExternalQuote', () => {
 
   describe('.onPress', () => {
     it('returns a function that calls AppAnalytics', () => {
-      const quote = new ExternalQuote({
-        quote: mockProviders[0].quote as SimplexQuote,
-        provider: mockProviders[0],
-        flow: CICOFlow.CashIn,
-        tokenId: mockCusdTokenId,
-      })
+      const quote = new ExternalQuote(mockCicoQuotes[0])
       quote.onPress(
         CICOFlow.CashIn,
         createMockStore().dispatch,
@@ -217,60 +103,27 @@ describe('ExternalQuote', () => {
 
   describe('.navigate', () => {
     it('calls navigate for simplex', () => {
-      const quote = new ExternalQuote({
-        quote: mockProviders[0].quote as SimplexQuote,
-        provider: mockProviders[0],
-        flow: CICOFlow.CashIn,
-        tokenId: mockCusdTokenId,
-      })
+      const quote = new ExternalQuote(mockCicoQuotes[0])
       quote.navigate()
       expect(navigate).toHaveBeenCalled()
     })
     it('calls navigateToURI for other', () => {
-      const quote = new ExternalQuote({
-        quote: (mockProviders[1].quote as RawProviderQuote[])[0],
-        provider: mockProviders[1],
-        flow: CICOFlow.CashIn,
-        tokenId: mockCusdTokenId,
-      })
+      const quote = new ExternalQuote(mockCicoQuotes[1])
       quote.navigate()
       expect(navigateToURI).toHaveBeenCalledWith('https://www.moonpay.com/')
-    })
-    it('calls navigateToURI with quote specific url', () => {
-      const quote = new ExternalQuote({
-        quote: {
-          ...(mockProviders[1].quote as RawProviderQuote[])[0],
-          url: 'https://example.com',
-        },
-        provider: mockProviders[1],
-        flow: CICOFlow.CashIn,
-        tokenId: mockCusdTokenId,
-      })
-      quote.navigate()
-      expect(navigateToURI).toHaveBeenCalledWith('https://example.com')
     })
   })
 
   describe('.getProviderName', () => {
     it('returns provider name', () => {
-      const quote = new ExternalQuote({
-        quote: (mockProviders[1].quote as RawProviderQuote[])[0],
-        provider: mockProviders[1],
-        flow: CICOFlow.CashIn,
-        tokenId: mockCusdTokenId,
-      })
+      const quote = new ExternalQuote(mockCicoQuotes[1])
       expect(quote.getProviderName()).toEqual('Moonpay')
     })
   })
 
   describe('.getProviderLogo', () => {
     it('returns provider logo', () => {
-      const quote = new ExternalQuote({
-        quote: (mockProviders[1].quote as RawProviderQuote[])[0],
-        provider: mockProviders[1],
-        flow: CICOFlow.CashIn,
-        tokenId: mockCusdTokenId,
-      })
+      const quote = new ExternalQuote(mockCicoQuotes[1])
       expect(quote.getProviderLogo()).toEqual(
         'https://firebasestorage.googleapis.com/v0/b/celo-mobile-mainnet.appspot.com/o/images%2Fsimplex.jpg?alt=media'
       )
@@ -279,62 +132,39 @@ describe('ExternalQuote', () => {
 
   describe('.getProviderId', () => {
     it('returns provider id', () => {
-      const quote = new ExternalQuote({
-        quote: (mockProviders[1].quote as RawProviderQuote[])[0],
-        provider: mockProviders[1],
-        flow: CICOFlow.CashIn,
-        tokenId: mockCusdTokenId,
-      })
+      const quote = new ExternalQuote(mockCicoQuotes[1])
       expect(quote.getProviderId()).toEqual('Moonpay')
     })
   })
 
   describe('.isProviderNew', () => {
     it('returns false', () => {
-      const quote = new ExternalQuote({
-        quote: (mockProviders[1].quote as RawProviderQuote[])[0],
-        provider: mockProviders[1],
-        flow: CICOFlow.CashIn,
-        tokenId: mockCusdTokenId,
-      })
+      const quote = new ExternalQuote(mockCicoQuotes[1])
       expect(quote.isProviderNew()).toEqual(false)
     })
   })
 
   describe('.getReceiveAmount', () => {
-    it('returns amount for simplex quote', () => {
-      const quote = new ExternalQuote({
-        quote: mockProviders[0].quote as SimplexQuote,
-        provider: mockProviders[0],
-        flow: CICOFlow.CashIn,
-        tokenId: mockCusdTokenId,
-      })
+    it('returns amount for cash in', () => {
+      const quote = new ExternalQuote(mockCicoQuotes[0])
       expect(quote.getReceiveAmount()).toEqual(new BigNumber(25))
     })
 
-    it('returns amount for other quotes', () => {
-      const quote = new ExternalQuote({
-        quote: {
-          paymentMethod: PaymentMethod.Bank,
-          digitalAsset: 'CELO',
-          returnedAmount: 20,
-        },
-        provider: mockProviders[1],
-        flow: CICOFlow.CashIn,
-        tokenId: mockCusdTokenId,
-      })
-      expect(quote.getReceiveAmount()).toEqual(new BigNumber(20))
+    it('returns amount for cash out', () => {
+      const quote = new ExternalQuote({ ...mockCicoQuotes[1], txType: 'cashOut' })
+      expect(quote.getReceiveAmount()).toEqual(new BigNumber(100))
     })
 
-    it('returns null if returned amount is not set in quote', () => {
+    it('returns null if crypto amount is not set in cash in quote', () => {
+      const quote = new ExternalQuote({ ...mockCicoQuotes[0], cryptoAmount: undefined as any })
+      expect(quote.getReceiveAmount()).toBeNull()
+    })
+
+    it('returns null if fiat amount is not set in cash out quote', () => {
       const quote = new ExternalQuote({
-        quote: {
-          paymentMethod: PaymentMethod.Bank,
-          digitalAsset: 'CELO',
-        },
-        provider: mockProviders[1],
-        flow: CICOFlow.CashIn,
-        tokenId: mockCusdTokenId,
+        ...mockCicoQuotes[0],
+        fiatAmount: undefined as any,
+        txType: 'cashOut',
       })
       expect(quote.getReceiveAmount()).toBeNull()
     })

--- a/src/fiatExchanges/quotes/ExternalQuote.ts
+++ b/src/fiatExchanges/quotes/ExternalQuote.ts
@@ -7,14 +7,14 @@ import {
   SettlementEstimation,
 } from 'src/fiatExchanges/quotes/constants'
 import NormalizedQuote from 'src/fiatExchanges/quotes/NormalizedQuote'
-import { CICOFlow, PaymentMethod, SimplexQuote } from 'src/fiatExchanges/types'
-import { FetchProvidersOutput, RawProviderQuote } from 'src/fiatExchanges/utils'
+import { CicoQuote, PaymentMethod } from 'src/fiatExchanges/types'
 import i18n from 'src/i18n'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import { TokenBalance } from 'src/tokens/slice'
 import { convertLocalToTokenAmount } from 'src/tokens/utils'
 import { navigateToURI } from 'src/utils/linking'
+import Logger from 'src/utils/Logger'
 
 const strings = {
   oneHour: i18n.t('selectProviderScreen.oneHour'),
@@ -30,51 +30,24 @@ const paymentMethodToSettlementTime = {
   [PaymentMethod.FiatConnectMobileMoney]: DEFAULT_MOBILE_MONEY_SETTLEMENT_ESTIMATION,
 }
 
-export const isSimplexQuote = (quote: RawProviderQuote | SimplexQuote): quote is SimplexQuote =>
-  !!quote && 'wallet_id' in quote
 export default class ExternalQuote extends NormalizedQuote {
-  quote: RawProviderQuote | SimplexQuote
-  provider: FetchProvidersOutput
-  flow: CICOFlow
-  tokenId: string
-  constructor({
-    quote,
-    provider,
-    flow,
-    tokenId,
-  }: {
-    quote: RawProviderQuote | SimplexQuote
-    provider: FetchProvidersOutput
-    flow: CICOFlow
-    tokenId: string
-  }) {
+  quote: CicoQuote
+  constructor(quote: CicoQuote) {
     super()
-    if (provider.restricted) {
-      throw new Error(`Error: ${provider.name}. Quote is restricted`)
-    }
-    if (provider.unavailable) {
-      throw new Error(`Error: ${provider.name}. Quote is unavailable`)
-    }
-    if (
-      (flow === CICOFlow.CashIn && !provider.cashIn) ||
-      (flow === CICOFlow.CashOut && !provider.cashOut)
-    ) {
-      throw new Error(
-        `Error: ${provider.name}. Quote not processed because it does not support the ${flow} CICO flow`
-      )
-    }
     this.quote = quote
-    this.provider = provider
-    this.flow = flow
-    this.tokenId = tokenId
   }
 
-  getPaymentMethod(): PaymentMethod {
-    return isSimplexQuote(this.quote) ? this.provider.paymentMethods[0] : this.quote.paymentMethod
+  getPaymentMethod() {
+    return {
+      Bank: PaymentMethod.Bank,
+      Card: PaymentMethod.Card,
+      Airtime: PaymentMethod.Airtime,
+      MobileMoney: PaymentMethod.FiatConnectMobileMoney,
+    }[this.quote.paymentMethod]
   }
 
   getCryptoType(): string {
-    return isSimplexQuote(this.quote) ? this.quote.digital_money.currency : this.quote.digitalAsset
+    throw new Error('Not required for this class')
   }
 
   getFeeInCrypto(usdToLocalRate: string | null, tokenInfo: TokenBalance): BigNumber | null {
@@ -87,22 +60,12 @@ export default class ExternalQuote extends NormalizedQuote {
   }
 
   getFeeInFiat(_usdToLocalRate: string | null, _tokenInfo: TokenBalance): BigNumber | null {
-    if (isSimplexQuote(this.quote)) {
-      return new BigNumber(this.quote.fiat_money.total_amount).minus(
-        new BigNumber(this.quote.fiat_money.base_amount)
-      )
-    } else if (typeof this.quote.fiatFee === 'number') {
-      // Can't just check for truthiness since `0` fails this and introduces a regression
-      return BigNumber(this.quote.fiatFee)
-    }
-    return null
+    return this.quote.fiatFee ? new BigNumber(this.quote.fiatFee) : null
   }
 
   getMobileCarrier(): string | undefined {
-    return !isSimplexQuote(this.quote) &&
-      this.getPaymentMethod() === PaymentMethod.Airtime &&
-      this.quote.extraReqs?.mobileCarrier
-      ? this.quote.extraReqs.mobileCarrier
+    return this.getPaymentMethod() === PaymentMethod.Airtime
+      ? this.quote.additionalInfo?.mobileCarrier
       : undefined
   }
 
@@ -115,27 +78,28 @@ export default class ExternalQuote extends NormalizedQuote {
   }
 
   navigate(): void {
-    if (isSimplexQuote(this.quote)) {
+    if (this.quote.additionalInfo?.simplexQuote) {
       navigate(Screens.Simplex, {
-        simplexQuote: this.quote,
-        tokenId: this.tokenId,
+        simplexQuote: this.quote.additionalInfo.simplexQuote,
+        tokenId: this.quote.tokenId,
       })
+    } else if (this.quote.url) {
+      navigateToURI(this.quote.url!)
     } else {
-      const url = this.quote.url ?? this.provider.url
-      navigateToURI(url!)
+      Logger.error('ExternalQuote', 'Missing url on non simplex quote', JSON.stringify(this.quote))
     }
   }
 
   getProviderName(): string {
-    return this.provider.name
+    return this.quote.provider.displayName
   }
 
   getProviderLogo(): string {
-    return this.provider.logoWide
+    return this.quote.provider.logoWideUrl
   }
 
   getProviderId(): string {
-    return this.provider.name
+    return this.quote.provider.id
   }
 
   isProviderNew(): boolean {
@@ -143,21 +107,15 @@ export default class ExternalQuote extends NormalizedQuote {
   }
 
   getReceiveAmount(): BigNumber | null {
-    if (isSimplexQuote(this.quote)) {
-      if (this.flow === CICOFlow.CashIn) {
-        return new BigNumber(this.quote.digital_money.amount)
-      } else {
-        // simplex is cash in only, this should never be reached
-        return null
-      }
+    // The amounts should never be undefined, but handling it just in case
+    if (this.quote.txType === 'cashIn') {
+      return this.quote.cryptoAmount ? new BigNumber(this.quote.cryptoAmount) : null
+    } else {
+      return this.quote.fiatAmount ? new BigNumber(this.quote.fiatAmount) : null
     }
-
-    return typeof this.quote.returnedAmount !== 'undefined'
-      ? new BigNumber(this.quote.returnedAmount)
-      : null
   }
 
   getTokenId(): string {
-    return this.tokenId
+    return this.quote.tokenId
   }
 }

--- a/src/fiatExchanges/quotes/normalizeQuotes.test.ts
+++ b/src/fiatExchanges/quotes/normalizeQuotes.test.ts
@@ -1,12 +1,10 @@
 import {
-  normalizeExternalProviders,
   normalizeFiatConnectQuotes,
   normalizeQuotes,
 } from 'src/fiatExchanges/quotes/normalizeQuotes'
-import { CICOFlow, PaymentMethod } from 'src/fiatExchanges/types'
-import { getFeatureGate } from 'src/statsig'
+import { CICOFlow } from 'src/fiatExchanges/types'
 import Logger from 'src/utils/Logger'
-import { mockCusdTokenId, mockFiatConnectQuotes, mockProviders } from 'test/values'
+import { mockCicoQuotes, mockCusdTokenId, mockFiatConnectQuotes } from 'test/values'
 
 jest.mock('src/utils/Logger', () => ({
   __esModule: true,
@@ -16,18 +14,15 @@ jest.mock('src/utils/Logger', () => ({
     warn: jest.fn(),
   },
 }))
-jest.mock('src/statsig')
 
 describe('normalizeQuotes', () => {
   it('returns both fiatconnect and external quotes sorted by receive amount', () => {
-    jest.mocked(getFeatureGate).mockReturnValue(true)
-    const normalizedQuotes = normalizeQuotes(
-      CICOFlow.CashIn,
-      mockFiatConnectQuotes,
-      mockProviders,
-      mockCusdTokenId,
-      'cUSD'
-    )
+    const normalizedQuotes = normalizeQuotes({
+      flow: CICOFlow.CashIn,
+      fiatConnectQuotes: mockFiatConnectQuotes,
+      cicoQuotes: mockCicoQuotes,
+      tokenId: mockCusdTokenId,
+    })
     expect(
       normalizedQuotes.map((quote) => [quote.getProviderId(), quote.getReceiveAmount()?.toNumber()])
     ).toEqual([
@@ -43,21 +38,19 @@ describe('normalizeQuotes', () => {
   })
 
   it('sorts quotes with no receive amount at the end of quotes', () => {
-    jest.mocked(getFeatureGate).mockReturnValue(true)
-    const normalizedQuotes = normalizeQuotes(
-      CICOFlow.CashIn,
-      [],
-      [
-        mockProviders[0],
-        mockProviders[2],
+    const normalizedQuotes = normalizeQuotes({
+      flow: CICOFlow.CashIn,
+      fiatConnectQuotes: [],
+      cicoQuotes: [
+        mockCicoQuotes[0],
+        mockCicoQuotes[3],
         {
-          ...mockProviders[1],
-          quote: [{ paymentMethod: PaymentMethod.Bank, digitalAsset: 'cusd' }],
+          ...mockCicoQuotes[1],
+          cryptoAmount: undefined as any,
         },
       ],
-      mockCusdTokenId,
-      'cUSD'
-    )
+      tokenId: mockCusdTokenId,
+    })
     expect(
       normalizedQuotes.map((quote) => [quote.getProviderId(), quote.getReceiveAmount()?.toNumber()])
     ).toEqual([
@@ -105,57 +98,5 @@ describe('normalizeFiatConnectQuotes', () => {
     )
     expect(Logger.warn).not.toHaveBeenCalled()
     expect(normalizedFiatConnectQuotes).toHaveLength(2)
-  })
-})
-
-describe('normalizeExternalProviders', () => {
-  beforeEach(() => {
-    jest.clearAllMocks()
-  })
-  it('logs when normalization fails', () => {
-    const normalizedExternalQuotes = normalizeExternalProviders({
-      flow: CICOFlow.CashIn,
-      input: [mockProviders[3]],
-      tokenId: mockCusdTokenId,
-      tokenSymbol: 'cUSD',
-    })
-    expect(Logger.warn).toHaveBeenCalledWith(
-      'NormalizeQuotes',
-      Error('Error: Xanpool. Quote is restricted')
-    )
-    expect(normalizedExternalQuotes).toHaveLength(0)
-  })
-  it('returns normalized quotes when quote is an array', () => {
-    // Moonpay with two quotes
-    const normalizedExternalQuotes = normalizeExternalProviders({
-      flow: CICOFlow.CashIn,
-      input: [mockProviders[1]],
-      tokenId: mockCusdTokenId,
-      tokenSymbol: 'cUSD',
-    })
-    expect(Logger.warn).not.toHaveBeenCalled()
-    expect(normalizedExternalQuotes).toHaveLength(2)
-  })
-  it('returns normalized quotes when quote is not an array', () => {
-    // Simplex quote
-    const normalizedExternalQuotes = normalizeExternalProviders({
-      flow: CICOFlow.CashIn,
-      input: [mockProviders[0]],
-      tokenId: mockCusdTokenId,
-      tokenSymbol: 'cUSD',
-    })
-    expect(Logger.warn).not.toHaveBeenCalled()
-    expect(normalizedExternalQuotes).toHaveLength(1)
-  })
-  it('returns normalized quotes when quote is an empty array, but provider is available', () => {
-    // Ramp quote, Bank and Card
-    const normalizedExternalQuotes = normalizeExternalProviders({
-      flow: CICOFlow.CashOut,
-      input: [mockProviders[6]],
-      tokenId: mockCusdTokenId,
-      tokenSymbol: 'cUSD',
-    })
-    expect(Logger.warn).not.toHaveBeenCalled()
-    expect(normalizedExternalQuotes).toHaveLength(2)
   })
 })

--- a/src/fiatExchanges/quotes/normalizeQuotes.ts
+++ b/src/fiatExchanges/quotes/normalizeQuotes.ts
@@ -4,23 +4,26 @@ import { FiatConnectQuoteError, FiatConnectQuoteSuccess } from 'src/fiatconnect'
 import ExternalQuote from 'src/fiatExchanges/quotes/ExternalQuote'
 import FiatConnectQuote from 'src/fiatExchanges/quotes/FiatConnectQuote'
 import NormalizedQuote from 'src/fiatExchanges/quotes/NormalizedQuote'
-import { CICOFlow, SimplexQuote } from 'src/fiatExchanges/types'
-import { FetchProvidersOutput, RawProviderQuote } from 'src/fiatExchanges/utils'
+import { CICOFlow, CicoQuote } from 'src/fiatExchanges/types'
 import Logger from 'src/utils/Logger'
 
 const TAG = 'NormalizeQuotes'
 
-// Take FiatConnect Quotes and External Provider Quotes and return NormalizedQuote class instances
-export function normalizeQuotes(
-  flow: CICOFlow,
-  fiatConnectQuotes: (FiatConnectQuoteSuccess | FiatConnectQuoteError)[] = [],
-  externalProviders: FetchProvidersOutput[] = [],
-  tokenId: string,
-  tokenSymbol: string
-): NormalizedQuote[] {
+// Take FiatConnect Quotes and External Cico Quotes and return NormalizedQuote class instances
+export function normalizeQuotes({
+  flow,
+  fiatConnectQuotes = [],
+  cicoQuotes = [],
+  tokenId,
+}: {
+  flow: CICOFlow
+  fiatConnectQuotes?: (FiatConnectQuoteSuccess | FiatConnectQuoteError)[]
+  cicoQuotes?: CicoQuote[]
+  tokenId: string
+}): NormalizedQuote[] {
   return [
     ...normalizeFiatConnectQuotes(flow, fiatConnectQuotes, tokenId),
-    ...normalizeExternalProviders({ flow, input: externalProviders, tokenId, tokenSymbol }),
+    ...cicoQuotes.map((quote) => new ExternalQuote(quote)),
   ].sort(quotesByReceiveAmountComparator)
 }
 
@@ -67,56 +70,6 @@ export function normalizeFiatConnectQuotes(
           }
         }
       )
-    }
-  })
-  return normalizedQuotes
-}
-
-export function normalizeExternalProviders({
-  flow,
-  input,
-  tokenId,
-  tokenSymbol,
-}: {
-  flow: CICOFlow
-  input: FetchProvidersOutput[]
-  tokenId: string
-  tokenSymbol: string
-}): NormalizedQuote[] {
-  const normalizedQuotes: NormalizedQuote[] = []
-  input.forEach((provider) => {
-    try {
-      const quotes: (RawProviderQuote | SimplexQuote)[] = []
-      if (Array.isArray(provider.quote)) {
-        // If the quote object is an array, it may contain quotes, or be empty.
-        // If it is empty, it does not necessarily mean that the provider does not
-        // support transfers.
-        if (provider.quote.length) {
-          quotes.push(...provider.quote)
-        } else if (!provider.unavailable && !provider.restricted) {
-          // If no quotes are provided, but the provider is not marked as unavailable,
-          // this means the provider supports transfers, but does not give specific quote details.
-          // We construct a partial quote object for each payment method. N.B., this will never occur
-          // for Simplex quotes, which are a special case.
-          provider.paymentMethods.forEach((paymentMethod) =>
-            quotes.push({
-              digitalAsset: tokenSymbol,
-              paymentMethod,
-            })
-          )
-        }
-      } else if (provider.quote) {
-        // If the quote is not an array, but does exist, we assume it to be an object representing
-        // a single quote.
-        quotes.push(provider.quote)
-      }
-
-      quotes.forEach((quote: RawProviderQuote | SimplexQuote) => {
-        const normalizedQuote = new ExternalQuote({ quote, provider, flow, tokenId })
-        normalizedQuotes.push(normalizedQuote)
-      })
-    } catch (err) {
-      Logger.warn(TAG, err)
     }
   })
   return normalizedQuotes

--- a/src/fiatExchanges/types.ts
+++ b/src/fiatExchanges/types.ts
@@ -1,3 +1,6 @@
+import { LocalCurrencyCode } from 'src/localCurrency/consts'
+import { UserLocationData } from 'src/networkInfo/saga'
+
 export enum SelectProviderExchangesText {
   CryptoExchange = 'CryptoExchange',
   DepositFrom = 'DepositFrom',
@@ -55,4 +58,45 @@ export type SimplexQuote = {
   }
   valid_until: string
   supported_digital_currencies: string[]
+}
+
+export type GetCicoQuotesRequest = {
+  tokenId: string
+  fiatCurrency: LocalCurrencyCode
+  address: string
+  userLocation: UserLocationData
+} & (
+  | {
+      txType: 'cashIn'
+      fiatAmount: string
+    }
+  | {
+      txType: 'cashOut'
+      cryptoAmount: string
+    }
+)
+
+export interface CicoQuote {
+  paymentMethod: 'Bank' | 'Card' | 'Airtime' | 'MobileMoney'
+  url?: string
+  fiatCurrency: LocalCurrencyCode
+  tokenId: string
+  txType: 'cashIn' | 'cashOut'
+  fiatAmount: string
+  cryptoAmount: string
+  fiatFee?: string
+  provider: {
+    id: string
+    displayName: string
+    logoUrl: string
+    logoWideUrl: string
+  }
+  additionalInfo?: {
+    mobileCarrier?: 'Safaricom' | 'MTN' // mobile carrier used for airtime
+    simplexQuote?: SimplexQuote | undefined // raw quote from Simplex, there is a wallet dependency on this
+  }
+}
+
+export interface GetCicoQuotesResponse {
+  quotes: CicoQuote[]
 }

--- a/src/fiatExchanges/utils.tsx
+++ b/src/fiatExchanges/utils.tsx
@@ -36,7 +36,7 @@ interface ProviderRequestData {
   txType: 'buy' | 'sell'
 }
 
-export interface FetchProvidersOutput {
+interface FetchProvidersOutput {
   name: string
   restricted: boolean
   unavailable?: boolean
@@ -49,7 +49,7 @@ export interface FetchProvidersOutput {
   cashOut: boolean
 }
 
-export interface RawProviderQuote {
+interface RawProviderQuote {
   paymentMethod: PaymentMethod
   digitalAsset: string
   returnedAmount?: number

--- a/src/fiatExchanges/utils.tsx
+++ b/src/fiatExchanges/utils.tsx
@@ -6,6 +6,8 @@ import { ExternalExchangeProvider } from 'src/fiatExchanges/ExternalExchanges'
 import NormalizedQuote from 'src/fiatExchanges/quotes/NormalizedQuote'
 import {
   CICOFlow,
+  GetCicoQuotesRequest,
+  GetCicoQuotesResponse,
   PaymentMethod,
   ProviderSelectionAnalyticsData,
   SimplexQuote,
@@ -317,5 +319,29 @@ export function getProviderSelectionAnalyticsData({
       (legacyMobileMoneyProviders?.length ?? 0) +
       normalizedQuotes.length,
     networkId: tokenInfo?.networkId,
+  }
+}
+
+export async function fetchCicoQuotes(
+  request: GetCicoQuotesRequest
+): Promise<GetCicoQuotesResponse> {
+  try {
+    const response = await fetchWithTimeout(
+      networkConfig.getCicoQuotesUrl,
+      composePostObject(request),
+      getDynamicConfigParams(DynamicConfigs[StatsigDynamicConfigs.WALLET_NETWORK_TIMEOUT_SECONDS])
+        .cico * 1000
+    )
+
+    if (!response.ok) {
+      throw Error(`Get cico quotes failed with status ${response?.status}`)
+    }
+
+    Logger.debug(`${TAG}:fetchCicoQuotes`, 'got cico quotes')
+
+    return response.json()
+  } catch (error) {
+    Logger.error(`${TAG}:fetchCicoQuotes`, 'Failed to fetch cico quotes', error)
+    throw error
   }
 }

--- a/src/web3/networkConfig.ts
+++ b/src/web3/networkConfig.ts
@@ -103,6 +103,7 @@ interface NetworkConfig {
   getWalletTransactionsUrl: string
   getWalletBalancesUrl: string
   getExchangeRateUrl: string
+  getCicoQuotesUrl: string
 }
 
 const ALCHEMY_ETHEREUM_RPC_URL_STAGING = 'https://eth-sepolia.g.alchemy.com/v2/'
@@ -286,6 +287,9 @@ const GET_WALLET_BALANCES_MAINNET = `${CLOUD_FUNCTIONS_MAINNET}/getWalletBalance
 const GET_EXCHANGE_RATE_ALFAJORES = `${CLOUD_FUNCTIONS_STAGING}/getExchangeRate`
 const GET_EXCHANGE_RATE_MAINNET = `${CLOUD_FUNCTIONS_MAINNET}/getExchangeRate`
 
+const GET_CICO_QUOTES_ALFAJORES = `${CLOUD_FUNCTIONS_STAGING}/getCicoQuotes`
+const GET_CICO_QUOTES_MAINNET = `${CLOUD_FUNCTIONS_MAINNET}/getCicoQuotes`
+
 const WEB3_AUTH_VERIFIER = 'valora-cab-auth0'
 
 const BASE_SET_REGISTRATION_PROPERTIES_AUTH = {
@@ -426,6 +430,7 @@ const networkConfigs: { [testnet: string]: NetworkConfig } = {
     getWalletTransactionsUrl: GET_WALLET_TRANSACTIONS_ALFAJORES,
     getWalletBalancesUrl: GET_WALLET_BALANCES_ALFAJORES,
     getExchangeRateUrl: GET_EXCHANGE_RATE_ALFAJORES,
+    getCicoQuotesUrl: GET_CICO_QUOTES_ALFAJORES,
   },
   [Testnets.mainnet]: {
     networkId: '42220',
@@ -528,6 +533,7 @@ const networkConfigs: { [testnet: string]: NetworkConfig } = {
     getWalletTransactionsUrl: GET_WALLET_TRANSACTIONS_MAINNET,
     getWalletBalancesUrl: GET_WALLET_BALANCES_MAINNET,
     getExchangeRateUrl: GET_EXCHANGE_RATE_MAINNET,
+    getCicoQuotesUrl: GET_CICO_QUOTES_MAINNET,
   },
 }
 

--- a/test/values.ts
+++ b/test/values.ts
@@ -15,8 +15,8 @@ import { range } from 'lodash'
 import { MinimalContact } from 'react-native-contacts'
 import { Dapp, DappWithCategoryNames } from 'src/dapps/types'
 import { ExternalExchangeProvider } from 'src/fiatExchanges/ExternalExchanges'
-import { PaymentMethod, ProviderSelectionAnalyticsData } from 'src/fiatExchanges/types'
-import { FetchProvidersOutput, LegacyMobileMoneyProvider } from 'src/fiatExchanges/utils'
+import { CicoQuote, PaymentMethod, ProviderSelectionAnalyticsData } from 'src/fiatExchanges/types'
+import { LegacyMobileMoneyProvider } from 'src/fiatExchanges/utils'
 import {
   FiatConnectProviderInfo,
   FiatConnectQuoteError,
@@ -689,123 +689,101 @@ export const mockSimplexQuote = {
   supported_digital_currencies: ['CUSD', 'CELO'],
 }
 
-export const mockProviders: FetchProvidersOutput[] = [
+export const mockCicoQuotes: CicoQuote[] = [
   {
-    name: 'Simplex',
-    restricted: false,
-    unavailable: false,
-    paymentMethods: [PaymentMethod.Card],
-    logo: 'https://firebasestorage.googleapis.com/v0/b/celo-mobile-mainnet.appspot.com/o/images%2Fsimplex.jpg?alt=media',
-    logoWide:
-      'https://firebasestorage.googleapis.com/v0/b/celo-mobile-mainnet.appspot.com/o/images%2Fsimplex.jpg?alt=media',
-    cashIn: true,
-    cashOut: false,
-    quote: mockSimplexQuote,
+    paymentMethod: 'Card',
+    url: undefined,
+    fiatCurrency: LocalCurrencyCode.USD,
+    tokenId: 'cusd',
+    txType: 'cashIn',
+    fiatAmount: '25',
+    cryptoAmount: '25',
+    fiatFee: '6',
+    provider: {
+      id: 'Simplex',
+      displayName: 'Simplex',
+      logoUrl:
+        'https://firebasestorage.googleapis.com/v0/b/celo-mobile-mainnet.appspot.com/o/images%2Fsimplex.jpg?alt=media',
+      logoWideUrl:
+        'https://firebasestorage.googleapis.com/v0/b/celo-mobile-mainnet.appspot.com/o/images%2Fsimplex.jpg?alt=media',
+    },
+    additionalInfo: { simplexQuote: mockSimplexQuote },
   },
   {
-    name: 'Moonpay',
-    restricted: false,
-    paymentMethods: [PaymentMethod.Card, PaymentMethod.Bank],
+    paymentMethod: 'Bank',
     url: 'https://www.moonpay.com/',
-    logo: 'https://firebasestorage.googleapis.com/v0/b/celo-mobile-mainnet.appspot.com/o/images%2Fmoonpay.png?alt=media',
-    logoWide:
-      'https://firebasestorage.googleapis.com/v0/b/celo-mobile-mainnet.appspot.com/o/images%2Fsimplex.jpg?alt=media',
-    cashIn: true,
-    cashOut: false,
-    quote: [
-      { paymentMethod: PaymentMethod.Bank, digitalAsset: 'cusd', returnedAmount: 95, fiatFee: 5 },
-      { paymentMethod: PaymentMethod.Card, digitalAsset: 'cusd', returnedAmount: 90, fiatFee: 10 },
-    ],
+    fiatCurrency: LocalCurrencyCode.USD,
+    tokenId: 'cusd',
+    txType: 'cashIn',
+    fiatAmount: '100',
+    cryptoAmount: '95',
+    fiatFee: '5',
+    provider: {
+      id: 'Moonpay',
+      displayName: 'Moonpay',
+      logoUrl:
+        'https://firebasestorage.googleapis.com/v0/b/celo-mobile-mainnet.appspot.com/o/images%2Fmoonpay.png?alt=media',
+      logoWideUrl:
+        'https://firebasestorage.googleapis.com/v0/b/celo-mobile-mainnet.appspot.com/o/images%2Fsimplex.jpg?alt=media',
+    },
+    additionalInfo: undefined,
   },
   {
-    name: 'Ramp',
-    restricted: false,
-    paymentMethods: [PaymentMethod.Card, PaymentMethod.Bank],
+    paymentMethod: 'Card',
+    url: 'https://www.moonpay.com/',
+    fiatCurrency: LocalCurrencyCode.USD,
+    tokenId: 'cusd',
+    txType: 'cashIn',
+    fiatAmount: '100',
+    cryptoAmount: '90',
+    fiatFee: '10',
+    provider: {
+      id: 'Moonpay',
+      displayName: 'Moonpay',
+      logoUrl:
+        'https://firebasestorage.googleapis.com/v0/b/celo-mobile-mainnet.appspot.com/o/images%2Fmoonpay.png?alt=media',
+      logoWideUrl:
+        'https://firebasestorage.googleapis.com/v0/b/celo-mobile-mainnet.appspot.com/o/images%2Fsimplex.jpg?alt=media',
+    },
+    additionalInfo: undefined,
+  },
+  {
+    paymentMethod: 'Card',
     url: 'www.fakewebsite.com',
-    logo: 'https://firebasestorage.googleapis.com/v0/b/celo-mobile-mainnet.appspot.com/o/images%2Framp.png?alt=media',
-    logoWide:
-      'https://firebasestorage.googleapis.com/v0/b/celo-mobile-mainnet.appspot.com/o/images%2Fsimplex.jpg?alt=media',
-    quote: [
-      { paymentMethod: PaymentMethod.Card, digitalAsset: 'cusd', returnedAmount: 100, fiatFee: 0 },
-    ],
-    cashIn: true,
-    cashOut: false,
+    fiatCurrency: LocalCurrencyCode.USD,
+    tokenId: 'cusd',
+    txType: 'cashIn',
+    fiatAmount: '100',
+    cryptoAmount: '100',
+    fiatFee: '0',
+    provider: {
+      id: 'Ramp',
+      displayName: 'Ramp',
+      logoUrl:
+        'https://firebasestorage.googleapis.com/v0/b/celo-mobile-mainnet.appspot.com/o/images%2Framp.png?alt=media',
+      logoWideUrl:
+        'https://firebasestorage.googleapis.com/v0/b/celo-mobile-mainnet.appspot.com/o/images%2Fsimplex.jpg?alt=media',
+    },
+    additionalInfo: undefined,
   },
   {
-    name: 'Xanpool',
-    restricted: true,
-    paymentMethods: [PaymentMethod.Card, PaymentMethod.Bank],
-    url: 'www.fakewebsite.com',
-    logo: 'https://firebasestorage.googleapis.com/v0/b/celo-mobile-mainnet.appspot.com/o/images%2Fxanpool.png?alt=media',
-    logoWide:
-      'https://firebasestorage.googleapis.com/v0/b/celo-mobile-mainnet.appspot.com/o/images%2Fsimplex.jpg?alt=media',
-    cashIn: true,
-    cashOut: true,
-    quote: [
-      { paymentMethod: PaymentMethod.Card, digitalAsset: 'cusd', returnedAmount: 97, fiatFee: 3 },
-    ],
-  },
-  {
-    name: 'Transak',
-    restricted: false,
-    unavailable: true,
-    paymentMethods: [PaymentMethod.Card, PaymentMethod.Bank],
-    url: 'www.fakewebsite.com',
-    logo: 'https://firebasestorage.googleapis.com/v0/b/celo-mobile-mainnet.appspot.com/o/images%2Ftransak.png?alt=media',
-    logoWide:
-      'https://firebasestorage.googleapis.com/v0/b/celo-mobile-mainnet.appspot.com/o/images%2Fsimplex.jpg?alt=media',
-    cashIn: true,
-    cashOut: false,
-    quote: [
-      { paymentMethod: PaymentMethod.Bank, digitalAsset: 'cusd', returnedAmount: 94, fiatFee: 6 },
-      { paymentMethod: PaymentMethod.Card, digitalAsset: 'cusd', returnedAmount: 88, fiatFee: 12 },
-    ],
-  },
-  {
-    name: 'CoinbasePay',
-    restricted: false,
-    unavailable: false,
-    paymentMethods: [PaymentMethod.Bank],
-    url: 'https://www.coinbase.com/',
-    logo: 'https://firebasestorage.googleapis.com/v0/b/celo-mobile-mainnet.appspot.com/o/images%2FcbPay-button.png?alt=media',
-    logoWide:
-      'https://firebasestorage.googleapis.com/v0/b/celo-mobile-mainnet.appspot.com/o/images%2FcbPay-button.png?alt=media',
-    quote: undefined,
-    cashIn: true,
-    cashOut: false,
-  },
-  {
-    name: 'Ramp',
-    restricted: false,
-    unavailable: false,
-    paymentMethods: [PaymentMethod.Card, PaymentMethod.Bank],
-    url: 'www.fakewebsite.com',
-    logo: 'https://firebasestorage.googleapis.com/v0/b/celo-mobile-mainnet.appspot.com/o/images%2Framp.png?alt=media',
-    logoWide:
-      'https://firebasestorage.googleapis.com/v0/b/celo-mobile-mainnet.appspot.com/o/images%2Fsimplex.jpg?alt=media',
-    quote: [],
-    cashIn: false,
-    cashOut: true,
-  },
-  {
-    name: 'Fonbnk',
-    restricted: false,
-    paymentMethods: [PaymentMethod.Airtime],
+    paymentMethod: 'Airtime',
     url: 'https://www.fakewebsite.com/',
-    logo: 'https://firebasestorage.googleapis.com/v0/b/celo-mobile-mainnet.appspot.com/o/images%2Ffonbnk.png?alt=media',
-    logoWide:
-      'https://firebasestorage.googleapis.com/v0/b/celo-mobile-mainnet.appspot.com/o/images%2Ffonbnk.png?alt=media',
-    cashIn: true,
-    cashOut: false,
-    quote: [
-      {
-        paymentMethod: PaymentMethod.Airtime,
-        digitalAsset: 'cusd',
-        returnedAmount: 93,
-        fiatFee: 7,
-        extraReqs: { mobileCarrier: 'MTN' },
-      },
-    ],
+    fiatCurrency: LocalCurrencyCode.USD,
+    tokenId: 'cusd',
+    txType: 'cashIn',
+    fiatAmount: '100',
+    cryptoAmount: '93',
+    fiatFee: '7',
+    provider: {
+      id: 'Fonbnk',
+      displayName: 'Fonbnk',
+      logoUrl:
+        'https://firebasestorage.googleapis.com/v0/b/celo-mobile-mainnet.appspot.com/o/images%2Ffonbnk.png?alt=media',
+      logoWideUrl:
+        'https://firebasestorage.googleapis.com/v0/b/celo-mobile-mainnet.appspot.com/o/images%2Ffonbnk.png?alt=media',
+    },
+    additionalInfo: { mobileCarrier: 'MTN' },
   },
 ]
 


### PR DESCRIPTION
### Description

Replace fetchProviders cloud function call with getCicoQuotes

### Test plan

CI - Unit test assertions have been retained for the most part

Manually by checking providers before and after

### Related issues

- Fixes ACT-1421

### Backwards compatibility

Yes

### Network scalability

N/A
