### PR TITLE
fix: new 2025 year causing one of the PointsHistoryBottomSheet tests to fail

### DIFF
--- a/src/points/PointsHistoryBottomSheet.test.tsx
+++ b/src/points/PointsHistoryBottomSheet.test.tsx
@@ -2,8 +2,8 @@ import { fireEvent, render, waitFor } from '@testing-library/react-native'
 import { FetchMock } from 'jest-fetch-mock/types'
 import * as React from 'react'
 import { Provider } from 'react-redux'
-import { PointsEvents } from 'src/analytics/Events'
 import AppAnalytics from 'src/analytics/AppAnalytics'
+import { PointsEvents } from 'src/analytics/Events'
 import PointsHistoryBottomSheet from 'src/points/PointsHistoryBottomSheet'
 import { getHistoryStarted } from 'src/points/slice'
 import { GetHistoryResponse } from 'src/points/types'
@@ -127,7 +127,7 @@ describe(PointsHistoryBottomSheet, () => {
     ).toBeTruthy()
     expect(tree.getByText('points.history.cards.createWallet.subtitle')).toBeTruthy()
 
-    expect(tree.getByText('March')).toBeTruthy()
+    expect(tree.getByText('March', { exact: false })).toBeTruthy()
     expect(tree.getByText('December 2023')).toBeTruthy()
     expect(tree.getByTestId('PointsHistoryBottomSheet/Loading')).toBeTruthy()
   })


### PR DESCRIPTION
### Description
As per the title. This change tweaks the test to not expect an exact string but to just check for a partial match.
Context: [thread](https://valora-app.slack.com/archives/C029Z1QMD7B/p1735811485840799)
GH run with an error: [run](https://github.com/valora-inc/wallet/actions/runs/12580445142/job/35062355717?pr=6247)

### Test plan
Tests pass

### Related issues
N/A

### Backwards compatibility
Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
