### PR TITLE
fix: swap amount in fiat is calculated wrong

### DIFF
--- a/src/components/TokenEnterAmount.test.tsx
+++ b/src/components/TokenEnterAmount.test.tsx
@@ -212,7 +212,9 @@ describe('TokenEnterAmount', () => {
         } as TokenBalance,
       })
 
-      await act(async () => result.current.handleToggleAmountType())
+      await act(async () => {
+        result.current.handleToggleAmountType()
+      })
       await act(async () => result.current.handleAmountInputChange('1234.67'))
       await act(async () => result.current.handleAmountInputChange('1234.678'))
 
@@ -255,7 +257,9 @@ describe('TokenEnterAmount', () => {
         } as TokenBalance,
       })
 
-      await act(() => result.current.handleToggleAmountType())
+      await act(() => {
+        result.current.handleToggleAmountType()
+      })
       expect(result.current.amountType).toBe('local')
       // the processedAmounts should be unchanged when toggling amount type with no amount entered
       expect(result.current.processedAmounts).toStrictEqual({

--- a/src/swap/SwapScreenV2.tsx
+++ b/src/swap/SwapScreenV2.tsx
@@ -162,10 +162,10 @@ export default function SwapScreenV2({ route }: Props) {
 
   const {
     amount: amountFrom,
-    amountType,
+    amountType: amountTypeFrom,
     processedAmounts: processedAmountsFrom,
     handleAmountInputChange,
-    handleToggleAmountType,
+    handleToggleAmountType: handleToggleAmountTypeFrom,
     handleSelectPercentageAmount,
   } = useEnterAmount({
     inputRef: inputFromRef,
@@ -177,8 +177,10 @@ export default function SwapScreenV2({ route }: Props) {
 
   const {
     amount: amountTo,
+    amountType: amountTypeTo,
     processedAmounts: processedAmountsTo,
     replaceAmount: replaceAmountTo,
+    handleToggleAmountType: handleToggleAmountTypeTo,
   } = useEnterAmount({ token: toToken, inputRef: inputToRef })
 
   const filterChipsFrom = useFilterChips(Field.FROM)
@@ -650,6 +652,11 @@ export default function SwapScreenV2({ route }: Props) {
     })
   }
 
+  function handleToggleAmountType() {
+    const newAmountType = handleToggleAmountTypeFrom()
+    handleToggleAmountTypeTo(newAmountType)
+  }
+
   function handleSelectAmountPercentage(percentage: number) {
     handleSelectPercentageAmount(percentage)
     setSelectedPercentage(percentage)
@@ -698,7 +705,7 @@ export default function SwapScreenV2({ route }: Props) {
                 tokenAmount={processedAmountsFrom.token.displayAmount}
                 localAmount={processedAmountsFrom.local.displayAmount}
                 onInputChange={handleAmountInputChange}
-                amountType={amountType}
+                amountType={amountTypeFrom}
                 toggleAmountType={handleToggleAmountType}
                 onOpenTokenPicker={() => handleOpenTokenPicker(Field.FROM)}
                 testID="SwapAmountInput"
@@ -723,7 +730,7 @@ export default function SwapScreenV2({ route }: Props) {
                 inputRef={inputToRef}
                 tokenAmount={processedAmountsTo.token.displayAmount}
                 localAmount={processedAmountsTo.local.displayAmount}
-                amountType={amountType}
+                amountType={amountTypeTo}
                 onOpenTokenPicker={() => handleOpenTokenPicker(Field.TO)}
                 loading={shouldShowSkeletons}
                 testID="SwapAmountInput"


### PR DESCRIPTION
### Description
This PR fixes SwapScreenV2 incorrect fiat calculations when entering amount in fiat.

P.S. This part will be covered with tests in the follow-up PR for the sake of not withholding the ability to patch the latest release as it appears to be more time-consuming.

### Test plan
https://github.com/user-attachments/assets/47e0c263-00c4-4ad3-b529-48839e28f70c

### Related issues
Fixes RET-1296

### Backwards compatibility
Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
