### PR TITLE
fix(enter amount): ensure that local amount can be updated always

### DIFF
--- a/src/components/TokenEnterAmount.test.tsx
+++ b/src/components/TokenEnterAmount.test.tsx
@@ -24,9 +24,9 @@ jest.mock('src/analytics/AppAnalytics')
 const mockStore = {
   localCurrency: {
     isLoading: false,
-    preferredCurrencyCode: LocalCurrencyCode['USD'],
-    fetchedCurrencyCode: LocalCurrencyCode['USD'],
-    usdToLocalRate: '1',
+    preferredCurrencyCode: LocalCurrencyCode['BOB'],
+    fetchedCurrencyCode: LocalCurrencyCode['BOB'],
+    usdToLocalRate: '0.5',
   } satisfies RootState['localCurrency'],
 }
 
@@ -194,8 +194,8 @@ describe('TokenEnterAmount', () => {
           displayAmount: '1,234.678 USDC',
         },
         local: {
-          bignum: new BigNumber('1235.912678'),
-          displayAmount: '$1,235.91',
+          bignum: new BigNumber('617.956339'),
+          displayAmount: 'Bs617.96',
         },
       })
     })
@@ -215,18 +215,18 @@ describe('TokenEnterAmount', () => {
       await act(async () => {
         result.current.handleToggleAmountType()
       })
-      await act(async () => result.current.handleAmountInputChange('1234.67'))
-      await act(async () => result.current.handleAmountInputChange('1234.678'))
+      await act(async () => result.current.handleAmountInputChange('Bs1234.67'))
+      await act(async () => result.current.handleAmountInputChange('Bs1234.678'))
 
       expect(result.current.amount).toBe('1234.67')
       expect(result.current.processedAmounts).toStrictEqual({
         local: {
           bignum: new BigNumber('1234.67'),
-          displayAmount: '$1,234.67',
+          displayAmount: 'Bs1,234.67',
         },
         token: {
-          bignum: new BigNumber('1233.436563'),
-          displayAmount: '1,233.436563 USDC',
+          bignum: new BigNumber('2466.873127'),
+          displayAmount: '2,466.873127 USDC',
         },
       })
     })
@@ -326,7 +326,7 @@ describe('TokenEnterAmount', () => {
         </Provider>
       )
 
-      expect(input.props.value).toBe('$0.1')
+      expect(input.props.value).toBe('Bs0.1')
       expect(converted.props.children).toBe(`${APPROX_SYMBOL} 1 CELO`)
     })
 

--- a/src/components/TokenEnterAmount.tsx
+++ b/src/components/TokenEnterAmount.tsx
@@ -228,7 +228,7 @@ export function useEnterAmount(props: {
   }
 
   function handleAmountInputChange(val: string) {
-    let value = val.startsWith(localCurrencySymbol) ? val.slice(1) : val
+    let value = val.startsWith(localCurrencySymbol) ? val.slice(localCurrencySymbol.length) : val
     value = unformatNumberForProcessing(value)
     value = value.startsWith('.') ? `0${value}` : value
 


### PR DESCRIPTION
### Description

This PR fixes a bug that prevented local amount from being changed when the local currency symbol has more than 1 character. There are [quite a number of currencies](https://github.com/valora-inc/wallet/blob/753750ba710f12c9d9f2aa005c3d5a4a1e3a0704/src/localCurrency/consts.ts#L50-L95) that fit into this category.


### Test plan

Before:


https://github.com/user-attachments/assets/3aef688d-c5a5-4a87-b8d9-07072c387efd


After:

https://github.com/user-attachments/assets/de3a8e06-b3e5-41a2-a55d-8853955545de

### Related issues

n/a

### Backwards compatibility

Y

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [ ] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
