### PR TITLE
fix(deeplinks): get url from the correct field for CT events

### DIFF
--- a/__mocks__/@react-native-firebase/dynamic-links.ts
+++ b/__mocks__/@react-native-firebase/dynamic-links.ts
@@ -1,11 +1,13 @@
 const getInitialLink = jest.fn()
 const buildShortLink = jest.fn()
 const buildLink = jest.fn()
+const onLink = jest.fn()
 
 export default function links() {
   return {
     getInitialLink,
     buildShortLink,
     buildLink,
+    onLink,
   }
 }

--- a/__mocks__/clevertap-react-native.ts
+++ b/__mocks__/clevertap-react-native.ts
@@ -2,4 +2,7 @@ export default {
   setPushToken: jest.fn(),
   createNotificationChannel: jest.fn(),
   registerForPush: jest.fn(),
+  getInitialUrl: jest.fn(),
+  addListener: jest.fn(),
+  removeListener: jest.fn(),
 }

--- a/src/app/saga.ts
+++ b/src/app/saga.ts
@@ -323,7 +323,11 @@ export function* handleDeepLink(action: OpenDeepLink) {
 }
 
 function* watchDeepLinks() {
-  yield* takeLatest(Actions.OPEN_DEEP_LINK, safely(handleDeepLink))
+  // using takeEvery over takeLatest because openScreen deep links could be
+  // fired by multiple handlers (one with isSecureOrigin and one without), and
+  // if takeLatest kills the call to the handler with isSecureOrigin, the deep
+  // link won't work.
+  yield* takeEvery(Actions.OPEN_DEEP_LINK, safely(handleDeepLink))
 }
 
 export function* handleOpenUrl(action: OpenUrlAction) {

--- a/src/app/useDeepLinks.test.tsx
+++ b/src/app/useDeepLinks.test.tsx
@@ -1,0 +1,86 @@
+import { act, renderHook } from '@testing-library/react-native'
+import CleverTap from 'clevertap-react-native'
+import React from 'react'
+import { Linking } from 'react-native'
+import { Provider } from 'react-redux'
+import { useDeepLinks } from 'src/app/useDeepLinks'
+import { createMockStore } from 'test/utils'
+
+describe('useDeepLinks', () => {
+  let cleverTapListenerCallback: Function
+  let linkingListenerCallback: Function
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.mocked(CleverTap.addListener).mockImplementation((event, callback) => {
+      if (event === 'CleverTapPushNotificationClicked') {
+        cleverTapListenerCallback = callback
+      }
+    })
+    jest.mocked(Linking.addEventListener).mockImplementation((event, callback) => {
+      if (event === 'url') {
+        linkingListenerCallback = callback
+      }
+      return {
+        remove: jest.fn(),
+      } as any
+    })
+  })
+
+  it('should handle clevertap push notifications with deep links', async () => {
+    const store = createMockStore()
+    renderHook(() => useDeepLinks(), {
+      wrapper: (component) => (
+        <Provider store={store}>{component?.children ? component.children : component}</Provider>
+      ),
+    })
+
+    await act(() => {
+      cleverTapListenerCallback({ wzrk_dl: 'some-link' })
+    })
+
+    expect(store.getActions()).toEqual([
+      {
+        deepLink: 'some-link',
+        isSecureOrigin: true,
+        type: 'APP/OPEN_DEEP_LINK',
+      },
+    ])
+  })
+
+  it('should not open deeplink if clevertap event does not have a deep link', async () => {
+    const store = createMockStore()
+    renderHook(() => useDeepLinks(), {
+      wrapper: (component) => (
+        <Provider store={store}>{component?.children ? component.children : component}</Provider>
+      ),
+    })
+
+    await act(() => {
+      cleverTapListenerCallback({})
+    })
+
+    expect(store.getActions()).toEqual([])
+  })
+
+  it('should handle linking events with deep links', async () => {
+    const store = createMockStore()
+    renderHook(() => useDeepLinks(), {
+      wrapper: (component) => (
+        <Provider store={store}>{component?.children ? component.children : component}</Provider>
+      ),
+    })
+
+    await act(() => {
+      linkingListenerCallback({ url: 'some-link' })
+    })
+
+    expect(store.getActions()).toEqual([
+      {
+        deepLink: 'some-link',
+        isSecureOrigin: false,
+        type: 'APP/OPEN_DEEP_LINK',
+      },
+    ])
+  })
+})


### PR DESCRIPTION
### Description

Per this [update](https://github.com/CleverTap/clevertap-react-native/blob/2c2ab9664b9e83cde936d14b511896d7edd5ecdc/docs/callbackPayloadFormat.md?plain=1#L12) in clever tap docs, this likely slipped through on a clevertap package upgrade

### Test plan

Can't easily test CT push notifications with a dev build, but this has been working on Android, where the url was extracted correctly, and also confirmed with logging on iOS that the deeplink field is present at the top level of the event.

Also tested the 2 callbacks being called scenario by updating the code to call handleOpenUrl twice (one with isSecureOrigin: false and the other with true)  in the Linking event listener, the 2nd call mimics the call that would've been done by the CT push notification listener callback, and also introducing a delay in the saga (to mimic slow sagas, which can be killed by `takeLatest` if another event of the same action type is fired). On opening a deeplink on the browser with an openScreen deeplink and the app backgrounded, confirmed that the navigation to the correct screen happens. 

### Related issues

- Fixes ACT-1469

### Backwards compatibility

Yes

### Network scalability

N/A
