### PR TITLE
feat(earn): Update earn deposit entry point bottom sheet

### DIFF
--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -2783,9 +2783,11 @@
     },
     "beforeDepositBottomSheet": {
       "youNeedTitle": "You Need {{tokenSymbol}} on {{tokenNetwork}} to Deposit",
+      "depositTitle": "Deposit to pool",
       "crossChainAlternativeDescription": "If you don’t want to use your tokens on {{tokenNetwork}}, choose an option below. You’ll need to return to complete your pool deposit later.",
       "beforeYouCanDepositTitle": "Before you can deposit...",
       "beforeYouCanDepositDescription": "You’ll need to add one of the pool tokens. Once added, you’ll need to return to complete your pool deposit.",
+      "beforeYouCanDepositDescriptionV1_101": "You’ll need to add {{tokenSymbol}} on {{tokenNetwork}}. Once added, you’ll need to return to complete your pool deposit.",
       "action": {
         "swapAndDeposit": "Swap & Deposit",
         "swapAndDepositDescription": "Choose any token on {{tokenNetwork}}. We’ll swap and deposit it simultaneously for you.",
@@ -2796,7 +2798,10 @@
         "add": "Buy",
         "addDescription": "Buy {{tokenSymbol}} on {{tokenNetwork}} using one of our trusted providers",
         "transfer": "Transfer",
-        "transferDescription": "Use any {{tokenNetwork}} compatible wallet or exchange to deposit {{tokenSymbol}}"
+        "transferDescription": "Use any {{tokenNetwork}} compatible wallet or exchange to deposit {{tokenSymbol}}",
+        "addMore": "Buy more {{tokenSymbol}}",
+        "deposit": "Deposit your {{tokenSymbol}}",
+        "depositDescription": "You have {{amount}} {{tokenSymbol}}"
       }
     }
   },

--- a/src/earn/hooks.ts
+++ b/src/earn/hooks.ts
@@ -9,6 +9,7 @@ import {
 } from 'src/earn/prepareTransactions'
 import { EarnActiveMode } from 'src/earn/types'
 import { fetchExchanges } from 'src/fiatExchanges/utils'
+import { isAppSwapsEnabledSelector } from 'src/navigator/selectors'
 import { userLocationDataSelector } from 'src/networkInfo/selectors'
 import { earnPositionsSelector } from 'src/positions/selectors'
 import { EarnPosition, Position } from 'src/positions/types'
@@ -43,7 +44,7 @@ export function useDepositEntrypointInfo({
 
   const { swappableFromTokens } = useSwappableTokens()
   const cashInTokens = useCashInTokens()
-  const isSwapEnabled = true // useSelector(isAppSwapsEnabledSelector)
+  const isSwapEnabled = useSelector(isAppSwapsEnabledSelector)
   const userLocation = useSelector(userLocationDataSelector)
 
   const hasDepositToken = useMemo(() => {

--- a/src/earn/hooks.ts
+++ b/src/earn/hooks.ts
@@ -9,7 +9,6 @@ import {
 } from 'src/earn/prepareTransactions'
 import { EarnActiveMode } from 'src/earn/types'
 import { fetchExchanges } from 'src/fiatExchanges/utils'
-import { isAppSwapsEnabledSelector } from 'src/navigator/selectors'
 import { userLocationDataSelector } from 'src/networkInfo/selectors'
 import { earnPositionsSelector } from 'src/positions/selectors'
 import { EarnPosition, Position } from 'src/positions/types'
@@ -44,7 +43,7 @@ export function useDepositEntrypointInfo({
 
   const { swappableFromTokens } = useSwappableTokens()
   const cashInTokens = useCashInTokens()
-  const isSwapEnabled = useSelector(isAppSwapsEnabledSelector)
+  const isSwapEnabled = true // useSelector(isAppSwapsEnabledSelector)
   const userLocation = useSelector(userLocationDataSelector)
 
   const hasDepositToken = useMemo(() => {

--- a/src/earn/poolInfoScreen/BeforeDepositBottomSheet.test.tsx
+++ b/src/earn/poolInfoScreen/BeforeDepositBottomSheet.test.tsx
@@ -1,0 +1,369 @@
+import { fireEvent, render } from '@testing-library/react-native'
+import React from 'react'
+import { Provider } from 'react-redux'
+import AppAnalytics from 'src/analytics/AppAnalytics'
+import { EarnEvents } from 'src/analytics/Events'
+import BeforeDepositBottomSheet from 'src/earn/poolInfoScreen/BeforeDepositBottomSheet'
+import { CICOFlow } from 'src/fiatExchanges/types'
+import { navigate } from 'src/navigator/NavigationService'
+import { Screens } from 'src/navigator/Screens'
+import MockedNavigator from 'test/MockedNavigator'
+import { createMockStore } from 'test/utils'
+import { mockEarnPositions, mockTokenBalances } from 'test/values'
+
+const mockPoolTokenId = mockEarnPositions[0].dataProps.depositTokenId
+
+describe('BeforeDepositBottomSheet', () => {
+  it('show bottom sheet correctly when hasDepositToken is true, no other tokens', () => {
+    const { getByTestId } = render(
+      <Provider store={createMockStore()}>
+        <MockedNavigator
+          component={BeforeDepositBottomSheet}
+          params={{
+            forwardedRef: null,
+            token: mockTokenBalances[mockPoolTokenId],
+            pool: mockEarnPositions[0],
+            hasDepositToken: true,
+            hasTokensOnSameNetwork: false,
+            hasTokensOnOtherNetworks: false,
+            canAdd: true,
+            exchanges: [],
+          }}
+        />
+      </Provider>
+    )
+    expect(getByTestId('Earn/ActionCard/Deposit')).toBeTruthy()
+    expect(getByTestId('Earn/ActionCard/AddMore')).toBeTruthy()
+  })
+  it('show bottom sheet correctly when hasDepositToken is true, token(s) on same chain', () => {
+    const { getByTestId } = render(
+      <Provider store={createMockStore()}>
+        <MockedNavigator
+          component={BeforeDepositBottomSheet}
+          params={{
+            forwardedRef: null,
+            token: mockTokenBalances[mockPoolTokenId],
+            pool: mockEarnPositions[0],
+            hasDepositToken: true,
+            hasTokensOnSameNetwork: true,
+            hasTokensOnOtherNetworks: false,
+            canAdd: true,
+            exchanges: [],
+          }}
+        />
+      </Provider>
+    )
+    expect(getByTestId('Earn/ActionCard/Deposit')).toBeTruthy()
+    expect(getByTestId('Earn/ActionCard/SwapAndDeposit')).toBeTruthy()
+    expect(getByTestId('Earn/ActionCard/AddMore')).toBeTruthy()
+  })
+  it('show bottom sheet correctly when hasDepositToken is true, token(s) on differnet chain', () => {
+    const { getByText, getByTestId } = render(
+      <Provider store={createMockStore()}>
+        <MockedNavigator
+          component={BeforeDepositBottomSheet}
+          params={{
+            forwardedRef: null,
+            token: mockTokenBalances[mockPoolTokenId],
+            pool: mockEarnPositions[0],
+            hasDepositToken: true,
+            hasTokensOnSameNetwork: false,
+            hasTokensOnOtherNetworks: true,
+            canAdd: true,
+            exchanges: [],
+          }}
+        />
+      </Provider>
+    )
+    fireEvent.press(getByText('earnFlow.poolInfoScreen.deposit'))
+    expect(AppAnalytics.track).toHaveBeenCalledWith(EarnEvents.earn_pool_info_tap_deposit, {
+      providerId: 'aave',
+      poolId: 'arbitrum-sepolia:0x460b97bd498e1157530aeb3086301d5225b91216',
+      networkId: 'arbitrum-sepolia',
+      depositTokenId: mockEarnPositions[0].dataProps.depositTokenId,
+      hasDepositToken: true,
+      hasTokensOnSameNetwork: false,
+      hasTokensOnOtherNetworks: true,
+    })
+
+    expect(getByTestId('Earn/ActionCard/Deposit')).toBeTruthy()
+    expect(getByTestId('Earn/ActionCard/Swap')).toBeTruthy()
+    expect(getByTestId('Earn/ActionCard/AddMore')).toBeTruthy()
+  })
+  it('show bottom sheet correctly when hasDepositToken is true, token(s) on same and different chains', () => {
+    const { getByTestId } = render(
+      <Provider store={createMockStore()}>
+        <MockedNavigator
+          component={BeforeDepositBottomSheet}
+          params={{
+            forwardedRef: null,
+            token: mockTokenBalances[mockPoolTokenId],
+            pool: mockEarnPositions[0],
+            hasDepositToken: true,
+            hasTokensOnSameNetwork: true,
+            hasTokensOnOtherNetworks: true,
+            canAdd: true,
+            exchanges: [],
+          }}
+        />
+      </Provider>
+    )
+    expect(getByTestId('Earn/ActionCard/Deposit')).toBeTruthy()
+    expect(getByTestId('Earn/ActionCard/SwapAndDeposit')).toBeTruthy()
+    expect(getByTestId('Earn/ActionCard/CrossChainSwap')).toBeTruthy()
+  })
+  it('show bottom sheet correctly when hasDepositToken is false, can same and cross chain swap', () => {
+    const { getByTestId } = render(
+      <Provider store={createMockStore()}>
+        <MockedNavigator
+          component={BeforeDepositBottomSheet}
+          params={{
+            forwardedRef: null,
+            token: mockTokenBalances[mockPoolTokenId],
+            pool: mockEarnPositions[0],
+            hasDepositToken: false,
+            hasTokensOnSameNetwork: true,
+            hasTokensOnOtherNetworks: true,
+            canAdd: true,
+            exchanges: [],
+          }}
+        />
+      </Provider>
+    )
+    expect(getByTestId('Earn/ActionCard/SwapAndDeposit')).toBeTruthy()
+    expect(getByTestId('Earn/ActionCard/CrossChainSwap')).toBeTruthy()
+    expect(getByTestId('Earn/ActionCard/Add')).toBeTruthy()
+  })
+
+  it('show bottom sheet correctly when hasDepositToken is false, can cross chain swap', () => {
+    const { getByTestId } = render(
+      <Provider store={createMockStore()}>
+        <MockedNavigator
+          component={BeforeDepositBottomSheet}
+          params={{
+            forwardedRef: null,
+            token: mockTokenBalances[mockPoolTokenId],
+            pool: mockEarnPositions[0],
+            hasDepositToken: false,
+            hasTokensOnSameNetwork: false,
+            hasTokensOnOtherNetworks: true,
+            canAdd: true,
+            exchanges: [],
+          }}
+        />
+      </Provider>
+    )
+    expect(getByTestId('Earn/ActionCard/Swap')).toBeTruthy()
+    expect(getByTestId('Earn/ActionCard/Add')).toBeTruthy()
+  })
+
+  it('show bottom sheet correctly when hasDepositToken is false, no tokens', () => {
+    const { getByTestId } = render(
+      <Provider store={createMockStore()}>
+        <MockedNavigator
+          component={BeforeDepositBottomSheet}
+          params={{
+            forwardedRef: null,
+            token: mockTokenBalances[mockPoolTokenId],
+            pool: mockEarnPositions[0],
+            hasDepositToken: false,
+            hasTokensOnSameNetwork: false,
+            hasTokensOnOtherNetworks: false,
+            canAdd: true,
+            exchanges: [],
+          }}
+        />
+      </Provider>
+    )
+    expect(getByTestId('Earn/ActionCard/Add')).toBeTruthy()
+    expect(getByTestId('Earn/ActionCard/Transfer')).toBeTruthy()
+  })
+
+  it('navigates correctly when swap and deposit action item is tapped', () => {
+    const { getByTestId } = render(
+      <Provider store={createMockStore()}>
+        <MockedNavigator
+          component={BeforeDepositBottomSheet}
+          params={{
+            forwardedRef: null,
+            token: mockTokenBalances[mockPoolTokenId],
+            pool: mockEarnPositions[0],
+            hasDepositToken: true,
+            hasTokensOnSameNetwork: true,
+            hasTokensOnOtherNetworks: true,
+            canAdd: true,
+            exchanges: [],
+          }}
+        />
+      </Provider>
+    )
+    expect(getByTestId('Earn/ActionCard/Deposit')).toBeTruthy()
+    fireEvent.press(getByTestId('Earn/ActionCard/Deposit'))
+    expect(navigate).toHaveBeenCalledWith(Screens.EarnEnterAmount, {
+      pool: mockEarnPositions[0],
+    })
+    expect(AppAnalytics.track).toHaveBeenCalledTimes(2)
+  })
+
+  it('navigates correctly when swap and deposit action item is tapped', () => {
+    const { getByTestId } = render(
+      <Provider store={createMockStore()}>
+        <MockedNavigator
+          component={BeforeDepositBottomSheet}
+          params={{
+            forwardedRef: null,
+            token: mockTokenBalances[mockPoolTokenId],
+            pool: mockEarnPositions[0],
+            hasDepositToken: true,
+            hasTokensOnSameNetwork: true,
+            hasTokensOnOtherNetworks: true,
+            canAdd: true,
+            exchanges: [],
+          }}
+        />
+      </Provider>
+    )
+    expect(getByTestId('Earn/ActionCard/SwapAndDeposit')).toBeTruthy()
+    fireEvent.press(getByTestId('Earn/ActionCard/SwapAndDeposit'))
+    expect(navigate).toHaveBeenCalledWith(Screens.EarnEnterAmount, {
+      pool: mockEarnPositions[0],
+      mode: 'swap-deposit',
+    })
+    expect(AppAnalytics.track).toHaveBeenCalledTimes(2)
+  })
+
+  it('navigates correctly when cross chain swap action item is tapped', () => {
+    const { getByTestId } = render(
+      <Provider store={createMockStore()}>
+        <MockedNavigator
+          component={BeforeDepositBottomSheet}
+          params={{
+            forwardedRef: null,
+            token: mockTokenBalances[mockPoolTokenId],
+            pool: mockEarnPositions[0],
+            hasDepositToken: true,
+            hasTokensOnSameNetwork: true,
+            hasTokensOnOtherNetworks: true,
+            canAdd: true,
+            exchanges: [],
+          }}
+        />
+      </Provider>
+    )
+    expect(getByTestId('Earn/ActionCard/CrossChainSwap')).toBeTruthy()
+    fireEvent.press(getByTestId('Earn/ActionCard/CrossChainSwap'))
+    expect(navigate).toHaveBeenCalledWith(Screens.SwapScreenWithBack, {
+      toTokenId: mockEarnPositions[0].dataProps.depositTokenId,
+    })
+    expect(AppAnalytics.track).toHaveBeenCalledTimes(2)
+  })
+
+  it('navigates correctly when add more action item is tapped', () => {
+    const { getByTestId } = render(
+      <Provider store={createMockStore()}>
+        <MockedNavigator
+          component={BeforeDepositBottomSheet}
+          params={{
+            forwardedRef: null,
+            token: mockTokenBalances[mockPoolTokenId],
+            pool: mockEarnPositions[0],
+            hasDepositToken: true,
+            hasTokensOnSameNetwork: false,
+            hasTokensOnOtherNetworks: false,
+            canAdd: true,
+            exchanges: [],
+          }}
+        />
+      </Provider>
+    )
+    expect(getByTestId('Earn/ActionCard/AddMore')).toBeTruthy()
+    fireEvent.press(getByTestId('Earn/ActionCard/AddMore'))
+    expect(navigate).toHaveBeenCalledWith(Screens.FiatExchangeAmount, {
+      tokenId: mockEarnPositions[0].dataProps.depositTokenId,
+      flow: CICOFlow.CashIn,
+      tokenSymbol: 'USDC',
+    })
+    expect(AppAnalytics.track).toHaveBeenCalledTimes(2)
+  })
+
+  it('navigates correctly when add action item is tapped', () => {
+    const { getByTestId } = render(
+      <Provider store={createMockStore()}>
+        <MockedNavigator
+          component={BeforeDepositBottomSheet}
+          params={{
+            forwardedRef: null,
+            token: mockTokenBalances[mockPoolTokenId],
+            pool: mockEarnPositions[0],
+            hasDepositToken: false,
+            hasTokensOnSameNetwork: false,
+            hasTokensOnOtherNetworks: false,
+            canAdd: true,
+            exchanges: [],
+          }}
+        />
+      </Provider>
+    )
+    expect(getByTestId('Earn/ActionCard/Add')).toBeTruthy()
+    fireEvent.press(getByTestId('Earn/ActionCard/Add'))
+    expect(navigate).toHaveBeenCalledWith(Screens.FiatExchangeAmount, {
+      tokenId: mockEarnPositions[0].dataProps.depositTokenId,
+      flow: CICOFlow.CashIn,
+      tokenSymbol: 'USDC',
+    })
+    expect(AppAnalytics.track).toHaveBeenCalledTimes(2)
+  })
+
+  it('navigates correctly when swap action item is tapped', () => {
+    const { getByTestId } = render(
+      <Provider store={createMockStore()}>
+        <MockedNavigator
+          component={BeforeDepositBottomSheet}
+          params={{
+            forwardedRef: null,
+            token: mockTokenBalances[mockPoolTokenId],
+            pool: mockEarnPositions[0],
+            hasDepositToken: false,
+            hasTokensOnSameNetwork: false,
+            hasTokensOnOtherNetworks: true,
+            canAdd: true,
+            exchanges: [],
+          }}
+        />
+      </Provider>
+    )
+    expect(getByTestId('Earn/ActionCard/Swap')).toBeTruthy()
+    fireEvent.press(getByTestId('Earn/ActionCard/Swap'))
+    expect(navigate).toHaveBeenCalledWith(Screens.SwapScreenWithBack, {
+      toTokenId: mockEarnPositions[0].dataProps.depositTokenId,
+    })
+    expect(AppAnalytics.track).toHaveBeenCalledTimes(2)
+  })
+
+  it('navigates correctly when transfer action item is tapped', () => {
+    const { getByTestId } = render(
+      <Provider store={createMockStore()}>
+        <MockedNavigator
+          component={BeforeDepositBottomSheet}
+          params={{
+            forwardedRef: null,
+            token: mockTokenBalances[mockPoolTokenId],
+            pool: mockEarnPositions[0],
+            hasDepositToken: false,
+            hasTokensOnSameNetwork: false,
+            hasTokensOnOtherNetworks: false,
+            canAdd: true,
+            exchanges: [],
+          }}
+        />
+      </Provider>
+    )
+    expect(getByTestId('Earn/ActionCard/Transfer')).toBeTruthy()
+    fireEvent.press(getByTestId('Earn/ActionCard/Transfer'))
+    expect(navigate).toHaveBeenCalledWith(Screens.ExchangeQR, {
+      flow: CICOFlow.CashIn,
+      exchanges: [],
+    })
+    expect(AppAnalytics.track).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/earn/poolInfoScreen/BeforeDepositBottomSheet.test.tsx
+++ b/src/earn/poolInfoScreen/BeforeDepositBottomSheet.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render } from '@testing-library/react-native'
+import BigNumber from 'bignumber.js'
 import React from 'react'
 import { Provider } from 'react-redux'
 import AppAnalytics from 'src/analytics/AppAnalytics'
@@ -7,28 +8,30 @@ import BeforeDepositBottomSheet from 'src/earn/poolInfoScreen/BeforeDepositBotto
 import { CICOFlow } from 'src/fiatExchanges/types'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
-import MockedNavigator from 'test/MockedNavigator'
 import { createMockStore } from 'test/utils'
 import { mockEarnPositions, mockTokenBalances } from 'test/values'
 
 const mockPoolTokenId = mockEarnPositions[0].dataProps.depositTokenId
+const mockToken = {
+  ...mockTokenBalances[mockPoolTokenId],
+  balance: new BigNumber(1),
+  priceUsd: new BigNumber(1),
+  lastKnownPriceUsd: new BigNumber(1),
+}
 
 describe('BeforeDepositBottomSheet', () => {
   it('show bottom sheet correctly when hasDepositToken is true, no other tokens', () => {
     const { getByTestId } = render(
       <Provider store={createMockStore()}>
-        <MockedNavigator
-          component={BeforeDepositBottomSheet}
-          params={{
-            forwardedRef: null,
-            token: mockTokenBalances[mockPoolTokenId],
-            pool: mockEarnPositions[0],
-            hasDepositToken: true,
-            hasTokensOnSameNetwork: false,
-            hasTokensOnOtherNetworks: false,
-            canAdd: true,
-            exchanges: [],
-          }}
+        <BeforeDepositBottomSheet
+          forwardedRef={{ current: null }}
+          token={mockToken}
+          pool={mockEarnPositions[0]}
+          hasDepositToken={true}
+          hasTokensOnSameNetwork={false}
+          hasTokensOnOtherNetworks={false}
+          canAdd={true}
+          exchanges={[]}
         />
       </Provider>
     )
@@ -38,18 +41,15 @@ describe('BeforeDepositBottomSheet', () => {
   it('show bottom sheet correctly when hasDepositToken is true, token(s) on same chain', () => {
     const { getByTestId } = render(
       <Provider store={createMockStore()}>
-        <MockedNavigator
-          component={BeforeDepositBottomSheet}
-          params={{
-            forwardedRef: null,
-            token: mockTokenBalances[mockPoolTokenId],
-            pool: mockEarnPositions[0],
-            hasDepositToken: true,
-            hasTokensOnSameNetwork: true,
-            hasTokensOnOtherNetworks: false,
-            canAdd: true,
-            exchanges: [],
-          }}
+        <BeforeDepositBottomSheet
+          forwardedRef={{ current: null }}
+          token={mockToken}
+          pool={mockEarnPositions[0]}
+          hasDepositToken={true}
+          hasTokensOnSameNetwork={true}
+          hasTokensOnOtherNetworks={false}
+          canAdd={true}
+          exchanges={[]}
         />
       </Provider>
     )
@@ -60,18 +60,15 @@ describe('BeforeDepositBottomSheet', () => {
   it('show bottom sheet correctly when hasDepositToken is true, token(s) on differnet chain', () => {
     const { getByText, getByTestId } = render(
       <Provider store={createMockStore()}>
-        <MockedNavigator
-          component={BeforeDepositBottomSheet}
-          params={{
-            forwardedRef: null,
-            token: mockTokenBalances[mockPoolTokenId],
-            pool: mockEarnPositions[0],
-            hasDepositToken: true,
-            hasTokensOnSameNetwork: false,
-            hasTokensOnOtherNetworks: true,
-            canAdd: true,
-            exchanges: [],
-          }}
+        <BeforeDepositBottomSheet
+          forwardedRef={{ current: null }}
+          token={mockToken}
+          pool={mockEarnPositions[0]}
+          hasDepositToken={true}
+          hasTokensOnSameNetwork={false}
+          hasTokensOnOtherNetworks={true}
+          canAdd={true}
+          exchanges={[]}
         />
       </Provider>
     )
@@ -93,18 +90,15 @@ describe('BeforeDepositBottomSheet', () => {
   it('show bottom sheet correctly when hasDepositToken is true, token(s) on same and different chains', () => {
     const { getByTestId } = render(
       <Provider store={createMockStore()}>
-        <MockedNavigator
-          component={BeforeDepositBottomSheet}
-          params={{
-            forwardedRef: null,
-            token: mockTokenBalances[mockPoolTokenId],
-            pool: mockEarnPositions[0],
-            hasDepositToken: true,
-            hasTokensOnSameNetwork: true,
-            hasTokensOnOtherNetworks: true,
-            canAdd: true,
-            exchanges: [],
-          }}
+        <BeforeDepositBottomSheet
+          forwardedRef={{ current: null }}
+          token={mockToken}
+          pool={mockEarnPositions[0]}
+          hasDepositToken={true}
+          hasTokensOnSameNetwork={true}
+          hasTokensOnOtherNetworks={true}
+          canAdd={true}
+          exchanges={[]}
         />
       </Provider>
     )
@@ -115,18 +109,15 @@ describe('BeforeDepositBottomSheet', () => {
   it('show bottom sheet correctly when hasDepositToken is false, can same and cross chain swap', () => {
     const { getByTestId } = render(
       <Provider store={createMockStore()}>
-        <MockedNavigator
-          component={BeforeDepositBottomSheet}
-          params={{
-            forwardedRef: null,
-            token: mockTokenBalances[mockPoolTokenId],
-            pool: mockEarnPositions[0],
-            hasDepositToken: false,
-            hasTokensOnSameNetwork: true,
-            hasTokensOnOtherNetworks: true,
-            canAdd: true,
-            exchanges: [],
-          }}
+        <BeforeDepositBottomSheet
+          forwardedRef={{ current: null }}
+          token={mockToken}
+          pool={mockEarnPositions[0]}
+          hasDepositToken={false}
+          hasTokensOnSameNetwork={true}
+          hasTokensOnOtherNetworks={true}
+          canAdd={true}
+          exchanges={[]}
         />
       </Provider>
     )
@@ -138,18 +129,15 @@ describe('BeforeDepositBottomSheet', () => {
   it('show bottom sheet correctly when hasDepositToken is false, can cross chain swap', () => {
     const { getByTestId } = render(
       <Provider store={createMockStore()}>
-        <MockedNavigator
-          component={BeforeDepositBottomSheet}
-          params={{
-            forwardedRef: null,
-            token: mockTokenBalances[mockPoolTokenId],
-            pool: mockEarnPositions[0],
-            hasDepositToken: false,
-            hasTokensOnSameNetwork: false,
-            hasTokensOnOtherNetworks: true,
-            canAdd: true,
-            exchanges: [],
-          }}
+        <BeforeDepositBottomSheet
+          forwardedRef={{ current: null }}
+          token={mockToken}
+          pool={mockEarnPositions[0]}
+          hasDepositToken={false}
+          hasTokensOnSameNetwork={false}
+          hasTokensOnOtherNetworks={true}
+          canAdd={true}
+          exchanges={[]}
         />
       </Provider>
     )
@@ -160,18 +148,15 @@ describe('BeforeDepositBottomSheet', () => {
   it('show bottom sheet correctly when hasDepositToken is false, no tokens', () => {
     const { getByTestId } = render(
       <Provider store={createMockStore()}>
-        <MockedNavigator
-          component={BeforeDepositBottomSheet}
-          params={{
-            forwardedRef: null,
-            token: mockTokenBalances[mockPoolTokenId],
-            pool: mockEarnPositions[0],
-            hasDepositToken: false,
-            hasTokensOnSameNetwork: false,
-            hasTokensOnOtherNetworks: false,
-            canAdd: true,
-            exchanges: [],
-          }}
+        <BeforeDepositBottomSheet
+          forwardedRef={{ current: null }}
+          token={mockToken}
+          pool={mockEarnPositions[0]}
+          hasDepositToken={false}
+          hasTokensOnSameNetwork={false}
+          hasTokensOnOtherNetworks={false}
+          canAdd={true}
+          exchanges={[]}
         />
       </Provider>
     )
@@ -179,21 +164,18 @@ describe('BeforeDepositBottomSheet', () => {
     expect(getByTestId('Earn/ActionCard/Transfer')).toBeTruthy()
   })
 
-  it('navigates correctly when swap and deposit action item is tapped', () => {
+  it('navigates correctly when deposit action item is tapped', () => {
     const { getByTestId } = render(
       <Provider store={createMockStore()}>
-        <MockedNavigator
-          component={BeforeDepositBottomSheet}
-          params={{
-            forwardedRef: null,
-            token: mockTokenBalances[mockPoolTokenId],
-            pool: mockEarnPositions[0],
-            hasDepositToken: true,
-            hasTokensOnSameNetwork: true,
-            hasTokensOnOtherNetworks: true,
-            canAdd: true,
-            exchanges: [],
-          }}
+        <BeforeDepositBottomSheet
+          forwardedRef={{ current: null }}
+          token={mockToken}
+          pool={mockEarnPositions[0]}
+          hasDepositToken={true}
+          hasTokensOnSameNetwork={true}
+          hasTokensOnOtherNetworks={true}
+          canAdd={true}
+          exchanges={[]}
         />
       </Provider>
     )
@@ -208,18 +190,15 @@ describe('BeforeDepositBottomSheet', () => {
   it('navigates correctly when swap and deposit action item is tapped', () => {
     const { getByTestId } = render(
       <Provider store={createMockStore()}>
-        <MockedNavigator
-          component={BeforeDepositBottomSheet}
-          params={{
-            forwardedRef: null,
-            token: mockTokenBalances[mockPoolTokenId],
-            pool: mockEarnPositions[0],
-            hasDepositToken: true,
-            hasTokensOnSameNetwork: true,
-            hasTokensOnOtherNetworks: true,
-            canAdd: true,
-            exchanges: [],
-          }}
+        <BeforeDepositBottomSheet
+          forwardedRef={{ current: null }}
+          token={mockToken}
+          pool={mockEarnPositions[0]}
+          hasDepositToken={true}
+          hasTokensOnSameNetwork={true}
+          hasTokensOnOtherNetworks={true}
+          canAdd={true}
+          exchanges={[]}
         />
       </Provider>
     )
@@ -235,18 +214,15 @@ describe('BeforeDepositBottomSheet', () => {
   it('navigates correctly when cross chain swap action item is tapped', () => {
     const { getByTestId } = render(
       <Provider store={createMockStore()}>
-        <MockedNavigator
-          component={BeforeDepositBottomSheet}
-          params={{
-            forwardedRef: null,
-            token: mockTokenBalances[mockPoolTokenId],
-            pool: mockEarnPositions[0],
-            hasDepositToken: true,
-            hasTokensOnSameNetwork: true,
-            hasTokensOnOtherNetworks: true,
-            canAdd: true,
-            exchanges: [],
-          }}
+        <BeforeDepositBottomSheet
+          forwardedRef={{ current: null }}
+          token={mockToken}
+          pool={mockEarnPositions[0]}
+          hasDepositToken={true}
+          hasTokensOnSameNetwork={true}
+          hasTokensOnOtherNetworks={true}
+          canAdd={true}
+          exchanges={[]}
         />
       </Provider>
     )
@@ -261,18 +237,15 @@ describe('BeforeDepositBottomSheet', () => {
   it('navigates correctly when add more action item is tapped', () => {
     const { getByTestId } = render(
       <Provider store={createMockStore()}>
-        <MockedNavigator
-          component={BeforeDepositBottomSheet}
-          params={{
-            forwardedRef: null,
-            token: mockTokenBalances[mockPoolTokenId],
-            pool: mockEarnPositions[0],
-            hasDepositToken: true,
-            hasTokensOnSameNetwork: false,
-            hasTokensOnOtherNetworks: false,
-            canAdd: true,
-            exchanges: [],
-          }}
+        <BeforeDepositBottomSheet
+          forwardedRef={{ current: null }}
+          token={mockToken}
+          pool={mockEarnPositions[0]}
+          hasDepositToken={true}
+          hasTokensOnSameNetwork={false}
+          hasTokensOnOtherNetworks={false}
+          canAdd={true}
+          exchanges={[]}
         />
       </Provider>
     )
@@ -289,18 +262,15 @@ describe('BeforeDepositBottomSheet', () => {
   it('navigates correctly when add action item is tapped', () => {
     const { getByTestId } = render(
       <Provider store={createMockStore()}>
-        <MockedNavigator
-          component={BeforeDepositBottomSheet}
-          params={{
-            forwardedRef: null,
-            token: mockTokenBalances[mockPoolTokenId],
-            pool: mockEarnPositions[0],
-            hasDepositToken: false,
-            hasTokensOnSameNetwork: false,
-            hasTokensOnOtherNetworks: false,
-            canAdd: true,
-            exchanges: [],
-          }}
+        <BeforeDepositBottomSheet
+          forwardedRef={{ current: null }}
+          token={mockToken}
+          pool={mockEarnPositions[0]}
+          hasDepositToken={false}
+          hasTokensOnSameNetwork={false}
+          hasTokensOnOtherNetworks={false}
+          canAdd={true}
+          exchanges={[]}
         />
       </Provider>
     )
@@ -317,18 +287,15 @@ describe('BeforeDepositBottomSheet', () => {
   it('navigates correctly when swap action item is tapped', () => {
     const { getByTestId } = render(
       <Provider store={createMockStore()}>
-        <MockedNavigator
-          component={BeforeDepositBottomSheet}
-          params={{
-            forwardedRef: null,
-            token: mockTokenBalances[mockPoolTokenId],
-            pool: mockEarnPositions[0],
-            hasDepositToken: false,
-            hasTokensOnSameNetwork: false,
-            hasTokensOnOtherNetworks: true,
-            canAdd: true,
-            exchanges: [],
-          }}
+        <BeforeDepositBottomSheet
+          forwardedRef={{ current: null }}
+          token={mockToken}
+          pool={mockEarnPositions[0]}
+          hasDepositToken={false}
+          hasTokensOnSameNetwork={false}
+          hasTokensOnOtherNetworks={true}
+          canAdd={true}
+          exchanges={[]}
         />
       </Provider>
     )
@@ -343,18 +310,15 @@ describe('BeforeDepositBottomSheet', () => {
   it('navigates correctly when transfer action item is tapped', () => {
     const { getByTestId } = render(
       <Provider store={createMockStore()}>
-        <MockedNavigator
-          component={BeforeDepositBottomSheet}
-          params={{
-            forwardedRef: null,
-            token: mockTokenBalances[mockPoolTokenId],
-            pool: mockEarnPositions[0],
-            hasDepositToken: false,
-            hasTokensOnSameNetwork: false,
-            hasTokensOnOtherNetworks: false,
-            canAdd: true,
-            exchanges: [],
-          }}
+        <BeforeDepositBottomSheet
+          forwardedRef={{ current: null }}
+          token={mockToken}
+          pool={mockEarnPositions[0]}
+          hasDepositToken={false}
+          hasTokensOnSameNetwork={false}
+          hasTokensOnOtherNetworks={false}
+          canAdd={true}
+          exchanges={[]}
         />
       </Provider>
     )

--- a/src/earn/poolInfoScreen/BeforeDepositBottomSheet.test.tsx
+++ b/src/earn/poolInfoScreen/BeforeDepositBottomSheet.test.tsx
@@ -2,8 +2,6 @@ import { fireEvent, render } from '@testing-library/react-native'
 import BigNumber from 'bignumber.js'
 import React from 'react'
 import { Provider } from 'react-redux'
-import AppAnalytics from 'src/analytics/AppAnalytics'
-import { EarnEvents } from 'src/analytics/Events'
 import BeforeDepositBottomSheet from 'src/earn/poolInfoScreen/BeforeDepositBottomSheet'
 import { CICOFlow } from 'src/fiatExchanges/types'
 import { navigate } from 'src/navigator/NavigationService'
@@ -58,7 +56,7 @@ describe('BeforeDepositBottomSheet', () => {
     expect(getByTestId('Earn/ActionCard/AddMore')).toBeTruthy()
   })
   it('show bottom sheet correctly when hasDepositToken is true, token(s) on differnet chain', () => {
-    const { getByText, getByTestId } = render(
+    const { getByTestId } = render(
       <Provider store={createMockStore()}>
         <BeforeDepositBottomSheet
           forwardedRef={{ current: null }}
@@ -72,17 +70,6 @@ describe('BeforeDepositBottomSheet', () => {
         />
       </Provider>
     )
-    fireEvent.press(getByText('earnFlow.poolInfoScreen.deposit'))
-    expect(AppAnalytics.track).toHaveBeenCalledWith(EarnEvents.earn_pool_info_tap_deposit, {
-      providerId: 'aave',
-      poolId: 'arbitrum-sepolia:0x460b97bd498e1157530aeb3086301d5225b91216',
-      networkId: 'arbitrum-sepolia',
-      depositTokenId: mockEarnPositions[0].dataProps.depositTokenId,
-      hasDepositToken: true,
-      hasTokensOnSameNetwork: false,
-      hasTokensOnOtherNetworks: true,
-    })
-
     expect(getByTestId('Earn/ActionCard/Deposit')).toBeTruthy()
     expect(getByTestId('Earn/ActionCard/Swap')).toBeTruthy()
     expect(getByTestId('Earn/ActionCard/AddMore')).toBeTruthy()
@@ -184,7 +171,6 @@ describe('BeforeDepositBottomSheet', () => {
     expect(navigate).toHaveBeenCalledWith(Screens.EarnEnterAmount, {
       pool: mockEarnPositions[0],
     })
-    expect(AppAnalytics.track).toHaveBeenCalledTimes(2)
   })
 
   it('navigates correctly when swap and deposit action item is tapped', () => {
@@ -208,7 +194,6 @@ describe('BeforeDepositBottomSheet', () => {
       pool: mockEarnPositions[0],
       mode: 'swap-deposit',
     })
-    expect(AppAnalytics.track).toHaveBeenCalledTimes(2)
   })
 
   it('navigates correctly when cross chain swap action item is tapped', () => {
@@ -231,7 +216,6 @@ describe('BeforeDepositBottomSheet', () => {
     expect(navigate).toHaveBeenCalledWith(Screens.SwapScreenWithBack, {
       toTokenId: mockEarnPositions[0].dataProps.depositTokenId,
     })
-    expect(AppAnalytics.track).toHaveBeenCalledTimes(2)
   })
 
   it('navigates correctly when add more action item is tapped', () => {
@@ -256,7 +240,6 @@ describe('BeforeDepositBottomSheet', () => {
       flow: CICOFlow.CashIn,
       tokenSymbol: 'USDC',
     })
-    expect(AppAnalytics.track).toHaveBeenCalledTimes(2)
   })
 
   it('navigates correctly when add action item is tapped', () => {
@@ -281,7 +264,6 @@ describe('BeforeDepositBottomSheet', () => {
       flow: CICOFlow.CashIn,
       tokenSymbol: 'USDC',
     })
-    expect(AppAnalytics.track).toHaveBeenCalledTimes(2)
   })
 
   it('navigates correctly when swap action item is tapped', () => {
@@ -304,7 +286,6 @@ describe('BeforeDepositBottomSheet', () => {
     expect(navigate).toHaveBeenCalledWith(Screens.SwapScreenWithBack, {
       toTokenId: mockEarnPositions[0].dataProps.depositTokenId,
     })
-    expect(AppAnalytics.track).toHaveBeenCalledTimes(2)
   })
 
   it('navigates correctly when transfer action item is tapped', () => {
@@ -328,6 +309,5 @@ describe('BeforeDepositBottomSheet', () => {
       flow: CICOFlow.CashIn,
       exchanges: [],
     })
-    expect(AppAnalytics.track).toHaveBeenCalledTimes(2)
   })
 })

--- a/src/earn/poolInfoScreen/BeforeDepositBottomSheet.tsx
+++ b/src/earn/poolInfoScreen/BeforeDepositBottomSheet.tsx
@@ -9,6 +9,7 @@ import { ActionCard } from 'src/earn/ActionCard'
 import { BeforeDepositAction } from 'src/earn/types'
 import { ExternalExchangeProvider } from 'src/fiatExchanges/ExternalExchanges'
 import { CICOFlow } from 'src/fiatExchanges/types'
+import EarnCoins from 'src/icons/EarnCoins'
 import QuickActionsAdd from 'src/icons/quick-actions/Add'
 import QuickActionsSend from 'src/icons/quick-actions/Send'
 import SwapAndDeposit from 'src/icons/SwapAndDeposit'
@@ -246,7 +247,7 @@ function DepositAction({
       amount: token.balance,
       tokenSymbol: token.symbol,
     }),
-    iconComponent: QuickActionsAdd, // TODO: update to be coins
+    iconComponent: EarnCoins,
     onPress: () => {
       AppAnalytics.track(EarnEvents.earn_before_deposit_action_press, {
         action: 'Deposit',

--- a/src/earn/poolInfoScreen/BeforeDepositBottomSheet.tsx
+++ b/src/earn/poolInfoScreen/BeforeDepositBottomSheet.tsx
@@ -302,7 +302,9 @@ export default function BeforeDepositBottomSheet({
   const showAdd = canAdd && !hasDepositToken
   const showAddMore =
     canAdd && hasDepositToken && !(hasTokensOnSameNetwork && hasTokensOnOtherNetworks)
-  const showTransfer = !hasDepositToken && !hasTokensOnSameNetwork && !hasTokensOnOtherNetworks
+  const showTransfer =
+    (!hasDepositToken && !hasTokensOnSameNetwork && !hasTokensOnOtherNetworks) ||
+    (!canAdd && !(hasDepositToken && hasTokensOnSameNetwork && hasTokensOnOtherNetworks))
 
   return (
     <BottomSheet
@@ -337,7 +339,7 @@ export default function BeforeDepositBottomSheet({
           />
         )}
         {(canSwapDeposit || hasDepositToken) &&
-          (showCrossChainSwap || showSwap || showAdd || showAddMore) && (
+          (showCrossChainSwap || showSwap || showAdd || showAddMore || showTransfer) && (
             <Text style={styles.actionDetails}>
               {t('earnFlow.beforeDepositBottomSheet.crossChainAlternativeDescription', {
                 tokenNetwork: NETWORK_NAMES[token.networkId],

--- a/src/earn/poolInfoScreen/BeforeDepositBottomSheet.tsx
+++ b/src/earn/poolInfoScreen/BeforeDepositBottomSheet.tsx
@@ -72,7 +72,7 @@ function AddMoreAction({
 
   const action: BeforeDepositAction = {
     name: 'AddMore',
-    title: t('earnFlow.beforeDepositBottomSheet.action.addMore'),
+    title: t('earnFlow.beforeDepositBottomSheet.action.addMore', { tokenSymbol: token.symbol }),
     details: t('earnFlow.beforeDepositBottomSheet.action.addDescription', {
       tokenSymbol: token.symbol,
       tokenNetwork: NETWORK_NAMES[token.networkId],
@@ -241,7 +241,7 @@ function DepositAction({
 
   const action: BeforeDepositAction = {
     name: 'Deposit',
-    title: t('earnFlow.beforeDepositBottomSheet.action.deposit'),
+    title: t('earnFlow.beforeDepositBottomSheet.action.deposit', { tokenSymbol: token.symbol }),
     details: t('earnFlow.beforeDepositBottomSheet.action.depositDescription', {
       amount: token.balance,
       tokenSymbol: token.symbol,
@@ -335,13 +335,14 @@ export default function BeforeDepositBottomSheet({
             analyticsProps={analyticsProps}
           />
         )}
-        {(canSwapDeposit || hasDepositToken) && (
-          <Text style={styles.actionDetails}>
-            {t('earnFlow.beforeDepositBottomSheet.crossChainAlternativeDescription', {
-              tokenNetwork: NETWORK_NAMES[token.networkId],
-            })}
-          </Text>
-        )}
+        {(canSwapDeposit || hasDepositToken) &&
+          (showCrossChainSwap || showSwap || showAdd || showAddMore) && (
+            <Text style={styles.actionDetails}>
+              {t('earnFlow.beforeDepositBottomSheet.crossChainAlternativeDescription', {
+                tokenNetwork: NETWORK_NAMES[token.networkId],
+              })}
+            </Text>
+          )}
         {showCrossChainSwap && (
           <CrossChainSwapAction
             token={token}

--- a/src/earn/poolInfoScreen/EarnPoolInfoScreen.tsx
+++ b/src/earn/poolInfoScreen/EarnPoolInfoScreen.tsx
@@ -241,11 +241,7 @@ export default function EarnPoolInfoScreen({ route, navigation }: Props) {
       hasTokensOnSameNetwork,
       hasTokensOnOtherNetworks,
     })
-    if (hasDepositToken) {
-      navigate(Screens.EarnEnterAmount, { pool })
-    } else {
-      beforeDepositBottomSheetRef.current?.snapToIndex(0)
-    }
+    beforeDepositBottomSheetRef.current?.snapToIndex(0)
   }
 
   const beforeDepositBottomSheetRef = useRef<BottomSheetModalRefType>(null)
@@ -427,6 +423,7 @@ export default function EarnPoolInfoScreen({ route, navigation }: Props) {
         forwardedRef={beforeDepositBottomSheetRef}
         token={depositToken}
         pool={pool}
+        hasDepositToken={hasDepositToken}
         hasTokensOnSameNetwork={hasTokensOnSameNetwork}
         hasTokensOnOtherNetworks={hasTokensOnOtherNetworks}
         canAdd={canCashIn}

--- a/src/earn/types.ts
+++ b/src/earn/types.ts
@@ -43,10 +43,12 @@ export interface PoolInfo {
 
 export type BeforeDepositActionName =
   | 'Add'
+  | 'AddMore'
   | 'Transfer'
   | 'SwapAndDeposit'
   | 'CrossChainSwap'
   | 'Swap'
+  | 'Deposit'
 
 export interface BeforeDepositAction {
   name: BeforeDepositActionName


### PR DESCRIPTION
### Description

Bottom sheet always shows when tapping deposit, options match designs

### Test plan

Unit tests updated / added

Manual tests (ignore + by deposit, it has been changed to the coins, see image at very bottom for coins icon)
| Case | Allbridge | Aave/Beefy | 
| -----| --------- | ----------- |
| Has deposit token, same chain and different chain | ![everythin-2](https://github.com/user-attachments/assets/e1e557fa-e2b3-4788-b4d3-975757ff368a) | ![everything-1](https://github.com/user-attachments/assets/b617683e-db62-48b4-9019-233fb231ed10) |
| Has deposit token and same chain | ![same-chain-1](https://github.com/user-attachments/assets/5aad2601-6131-494c-a924-0028c5c3559b) | ![same-chain-2](https://github.com/user-attachments/assets/07633c9c-61ee-4301-9805-511b276fdacf) |
| Has deposit token and different chain | ![different-chain-1](https://github.com/user-attachments/assets/a90b8cdb-6324-45eb-8886-23d0e1e6fe12) | ![different-chain-2](https://github.com/user-attachments/assets/d942f75b-dcb8-4261-be01-1c347f519df2) |
| Has only deposit token | ![only-deposit](https://github.com/user-attachments/assets/4697fd2e-44c3-4819-b966-f30d9d1e68ea) | ![only-deposit-2](https://github.com/user-attachments/assets/e6758dd9-5d0d-406f-8532-40f89e02de1e) |
| Has same and different chain but not deposit token | ![both-3](https://github.com/user-attachments/assets/f31f9b6c-2724-4221-8e92-33b880fa43c9) | ![both-4](https://github.com/user-attachments/assets/e26f683b-bb7e-4a22-a4e1-8b31f2548cdd) |
| Has same chain but not deposit token | ![same-3](https://github.com/user-attachments/assets/e3552034-877e-41e7-9c0b-e14cc49a8bcd) | ![same-4](https://github.com/user-attachments/assets/b975d024-00f3-4f87-8e7d-5d072bf58b43) |
| Has different chain but not deposit token | ![different-3](https://github.com/user-attachments/assets/13e1c4b4-297f-44e5-aed9-180bb4e7cd5a) | ![different-4](https://github.com/user-attachments/assets/2fcf6adc-9ac9-4dca-8f0f-95a2bbad123f) |
| Has no tokens | ![none-3](https://github.com/user-attachments/assets/1c12b320-7df4-4f78-bb9a-d7ae7e868415) | ![none-4](https://github.com/user-attachments/assets/7c1a539c-3b1a-4ec8-a087-0b9c25c9d246) |

Coins icon for deposit:
<img src="https://github.com/user-attachments/assets/985c7ba2-f6d8-4ef1-951e-c738f89fafe7" width="250" />

Show transfer if deposit token is not cash-in (except for case where deposit, swap&deposit and cross-chain swap is shown):
<img src="https://github.com/user-attachments/assets/c333aed4-d9f8-4f07-8b5e-0fbeee8bc079" width="250" />

### Related issues

- Fixes ACT-1494

### Backwards compatibility

Yes
### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- N/A
