### PR TITLE
fix(colors): avoid hard coded colors in GradientIcon

### DIFF
--- a/src/icons/GradientIcon.tsx
+++ b/src/icons/GradientIcon.tsx
@@ -64,9 +64,7 @@ const styles = StyleSheet.create({
     height: '100%',
   },
   mask: {
-    // White is intentionally hardcoded as it effectively softens the gradient
-    // without altering its color balance, ensuring the design remains consistent.
-    backgroundColor: 'white',
+    backgroundColor: Colors.background,
     opacity: 0.9,
   },
 })

--- a/src/icons/GradientIcon.tsx
+++ b/src/icons/GradientIcon.tsx
@@ -10,6 +10,15 @@ interface Props {
 }
 
 export default function GradientIcon({ radius = 50, borderWidth = 1, children }: Props) {
+  const gradientBackgroundStyles = [
+    styles.background,
+    {
+      borderRadius: radius,
+      height: radius - borderWidth * 2,
+      width: radius - borderWidth * 2,
+    },
+  ]
+
   return (
     <View
       style={[
@@ -31,19 +40,14 @@ export default function GradientIcon({ radius = 50, borderWidth = 1, children }:
         />
       )}
       <LinearGradient
-        colors={['#e8fbf2', '#fffaea']}
+        colors={[Colors.gradientBorderLeft, Colors.gradientBorderRight]}
         locations={[0.1085, 1]}
         useAngle={true}
         angle={90}
-        style={[
-          styles.background,
-          {
-            borderRadius: radius,
-            height: radius - borderWidth * 2,
-            width: radius - borderWidth * 2,
-          },
-        ]}
+        style={gradientBackgroundStyles}
       />
+      {/* Apply a semi-transparent white overlay to tone down the brand gradient. react-native-linear-gradient doesn't support semi-transparent gradients with different colors. */}
+      <View style={[gradientBackgroundStyles, styles.mask]} />
       {children}
     </View>
   )
@@ -58,5 +62,11 @@ const styles = StyleSheet.create({
     position: 'absolute',
     width: '100%',
     height: '100%',
+  },
+  mask: {
+    // White is intentionally hardcoded as it effectively softens the gradient
+    // without altering its color balance, ensuring the design remains consistent.
+    backgroundColor: 'white',
+    opacity: 0.9,
   },
 })


### PR DESCRIPTION
### Description

As the title - to avoid hard coded "muted" colors here, I am using a semi transparent mask.

### Test plan

no visual changes

### Related issues

- Related to RET-1293

### Backwards compatibility

Y

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [ ] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
