### PR TITLE
feat(ReviewTransaction): add initial structure for ReviewTransaction component

### DIFF
--- a/knip.ts
+++ b/knip.ts
@@ -38,6 +38,7 @@ const config: KnipConfig = {
     'src/account/__mocks__/Persona.tsx', // unit test mocks
     'src/firebase/remoteConfigValuesDefaults.e2e.ts', // e2e test setup
     'src/setupE2eEnv.e2e.ts', // e2e test setup
+    'src/components/ReviewTransaction.tsx', // will be removed once used in SendConfirmation
   ],
 }
 

--- a/src/components/ReviewTransaction.test.tsx
+++ b/src/components/ReviewTransaction.test.tsx
@@ -1,0 +1,84 @@
+import { render } from '@testing-library/react-native'
+import React from 'react'
+import { typeScale } from 'src/styles/fonts'
+import {
+  ReviewContent,
+  ReviewDetailsItem,
+  ReviewSummaryItem,
+  ReviewTransaction,
+} from './ReviewTransaction'
+
+jest.mock('src/utils/Logger')
+
+describe('ReviewTransaction', () => {
+  it('uses the custom headerAction if provided', async () => {
+    const tree = render(
+      <ReviewTransaction
+        title="Custom HeaderAction"
+        headerAction={<>Custom Left Action</>}
+        testID="Review"
+      >
+        <ReviewContent>
+          <></>
+        </ReviewContent>
+      </ReviewTransaction>
+    )
+
+    expect(tree.getByTestId('Review')).toHaveTextContent('Custom Left Action')
+  })
+})
+
+describe('ReviewSummaryItem', () => {
+  it('renders the title and optional subtitle', () => {
+    const tree = render(
+      <ReviewSummaryItem
+        header="Item Header"
+        title="Item Title"
+        subtitle="Item Subtitle"
+        icon={<>Item Icon</>}
+        testID="MyItem"
+      />
+    )
+
+    expect(tree.getByTestId('MyItem/Header')).toHaveTextContent('Item Header')
+    expect(tree.getByTestId('MyItem/Title')).toHaveTextContent('Item Title')
+    expect(tree.getByTestId('MyItem/Subtitle')).toHaveTextContent('Item Subtitle')
+    expect(tree.getByTestId('MyItem')).toHaveTextContent('Item Icon')
+  })
+
+  it('does not render subtitle if not provided', () => {
+    const tree = render(
+      <ReviewSummaryItem header="Header" title="Title" icon={<></>} testID="NoSubtitleItem" />
+    )
+    expect(tree.queryByTestId('NoSubtitleItem/Subtitle')).toBeNull()
+  })
+})
+
+describe('ReviewDetailsItem', () => {
+  it('renders loading skeleton if isLoading is true', () => {
+    const tree = render(
+      <ReviewDetailsItem
+        isLoading
+        label="Loading Label"
+        value="Should not show"
+        testID="LoadingItem"
+      />
+    )
+
+    expect(tree.getByTestId('LoadingItem/Loader')).toBeTruthy()
+    expect(tree.queryByText('Should not show')).toBeNull()
+  })
+
+  it('renders value text if isLoading is false', () => {
+    const tree = render(<ReviewDetailsItem label="Label" value="Value" testID="DetailsItem" />)
+    expect(tree.queryByTestId('DetailsItem/Loader')).toBeNull()
+    expect(tree.getByTestId('DetailsItem/Value')).toHaveTextContent('Value')
+  })
+
+  it('applies bold variant if specified', () => {
+    const tree = render(
+      <ReviewDetailsItem label="Bold Label" value="Bold Value" variant="bold" testID="BoldItem" />
+    )
+    expect(tree.getByTestId('BoldItem/Label')).toHaveStyle(typeScale.labelSemiBoldMedium)
+  })
+})

--- a/src/components/ReviewTransaction.test.tsx
+++ b/src/components/ReviewTransaction.test.tsx
@@ -14,9 +14,9 @@ describe('ReviewTransaction', () => {
   it('uses the custom headerAction if provided', async () => {
     const tree = render(
       <ReviewTransaction
+        testID="Review"
         title="Custom HeaderAction"
         headerAction={<>Custom Left Action</>}
-        testID="Review"
       >
         <ReviewContent>
           <></>
@@ -32,25 +32,30 @@ describe('ReviewSummaryItem', () => {
   it('renders the title and optional subtitle', () => {
     const tree = render(
       <ReviewSummaryItem
-        header="Item Header"
-        title="Item Title"
-        subtitle="Item Subtitle"
-        icon={<>Item Icon</>}
         testID="MyItem"
+        label="Item Label"
+        primaryValue="Item Primary Value"
+        secondaryValue="Item Secondary Value"
+        icon={<>Item Icon</>}
       />
     )
 
-    expect(tree.getByTestId('MyItem/Header')).toHaveTextContent('Item Header')
-    expect(tree.getByTestId('MyItem/Title')).toHaveTextContent('Item Title')
-    expect(tree.getByTestId('MyItem/Subtitle')).toHaveTextContent('Item Subtitle')
+    expect(tree.getByTestId('MyItem/Label')).toHaveTextContent('Item Label')
+    expect(tree.getByTestId('MyItem/PrimaryValue')).toHaveTextContent('Item Primary Value')
+    expect(tree.getByTestId('MyItem/SecondaryValue')).toHaveTextContent('Item Secondary Value')
     expect(tree.getByTestId('MyItem')).toHaveTextContent('Item Icon')
   })
 
   it('does not render subtitle if not provided', () => {
     const tree = render(
-      <ReviewSummaryItem header="Header" title="Title" icon={<></>} testID="NoSubtitleItem" />
+      <ReviewSummaryItem
+        testID="NoSubtitleItem"
+        label="Label"
+        primaryValue="Primary Value"
+        icon={<></>}
+      />
     )
-    expect(tree.queryByTestId('NoSubtitleItem/Subtitle')).toBeNull()
+    expect(tree.queryByTestId('NoSubtitleItem/SecondaryValue')).toBeNull()
   })
 })
 
@@ -59,9 +64,9 @@ describe('ReviewDetailsItem', () => {
     const tree = render(
       <ReviewDetailsItem
         isLoading
+        testID="LoadingItem"
         label="Loading Label"
         value="Should not show"
-        testID="LoadingItem"
       />
     )
 
@@ -70,14 +75,14 @@ describe('ReviewDetailsItem', () => {
   })
 
   it('renders value text if isLoading is false', () => {
-    const tree = render(<ReviewDetailsItem label="Label" value="Value" testID="DetailsItem" />)
+    const tree = render(<ReviewDetailsItem testID="DetailsItem" label="Label" value="Value" />)
     expect(tree.queryByTestId('DetailsItem/Loader')).toBeNull()
     expect(tree.getByTestId('DetailsItem/Value')).toHaveTextContent('Value')
   })
 
   it('applies bold variant if specified', () => {
     const tree = render(
-      <ReviewDetailsItem label="Bold Label" value="Bold Value" variant="bold" testID="BoldItem" />
+      <ReviewDetailsItem testID="BoldItem" label="Bold Label" value="Bold Value" variant="bold" />
     )
     expect(tree.getByTestId('BoldItem/Label')).toHaveStyle(typeScale.labelSemiBoldMedium)
   })

--- a/src/components/ReviewTransaction.test.tsx
+++ b/src/components/ReviewTransaction.test.tsx
@@ -16,7 +16,7 @@ describe('ReviewTransaction', () => {
       <ReviewTransaction
         testID="Review"
         title="Custom HeaderAction"
-        headerAction={<>Custom Left Action</>}
+        headerLeftButton={<>Custom Left Button</>}
       >
         <ReviewContent>
           <></>
@@ -24,7 +24,7 @@ describe('ReviewTransaction', () => {
       </ReviewTransaction>
     )
 
-    expect(tree.getByTestId('Review')).toHaveTextContent('Custom Left Action')
+    expect(tree.getByTestId('Review')).toHaveTextContent('Custom Left Button')
   })
 })
 

--- a/src/components/ReviewTransaction.tsx
+++ b/src/components/ReviewTransaction.tsx
@@ -12,7 +12,7 @@ import variables from 'src/styles/variables'
 export function ReviewTransaction(props: {
   title: string
   children: ReactNode
-  headerAction?: ReactNode
+  headerLeftButton?: ReactNode
   testID?: string
 }) {
   const insets = useSafeAreaInsets()
@@ -21,7 +21,7 @@ export function ReviewTransaction(props: {
     <SafeAreaView style={styles.safeAreaView} edges={['top']} testID={props.testID}>
       <CustomHeader
         style={styles.header}
-        left={props.headerAction ?? <BackButton />}
+        left={props.headerLeftButton ?? <BackButton />}
         title={props.title}
       />
       <ScrollView

--- a/src/components/ReviewTransaction.tsx
+++ b/src/components/ReviewTransaction.tsx
@@ -45,26 +45,32 @@ export function ReviewSummary(props: { children: ReactNode }) {
 }
 
 export function ReviewSummaryItem(props: {
-  header: string
+  label: string
   icon: ReactNode
-  title: string
-  subtitle?: string
+  primaryValue: string
+  secondaryValue?: string
   testID?: string
 }) {
   return (
     <View style={styles.reviewSummaryItem} testID={props.testID}>
-      <Text style={styles.reviewSummaryItemHeader} testID={`${props.testID}/Header`}>
-        {props.header}
+      <Text style={styles.reviewSummaryItemLabel} testID={`${props.testID}/Label`}>
+        {props.label}
       </Text>
       <View style={styles.reviewSummaryItemContent}>
         {props.icon}
-        <View style={styles.reviewSummaryItemTitlesWrapper}>
-          <Text style={styles.reviewSummaryItemTitle} testID={`${props.testID}/Title`}>
-            {props.title}
+        <View style={styles.reviewSummaryItemValuesWrapper}>
+          <Text
+            style={styles.reviewSummaryItemPrimaryValue}
+            testID={`${props.testID}/PrimaryValue`}
+          >
+            {props.primaryValue}
           </Text>
-          {!!props.subtitle && (
-            <Text style={styles.reviewSummaryItemSubtitle} testID={`${props.testID}/Subtitle`}>
-              {props.subtitle}
+          {!!props.secondaryValue && (
+            <Text
+              style={styles.reviewSummaryItemSecondaryValue}
+              testID={`${props.testID}/SecondaryValue`}
+            >
+              {props.secondaryValue}
             </Text>
           )}
         </View>
@@ -154,7 +160,7 @@ const styles = StyleSheet.create({
   reviewSummaryItem: {
     gap: Spacing.Tiny4,
   },
-  reviewSummaryItemHeader: {
+  reviewSummaryItemLabel: {
     ...typeScale.labelSmall,
     color: Colors.contentSecondary,
   },
@@ -163,13 +169,13 @@ const styles = StyleSheet.create({
     gap: Spacing.Smallest8,
     alignItems: 'center',
   },
-  reviewSummaryItemTitlesWrapper: {
+  reviewSummaryItemValuesWrapper: {
     flexShrink: 1,
   },
-  reviewSummaryItemTitle: {
+  reviewSummaryItemPrimaryValue: {
     ...typeScale.labelSemiBoldLarge,
   },
-  reviewSummaryItemSubtitle: {
+  reviewSummaryItemSecondaryValue: {
     ...typeScale.bodySmall,
     color: Colors.contentSecondary,
   },

--- a/src/components/ReviewTransaction.tsx
+++ b/src/components/ReviewTransaction.tsx
@@ -1,0 +1,208 @@
+import React, { type ReactNode } from 'react'
+import { ScrollView, StyleSheet, Text, View } from 'react-native'
+import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context'
+import SkeletonPlaceholder from 'react-native-skeleton-placeholder'
+import BackButton from 'src/components/BackButton'
+import CustomHeader from 'src/components/header/CustomHeader'
+import Colors from 'src/styles/colors'
+import { typeScale } from 'src/styles/fonts'
+import { Spacing } from 'src/styles/styles'
+import variables from 'src/styles/variables'
+
+export function ReviewTransaction(props: {
+  title: string
+  children: ReactNode
+  headerAction?: ReactNode
+  testID?: string
+}) {
+  const insets = useSafeAreaInsets()
+
+  return (
+    <SafeAreaView style={styles.safeAreaView} edges={['top']} testID={props.testID}>
+      <CustomHeader
+        style={styles.header}
+        left={props.headerAction ?? <BackButton />}
+        title={props.title}
+      />
+      <ScrollView
+        contentContainerStyle={{
+          flex: 1,
+          paddingBottom: Math.max(insets.bottom, Spacing.Thick24),
+        }}
+      >
+        <View style={styles.reviewContainer}>{props.children}</View>
+      </ScrollView>
+    </SafeAreaView>
+  )
+}
+
+export function ReviewContent(props: { children: ReactNode }) {
+  return <View style={styles.reviewContent}>{props.children}</View>
+}
+
+export function ReviewSummary(props: { children: ReactNode }) {
+  return <View style={styles.reviewSummary}>{props.children}</View>
+}
+
+export function ReviewSummaryItem(props: {
+  header: string
+  icon: ReactNode
+  title: string
+  subtitle?: string
+  testID?: string
+}) {
+  return (
+    <View style={styles.reviewSummaryItem} testID={props.testID}>
+      <Text style={styles.reviewSummaryItemHeader} testID={`${props.testID}/Header`}>
+        {props.header}
+      </Text>
+      <View style={styles.reviewSummaryItemContent}>
+        {props.icon}
+        <View style={styles.reviewSummaryItemTitlesWrapper}>
+          <Text style={styles.reviewSummaryItemTitle} testID={`${props.testID}/Title`}>
+            {props.title}
+          </Text>
+          {!!props.subtitle && (
+            <Text style={styles.reviewSummaryItemSubtitle} testID={`${props.testID}/Subtitle`}>
+              {props.subtitle}
+            </Text>
+          )}
+        </View>
+      </View>
+    </View>
+  )
+}
+
+export function ReviewDetails(props: { children: ReactNode }) {
+  return <View style={styles.reviewDetails}>{props.children}</View>
+}
+
+export function ReviewDetailsItem({
+  label,
+  value,
+  variant = 'default',
+  isLoading,
+  testID,
+}: {
+  label: ReactNode
+  value: ReactNode
+  variant?: 'default' | 'bold'
+  isLoading?: boolean
+  testID?: string
+}) {
+  const textStyle =
+    variant === 'bold' ? styles.reviewDetailsItemTextBold : styles.reviewDetailsItemText
+
+  return (
+    <View style={styles.reviewDetailsItem} testID={testID}>
+      <View style={styles.reviewDetailsItemLabel}>
+        <Text style={textStyle} testID={`${testID}/Label`}>
+          {label}
+        </Text>
+        {/* TODO Add <InfoIcon /> for Earn Deposit/Withdrawal */}
+      </View>
+      <View>
+        {isLoading ? (
+          <View testID={`${testID}/Loader`} style={styles.loaderContainer}>
+            <SkeletonPlaceholder
+              borderRadius={100}
+              backgroundColor={Colors.skeletonPlaceholderBackground}
+              highlightColor={Colors.skeletonPlaceholderHighlight}
+            >
+              <View style={styles.loader} />
+            </SkeletonPlaceholder>
+          </View>
+        ) : (
+          <Text style={textStyle} testID={`${testID}/Value`}>
+            {value}
+          </Text>
+        )}
+      </View>
+    </View>
+  )
+}
+
+export function ReviewFooter(props: { children: ReactNode }) {
+  return <View style={styles.reviewFooter}>{props.children}</View>
+}
+
+const styles = StyleSheet.create({
+  safeAreaView: {
+    flex: 1,
+  },
+  header: {
+    paddingHorizontal: variables.contentPadding,
+  },
+  reviewContainer: {
+    margin: Spacing.Regular16,
+    gap: Spacing.Thick24,
+    flex: 1,
+    justifyContent: 'space-between',
+  },
+  reviewContent: {
+    gap: Spacing.Thick24,
+  },
+  reviewSummary: {
+    borderWidth: 1,
+    borderColor: Colors.border,
+    borderRadius: Spacing.Small12,
+    backgroundColor: Colors.backgroundSecondary,
+    padding: Spacing.Regular16,
+    gap: Spacing.Regular16,
+    flexShrink: 1,
+  },
+  reviewSummaryItem: {
+    gap: Spacing.Tiny4,
+  },
+  reviewSummaryItemHeader: {
+    ...typeScale.labelSmall,
+    color: Colors.contentSecondary,
+  },
+  reviewSummaryItemContent: {
+    flexDirection: 'row',
+    gap: Spacing.Smallest8,
+    alignItems: 'center',
+  },
+  reviewSummaryItemTitlesWrapper: {
+    flexShrink: 1,
+  },
+  reviewSummaryItemTitle: {
+    ...typeScale.labelSemiBoldLarge,
+  },
+  reviewSummaryItemSubtitle: {
+    ...typeScale.bodySmall,
+    color: Colors.contentSecondary,
+  },
+  reviewDetails: {
+    gap: Spacing.Regular16,
+    width: '100%',
+  },
+  reviewDetailsItem: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    gap: Spacing.Smallest8,
+  },
+  reviewDetailsItemLabel: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.Tiny4,
+  },
+  reviewDetailsItemText: {
+    ...typeScale.bodyMedium,
+    color: Colors.contentSecondary,
+  },
+  reviewDetailsItemTextBold: {
+    ...typeScale.labelSemiBoldMedium,
+  },
+  reviewFooter: {
+    gap: Spacing.Regular16,
+  },
+  loaderContainer: {
+    height: 20,
+    width: 96,
+  },
+  loader: {
+    height: '100%',
+    width: '100%',
+  },
+})


### PR DESCRIPTION
### Description
This PR adds an initial structure for the new ReviewTransaction component that is supposed to be used as a common component for all the review screens. The implementation approach was inspired by the way components are utilizing composition in libraries like [shadcn/ui](https://ui.shadcn.com/docs/components/card) and [MUI](https://mui.com/material-ui/guides/composition/).

[Link to the design](https://www.figma.com/design/z88kTrIfLyddOCSiAp2dZV/Updates-for-Consistency?node-id=2487-40727&t=2uUaB4bMg2tpNaz0-4)

### Test plan
Added tests to test the initial configurable aspects of the component.

### Related issues
Relates to RET-1295

### Backwards compatibility
Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
