### PR TITLE
chore(ci): specify Android API level as number

### DIFF
--- a/.github/workflows/e2e-main.yml
+++ b/.github/workflows/e2e-main.yml
@@ -32,7 +32,7 @@ jobs:
         # 24 is failing due to Let's Encrypt root certificate expiration
         # 25 is failing (RET-1274)
         # 26 is failing (RET-1275)
-        android-api-level: ['27']
+        android-api-level: [27]
     uses: ./.github/workflows/e2e-android.yml
     with:
       android-api-level: ${{ matrix.android-api-level }}


### PR DESCRIPTION
### Description

Follow up to #6031 

The Android API level must be specified not as a string but as a number, as is expected in [e2e-android.yml](https://github.com/valora-inc/wallet/blob/c6e23572ea8db100a3de9d65f0bae6d3f843b4c3/.github/workflows/e2e-android.yml#L7)

### Test plan

CI works

### Related issues

- Related to RET-1194

### Backwards compatibility

NA

### Network scalability

NA