### PR TITLE
feat: support running without a STATSIG_API_KEY

### DIFF
--- a/src/analytics/AppAnalytics.test.ts
+++ b/src/analytics/AppAnalytics.test.ts
@@ -233,7 +233,7 @@ describe('AppAnalytics', () => {
       expect(Statsig.initialize).toHaveBeenCalledWith(
         'statsig-key',
         { userID: 'someUserId' },
-        { environment: { tier: 'development' }, overrideStableID: 'anonId', localMode: false }
+        { environment: { tier: 'development' }, overrideStableID: 'anonId' }
       )
     })
 

--- a/src/analytics/AppAnalytics.test.ts
+++ b/src/analytics/AppAnalytics.test.ts
@@ -2,6 +2,7 @@ import { createClient } from '@segment/analytics-react-native'
 import { PincodeType } from 'src/account/reducer'
 import AppAnalyticsModule from 'src/analytics/AppAnalytics'
 import { OnboardingEvents } from 'src/analytics/Events'
+import * as config from 'src/config'
 import { store } from 'src/redux/store'
 import { getDefaultStatsigUser, getFeatureGate, getMultichainFeatures } from 'src/statsig'
 import { NetworkId } from 'src/transactions/types'
@@ -25,10 +26,6 @@ jest.mock('@segment/analytics-react-native-plugin-clevertap')
 jest.mock('@segment/analytics-react-native-plugin-firebase')
 jest.mock('@sentry/react-native', () => ({ init: jest.fn() }))
 jest.mock('src/redux/store', () => ({ store: { getState: jest.fn() } }))
-jest.mock('src/config', () => ({
-  ...(jest.requireActual('src/config') as any),
-  STATSIG_API_KEY: 'statsig-key',
-}))
 jest.mock('statsig-react-native')
 jest.mock('src/statsig')
 jest.mock('src/web3/networkConfig', () => {
@@ -186,6 +183,7 @@ beforeAll(() => {
 
 describe('AppAnalytics', () => {
   let AppAnalytics: typeof AppAnalyticsModule
+  let mockConfig: jest.MockedObject<typeof config>
   const mockSegmentClient = {
     identify: jest.fn().mockResolvedValue(undefined),
     track: jest.fn().mockResolvedValue(undefined),
@@ -205,7 +203,11 @@ describe('AppAnalytics', () => {
     jest.unmock('src/analytics/AppAnalytics')
     jest.isolateModules(() => {
       AppAnalytics = require('src/analytics/AppAnalytics').default
+      mockConfig = require('src/config')
     })
+
+    mockConfig.STATSIG_API_KEY = 'statsig-key'
+    mockConfig.STATSIG_ENABLED = true
     mockStore.getState.mockImplementation(() => state)
     jest.mocked(getFeatureGate).mockReturnValue(true)
     jest.mocked(getMultichainFeatures).mockReturnValue({
@@ -213,14 +215,33 @@ describe('AppAnalytics', () => {
     })
   })
 
-  it('creates statsig client on initialization with default statsig user', async () => {
-    jest.mocked(getDefaultStatsigUser).mockReturnValue({ userID: 'someUserId' })
-    await AppAnalytics.init()
-    expect(Statsig.initialize).toHaveBeenCalledWith(
-      'statsig-key',
-      { userID: 'someUserId' },
-      { environment: { tier: 'development' }, overrideStableID: 'anonId', localMode: false }
-    )
+  describe('init', () => {
+    it('initializes segment', async () => {
+      await AppAnalytics.init()
+      expect(mockCreateSegmentClient).toHaveBeenCalled()
+    })
+
+    it('does not initialize segment if SEGMENT_API_KEY is not present', async () => {
+      mockConfig.SEGMENT_API_KEY = undefined
+      await AppAnalytics.init()
+      expect(mockCreateSegmentClient).not.toHaveBeenCalled()
+    })
+
+    it('creates statsig client on initialization with default statsig user', async () => {
+      jest.mocked(getDefaultStatsigUser).mockReturnValue({ userID: 'someUserId' })
+      await AppAnalytics.init()
+      expect(Statsig.initialize).toHaveBeenCalledWith(
+        'statsig-key',
+        { userID: 'someUserId' },
+        { environment: { tier: 'development' }, overrideStableID: 'anonId', localMode: false }
+      )
+    })
+
+    it('does not initialize statsig if STATSIG_ENABLED is false', async () => {
+      mockConfig.STATSIG_ENABLED = false
+      await AppAnalytics.init()
+      expect(Statsig.initialize).not.toHaveBeenCalled()
+    })
   })
 
   it('delays identify calls until async init has finished', async () => {

--- a/src/analytics/AppAnalytics.ts
+++ b/src/analytics/AppAnalytics.ts
@@ -149,7 +149,6 @@ class AppAnalytics {
           // StableID should match Segment anonymousId
           overrideStableID,
           environment: STATSIG_ENV,
-          localMode: isE2EEnv,
         })
       } catch (error) {
         Logger.warn(TAG, `Statsig setup error`, error)

--- a/src/analytics/AppAnalytics.ts
+++ b/src/analytics/AppAnalytics.ts
@@ -14,11 +14,11 @@ import { AnalyticsPropertiesList } from 'src/analytics/Properties'
 import { getCurrentUserTraits } from 'src/analytics/selectors'
 import {
   DEFAULT_TESTNET,
-  E2E_TEST_STATSIG_ID,
   FIREBASE_ENABLED,
   isE2EEnv,
   SEGMENT_API_KEY,
   STATSIG_API_KEY,
+  STATSIG_ENABLED,
   STATSIG_ENV,
 } from 'src/config'
 import { store } from 'src/redux/store'
@@ -101,60 +101,61 @@ class AppAnalytics {
 
   async init() {
     let uniqueID
-    try {
-      if (!SEGMENT_API_KEY) {
-        throw Error('API Key not present, likely due to environment. Skipping enabling')
-      }
-      this.segmentClient = createClient({
-        debug: __DEV__,
-        trackAppLifecycleEvents: true,
-        trackDeepLinks: true,
-        writeKey: SEGMENT_API_KEY,
-        storePersistor: AsyncStoragePersistor,
-      })
-
-      this.segmentClient.add({ plugin: new DestinationFiltersPlugin() })
-      this.segmentClient.add({ plugin: new InjectTraits() })
-      this.segmentClient.add({ plugin: new AdjustPlugin() })
-      this.segmentClient.add({ plugin: new ClevertapPlugin() })
-      if (FIREBASE_ENABLED) {
-        this.segmentClient.add({ plugin: new FirebasePlugin() })
-      }
-
+    if (SEGMENT_API_KEY) {
       try {
-        const deviceInfo = await getDeviceInfo()
-        this.deviceInfo = deviceInfo
-        uniqueID = deviceInfo.UniqueID
-        this.sessionId = sha256(Buffer.from(uniqueID + String(Date.now()))).slice(2)
-      } catch (error) {
-        Logger.error(TAG, 'getDeviceInfo error', error)
-      }
+        this.segmentClient = createClient({
+          debug: __DEV__,
+          trackAppLifecycleEvents: true,
+          trackDeepLinks: true,
+          writeKey: SEGMENT_API_KEY,
+          storePersistor: AsyncStoragePersistor,
+        })
 
-      Logger.info(TAG, 'Segment Analytics Integration initialized!')
-    } catch (err) {
-      const error = ensureError(err)
-      Logger.error(TAG, `Segment setup error: ${error.message}\n`, error)
+        this.segmentClient.add({ plugin: new DestinationFiltersPlugin() })
+        this.segmentClient.add({ plugin: new InjectTraits() })
+        this.segmentClient.add({ plugin: new AdjustPlugin() })
+        this.segmentClient.add({ plugin: new ClevertapPlugin() })
+        if (FIREBASE_ENABLED) {
+          this.segmentClient.add({ plugin: new FirebasePlugin() })
+        }
+
+        try {
+          const deviceInfo = await getDeviceInfo()
+          this.deviceInfo = deviceInfo
+          uniqueID = deviceInfo.UniqueID
+          this.sessionId = sha256(Buffer.from(uniqueID + String(Date.now()))).slice(2)
+        } catch (error) {
+          Logger.error(TAG, 'getDeviceInfo error', error)
+        }
+
+        Logger.info(TAG, 'Segment Analytics Integration initialized!')
+      } catch (err) {
+        const error = ensureError(err)
+        Logger.error(TAG, `Segment setup error: ${error.message}\n`, error)
+      }
+    } else {
+      Logger.info(TAG, 'Segment API key not present, skipping setup')
     }
 
-    try {
-      const statsigUser = getDefaultStatsigUser()
-      // getAnonymousId causes the e2e tests to fail
-      let overrideStableID: string = E2E_TEST_STATSIG_ID
-      if (!isE2EEnv) {
+    if (STATSIG_ENABLED) {
+      try {
+        const statsigUser = getDefaultStatsigUser()
         if (!this.segmentClient) {
           throw new Error('segmentClient is undefined, cannot get anonymous ID')
         }
-        overrideStableID = this.segmentClient.userInfo.get().anonymousId
+        const overrideStableID = this.segmentClient.userInfo.get().anonymousId
+        Logger.debug(TAG, 'Statsig stable ID', overrideStableID)
+        await Statsig.initialize(STATSIG_API_KEY, statsigUser, {
+          // StableID should match Segment anonymousId
+          overrideStableID,
+          environment: STATSIG_ENV,
+          localMode: isE2EEnv,
+        })
+      } catch (error) {
+        Logger.warn(TAG, `Statsig setup error`, error)
       }
-      Logger.debug(TAG, 'Statsig stable ID', overrideStableID)
-      await Statsig.initialize(STATSIG_API_KEY, statsigUser, {
-        // StableID should match Segment anonymousId
-        overrideStableID,
-        environment: STATSIG_ENV,
-        localMode: isE2EEnv,
-      })
-    } catch (error) {
-      Logger.warn(TAG, `Statsig setup error`, error)
+    } else {
+      Logger.info(TAG, 'Statsig is not enabled, skipping setup')
     }
   }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -79,7 +79,6 @@ export const FIATCONNECT_NETWORK =
 export const STATSIG_ENV = {
   tier: DEFAULT_TESTNET === 'mainnet' ? 'production' : 'development',
 }
-export const E2E_TEST_STATSIG_ID = 'e2e_test_statsig_id'
 
 // Keyless backup settings
 export const TORUS_NETWORK =
@@ -122,10 +121,8 @@ export const ALCHEMY_BASE_API_KEY = keyOrUndefined(
 )
 
 export const ZENDESK_API_KEY = keyOrUndefined(secretsFile, DEFAULT_TESTNET, 'ZENDESK_API_KEY')
-export const STATSIG_API_KEY =
-  keyOrUndefined(secretsFile, DEFAULT_TESTNET, 'STATSIG_API_KEY') ??
-  // dummy key as fallback for e2e tests, which use local mode
-  'client-key'
+export const STATSIG_API_KEY = keyOrUndefined(secretsFile, DEFAULT_TESTNET, 'STATSIG_API_KEY')
+export const STATSIG_ENABLED = !isE2EEnv && !!STATSIG_API_KEY
 export const SEGMENT_API_KEY = keyOrUndefined(secretsFile, DEFAULT_TESTNET, 'SEGMENT_API_KEY')
 export const SENTRY_CLIENT_URL = keyOrUndefined(secretsFile, DEFAULT_TESTNET, 'SENTRY_CLIENT_URL')
 export const BIDALI_URL = keyOrUndefined(secretsFile, DEFAULT_TESTNET, 'BIDALI_URL')

--- a/src/navigator/SettingsMenu.test.tsx
+++ b/src/navigator/SettingsMenu.test.tsx
@@ -23,6 +23,11 @@ jest.mock('statsig-react-native', () => ({
   },
 }))
 
+jest.mock('src/config', () => ({
+  ...jest.requireActual('src/config'),
+  STATSIG_ENABLED: true,
+}))
+
 describe('SettingsMenu', () => {
   beforeEach(() => {
     jest.clearAllMocks()

--- a/src/navigator/SettingsMenu.tsx
+++ b/src/navigator/SettingsMenu.tsx
@@ -31,6 +31,7 @@ import ContactCircleSelf from 'src/components/ContactCircleSelf'
 import GradientBlock from 'src/components/GradientBlock'
 import { SettingsItemTextValue } from 'src/components/SettingsItem'
 import Touchable from 'src/components/Touchable'
+import { STATSIG_ENABLED } from 'src/config'
 import Envelope from 'src/icons/Envelope'
 import ForwardChevron from 'src/icons/ForwardChevron'
 import Lock from 'src/icons/Lock'
@@ -162,7 +163,7 @@ export default function SettingsMenu({ route }: Props) {
     if (!devModeActive) {
       return null
     } else {
-      const statsigStableId = Statsig.getStableID()
+      const statsigStableId = STATSIG_ENABLED ? Statsig.getStableID() : 'statsig-not-enabled'
       return (
         <View style={styles.devSettings}>
           <Touchable onPress={onCopyText(sessionId)} style={styles.devSettingsItem}>

--- a/src/statsig/index.ts
+++ b/src/statsig/index.ts
@@ -123,8 +123,8 @@ export function getDynamicConfigParams<T extends Record<string, StatsigParameter
 }
 
 export function getFeatureGate(featureGateName: StatsigFeatureGates) {
-  // gates should always default to false, this boolean is to just remain BC
-  // with two gates defaulting to true
+  // gates should always default to false, this boolean is to just remain backwards compatible
+  // with gates defaulting to true
   const defaultGateValue = featureGateName === StatsigFeatureGates.ALLOW_HOOKS_PREVIEW
   try {
     if (featureGateName in gateOverrides) {

--- a/src/statsig/index.ts
+++ b/src/statsig/index.ts
@@ -185,7 +185,7 @@ export async function patchUpdateStatsigUser(statsigUser?: StatsigUser) {
 export function setupOverridesFromLaunchArgs() {
   try {
     Logger.debug(TAG, 'Cleaning up local overrides')
-    let newGateOverrides: typeof gateOverrides = {}
+    const newGateOverrides: typeof gateOverrides = {}
     const { statsigGateOverrides } = LaunchArguments.value<ExpectedLaunchArgs>()
     if (statsigGateOverrides) {
       Logger.debug(TAG, 'Setting up gate overrides', statsigGateOverrides)


### PR DESCRIPTION
### Description

As the title says.

Before this, running the app without a STATSIG_API_KEY was throwing a bunch of errors. And crashing in dev mode in the settings.
See https://github.com/mobilestack-xyz/mobilestack-beefy/pull/2#issuecomment-2573675533

### Test plan

- Tests pass

### Related issues

- Part of RET-1284

### Backwards compatibility

Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
