### PR TITLE
refactor(earn): check allow X chain swaps gate when showing deposit options

### DIFF
--- a/src/earn/poolInfoScreen/BeforeDepositBottomSheet.test.tsx
+++ b/src/earn/poolInfoScreen/BeforeDepositBottomSheet.test.tsx
@@ -6,6 +6,8 @@ import BeforeDepositBottomSheet from 'src/earn/poolInfoScreen/BeforeDepositBotto
 import { CICOFlow } from 'src/fiatExchanges/types'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
+import { getFeatureGate } from 'src/statsig'
+import { StatsigFeatureGates } from 'src/statsig/types'
 import { createMockStore } from 'test/utils'
 import { mockEarnPositions, mockTokenBalances } from 'test/values'
 
@@ -17,139 +19,99 @@ const mockToken = {
   lastKnownPriceUsd: new BigNumber(1),
 }
 
+jest.mock('src/statsig')
+
 describe('BeforeDepositBottomSheet', () => {
-  it('show bottom sheet correctly when hasDepositToken is true, no other tokens', () => {
-    const { getByTestId } = render(
-      <Provider store={createMockStore()}>
-        <BeforeDepositBottomSheet
-          forwardedRef={{ current: null }}
-          token={mockToken}
-          pool={mockEarnPositions[0]}
-          hasDepositToken={true}
-          hasTokensOnSameNetwork={false}
-          hasTokensOnOtherNetworks={false}
-          canAdd={true}
-          exchanges={[]}
-        />
-      </Provider>
-    )
-    expect(getByTestId('Earn/ActionCard/Deposit')).toBeTruthy()
-    expect(getByTestId('Earn/ActionCard/AddMore')).toBeTruthy()
-  })
-  it('show bottom sheet correctly when hasDepositToken is true, token(s) on same chain', () => {
-    const { getByTestId } = render(
-      <Provider store={createMockStore()}>
-        <BeforeDepositBottomSheet
-          forwardedRef={{ current: null }}
-          token={mockToken}
-          pool={mockEarnPositions[0]}
-          hasDepositToken={true}
-          hasTokensOnSameNetwork={true}
-          hasTokensOnOtherNetworks={false}
-          canAdd={true}
-          exchanges={[]}
-        />
-      </Provider>
-    )
-    expect(getByTestId('Earn/ActionCard/Deposit')).toBeTruthy()
-    expect(getByTestId('Earn/ActionCard/SwapAndDeposit')).toBeTruthy()
-    expect(getByTestId('Earn/ActionCard/AddMore')).toBeTruthy()
-  })
-  it('show bottom sheet correctly when hasDepositToken is true, token(s) on differnet chain', () => {
-    const { getByTestId } = render(
-      <Provider store={createMockStore()}>
-        <BeforeDepositBottomSheet
-          forwardedRef={{ current: null }}
-          token={mockToken}
-          pool={mockEarnPositions[0]}
-          hasDepositToken={true}
-          hasTokensOnSameNetwork={false}
-          hasTokensOnOtherNetworks={true}
-          canAdd={true}
-          exchanges={[]}
-        />
-      </Provider>
-    )
-    expect(getByTestId('Earn/ActionCard/Deposit')).toBeTruthy()
-    expect(getByTestId('Earn/ActionCard/Swap')).toBeTruthy()
-    expect(getByTestId('Earn/ActionCard/AddMore')).toBeTruthy()
-  })
-  it('show bottom sheet correctly when hasDepositToken is true, token(s) on same and different chains', () => {
-    const { getByTestId } = render(
-      <Provider store={createMockStore()}>
-        <BeforeDepositBottomSheet
-          forwardedRef={{ current: null }}
-          token={mockToken}
-          pool={mockEarnPositions[0]}
-          hasDepositToken={true}
-          hasTokensOnSameNetwork={true}
-          hasTokensOnOtherNetworks={true}
-          canAdd={true}
-          exchanges={[]}
-        />
-      </Provider>
-    )
-    expect(getByTestId('Earn/ActionCard/Deposit')).toBeTruthy()
-    expect(getByTestId('Earn/ActionCard/SwapAndDeposit')).toBeTruthy()
-    expect(getByTestId('Earn/ActionCard/CrossChainSwap')).toBeTruthy()
-  })
-  it('show bottom sheet correctly when hasDepositToken is false, can same and cross chain swap', () => {
-    const { getByTestId } = render(
-      <Provider store={createMockStore()}>
-        <BeforeDepositBottomSheet
-          forwardedRef={{ current: null }}
-          token={mockToken}
-          pool={mockEarnPositions[0]}
-          hasDepositToken={false}
-          hasTokensOnSameNetwork={true}
-          hasTokensOnOtherNetworks={true}
-          canAdd={true}
-          exchanges={[]}
-        />
-      </Provider>
-    )
-    expect(getByTestId('Earn/ActionCard/SwapAndDeposit')).toBeTruthy()
-    expect(getByTestId('Earn/ActionCard/CrossChainSwap')).toBeTruthy()
-    expect(getByTestId('Earn/ActionCard/Add')).toBeTruthy()
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest
+      .mocked(getFeatureGate)
+      .mockImplementation((gate) => gate === StatsigFeatureGates.ALLOW_CROSS_CHAIN_SWAPS)
   })
 
-  it('show bottom sheet correctly when hasDepositToken is false, can cross chain swap', () => {
-    const { getByTestId } = render(
-      <Provider store={createMockStore()}>
-        <BeforeDepositBottomSheet
-          forwardedRef={{ current: null }}
-          token={mockToken}
-          pool={mockEarnPositions[0]}
-          hasDepositToken={false}
-          hasTokensOnSameNetwork={false}
-          hasTokensOnOtherNetworks={true}
-          canAdd={true}
-          exchanges={[]}
-        />
-      </Provider>
-    )
-    expect(getByTestId('Earn/ActionCard/Swap')).toBeTruthy()
-    expect(getByTestId('Earn/ActionCard/Add')).toBeTruthy()
-  })
-
-  it('show bottom sheet correctly when hasDepositToken is false, no tokens', () => {
-    const { getByTestId } = render(
-      <Provider store={createMockStore()}>
-        <BeforeDepositBottomSheet
-          forwardedRef={{ current: null }}
-          token={mockToken}
-          pool={mockEarnPositions[0]}
-          hasDepositToken={false}
-          hasTokensOnSameNetwork={false}
-          hasTokensOnOtherNetworks={false}
-          canAdd={true}
-          exchanges={[]}
-        />
-      </Provider>
-    )
-    expect(getByTestId('Earn/ActionCard/Add')).toBeTruthy()
-    expect(getByTestId('Earn/ActionCard/Transfer')).toBeTruthy()
-  })
+  it.each`
+    scenario                                                                            | expectedActions                                    | hasDepositToken | hasTokensOnSameNetwork | hasTokensOnOtherNetworks | canAdd   | poolCannotSwapAndDeposit | allowCrossChainSwaps
+    ${'does not have any tokens'}                                                       | ${['Add', 'Transfer']}                             | ${false}        | ${false}               | ${false}                 | ${true}  | ${false}                 | ${true}
+    ${'does not have any tokens, cannot buy'}                                           | ${['Transfer']}                                    | ${false}        | ${false}               | ${false}                 | ${false} | ${false}                 | ${true}
+    ${'only has deposit token'}                                                         | ${['Deposit', 'AddMore']}                          | ${true}         | ${false}               | ${false}                 | ${true}  | ${false}                 | ${true}
+    ${'only has deposit token, cannot buy'}                                             | ${['Deposit', 'Transfer']}                         | ${true}         | ${false}               | ${false}                 | ${false} | ${false}                 | ${true}
+    ${'only has other tokens on same chain'}                                            | ${['SwapAndDeposit', 'Add']}                       | ${false}        | ${true}                | ${false}                 | ${true}  | ${false}                 | ${true}
+    ${'only has other tokens on same chain, cannot buy'}                                | ${['SwapAndDeposit', 'Transfer']}                  | ${false}        | ${true}                | ${false}                 | ${false} | ${false}                 | ${true}
+    ${'only has other tokens on same chain, pool cannot swap and deposit'}              | ${['Swap', 'Add']}                                 | ${false}        | ${true}                | ${false}                 | ${true}  | ${true}                  | ${true}
+    ${'only has other tokens on same chain, pool cannot swap and deposit, cannot buy'}  | ${['Swap', 'Transfer']}                            | ${false}        | ${true}                | ${false}                 | ${false} | ${true}                  | ${true}
+    ${'only has tokens on different chain'}                                             | ${['Swap', 'Add']}                                 | ${false}        | ${false}               | ${true}                  | ${true}  | ${false}                 | ${true}
+    ${'only has tokens on different chain, cannot buy'}                                 | ${['Swap', 'Transfer']}                            | ${false}        | ${false}               | ${true}                  | ${false} | ${false}                 | ${true}
+    ${'only has tokens on different chain, cross chain swap disabled'}                  | ${['Add', 'Transfer']}                             | ${false}        | ${false}               | ${true}                  | ${true}  | ${false}                 | ${false}
+    ${'has deposit token and other tokens on same chain'}                               | ${['Deposit', 'SwapAndDeposit', 'AddMore']}        | ${true}         | ${true}                | ${false}                 | ${true}  | ${false}                 | ${true}
+    ${'has deposit token and other tokens on same chain, cannot buy'}                   | ${['Deposit', 'SwapAndDeposit', 'Transfer']}       | ${true}         | ${true}                | ${false}                 | ${false} | ${false}                 | ${true}
+    ${'has deposit token and other tokens on same chain, pool cannot swap and deposit'} | ${['Deposit', 'Swap', 'AddMore']}                  | ${true}         | ${true}                | ${false}                 | ${true}  | ${true}                  | ${true}
+    ${'has deposit token and tokens on different chain, cross chain swap disabled'}     | ${['Deposit', 'AddMore']}                          | ${true}         | ${false}               | ${true}                  | ${true}  | ${false}                 | ${false}
+    ${'has deposit token and tokens on different chain'}                                | ${['Deposit', 'Swap', 'AddMore']}                  | ${true}         | ${false}               | ${true}                  | ${true}  | ${false}                 | ${true}
+    ${'has deposit token and tokens on different chain, cannot buy'}                    | ${['Deposit', 'Swap', 'Transfer']}                 | ${true}         | ${false}               | ${true}                  | ${false} | ${false}                 | ${true}
+    ${'has other tokens on same and different chain'}                                   | ${['SwapAndDeposit', 'CrossChainSwap', 'Add']}     | ${false}        | ${true}                | ${true}                  | ${true}  | ${false}                 | ${true}
+    ${'has other tokens on same and different chain, pool cannot swap and deposit'}     | ${['Swap', 'Add']}                                 | ${false}        | ${true}                | ${true}                  | ${true}  | ${true}                  | ${true}
+    ${'has other tokens on same and different chain, cross chain swap disabled'}        | ${['SwapAndDeposit', 'Add']}                       | ${false}        | ${true}                | ${true}                  | ${true}  | ${false}                 | ${false}
+    ${'has all types of tokens'}                                                        | ${['Deposit', 'SwapAndDeposit', 'CrossChainSwap']} | ${true}         | ${true}                | ${true}                  | ${true}  | ${false}                 | ${true}
+    ${'has all types of tokens, pool cannot swap and deposit'}                          | ${['Deposit', 'Swap']}                             | ${true}         | ${true}                | ${true}                  | ${true}  | ${true}                  | ${true}
+    ${'has all types of tokens, cross chain swap disabled'}                             | ${['Deposit', 'SwapAndDeposit', 'AddMore']}        | ${true}         | ${true}                | ${true}                  | ${true}  | ${false}                 | ${false}
+    ${'has all types of tokens, cross chain swap disabled, cannot buy'}                 | ${['Deposit', 'SwapAndDeposit', 'Transfer']}       | ${true}         | ${true}                | ${true}                  | ${false} | ${false}                 | ${false}
+    ${'has all types of tokens, cannot buy'}                                            | ${['Deposit', 'SwapAndDeposit', 'CrossChainSwap']} | ${true}         | ${true}                | ${true}                  | ${false} | ${false}                 | ${true}
+  `(
+    'shows correct title and actions when user $scenario',
+    ({
+      hasDepositToken,
+      hasTokensOnSameNetwork,
+      hasTokensOnOtherNetworks,
+      canAdd,
+      expectedActions,
+      poolCannotSwapAndDeposit,
+      allowCrossChainSwaps,
+    }: {
+      hasDepositToken: boolean
+      hasTokensOnSameNetwork: boolean
+      hasTokensOnOtherNetworks: boolean
+      canAdd: boolean
+      expectedActions: string[]
+      poolCannotSwapAndDeposit: boolean
+      allowCrossChainSwaps: boolean
+    }) => {
+      jest
+        .mocked(getFeatureGate)
+        .mockImplementation(
+          (gate) => gate === StatsigFeatureGates.ALLOW_CROSS_CHAIN_SWAPS && allowCrossChainSwaps
+        )
+      const { getAllByTestId, getByText, queryByTestId } = render(
+        <Provider store={createMockStore()}>
+          <BeforeDepositBottomSheet
+            forwardedRef={{ current: null }}
+            token={mockToken}
+            pool={{
+              ...mockEarnPositions[0],
+              availableShortcutIds: poolCannotSwapAndDeposit
+                ? ['deposit', 'withdraw']
+                : mockEarnPositions[0].availableShortcutIds,
+            }}
+            hasDepositToken={hasDepositToken}
+            hasTokensOnSameNetwork={hasTokensOnSameNetwork}
+            hasTokensOnOtherNetworks={hasTokensOnOtherNetworks}
+            canAdd={canAdd}
+            exchanges={[]}
+          />
+        </Provider>
+      )
+      expect(getAllByTestId(/^Earn\/ActionCard/).map((element) => element.props.testID)).toEqual(
+        expectedActions.map((action) => `Earn/ActionCard/${action}`)
+      )
+      expect(
+        getByText(
+          `earnFlow.beforeDepositBottomSheet.${expectedActions.includes('Deposit') || expectedActions.includes('SwapAndDeposit') ? 'depositTitle' : 'beforeYouCanDepositTitle'}`
+        )
+      ).toBeTruthy()
+      expect(!!queryByTestId('Earn/BeforeDepositBottomSheet/AlternativeDescription')).toBe(
+        expectedActions.includes('Deposit') || expectedActions.includes('SwapAndDeposit')
+      )
+    }
+  )
 
   it('navigates correctly when deposit action item is tapped', () => {
     const { getByTestId } = render(


### PR DESCRIPTION
### Description

Currently, cross chain swaps show up even if the cross chain swaps gate is off. This updates the before deposit bottom sheet to check for the gate before showing the cross chain swap option. Also simplified the booleans a bit to make it more readable and added more thorough tests

### Test plan

Unit tests

### Related issues

- Part of ACT-1507

### Backwards compatibility

Yes

### Network scalability

N/A