### PR TITLE
refactor(colors): replace gray2 with semantic counterparts

### DIFF
--- a/src/account/SupportContact.tsx
+++ b/src/account/SupportContact.tsx
@@ -218,6 +218,7 @@ const styles = StyleSheet.create({
     height: 40,
     alignItems: 'center',
     marginTop: 4,
+    gap: 12,
   },
   logsSwitch: {
     marginBottom: 3,

--- a/src/backup/BackupQuiz.tsx
+++ b/src/backup/BackupQuiz.tsx
@@ -374,7 +374,7 @@ const styles = StyleSheet.create({
     borderRadius: 100,
   },
   chosenWordWrapperFilled: {
-    backgroundColor: colors.gray2,
+    backgroundColor: colors.backgroundTertiary,
   },
   chosenWord: {
     ...typeScale.bodySmall,

--- a/src/components/BottomSheetBase.tsx
+++ b/src/components/BottomSheetBase.tsx
@@ -26,7 +26,7 @@ const BottomSheetBase = ({
   snapPoints,
   handleComponent,
   backgroundStyle,
-  handleIndicatorStyle = styles.handle,
+  handleIndicatorStyle,
 }: BottomSheetBaseProps) => {
   const reduceMotionEnabled = useReducedMotion()
 
@@ -64,7 +64,7 @@ const BottomSheetBase = ({
       enablePanDownToClose
       backdropComponent={renderBackdrop}
       handleComponent={handleComponent}
-      handleIndicatorStyle={handleIndicatorStyle}
+      handleIndicatorStyle={[styles.handle, handleIndicatorStyle]}
       backgroundStyle={backgroundStyle}
       onAnimate={handleAnimate}
       onDismiss={onClose}
@@ -81,7 +81,7 @@ const BottomSheetBase = ({
 
 const styles = StyleSheet.create({
   handle: {
-    backgroundColor: Colors.border,
+    backgroundColor: Colors.bottomSheetHandleBar,
     width: 40,
   },
 })

--- a/src/components/BottomSheetBase.tsx
+++ b/src/components/BottomSheetBase.tsx
@@ -81,7 +81,7 @@ const BottomSheetBase = ({
 
 const styles = StyleSheet.create({
   handle: {
-    backgroundColor: Colors.bottomSheetHandleBar,
+    backgroundColor: Colors.bottomSheetHandle,
     width: 40,
   },
 })

--- a/src/components/SelectRecipientButton.tsx
+++ b/src/components/SelectRecipientButton.tsx
@@ -80,7 +80,7 @@ const styles = StyleSheet.create({
     position: 'absolute',
     left: 26,
     top: 26,
-    backgroundColor: colors.gray2,
+    backgroundColor: colors.backgroundTertiary,
     borderRadius: 100,
     padding: 2,
   },

--- a/src/components/Switch.tsx
+++ b/src/components/Switch.tsx
@@ -6,7 +6,7 @@ export default function Switch(props: SwitchProps) {
   return (
     <RNSwitch
       trackColor={SWITCH_TRACK}
-      thumbColor={colors.gray2}
+      thumbColor={colors.backgroundTertiary}
       ios_backgroundColor={colors.inactive}
       {...props}
     />

--- a/src/components/TokenIcon.tsx
+++ b/src/components/TokenIcon.tsx
@@ -138,7 +138,7 @@ const styles = StyleSheet.create({
   tokenCircle: {
     justifyContent: 'center',
     alignItems: 'center',
-    backgroundColor: colors.gray2,
+    backgroundColor: colors.backgroundTertiary,
   },
   tokenText: {
     textAlign: 'center',

--- a/src/earn/poolInfoScreen/SafetyCard.test.tsx
+++ b/src/earn/poolInfoScreen/SafetyCard.test.tsx
@@ -40,8 +40,8 @@ describe('SafetyCard', () => {
   })
 
   it.each([
-    { level: 'low', colors: [Colors.accent, Colors.gray2, Colors.gray2] },
-    { level: 'medium', colors: [Colors.accent, Colors.accent, Colors.gray2] },
+    { level: 'low', colors: [Colors.accent, Colors.disabled, Colors.disabled] },
+    { level: 'medium', colors: [Colors.accent, Colors.accent, Colors.disabled] },
     { level: 'high', colors: [Colors.accent, Colors.accent, Colors.accent] },
   ] as const)('should render correct triple bars for safety level $level', ({ level, colors }) => {
     const { getAllByTestId } = render(<SafetyCard {...mockProps} safety={{ level, risks: [] }} />)

--- a/src/earn/poolInfoScreen/SafetyCard.tsx
+++ b/src/earn/poolInfoScreen/SafetyCard.tsx
@@ -116,7 +116,7 @@ const styles = StyleSheet.create({
   },
   bar: {
     width: 4,
-    backgroundColor: Colors.gray2,
+    backgroundColor: Colors.disabled,
   },
   barHighlighted: {
     backgroundColor: Colors.accent,

--- a/src/home/celebration/NftCelebration.tsx
+++ b/src/home/celebration/NftCelebration.tsx
@@ -189,7 +189,7 @@ const styles = StyleSheet.create({
     width: 40,
     height: 4,
     borderRadius: 4,
-    backgroundColor: Colors.bottomSheetHandleBar,
+    backgroundColor: Colors.bottomSheetHandle,
   },
   title: {
     ...typeScale.titleSmall,

--- a/src/home/celebration/NftCelebration.tsx
+++ b/src/home/celebration/NftCelebration.tsx
@@ -189,7 +189,7 @@ const styles = StyleSheet.create({
     width: 40,
     height: 4,
     borderRadius: 4,
-    backgroundColor: Colors.gray2,
+    backgroundColor: Colors.bottomSheetHandleBar,
   },
   title: {
     ...typeScale.titleSmall,

--- a/src/keylessBackup/KeylessBackupPhoneInput.tsx
+++ b/src/keylessBackup/KeylessBackupPhoneInput.tsx
@@ -195,7 +195,7 @@ const styles = StyleSheet.create({
     padding: Spacing.Thick24,
   },
   countryFlagStyle: {
-    backgroundColor: Colors.gray2,
+    backgroundColor: Colors.backgroundTertiary,
     marginRight: Spacing.Smallest8,
   },
 })

--- a/src/nfts/NftsInfoCarousel.tsx
+++ b/src/nfts/NftsInfoCarousel.tsx
@@ -271,7 +271,7 @@ const styles = StyleSheet.create({
   errorThumbnail: {
     alignItems: 'center',
     justifyContent: 'center',
-    backgroundColor: colors.gray2,
+    backgroundColor: colors.backgroundTertiary,
   },
   errorImageText: {
     marginTop: Spacing.Regular16,

--- a/src/send/EnterAmountOptions.tsx
+++ b/src/send/EnterAmountOptions.tsx
@@ -136,7 +136,7 @@ export default function EnterAmountOptions({
 
 const styles = StyleSheet.create({
   container: {
-    backgroundColor: Colors.gray2,
+    backgroundColor: Colors.backgroundTertiary,
   },
   contentContainer: {
     flexDirection: 'row',

--- a/src/styles/colors.tsx
+++ b/src/styles/colors.tsx
@@ -31,7 +31,7 @@ enum Colors {
   buttonSecondary = '#F8F9F9',
   accent = '#1AB775',
   textLink = '#757575', // similar to secondary text but for interactive links
-  bottomSheetHandleBar = '#E6E6E6',
+  bottomSheetHandle = '#E6E6E6',
 
   // states
   disabled = '#E6E6E6',

--- a/src/styles/colors.tsx
+++ b/src/styles/colors.tsx
@@ -5,6 +5,7 @@ enum Colors {
   background = '#FFFFFF', // primary background
   backgroundInverse = '#2E3338', // inverse background (e.g. high contrast to primary)
   backgroundSecondary = '#F8F9F9', // secondary background (e.g. cards, input fields)
+  backgroundTertiary = '#E6E6E6', // tertiary background (e.g. used on top of secondary background)
 
   // text
   textPrimary = '#2E3338', // text on primary background
@@ -30,6 +31,7 @@ enum Colors {
   buttonSecondary = '#F8F9F9',
   accent = '#1AB775',
   textLink = '#757575', // similar to secondary text but for interactive links
+  bottomSheetHandleBar = '#E6E6E6',
 
   // states
   disabled = '#E6E6E6',
@@ -45,9 +47,6 @@ enum Colors {
   // brand
   gradientBorderLeft = '#26d98a',
   gradientBorderRight = '#ffd52c',
-
-  /** @deprecated */
-  gray2 = '#E6E6E6',
 }
 
 export default Colors

--- a/src/styles/progressDots.ts
+++ b/src/styles/progressDots.ts
@@ -14,7 +14,7 @@ const circle = {
 export default StyleSheet.create({
   circlePassive: {
     ...circle,
-    backgroundColor: colors.gray2,
+    backgroundColor: colors.disabled,
   },
   circleActive: {
     ...circle,

--- a/src/tokens/AssetList.tsx
+++ b/src/tokens/AssetList.tsx
@@ -354,7 +354,7 @@ const styles = StyleSheet.create({
     flex: 1,
     alignItems: 'center',
     justifyContent: 'center',
-    backgroundColor: Colors.gray2,
+    backgroundColor: Colors.backgroundTertiary,
     borderRadius: Spacing.Regular16,
   },
   nftsNoMetadataText: {

--- a/src/transactions/UserSection.tsx
+++ b/src/transactions/UserSection.tsx
@@ -122,7 +122,7 @@ const styles = StyleSheet.create({
   },
   accountBox: {
     borderRadius: 4,
-    backgroundColor: colors.gray2,
+    backgroundColor: colors.backgroundTertiary,
     flexDirection: 'column',
     padding: 16,
   },

--- a/src/transactions/feed/NftFeedItem.tsx
+++ b/src/transactions/feed/NftFeedItem.tsx
@@ -81,7 +81,7 @@ const styles = StyleSheet.create({
     width: 40,
     height: 40,
     borderRadius: 20,
-    backgroundColor: colors.gray2,
+    backgroundColor: colors.backgroundTertiary,
     alignItems: 'center',
     justifyContent: 'center',
   },

--- a/src/walletConnect/screens/SessionRequest.tsx
+++ b/src/walletConnect/screens/SessionRequest.tsx
@@ -204,7 +204,7 @@ const styles = StyleSheet.create({
   },
   networkChip: {
     ...typeScale.labelXSmall,
-    backgroundColor: Colors.gray2,
+    backgroundColor: Colors.backgroundTertiary,
     paddingVertical: Spacing.Tiny4,
     paddingHorizontal: Spacing.Smallest8,
     borderRadius: 8,

--- a/src/webview/WebViewAndroidBottomSheet.tsx
+++ b/src/webview/WebViewAndroidBottomSheet.tsx
@@ -44,12 +44,15 @@ export function WebViewAndroidBottomSheet({
         <Pressable
           style={styles.pressable}
           onPress={openExternalLink}
-          android_ripple={{ color: Colors.gray2, borderless: false }}
+          android_ripple={{ color: Colors.lightShadow, borderless: false }}
           testID="OpenInExternalBrowser"
         >
           <Text style={styles.bottomSheetText}>{t('webView.openExternal')}</Text>
         </Pressable>
-        <Pressable onPress={onClose} android_ripple={{ color: Colors.gray2, borderless: false }}>
+        <Pressable
+          onPress={onClose}
+          android_ripple={{ color: Colors.lightShadow, borderless: false }}
+        >
           <Text style={styles.bottomSheetText}>{t('dismiss')}</Text>
         </Pressable>
       </View>


### PR DESCRIPTION
### Description

Pretty straightforward, replace gray2 with:
- `backgroundTertiary` when used for backgrounds
- `disabled` for the safety indicators (i intend to rename this in the next PR)
- `bottomSheetHandle` for the bottom sheet

### Test plan

n/a

### Related issues

- Related to RET-1293

### Backwards compatibility

Y

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [ ] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
