### PR TITLE
fix(onboarding): ensure success screen is shown always at the end

### DIFF
--- a/src/keylessBackup/SignInWithEmail.test.tsx
+++ b/src/keylessBackup/SignInWithEmail.test.tsx
@@ -9,9 +9,18 @@ import { KeylessBackupFlow, KeylessBackupOrigin } from 'src/keylessBackup/types'
 import { noHeader } from 'src/navigator/Headers'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
+import { goToNextOnboardingScreen } from 'src/onboarding/steps'
 import Logger from 'src/utils/Logger'
 import MockedNavigator from 'test/MockedNavigator'
 import { createMockStore } from 'test/utils'
+import { mockOnboardingProps } from 'test/values'
+
+const mockOnboardingPropsSelector = jest.fn(() => mockOnboardingProps)
+jest.mock('src/onboarding/steps', () => ({
+  goToNextOnboardingScreen: jest.fn(),
+  getOnboardingStepValues: () => ({ step: 2, totalSteps: 3 }),
+  onboardingPropsSelector: () => mockOnboardingPropsSelector(),
+}))
 
 const mockAuthorize = jest.fn()
 const mockGetCredentials = jest.fn()
@@ -247,7 +256,10 @@ describe('SignInWithEmail', () => {
     expect(getByTestId('KeylessBackupSignInWithEmail/BottomSheet')).toBeTruthy()
 
     fireEvent.press(getByText('signInWithEmail.bottomSheet.skip'))
-    expect(navigate).toHaveBeenCalledWith(Screens.VerificationStartScreen)
+    expect(goToNextOnboardingScreen).toHaveBeenCalledWith({
+      firstScreenInCurrentStep: Screens.SignInWithEmail,
+      onboardingProps: mockOnboardingProps,
+    })
     expect(AppAnalytics.track).toHaveBeenCalledWith(
       KeylessBackupEvents.cab_sign_in_with_email_screen_skip,
       {

--- a/src/navigator/types.tsx
+++ b/src/navigator/types.tsx
@@ -306,7 +306,7 @@ export type StackParamList = {
     registrationStep?: { step: number; totalSteps: number }
     e164Number: string
     countryCallingCode: string
-    verificationCompletionScreen: keyof StackParamList
+    hasOnboarded?: boolean
   }
   [Screens.OnboardingSuccessScreen]: undefined
   [Screens.WalletConnectRequest]:

--- a/src/onboarding/success/OnboardingSuccessScreen.tsx
+++ b/src/onboarding/success/OnboardingSuccessScreen.tsx
@@ -4,24 +4,15 @@ import { Image, StyleSheet, Text, View } from 'react-native'
 import { background } from 'src/images/Images'
 import Logo from 'src/images/Logo'
 import { nuxNavigationOptionsNoBackButton } from 'src/navigator/Headers'
+import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
-import { goToNextOnboardingScreen, onboardingPropsSelector } from 'src/onboarding/steps'
-import { useSelector } from 'src/redux/hooks'
 import colors from 'src/styles/colors'
 import { typeScale } from 'src/styles/fonts'
 import { Spacing } from 'src/styles/styles'
 
 function OnboardingSuccessScreen() {
-  const onboardingProps = useSelector(onboardingPropsSelector)
   useEffect(() => {
-    const timeout = setTimeout(
-      () =>
-        goToNextOnboardingScreen({
-          firstScreenInCurrentStep: Screens.VerificationStartScreen,
-          onboardingProps,
-        }),
-      3000
-    )
+    const timeout = setTimeout(() => navigate(Screens.ChooseYourAdventure), 3000)
 
     return () => clearTimeout(timeout)
   }, [])

--- a/src/verify/VerificationStartScreen.test.tsx
+++ b/src/verify/VerificationStartScreen.test.tsx
@@ -166,7 +166,7 @@ describe('VerificationStartScreen', () => {
       countryCallingCode: '+31',
       e164Number: '+31619123456',
       registrationStep: { step: 3, totalSteps: 3 },
-      verificationCompletionScreen: 'OnboardingSuccessScreen',
+      hasOnboarded: false,
     })
   })
 
@@ -189,7 +189,7 @@ describe('VerificationStartScreen', () => {
       countryCallingCode: '+31',
       e164Number: '+31619123456',
       registrationStep: undefined,
-      verificationCompletionScreen: 'OnboardingSuccessScreen',
+      hasOnboarded: false,
     })
   })
 
@@ -212,7 +212,7 @@ describe('VerificationStartScreen', () => {
       countryCallingCode: '+31',
       e164Number: '+31619123456',
       registrationStep: undefined,
-      verificationCompletionScreen: 'TabHome',
+      hasOnboarded: true,
     })
   })
 })

--- a/src/verify/VerificationStartScreen.tsx
+++ b/src/verify/VerificationStartScreen.tsx
@@ -82,20 +82,11 @@ function VerificationStartScreen({
       countryCallingCode: country?.countryCallingCode || '',
     })
 
-    const routes = navigation.getState().routes
-    const prevRoute = routes[routes.length - 2] // -2 because -1 is the current route
-    // Usually it makes sense to navigate the user back to where they launched
-    // the verification flow after they complete it, but during onboarding we
-    // want to navigate to the next step.
-    const verificationCompletionScreen = !route.params?.hasOnboarded
-      ? Screens.OnboardingSuccessScreen
-      : (prevRoute?.name ?? Screens.TabHome)
-
     navigate(Screens.VerificationCodeInputScreen, {
       registrationStep: showSteps ? { step, totalSteps } : undefined,
       e164Number: phoneNumberInfo.e164Number,
       countryCallingCode: country?.countryCallingCode || '',
-      verificationCompletionScreen,
+      hasOnboarded: route.params?.hasOnboarded,
     })
   }
 


### PR DESCRIPTION
### Description

Instead of CYA being the last screen, make the success screen the last screen and have it navigate to CYA

Also, consolidate the next functions to make it more DRY and fixes a couple of bugs:
- if protect wallet is disabled, phone verification is never shown even if `skipVerification` is false.
- CAB sign in with email screen skips LinkPhoneNumber screen

Also, update CPV screen to use goToNextOnboardingScreen instead of directly going to the success screen. And fix a bug where the stack is broken after finishing phone verification from a non onboarding flow

### Test plan

Go through onboarding steps and break at different points and ensure success screen is shown.

Link phone number from settings, and ensure back doesn't go back to the phone verification code input screen

| Scenario | Before | After |
|--------|--------|--------|
| Onboarding early skip | [Video](https://drive.google.com/file/d/1YqToJJiZpUseFKA3khCJUcHJVX-zzLJX/view?usp=drive_link) | [Video](https://drive.google.com/file/d/1dZeqi1iEp2XGKQ46tXwlDkbTstVkT46o/view?usp=drive_link) |
| Phone verification | [Video](https://drive.google.com/file/d/1t1yQCHYpDfwUNWsu8sb53MOS_VEy6hYC/view?usp=drive_link) | [Video](https://drive.google.com/file/d/16f0KtpHc6oOOD1m_yWJOSHk19vfE-27V/view?usp=drive_link) | 


### Related issues

- Related to ACT-1523

### Backwards compatibility

Yes

### Network scalability

N/A
