### PR TITLE
fix: number is formatted wrong when a dot is a grouping separator

### DIFF
--- a/src/components/TokenEnterAmount.test.tsx
+++ b/src/components/TokenEnterAmount.test.tsx
@@ -70,6 +70,7 @@ describe('TokenEnterAmount', () => {
     expect(unformatNumberForProcessing('')).toBe('')
     expect(unformatNumberForProcessing('0.25')).toBe('0.25')
     expect(unformatNumberForProcessing('1,234.34567')).toBe('1234.34567')
+    expect(unformatNumberForProcessing('1234.34567')).toBe('1234.34567')
 
     expect(roundFiatValue(null)).toBe('')
     expect(roundFiatValue(new BigNumber('0.01'))).toBe('0.01')
@@ -119,6 +120,7 @@ describe('TokenEnterAmount', () => {
     expect(unformatNumberForProcessing('')).toBe('')
     expect(unformatNumberForProcessing('0,25')).toBe('0.25')
     expect(unformatNumberForProcessing('1.234,34567')).toBe('1234.34567')
+    expect(unformatNumberForProcessing('1234.34567')).toBe('1234.34567')
 
     expect(roundFiatValue(null)).toBe('')
     expect(roundFiatValue(new BigNumber('0.01'))).toBe('0.01')

--- a/src/components/TokenEnterAmount.tsx
+++ b/src/components/TokenEnterAmount.tsx
@@ -53,6 +53,19 @@ export function formatNumber(value: string) {
 
 export function unformatNumberForProcessing(value: string) {
   const { decimalSeparator, groupingSeparator } = getNumberFormatSettings()
+
+  /**
+   * If the number passed is a regular number which is formatted in the standard JS number format
+   * (e.g. "123456.789") then just keep it as is. This will ensure this function will properly
+   * unformat different numbers, including those that come from external sources (e.g from API
+   * response)
+   *
+   * Number.isNaN considers unfinished decimal number e.g. "1." a valid number. If the number ends with grouping separator instead of decimal separator - it can be simply erased by casting it to a number.
+   */
+  if (!Number.isNaN(+value)) {
+    return value.endsWith(groupingSeparator) ? `${+value}` : value
+  }
+
   return value.replaceAll(groupingSeparator, '').replaceAll(decimalSeparator, '.')
 }
 


### PR DESCRIPTION
### Description
When phone number format settings are set to "1.234.567,89" – the number formatting is all over the place. The issue was an `unformatNumberForProcessing` function which was only expecting numbers that were formatted according to the phone's number format settings while SwapScreenV2 was using numbers sent by a prepare transaction quote which are formatted as a regular JS number ("1234567.89"). 

This PR fixes this issue.

### Test plan
<img src="https://github.com/user-attachments/assets/e7eab81f-0df0-41d9-95f4-64f7f2076f0d" width="300" />


### Related issues
N/A

### Backwards compatibility
Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
