### PR TITLE
refactor(colors): remove shadow color

### DIFF
--- a/src/icons/CircleArrowIcon.tsx
+++ b/src/icons/CircleArrowIcon.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { StyleSheet, View, ViewStyle } from 'react-native'
 import Svg, { Path } from 'react-native-svg'
 import colors from 'src/styles/colors'
-import { elevationShadowStyle } from 'src/styles/styles'
+import globalStyles from 'src/styles/styles'
 
 const SIZE = 24
 
@@ -28,12 +28,12 @@ export default function CircleArrowIcon({ style }: Props) {
 
 const styles = StyleSheet.create({
   container: {
+    ...globalStyles.softShadowLight,
     backgroundColor: colors.backgroundPrimary,
     width: SIZE,
     height: SIZE,
     borderRadius: SIZE / 2,
     alignItems: 'center',
     justifyContent: 'center',
-    ...elevationShadowStyle(3),
   },
 })

--- a/src/icons/HamburgerCard.tsx
+++ b/src/icons/HamburgerCard.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { StyleSheet, View } from 'react-native'
 import { Line, Svg } from 'react-native-svg'
 import { default as Colors, default as colors } from 'src/styles/colors'
-import { elevationShadowStyle } from 'src/styles/styles'
+import globalStyles from 'src/styles/styles'
 
 function HamburgerCard() {
   return (
@@ -43,7 +43,7 @@ function HamburgerCard() {
 const styles = StyleSheet.create({
   container: {
     backgroundColor: colors.backgroundPrimary,
-    ...elevationShadowStyle(12),
+    ...globalStyles.softShadowLight,
     alignItems: 'center',
     justifyContent: 'center',
     borderRadius: 4,

--- a/src/styles/colors.tsx
+++ b/src/styles/colors.tsx
@@ -15,7 +15,6 @@ enum Colors {
 
   // borders, shadows, highlights, visual effects
   border = '#E6E6E6',
-  shadow = '#2E3338', // shadow base color
   softShadow = 'rgba(156, 164, 169, 0.4)',
   lightShadow = 'rgba(48, 46, 37, 0.15)',
   barShadow = 'rgba(129, 134, 139, 0.5)',

--- a/src/styles/styles.ts
+++ b/src/styles/styles.ts
@@ -30,16 +30,6 @@ export function getShadowStyle(shadow: Shadow) {
   }
 }
 
-export function elevationShadowStyle(elevation: number) {
-  return {
-    elevation,
-    shadowColor: Colors.shadow,
-    shadowOffset: { width: 0, height: 0.5 * elevation },
-    shadowOpacity: 0.3,
-    shadowRadius: 0.8 * elevation,
-  }
-}
-
 const styles = StyleSheet.create({
   softShadow: {
     elevation: 12,


### PR DESCRIPTION
### Description

The `shadow` color isn't really used in designs by Kayla and doesn't make sense to keep in the palette. The two places it's used can be switched without much visual difference.

### Test plan

These are the two places that were changed, and proof they look okay (although the secure send content really needs to be updated)

![Simulator Screenshot - iPhone 15 Pro - 2025-01-23 at 18 13 35](https://github.com/user-attachments/assets/e5466fec-309e-41bb-bb5d-10575df8fc66)
![Simulator Screenshot - iPhone 15 Pro - 2025-01-23 at 18 12 55](https://github.com/user-attachments/assets/e6dcbc16-2124-46c2-af13-78258c7f211d)

### Related issues

- Related to RET-1293

### Backwards compatibility

Y

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [ ] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
