### PR TITLE
chore: remove redundant translation line

### DIFF
--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -2827,6 +2827,5 @@
     "selectToken": "Select token",
     "fiatPriceUnavailable": "Price unavailable",
     "tokenDescription": "{{tokenName}} on {{tokenNetwork}}"
-  },
-  "on": "on"
+  }
 }


### PR DESCRIPTION
### Description
Remore redundant unused translation line.

### Test plan
No testing needed.

### Related issues
N/A

### Backwards compatibility
Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
