### PR TITLE
chore(swap): track swap cancel

### DIFF
--- a/src/analytics/Events.tsx
+++ b/src/analytics/Events.tsx
@@ -529,6 +529,7 @@ export enum SwapEvents {
   swap_review_submit = 'swap_review_submit',
   swap_execute_success = 'swap_execute_success',
   swap_execute_error = 'swap_execute_error',
+  swap_cancel = 'swap_cancel',
   swap_learn_more = 'swap_learn_more',
   swap_price_impact_warning_displayed = 'swap_price_impact_warning_displayed',
   swap_show_info = 'swap_show_info',

--- a/src/analytics/Properties.tsx
+++ b/src/analytics/Properties.tsx
@@ -1271,6 +1271,19 @@ interface SwapEventsProperties {
       estimatedAppFeeUsdValue: number | undefined
       areSwapTokensShuffled: boolean
     }
+  [SwapEvents.swap_cancel]: SwapQuoteEvent &
+    SwapTimeMetrics &
+    Web3LibraryProps &
+    Partial<SwapTxsProperties> &
+    SwapTxsReceiptProperties & {
+      fromTokenBalance: string
+      swapExecuteTxId: string
+      swapApproveTxId: string
+      estimatedSellTokenUsdValue?: number
+      estimatedBuyTokenUsdValue?: number
+      estimatedAppFeeUsdValue: number | undefined
+      areSwapTokensShuffled: boolean
+    }
   [SwapEvents.swap_learn_more]: undefined
   [SwapEvents.swap_price_impact_warning_displayed]: SwapEvent & {
     provider: string

--- a/src/analytics/docs.ts
+++ b/src/analytics/docs.ts
@@ -529,6 +529,7 @@ export const eventDocs: Record<AnalyticsEventType, string> = {
   [SwapEvents.swap_gas_fees_learn_more]: `When a user taps on the learn more text on the max swap amount warning`,
   [SwapEvents.swap_execute_success]: `When the swap is executed successfully`,
   [SwapEvents.swap_execute_error]: `When the swap returns an error`,
+  [SwapEvents.swap_cancel]: `When the swap is cancelled by the user on the pincode screen`,
   [SwapEvents.swap_learn_more]: `When a user taps on the learn more button on the swap screen`,
   [SwapEvents.swap_price_impact_warning_displayed]: `When the price impact warning is displayed`,
   [SwapEvents.swap_show_info]: `When a user taps an info icon to show more information on the swap screen`,

--- a/src/swap/saga.test.ts
+++ b/src/swap/saga.test.ts
@@ -817,7 +817,7 @@ describe(swapSubmitSaga, () => {
       .not.put(swapError('test-swap-id'))
       .run()
     expect(navigate).not.toHaveBeenCalled()
-    expect(AppAnalytics.track).not.toHaveBeenCalled()
+    expect(AppAnalytics.track).toHaveBeenLastCalledWith(SwapEvents.swap_cancel, expect.anything())
   })
 
   it('should track swap result for a user in the swap tokens order holdout group', async () => {

--- a/src/swap/saga.ts
+++ b/src/swap/saga.ts
@@ -294,12 +294,21 @@ export function* swapSubmitSaga(action: PayloadAction<SwapInfo>) {
       })
     }
   } catch (err) {
+    const error = ensureError(err)
+
     if (err === CANCELLED_PIN_INPUT) {
       Logger.info(TAG, 'Swap cancelled by user')
       yield* put(swapCancel(swapId))
+
+      AppAnalytics.track(SwapEvents.swap_cancel, {
+        ...defaultSwapExecuteProps,
+        ...getTimeMetrics(),
+        ...getSwapTxsReceiptAnalyticsProperties(trackedTxs, networkId, tokensById),
+        swapId,
+      })
+
       return
     }
-    const error = ensureError(err)
     // dispatch the error early, in case the rest of the handling throws
     // and leaves the app in a bad state
     yield* put(swapError(swapId))


### PR DESCRIPTION
### Description

When the swap is cancelled by the user we [aren't tracking anything](https://github.com/valora-inc/wallet/blob/e72427d4ecad0f011fa859067adb3e78c3884d3f/src/swap/saga.ts#L297-L301). This fixes it.

After this fix, we can expect that the number of submitted same-chain swaps should equal to sum of successful, errored,  _and cancelled_ swaps.

A new event `swap_cancel` is introduced instead of reusing `swap_execute_error` to not contribute to the swap error count.

### Test plan

Updated unit test

### Related issues

- Related to RET-1276

### Backwards compatibility

Y

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
