### PR TITLE
test(e2e): bypass network select modal when served on reload

### DIFF
--- a/e2e/src/usecases/OnRamps.js
+++ b/e2e/src/usecases/OnRamps.js
@@ -1,3 +1,4 @@
+import { sleep } from '../../../src/utils/sleep'
 import { launchApp } from '../utils/retries'
 import { isElementVisible, waitForElementById, waitForElementByText } from '../utils/utils'
 
@@ -17,6 +18,7 @@ export default onRamps = () => {
   beforeEach(async () => {
     await waitForElementById('HomeAction-Add')
     await element(by.id('HomeAction-Add')).tap()
+    await sleep(5000)
   })
 
   afterEach(async () => {

--- a/e2e/src/usecases/OnRamps.js
+++ b/e2e/src/usecases/OnRamps.js
@@ -20,10 +20,7 @@ export default onRamps = () => {
   })
 
   afterEach(async () => {
-    try {
-      // Avoid reloading the app which can cause issues with the bottom sheet display
-      await multiTap('BackChevron')
-    } catch {}
+    await multiTap('BackChevron')
   })
 
   it.each`

--- a/e2e/src/usecases/OnRamps.js
+++ b/e2e/src/usecases/OnRamps.js
@@ -40,7 +40,7 @@ export default onRamps = () => {
     await multiTap(`${token}Symbol`)
     await waitForElementById('FiatExchangeInput')
     await element(by.id('FiatExchangeInput')).replaceText(`${amount}`)
-    await element(by.id('FiatExchangeNextButton')).tap()
+    await waitForElementById('FiatExchangeNextButton', { tap: true })
     await waitForElementByText({ text: 'Select Payment Method' })
     // Check IF Single Card Provider
     if (await isElementVisible('Card/singleProvider')) {

--- a/e2e/src/usecases/OnRamps.js
+++ b/e2e/src/usecases/OnRamps.js
@@ -1,10 +1,12 @@
 import { launchApp } from '../utils/retries'
 import { isElementVisible, waitForElementById, waitForElementByText } from '../utils/utils'
 
-goBackNScreens = async (numOfScreens = 2) => {
-  for (let i = 0; i < numOfScreens; i++) {
-    await waitForElementById('BackChevron', { tap: true })
-  }
+async function multiTap(testID, { numberOfTaps = 2 } = {}) {
+  try {
+    for (let i = 0; i < numberOfTaps; i++) {
+      await waitForElementById(testID, { tap: true })
+    }
+  } catch {}
 }
 
 export default onRamps = () => {
@@ -20,7 +22,7 @@ export default onRamps = () => {
   afterEach(async () => {
     try {
       // Avoid reloading the app which can cause issues with the bottom sheet display
-      await goBackNScreens()
+      await multiTap('BackChevron')
     } catch {}
   })
 
@@ -33,9 +35,9 @@ export default onRamps = () => {
     ${'CELO'} | ${'20'}
     ${'CELO'} | ${'2'}
   `('Should display $token provider(s) for $$amount', async ({ token, amount }) => {
-    await waitForElementById(`${token}Symbol`)
-    await element(by.id(`${token}Symbol`)).tap()
-
+    // We use multiTap as sometimes the network select renders above the bottom sheet
+    // This appears to be a detox specific issue as it is not reproducible in a non detox build
+    await multiTap(`${token}Symbol`)
     await waitForElementById('FiatExchangeInput')
     await element(by.id('FiatExchangeInput')).replaceText(`${amount}`)
     await element(by.id('FiatExchangeNextButton')).tap()

--- a/e2e/src/usecases/OnRamps.js
+++ b/e2e/src/usecases/OnRamps.js
@@ -11,7 +11,6 @@ export default onRamps = () => {
     await reloadReactNative()
     await waitForElementById('HomeAction-Add')
     await element(by.id('HomeAction-Add')).tap()
-    await sleep(5000)
   })
 
   it.each`
@@ -24,6 +23,7 @@ export default onRamps = () => {
     ${'CELO'} | ${'2'}
   `('Should display $token provider(s) for $$amount', async ({ token, amount }) => {
     await waitForElementById(`${token}Symbol`)
+    await sleep(5000) // Wait for the bottom sheet to animate
     await element(by.id(`${token}Symbol`)).tap()
 
     await waitForElementById('FiatExchangeInput')


### PR DESCRIPTION
### Description

Follow-up PR to prevent the test flake bypassing an issue seen in Detox e2e test builds on Android: the network select modal sometimes renders above the bottom sheet before selection.

Example video on Detox build

https://github.com/user-attachments/assets/343acd4a-986d-42e4-904f-6656acce8c62

### Test plan

Tested in CI.

### Related issues

https://github.com/valora-inc/wallet/pull/6407

### Backwards compatibility

Yes

### Network scalability

N/A
