### PR TITLE
refactor(colors): replace backgroundInverse with scrim and qr colors

### DIFF
--- a/src/components/BottomSheetBase.tsx
+++ b/src/components/BottomSheetBase.tsx
@@ -32,7 +32,12 @@ const BottomSheetBase = ({
 
   const renderBackdrop = useCallback(
     (props: BottomSheetDefaultBackdropProps) => (
-      <BottomSheetBackdrop {...props} disappearsOnIndex={-1} appearsOnIndex={0} />
+      <BottomSheetBackdrop
+        {...props}
+        style={[props.style, styles.bottomSheetBackdrop]}
+        disappearsOnIndex={-1}
+        appearsOnIndex={0}
+      />
     ),
     []
   )

--- a/src/components/SegmentedControl.tsx
+++ b/src/components/SegmentedControl.tsx
@@ -32,12 +32,12 @@ export default function SegmentedControl({ values, selectedIndex = 0, onChange }
   const color = interpolateColor(
     selectedIndex,
     [0.5, 1],
-    [colors.backgroundInverse, colors.backgroundPrimary]
+    [colors.qrTabBarPrimary, colors.qrTabBarSecondary]
   )
   const colorInverted = interpolateColor(
     selectedIndex,
     [0.5, 1],
-    [colors.backgroundPrimary, colors.backgroundInverse]
+    [colors.qrTabBarSecondary, colors.qrTabBarPrimary]
   )
 
   const onLayout = ({
@@ -135,7 +135,6 @@ const styles = StyleSheet.create({
     bottom: 0,
     right: 0,
     left: 0,
-    backgroundColor: colors.backgroundInverse,
   },
   maskedContainer: {
     // Transparent background because mask is based off alpha channel.

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -166,7 +166,7 @@ const styles = StyleSheet.create({
     ...StyleSheet.absoluteFillObject,
   },
   backdrop: {
-    backgroundColor: Colors.backgroundInverse,
+    backgroundColor: Colors.backgroundScrim,
   },
   notificationContainer: {
     position: 'absolute',

--- a/src/components/TokenBalance.tsx
+++ b/src/components/TokenBalance.tsx
@@ -274,7 +274,7 @@ const styles = StyleSheet.create({
     width: 190,
     paddingVertical: Spacing.Smallest8,
     paddingHorizontal: Spacing.Regular16,
-    backgroundColor: Colors.backgroundInverse,
+    backgroundColor: Colors.backgroundScrim,
     borderRadius: 8,
   },
   totalAssetsInfoText: {

--- a/src/home/celebration/ConfettiCelebration.tsx
+++ b/src/home/celebration/ConfettiCelebration.tsx
@@ -142,7 +142,7 @@ const styles = StyleSheet.create({
     ...StyleSheet.absoluteFillObject,
   },
   backdrop: {
-    backgroundColor: Colors.backgroundInverse,
+    backgroundColor: Colors.backgroundScrim,
   },
   confetti: {
     ...StyleSheet.absoluteFillObject,

--- a/src/keylessBackup/KeylessBackupIntro.tsx
+++ b/src/keylessBackup/KeylessBackupIntro.tsx
@@ -136,7 +136,7 @@ const styles = StyleSheet.create({
   },
   authFactorsContainer: {
     borderBottomWidth: 1,
-    borderBottomColor: `${Colors.backgroundInverse}33`, // alpha 0.2 (20% opacity)
+    borderBottomColor: Colors.border,
     gap: Spacing.Thick24,
     paddingBottom: Spacing.Thick24,
   },

--- a/src/navigator/Navigator.tsx
+++ b/src/navigator/Navigator.tsx
@@ -744,7 +744,13 @@ function ModalStackScreen() {
 function RootStackScreen() {
   const renderBackdrop = React.useCallback(
     (props: BottomSheetBackdropProps) => (
-      <BottomSheetBackdrop opacity={0.25} appearsOnIndex={0} disappearsOnIndex={-1} {...props} />
+      <BottomSheetBackdrop
+        {...props}
+        style={[props.style, styles.bottomSheetBackdrop]}
+        opacity={0.25}
+        appearsOnIndex={0}
+        disappearsOnIndex={-1}
+      />
     ),
     []
   )

--- a/src/navigator/QRNavigator.tsx
+++ b/src/navigator/QRNavigator.tsx
@@ -20,7 +20,6 @@ import QRTabBar from 'src/qrcode/QRTabBar'
 import { useDispatch } from 'src/redux/hooks'
 import { SVG, handleQRCodeDetected } from 'src/send/actions'
 import { QrCode } from 'src/send/types'
-import Colors from 'src/styles/colors'
 import Logger from 'src/utils/Logger'
 
 const Tab = createMaterialTopTabNavigator()
@@ -113,8 +112,6 @@ export default function QRNavigator({ route }: Props) {
       tabBar={tabBar}
       // Trick to position the tabs floating on top
       tabBarPosition="bottom"
-      style={styles.container}
-      screenOptions={{ sceneStyle: styles.sceneContainerStyle }}
       initialLayout={initialLayout}
     >
       <Tab.Screen name={Screens.QRCode} options={{ title: t('myCode') ?? undefined }}>
@@ -141,12 +138,6 @@ QRNavigator.navigationOptions = {
 }
 
 const styles = StyleSheet.create({
-  container: {
-    backgroundColor: Colors.backgroundInverse,
-  },
-  sceneContainerStyle: {
-    backgroundColor: Colors.backgroundInverse,
-  },
   viewContainer: {
     flex: 1,
     justifyContent: 'center',

--- a/src/qrcode/NotAuthorizedView.tsx
+++ b/src/qrcode/NotAuthorizedView.tsx
@@ -36,11 +36,11 @@ const styles = StyleSheet.create({
   title: {
     ...typeScale.titleSmall,
     marginBottom: 8,
-    color: colors.contentInverse,
+    color: colors.qrTabBarSecondary,
   },
   description: {
     ...typeScale.bodyMedium,
-    color: colors.contentInverse,
+    color: colors.qrTabBarSecondary,
     textAlign: 'center',
     marginBottom: 16,
   },

--- a/src/qrcode/QRScanner.tsx
+++ b/src/qrcode/QRScanner.tsx
@@ -155,7 +155,7 @@ const styles = StyleSheet.create({
     bottom: 32,
     ...typeScale.labelSemiBoldSmall,
     lineHeight: undefined,
-    color: colors.contentInverse,
+    color: colors.qrTabBarSecondary,
     textAlign: 'center',
     paddingHorizontal: 30,
   },

--- a/src/qrcode/QRScanner.tsx
+++ b/src/qrcode/QRScanner.tsx
@@ -25,11 +25,14 @@ const SeeThroughOverlay = () => {
 
   // TODO(jeanregisser): Investigate why the mask is pixelated on iOS.
   // It's visible on the rounded corners but since they are small, I'm ignoring it for now.
+
+  // Node that the Mask component is using hard coded color values solely to
+  // create the "cutout" effect.
   return (
     <Svg height={height} width={width} viewBox={`0 0 ${width} ${height}`}>
       <Defs>
         <Mask id="mask" x="0" y="0" height="100%" width="100%">
-          <Rect height="100%" width="100%" fill={colors.backgroundPrimary} />
+          <Rect height="100%" width="100%" fill={'#FFFFFF'} />
           <Rect
             x={margin}
             y={(height - centerBoxSize) / 2}
@@ -37,11 +40,11 @@ const SeeThroughOverlay = () => {
             ry={centerBoxBorderRadius}
             width={centerBoxSize}
             height={centerBoxSize}
-            fill={colors.backgroundInverse}
+            fill={'#000000'}
           />
         </Mask>
       </Defs>
-      <Rect height="100%" width="100%" fill={`${colors.backgroundInverse}80`} mask="url(#mask)" />
+      <Rect height="100%" width="100%" fill={`${colors.backgroundScrim}80`} mask="url(#mask)" />
     </Svg>
   )
 }

--- a/src/qrcode/QRScanner.tsx
+++ b/src/qrcode/QRScanner.tsx
@@ -32,7 +32,7 @@ const SeeThroughOverlay = () => {
     <Svg height={height} width={width} viewBox={`0 0 ${width} ${height}`}>
       <Defs>
         <Mask id="mask" x="0" y="0" height="100%" width="100%">
-          <Rect height="100%" width="100%" fill={'#FFFFFF'} />
+          <Rect height="100%" width="100%" fill="#FFFFFF" />
           <Rect
             x={margin}
             y={(height - centerBoxSize) / 2}
@@ -40,7 +40,7 @@ const SeeThroughOverlay = () => {
             ry={centerBoxBorderRadius}
             width={centerBoxSize}
             height={centerBoxSize}
-            fill={'#000000'}
+            fill="#000000"
           />
         </Mask>
       </Defs>

--- a/src/qrcode/QRTabBar.tsx
+++ b/src/qrcode/QRTabBar.tsx
@@ -41,7 +41,7 @@ export default function QRTabBar({
     [state, descriptors]
   )
 
-  const color = state.index === 0 ? colors.backgroundInverse : colors.backgroundPrimary
+  const color = state.index === 0 ? colors.qrTabBarPrimary : colors.qrTabBarSecondary
   const shareOpacity = interpolate(state.index, [0, 0.1], [1, 0], Extrapolation.CLAMP)
 
   const onPressClose = () => {

--- a/src/qrcode/QRTabBar.tsx
+++ b/src/qrcode/QRTabBar.tsx
@@ -87,7 +87,7 @@ export default function QRTabBar({
             testID="HeaderTitle"
             style={{
               ...styles.headerTitle,
-              color: state.index === 0 ? colors.contentPrimary : colors.contentInverse,
+              color: state.index === 0 ? colors.qrTabBarPrimary : colors.qrTabBarSecondary,
             }}
             numberOfLines={1}
             allowFontScaling={false}
@@ -100,7 +100,7 @@ export default function QRTabBar({
         style={[styles.rightContainer, { opacity: shareOpacity }]}
         pointerEvents={state.index > 0 ? 'none' : undefined}
       >
-        <TopBarIconButton icon={<Share color={colors.contentPrimary} />} onPress={onPressShare} />
+        <TopBarIconButton icon={<Share color={colors.qrTabBarPrimary} />} onPress={onPressShare} />
       </Animated.View>
     </SafeAreaView>
   )

--- a/src/send/EnterAmountOptions.tsx
+++ b/src/send/EnterAmountOptions.tsx
@@ -104,7 +104,7 @@ export default function EnterAmountOptions({
                 styles.chip,
                 {
                   backgroundColor:
-                    selectedAmount === amount ? Colors.backgroundInverse : 'transparent',
+                    selectedAmount === amount ? Colors.contentPrimary : 'transparent',
                 },
               ]}
             >

--- a/src/styles/colors.tsx
+++ b/src/styles/colors.tsx
@@ -3,9 +3,9 @@
 enum Colors {
   // backgrounds
   backgroundPrimary = '#FFFFFF', // Main background color for the app, used for primary surfaces (screens, navigation).
-  backgroundInverse = '#2E3338', // High-contrast background color for the app.
   backgroundSecondary = '#F8F9F9', // Subtle contrast background for secondary surfaces like cards, panels, or inputs.
   backgroundTertiary = '#E6E6E6', // Low-emphasis background for subtle supporting areas, typically used when both primary and secondary backgrounds are present, and an additional layer of distinction is needed.
+  backgroundScrim = '#000000', // Semi-transparent underlay behind bottom sheets, modals, dialogs, and other temporary surfaces to dim the background.
 
   // text, icons, and other content
   contentPrimary = '#2E3338', // main content on primary background
@@ -41,6 +41,8 @@ enum Colors {
   buttonQuickActionBackground = '#F1FDF1', // Background color for quick action buttons (specialized high-priority actions).
   buttonQuickActionContent = '#137211', // Text and icon color for quick action buttons.
   buttonQuickActionBorder = '#F1FDF1', // Border color for quick action buttons.
+  qrTabBarPrimary = '#2E3338', // color for text and icons on QR tab bar
+  qrTabBarSecondary = '#FFFFFF', // secondary color for text and icons on QR tab bar
 
   // statuses and UI feedback colors
   disabled = '#E6E6E6', // Used for disabled elements that are non-interactive or visually de-emphasized.

--- a/src/styles/styles.ts
+++ b/src/styles/styles.ts
@@ -69,6 +69,9 @@ const styles = StyleSheet.create({
   bottomSheetBackground: {
     backgroundColor: Colors.backgroundPrimary,
   },
+  bottomSheetBackdrop: {
+    backgroundColor: Colors.backgroundScrim,
+  },
 })
 
 export default styles


### PR DESCRIPTION
### Description

This PR replaces `backgroundInverse` with other colors, since the concept is not really aligned with how Kayla is using the colors. Now we have:
1. `backgroundScrim` for bottom sheets and underlays
2. `qrTabBar` primary and secondary - these colors are specific to the QR tab segmented control and Kayla suggested that we are able to control them separately.

### Test plan

n/a

### Related issues

- Related to RET-1293

### Backwards compatibility

Y

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [ ] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
