### PR TITLE
chore(swap): track `swapId` for same-chain swap events

### DIFF
--- a/src/analytics/Properties.tsx
+++ b/src/analytics/Properties.tsx
@@ -1127,6 +1127,7 @@ type SwapQuoteEvent = SwapEvent & {
   appFeePercentageIncludedInPrice: string | null | undefined
   provider: string
   swapType: SwapType
+  swapId: string
 }
 
 export interface SwapTimeMetrics {

--- a/src/swap/SwapScreen.test.tsx
+++ b/src/swap/SwapScreen.test.tsx
@@ -42,6 +42,7 @@ import {
   mockTokenBalances,
   mockUSDCTokenId,
 } from 'test/values'
+import { v4 as uuidv4 } from 'uuid'
 
 const mockFetch = fetch as FetchMock
 const mockGetNumberFormatSettings = jest.fn()
@@ -78,6 +79,12 @@ jest.mock('src/viem/estimateFeesPerGas', () => ({
     baseFeePerGas: BigInt(6_000_000_000),
   })),
 }))
+
+jest.mock('uuid', () => ({
+  v4: jest.fn().mockReturnValue('mocked-uuid'),
+}))
+
+const mockedUuidv4 = uuidv4 as jest.Mock
 
 const mockStoreTokenBalances = {
   [mockCeurTokenId]: {
@@ -1221,6 +1228,10 @@ describe('SwapScreen', () => {
 
   it('should have correct analytics on swap submission', async () => {
     mockFetch.mockResponse(defaultQuoteResponse)
+
+    const mockSwapId = 'test-swap-id'
+    mockedUuidv4.mockReturnValue(mockSwapId)
+
     const { getByText, swapScreen } = renderScreen({})
 
     selectSwapTokens('CELO', 'cUSD', swapScreen)
@@ -1261,6 +1272,7 @@ describe('SwapScreen', () => {
       feeCurrencySymbol: 'CELO',
       txCount: 2,
       swapType: 'same-chain',
+      swapId: mockSwapId,
     })
   })
 

--- a/src/swap/SwapScreen.tsx
+++ b/src/swap/SwapScreen.tsx
@@ -406,7 +406,10 @@ export function SwapScreen({ route }: Props) {
         // to confirm the swap in this case.
         break
       case 'possible':
+        const swapId = uuidv4()
+
         AppAnalytics.track(SwapEvents.swap_review_submit, {
+          swapId,
           toToken: toToken.address,
           toTokenId: toToken.tokenId,
           toTokenNetworkId: toToken.networkId,
@@ -431,7 +434,6 @@ export function SwapScreen({ route }: Props) {
           ),
         })
 
-        const swapId = uuidv4()
         localDispatch(startSwap({ swapId }))
         dispatch(
           swapStart({

--- a/src/swap/SwapScreenV2.test.tsx
+++ b/src/swap/SwapScreenV2.test.tsx
@@ -43,6 +43,7 @@ import {
   mockTokenBalances,
   mockUSDCTokenId,
 } from 'test/values'
+import { v4 as uuidv4 } from 'uuid'
 
 const mockFetch = fetch as FetchMock
 const mockGetNumberFormatSettings = jest.fn()
@@ -79,6 +80,12 @@ jest.mock('src/viem/estimateFeesPerGas', () => ({
     baseFeePerGas: BigInt(6_000_000_000),
   })),
 }))
+
+jest.mock('uuid', () => ({
+  v4: jest.fn().mockReturnValue('mocked-uuid'),
+}))
+
+const mockedUuidv4 = uuidv4 as jest.Mock
 
 const mockStoreTokenBalances = {
   [mockCeurTokenId]: {
@@ -1313,6 +1320,10 @@ describe('SwapScreen', () => {
 
   it('should have correct analytics on swap submission', async () => {
     mockFetch.mockResponse(defaultQuoteResponse)
+
+    const mockSwapId = 'test-swap-id'
+    mockedUuidv4.mockReturnValue(mockSwapId)
+
     const { getByText, swapScreen } = renderScreen({})
 
     selectSwapTokens('CELO', 'cUSD', swapScreen)
@@ -1353,6 +1364,7 @@ describe('SwapScreen', () => {
       feeCurrencySymbol: 'CELO',
       txCount: 2,
       swapType: 'same-chain',
+      swapId: mockSwapId,
     })
   })
 

--- a/src/swap/SwapScreenV2.tsx
+++ b/src/swap/SwapScreenV2.tsx
@@ -463,7 +463,10 @@ export default function SwapScreenV2({ route }: Props) {
         // to confirm the swap in this case.
         break
       case 'possible':
+        const swapId = uuidv4()
+
         AppAnalytics.track(SwapEvents.swap_review_submit, {
+          swapId,
           toToken: toToken.address,
           toTokenId: toToken.tokenId,
           toTokenNetworkId: toToken.networkId,
@@ -488,7 +491,6 @@ export default function SwapScreenV2({ route }: Props) {
           ),
         })
 
-        const swapId = uuidv4()
         setStartedSwapId(swapId)
         dispatch(
           swapStart({

--- a/src/swap/saga.test.ts
+++ b/src/swap/saga.test.ts
@@ -506,6 +506,7 @@ describe(swapSubmitSaga, () => {
         swapTxHash: '0x2',
         areSwapTokensShuffled: false,
         swapType: 'same-chain',
+        swapId: 'test-swap-id',
       })
 
       const analyticsProps = (AppAnalytics.track as jest.Mock).mock.calls[0][1]
@@ -787,6 +788,7 @@ describe(swapSubmitSaga, () => {
       swapTxHash: undefined,
       areSwapTokensShuffled: false,
       swapType: 'same-chain',
+      swapId: 'test-swap-id',
     })
     const analyticsProps = (AppAnalytics.track as jest.Mock).mock.calls[0][1]
     expect(analyticsProps.gas).toBeCloseTo(

--- a/src/swap/saga.ts
+++ b/src/swap/saga.ts
@@ -290,6 +290,7 @@ export function* swapSubmitSaga(action: PayloadAction<SwapInfo>) {
         ...getTimeMetrics(),
         ...getSwapTxsReceiptAnalyticsProperties(trackedTxs, networkId, tokensById),
         swapType,
+        swapId,
       })
     }
   } catch (err) {
@@ -315,6 +316,7 @@ export function* swapSubmitSaga(action: PayloadAction<SwapInfo>) {
       ...getTimeMetrics(),
       ...getSwapTxsReceiptAnalyticsProperties(trackedTxs, networkId, tokensById),
       error: error.message,
+      swapId,
     })
   }
 }


### PR DESCRIPTION
### Description

It is expected that each submitted same-chain swap should result either in success or an error. 

From an analytics perspective, the number of `swap_review_submit` events must equal the sum of `swap_execute_success` and `swap_execute_error` events.

Unfortunately, currently we have more `swap_reveiw_submit` events than the sum of success and error ones. It suggests that either we send duplicated submit events, or miss some success or error events.

This PR adds a `swapId` property shared between sequential swap events to ensure we can trace them in analytics.

Context: https://valora-app.slack.com/archives/C029Z1QMD7B/p1733859318155609

### Test plan

Updated unit tests

### Related issues

- Related to RET-1276

### Backwards compatibility

Y

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
