### PR TITLE
chore(tokens): update price history endpoint

### DIFF
--- a/src/priceHistory/saga.test.ts
+++ b/src/priceHistory/saga.test.ts
@@ -50,7 +50,7 @@ describe('watchFetchTokenPriceHistory', () => {
 
     expect(mockFetch).toHaveBeenCalledTimes(1)
     expect(mockFetch).toHaveBeenCalledWith(
-      `${networkConfig.blockchainApiUrl}/tokensInfo/${mockCusdTokenId}/priceHistory?startTimestamp=1700378258000&endTimestamp=1702941458000`,
+      `${networkConfig.getTokenPriceHistoryUrl}?tokenId=${encodeURIComponent(mockCusdTokenId)}&startTimestamp=1700378258000&endTimestamp=1702941458000`,
       expect.any(Object)
     )
   })

--- a/src/priceHistory/saga.ts
+++ b/src/priceHistory/saga.ts
@@ -25,11 +25,12 @@ export async function fetchTokenPriceHistory(
   endTimestamp: number
 ): Promise<Price[]> {
   const queryParams = new URLSearchParams({
+    tokenId,
     startTimestamp: `${startTimestamp}`,
     endTimestamp: `${endTimestamp}`,
   }).toString()
 
-  const url = `${networkConfig.blockchainApiUrl}/tokensInfo/${tokenId}/priceHistory?${queryParams}`
+  const url = `${networkConfig.getTokenPriceHistoryUrl}?${queryParams}`
   const response = await fetchWithTimeout(url)
   if (!response.ok) {
     throw new Error(

--- a/src/web3/networkConfig.ts
+++ b/src/web3/networkConfig.ts
@@ -84,6 +84,7 @@ interface NetworkConfig {
   getWalletTransactionsUrl: string
   getWalletBalancesUrl: string
   getExchangeRateUrl: string
+  getTokenPriceHistoryUrl: string
   getCicoQuotesUrl: string
   getCeloNewsFeedUrl: string
 }
@@ -244,6 +245,9 @@ const GET_WALLET_BALANCES_MAINNET = `${CLOUD_FUNCTIONS_MAINNET}/getWalletBalance
 const GET_EXCHANGE_RATE_ALFAJORES = `${CLOUD_FUNCTIONS_STAGING}/getExchangeRate`
 const GET_EXCHANGE_RATE_MAINNET = `${CLOUD_FUNCTIONS_MAINNET}/getExchangeRate`
 
+const GET_TOKEN_PRICE_HISTORY_ALFAJORES = `${CLOUD_FUNCTIONS_STAGING}/getTokenPriceHistory`
+const GET_TOKEN_PRICE_HISTORY_MAINNET = `${CLOUD_FUNCTIONS_MAINNET}/getTokenPriceHistory`
+
 const GET_CICO_QUOTES_ALFAJORES = `${CLOUD_FUNCTIONS_STAGING}/getCicoQuotes`
 const GET_CICO_QUOTES_MAINNET = `${CLOUD_FUNCTIONS_MAINNET}/getCicoQuotes`
 
@@ -372,6 +376,7 @@ const networkConfigs: { [testnet: string]: NetworkConfig } = {
     getWalletTransactionsUrl: GET_WALLET_TRANSACTIONS_ALFAJORES,
     getWalletBalancesUrl: GET_WALLET_BALANCES_ALFAJORES,
     getExchangeRateUrl: GET_EXCHANGE_RATE_ALFAJORES,
+    getTokenPriceHistoryUrl: GET_TOKEN_PRICE_HISTORY_ALFAJORES,
     getCicoQuotesUrl: GET_CICO_QUOTES_ALFAJORES,
     getCeloNewsFeedUrl: GET_CELO_NEWS_FEED_ALFAJORES,
   },
@@ -459,6 +464,7 @@ const networkConfigs: { [testnet: string]: NetworkConfig } = {
     getWalletTransactionsUrl: GET_WALLET_TRANSACTIONS_MAINNET,
     getWalletBalancesUrl: GET_WALLET_BALANCES_MAINNET,
     getExchangeRateUrl: GET_EXCHANGE_RATE_MAINNET,
+    getTokenPriceHistoryUrl: GET_TOKEN_PRICE_HISTORY_MAINNET,
     getCicoQuotesUrl: GET_CICO_QUOTES_MAINNET,
     getCeloNewsFeedUrl: GET_CELO_NEWS_FEED_MAINNET,
   },


### PR DESCRIPTION
### Description

Fetch price history from the new `https://api.mainnet.valora.xyz/getTokenPriceHistory` enpdoint instead of the blockchain-api.

### Test plan

* Tested manually
* Updated unit test

### Related issues

- Part of RET-1240

### Backwards compatibility

Y

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
