### PR TITLE
feat(earn): support cross chain swap and deposit

### DIFF
--- a/src/analytics/Properties.tsx
+++ b/src/analytics/Properties.tsx
@@ -1551,7 +1551,7 @@ interface PointsEventsProperties {
 export interface EarnCommonProperties {
   providerId: string
   poolId: string
-  networkId: NetworkId
+  networkId: NetworkId // this is always the pool's networkId
   depositTokenId: string
 }
 
@@ -1562,6 +1562,8 @@ interface EarnDepositProperties extends EarnCommonProperties {
   // same as the depositTokenAmount and depositTokenId
   fromTokenAmount: string
   fromTokenId: string
+  fromNetworkId: NetworkId
+  swapType?: SwapType
 }
 
 interface EarnWithdrawProperties extends EarnCommonProperties {
@@ -1609,7 +1611,9 @@ interface EarnEventsProperties {
     // For withdrawals this will be in units of the depositToken
     fromTokenAmount: string
     fromTokenId: string
+    fromNetworkId: NetworkId
     depositTokenAmount?: string
+    swapType?: SwapType // only for swap-deposit
   } & EarnCommonProperties
   [EarnEvents.earn_deposit_add_gas_press]: EarnCommonProperties & { gasTokenId: string }
   [EarnEvents.earn_feed_item_select]: {

--- a/src/earn/EarnDepositBottomSheet.tsx
+++ b/src/earn/EarnDepositBottomSheet.tsx
@@ -72,9 +72,11 @@ export default function EarnDepositBottomSheet({
     depositTokenAmount: depositAmount.toString(),
     fromTokenId: inputTokenId,
     fromTokenAmount: inputAmount.toString(),
+    fromNetworkId: preparedTransaction.feeCurrency.networkId,
     networkId: pool.networkId,
     poolId: pool.positionId,
     mode,
+    swapType: swapTransaction?.swapType,
   }
 
   const { estimatedFeeAmount, feeCurrency } = getFeeCurrencyAndAmounts(preparedTransaction)
@@ -84,7 +86,7 @@ export default function EarnDepositBottomSheet({
     return null
   }
 
-  const isGasSubsidized = isGasSubsidizedForNetwork(pool.networkId)
+  const isGasSubsidized = isGasSubsidizedForNetwork(preparedTransaction.feeCurrency.networkId)
   const { termsUrl } = pool.dataProps
 
   const onPressProviderIcon = () => {
@@ -236,9 +238,7 @@ export default function EarnDepositBottomSheet({
           </View>
         </LabelledItem>
         <LabelledItem label={t('earnFlow.depositBottomSheet.network')}>
-          <Text style={styles.value}>
-            {NETWORK_NAMES[preparedTransaction.feeCurrency.networkId]}
-          </Text>
+          <Text style={styles.value}>{NETWORK_NAMES[pool.networkId]}</Text>
         </LabelledItem>
         {termsUrl ? (
           <Text style={styles.footer}>

--- a/src/earn/EarnEnterAmount.test.tsx
+++ b/src/earn/EarnEnterAmount.test.tsx
@@ -492,7 +492,7 @@ describe('EarnEnterAmount', () => {
       jest.mocked(usePrepareEnterAmountTransactionsCallback).mockReturnValue({
         prepareTransactionsResult: {
           prepareTransactionsResult: mockPreparedTransaction,
-          swapTransaction: mockCrossChainSwapTransaction,
+          swapTransaction: mockSwapTransaction,
         },
         refreshPreparedTransactions: jest.fn(),
         clearPreparedTransactions: jest.fn(),
@@ -539,7 +539,7 @@ describe('EarnEnterAmount', () => {
         fromNetworkId: NetworkId['arbitrum-sepolia'],
         depositTokenAmount: '0.99999',
         mode: 'swap-deposit',
-        swapType: 'cross-chain',
+        swapType: 'same-chain',
       })
       await waitFor(() => expect(getByText('earnFlow.depositBottomSheet.title')).toBeVisible())
     })
@@ -706,6 +706,7 @@ describe('EarnEnterAmount', () => {
         poolId: mockEarnPositions[0].positionId,
         fromTokenId: 'arbitrum-sepolia:0x94a9d9ac8a22534e3faca9f4e7f2e2cf85d5e4c8',
         fromTokenAmount: '8',
+        fromNetworkId: NetworkId['arbitrum-sepolia'],
         mode: 'withdraw',
       })
 

--- a/src/earn/prepareTransactions.test.ts
+++ b/src/earn/prepareTransactions.test.ts
@@ -12,7 +12,7 @@ import { StatsigDynamicConfigs } from 'src/statsig/types'
 import { TokenBalance } from 'src/tokens/slice'
 import { NetworkId } from 'src/transactions/types'
 import { prepareTransactions } from 'src/viem/prepareTransactions'
-import { mockEarnPositions, mockRewardsPositions } from 'test/values'
+import { mockCeloTokenBalance, mockEarnPositions, mockRewardsPositions } from 'test/values'
 import { Address, encodeFunctionData } from 'viem'
 
 const mockFeeCurrency: TokenBalance = {
@@ -143,6 +143,7 @@ describe('prepareTransactions', () => {
     it.each([
       { isNative: true, testSuffix: 'native token', token: mockFeeCurrency },
       { isNative: false, testSuffix: 'non native token', token: mockToken },
+      { isNative: true, testSuffix: 'cross chain token', token: mockCeloTokenBalance },
     ])(
       'prepares transactions using swap-deposit shortcut ($testSuffix)',
       async ({ isNative, token }) => {
@@ -206,7 +207,7 @@ describe('prepareTransactions', () => {
           isGasSubsidized: false,
           origin: 'earn-swap-deposit',
         })
-        expect(isGasSubsidizedForNetwork).toHaveBeenCalledWith(mockToken.networkId)
+        expect(isGasSubsidizedForNetwork).toHaveBeenCalledWith(token.networkId)
         expect(triggerShortcutRequest).toHaveBeenCalledWith('https://hooks.api', {
           address: '0x1234',
           appId: mockEarnPositions[0].appId,
@@ -219,6 +220,7 @@ describe('prepareTransactions', () => {
             decimals: token.decimals,
             address: token.address,
             isNative,
+            networkId: token.networkId,
           },
         })
       }

--- a/src/earn/prepareTransactions.ts
+++ b/src/earn/prepareTransactions.ts
@@ -53,6 +53,7 @@ export async function prepareDepositTransactions({
             decimals: token.decimals,
             address: token.address,
             isNative: token.isNative ?? false,
+            networkId: token.networkId,
           },
           enableAppFee,
         }

--- a/src/statsig/types.ts
+++ b/src/statsig/types.ts
@@ -34,6 +34,7 @@ export enum StatsigFeatureGates {
   SHOW_UK_COMPLIANT_VARIANT = 'show_uk_compliant_variant',
   ALLOW_EARN_PARTIAL_WITHDRAWAL = 'allow_earn_partial_withdrawal',
   SHOW_ZERION_TRANSACTION_FEED = 'show_zerion_transaction_feed',
+  ALLOW_CROSS_CHAIN_SWAP_AND_DEPOSIT = 'allow_cross_chain_swap_and_deposit',
 }
 
 export enum StatsigExperiments {


### PR DESCRIPTION
### Description

Support cross chain swap and deposit behind a statsig feature gate. UI changes not in scope for this PR and will be in a follow up (showing cross chain fees, updating bottom sheet to no longer show cross chain swap as a separate option, showing cross chain fee error if not enough for gas)

### Test plan

Manually tested and ensured 
- Right tokens show up in the expected order (same chain first, then cross chain, by balance within each section)
- Tx submitted and executed sucessfully

https://github.com/user-attachments/assets/8a7fb73b-3f71-4b1d-97da-6e8f53435ec0

[Source chain tx](https://optimistic.etherscan.io/tx/0x22795465cdddbfc29d2cefba6056562401172b867be6dd1cc069e860e7c639cf)
[Destination chain tx](https://arbiscan.io/tx/0x9062beb6d00bc0ba29d9196eabb1cafa439cf689c47cf0fa2c0528a96532454e)
[Alexar scan](https://axelarscan.io/gmp/0x22795465cdddbfc29d2cefba6056562401172b867be6dd1cc069e860e7c639cf)


### Related issues

- Part of ACT-1507

### Backwards compatibility

Y

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
