### PR TITLE
refactor(colors): replace contentInverse

### DIFF
--- a/src/components/CircleButton.tsx
+++ b/src/components/CircleButton.tsx
@@ -32,7 +32,7 @@ export default class CircleButton extends React.PureComponent<ButtonProps> {
       borderWidth !== undefined ? { borderWidth } : { borderWidth: 0 },
       { borderColor: color, width: size, height: size, borderRadius: Math.floor(size! / 2) },
     ]
-    const xColor = solid ? colors.contentInverse : color
+    const xColor = solid ? colors.contentTertiary : color
 
     return (
       <View style={[styles.row, this.props.style]}>

--- a/src/components/FilterChipsCarousel.tsx
+++ b/src/components/FilterChipsCarousel.tsx
@@ -88,15 +88,17 @@ function FilterChipsCarousel<T>({
                   style={[
                     styles.filterChipText,
                     chip.isSelected
-                      ? { color: Colors.contentInverse }
-                      : { color: Colors.contentSecondary },
+                      ? { color: Colors.buttonPrimaryContent }
+                      : { color: Colors.buttonSecondaryContent },
                   ]}
                 >
                   {chip.name}
                 </Text>
                 {isNetworkChip(chip) && (
                   <DownArrowIcon
-                    color={chip.isSelected ? Colors.contentInverse : Colors.contentSecondary}
+                    color={
+                      chip.isSelected ? Colors.buttonPrimaryContent : Colors.buttonSecondaryContent
+                    }
                     strokeWidth={2}
                     height={Spacing.Regular16}
                     style={{ marginBottom: 2, marginLeft: 4 }}

--- a/src/components/SmallButton.test.tsx
+++ b/src/components/SmallButton.test.tsx
@@ -8,24 +8,20 @@ describe('SmallButton', () => {
   describe('when pressed', () => {
     it('fires the onPress prop', () => {
       const handler = jest.fn()
-      const { UNSAFE_getByType } = render(
-        <SmallButton solid={true} onPress={handler} text="SmallButton" />
-      )
+      const { UNSAFE_getByType } = render(<SmallButton onPress={handler} text="SmallButton" />)
       fireEvent.press(UNSAFE_getByType(Touchable))
       expect(handler).toBeCalled()
     })
   })
   it('renders with minimum props', () => {
-    const { getByText } = render(
-      <SmallButton solid={true} onPress={jest.fn()} text="SmallButton" />
-    )
+    const { getByText } = render(<SmallButton onPress={jest.fn()} text="SmallButton" />)
     expect(getByText('SmallButton')).toBeTruthy()
   })
   describe('when disabled', () => {
     it('passes them to Touchable', () => {
       const onPress = jest.fn()
       const { UNSAFE_getByType } = render(
-        <SmallButton solid={true} disabled={true} onPress={onPress} text="SmallButton">
+        <SmallButton disabled={true} onPress={onPress} text="SmallButton">
           <Text>child text</Text>
         </SmallButton>
       )
@@ -36,12 +32,7 @@ describe('SmallButton', () => {
   describe('when passed accessibilityLabel', () => {
     it('sets it', () => {
       const { getByLabelText } = render(
-        <SmallButton
-          solid={true}
-          accessibilityLabel="link"
-          onPress={jest.fn()}
-          text="SmallButton"
-        />
+        <SmallButton accessibilityLabel="link" onPress={jest.fn()} text="SmallButton" />
       )
 
       expect(getByLabelText('link')).toBeTruthy()

--- a/src/components/SmallButton.tsx
+++ b/src/components/SmallButton.tsx
@@ -8,7 +8,6 @@ interface ButtonProps {
   onPress: () => void
   text: string
   accessibilityLabel?: string
-  solid: boolean
   disabled?: boolean
   style?: ViewStyle
   textStyle?: TextStyle
@@ -20,8 +19,7 @@ const TOUCH_OVERFLOW = 7
 
 export default class SmallButton extends React.Component<ButtonProps> {
   render() {
-    const { onPress, text, accessibilityLabel, solid, disabled, style, textStyle, children } =
-      this.props
+    const { onPress, text, accessibilityLabel, disabled, style, textStyle, children } = this.props
     return (
       <Touchable
         testID={this.props.testID}
@@ -33,18 +31,13 @@ export default class SmallButton extends React.Component<ButtonProps> {
           bottom: TOUCH_OVERFLOW,
           right: TOUCH_OVERFLOW,
         }}
-        style={[styles.button, solid ? styles.solid : styles.hollow, style]}
+        style={[styles.button, style]}
       >
         <>
           {children}
           <Text
             accessibilityLabel={accessibilityLabel}
-            style={[
-              styles.text,
-              solid ? { color: colors.contentInverse } : { color: colors.accent },
-              children ? styles.textPadding : null,
-              textStyle,
-            ]}
+            style={[styles.text, children ? styles.textPadding : null, textStyle]}
           >
             {text}
           </Text>
@@ -65,16 +58,7 @@ const styles = StyleSheet.create({
     paddingVertical: PADDING_VERTICAL,
     paddingHorizontal: PADDING_HORIZONTAL,
     borderRadius: 2,
-  },
-  solid: {
-    backgroundColor: colors.accent,
-    paddingVertical: PADDING_VERTICAL + 2,
-    paddingHorizontal: PADDING_HORIZONTAL + 2,
-  },
-  hollow: {
     backgroundColor: 'transparent',
-    borderWidth: 2,
-    borderColor: colors.accent,
   },
   text: {
     ...typeScale.labelMedium,

--- a/src/components/SmartTopAlert.tsx
+++ b/src/components/SmartTopAlert.tsx
@@ -120,7 +120,7 @@ function SmartTopAlert({ alert }: Props) {
             },
           ]}
         >
-          {isError && <Error style={styles.errorIcon} />}
+          {isError && <Error color={colors.contentTertiary} style={styles.errorIcon} />}
           <Text style={[typeScale.bodySmall, isError && typeScale.labelSmall, styles.text]}>
             {!!title && <Text style={[typeScale.labelSmall, styles.text]}> {title} </Text>}
             {message}
@@ -129,7 +129,6 @@ function SmartTopAlert({ alert }: Props) {
             <SmallButton
               onPress={onPress}
               text={buttonMessage}
-              solid={false}
               style={styles.button}
               textStyle={styles.buttonText}
               testID={'SmartTopAlertButton'}
@@ -162,7 +161,7 @@ const styles = StyleSheet.create({
     flexDirection: 'column',
   },
   text: {
-    color: colors.contentInverse,
+    color: colors.contentTertiary,
     // Unset explicit lineHeight set by fonts.tsx otherwise the text is not centered vertically
     lineHeight: undefined,
     textAlign: 'center',
@@ -173,11 +172,11 @@ const styles = StyleSheet.create({
   },
   button: {
     marginTop: 8,
-    borderColor: colors.contentInverse,
+    borderColor: colors.contentTertiary,
     alignSelf: 'center',
   },
   buttonText: {
-    color: colors.contentInverse,
+    color: colors.contentTertiary,
   },
 })
 

--- a/src/components/TokenBalance.tsx
+++ b/src/components/TokenBalance.tsx
@@ -279,7 +279,7 @@ const styles = StyleSheet.create({
   },
   totalAssetsInfoText: {
     ...typeScale.bodySmall,
-    color: Colors.contentInverse,
+    color: Colors.contentTertiary,
     textAlign: 'center',
   },
   titleExchange: {

--- a/src/fiatExchanges/PaymentMethodSection.tsx
+++ b/src/fiatExchanges/PaymentMethodSection.tsx
@@ -149,7 +149,7 @@ export function PaymentMethodSection({
         >
           <>
             <Text style={styles.newLabelText}>{t('selectProviderScreen.newLabel')}</Text>
-            <InfoIcon size={16} color={colors.contentInverse} />
+            <InfoIcon size={16} color={colors.contentTertiary} />
           </>
         </Touchable>
       )}
@@ -342,7 +342,7 @@ const styles = StyleSheet.create({
   },
   newLabelText: {
     ...typeScale.labelSemiBoldSmall,
-    color: colors.contentInverse,
+    color: colors.contentTertiary,
     marginRight: 5,
   },
   category: {

--- a/src/fiatconnect/TransferStatusScreen.tsx
+++ b/src/fiatconnect/TransferStatusScreen.tsx
@@ -148,7 +148,7 @@ function SuccessOrProcessingSection({
   if (status === SendingTransferStatus.Completed) {
     icon = (
       <CircledIcon>
-        <Checkmark color={Colors.contentInverse} height={22} width={22} />
+        <Checkmark color={Colors.contentTertiary} height={22} width={22} />
       </CircledIcon>
     )
     title = t('fiatConnectStatusScreen.success.title')
@@ -158,7 +158,7 @@ function SuccessOrProcessingSection({
   } else {
     icon = (
       <CircledIcon>
-        <ClockIcon color={Colors.contentInverse} height={22} width={22} />
+        <ClockIcon color={Colors.contentTertiary} height={22} width={22} />
       </CircledIcon>
     )
     title = t('fiatConnectStatusScreen.txProcessing.title')

--- a/src/fiatconnect/kyc/KycPending.tsx
+++ b/src/fiatconnect/kyc/KycPending.tsx
@@ -48,9 +48,9 @@ function KycPending({ route, navigation }: Props) {
         >
           <BankIcon color={colors.contentPrimary} height={24} width={24} />
         </CircledIcon>
-        <CircledIcon radius={85} backgroundColor={colors.contentInverse} style={styles.clockIcon}>
+        <CircledIcon radius={85} backgroundColor={colors.contentTertiary} style={styles.clockIcon}>
           <CircledIcon radius={80}>
-            <ClockIcon color={colors.contentInverse} height={24} width={24} />
+            <ClockIcon color={colors.contentTertiary} height={24} width={24} />
           </CircledIcon>
         </CircledIcon>
       </View>

--- a/src/icons/CrossChainIndicator.tsx
+++ b/src/icons/CrossChainIndicator.tsx
@@ -11,7 +11,7 @@ interface Props {
 function CrossChainIndicator({
   size = 16,
   backgroundColor = Colors.contentPrimary,
-  color = Colors.contentInverse,
+  color = Colors.backgroundPrimary,
 }: Props) {
   return (
     <Svg width={size} height={size} fill="none" viewBox="0 0 16 16">

--- a/src/icons/Error.tsx
+++ b/src/icons/Error.tsx
@@ -1,18 +1,16 @@
 import * as React from 'react'
 import { View, ViewStyle } from 'react-native'
-import colors from 'src/styles/colors'
 import Svg, { Circle, Path } from 'svgs'
 import { getSizing } from '../styles/accessibility'
 
 interface Props {
-  color?: string
+  color: string
   width?: number
   style?: ViewStyle
 }
 
 export default class Error extends React.PureComponent<Props> {
   static defaultProps = {
-    color: colors.contentInverse,
     width: getSizing(),
     style: {},
   }
@@ -26,7 +24,6 @@ export default class Error extends React.PureComponent<Props> {
           height={this.props.width}
           viewBox="0 0 16 16"
           fill="none"
-          xmlns="http://www.w3.org/2000/svg"
         >
           <Path
             fillRule="evenodd"

--- a/src/onboarding/success/OnboardingSuccessScreen.tsx
+++ b/src/onboarding/success/OnboardingSuccessScreen.tsx
@@ -22,7 +22,7 @@ function OnboardingSuccessScreen() {
   return (
     <View style={styles.container}>
       <Image source={background} style={styles.backgroundImage} />
-      <Logo color={colors.contentInverse} size={70} />
+      <Logo color={colors.contentOnboardingComplete} size={70} />
       <Text style={styles.text}>{t('success.message')}</Text>
     </View>
   )
@@ -46,7 +46,7 @@ const styles = StyleSheet.create({
     ...typeScale.titleSmall,
     fontSize: 30,
     lineHeight: 36,
-    color: colors.contentInverse,
+    color: colors.contentOnboardingComplete,
     marginTop: Spacing.Regular16,
     marginBottom: 30,
     shadowOffset: { width: 0, height: 1 },

--- a/src/positions/HooksPreviewModeBanner.tsx
+++ b/src/positions/HooksPreviewModeBanner.tsx
@@ -62,7 +62,7 @@ const styles = StyleSheet.create({
   },
   text: {
     ...typeScale.labelXSmall,
-    color: colors.contentInverse,
+    color: colors.contentTertiary,
     textAlign: 'center',
     paddingHorizontal: 10,
   },

--- a/src/recipients/RecipientItemV2.tsx
+++ b/src/recipients/RecipientItemV2.tsx
@@ -64,7 +64,7 @@ function RecipientItem({ recipient, onSelectRecipient, loading, selected }: Prop
           />
           {!!showAppIcon && (
             <Logo
-              color={Colors.contentInverse}
+              color={Colors.contentSecondary}
               style={styles.appIcon}
               size={ICON_SIZE}
               testID="RecipientItem/AppIcon"

--- a/src/send/EnterAmountOptions.tsx
+++ b/src/send/EnterAmountOptions.tsx
@@ -104,7 +104,14 @@ export default function EnterAmountOptions({
                 styles.chip,
                 {
                   backgroundColor:
-                    selectedAmount === amount ? Colors.contentPrimary : 'transparent',
+                    selectedAmount === amount
+                      ? Colors.buttonPrimaryBackground
+                      : Colors.buttonSecondaryBackground,
+                  borderColor:
+                    selectedAmount === amount
+                      ? Colors.buttonPrimaryBorder
+                      : Colors.buttonSecondaryBorder,
+                  borderWidth: 1,
                 },
               ]}
             >
@@ -113,7 +120,9 @@ export default function EnterAmountOptions({
                   styles.chipText,
                   {
                     color:
-                      selectedAmount === amount ? Colors.contentInverse : Colors.contentPrimary,
+                      selectedAmount === amount
+                        ? Colors.buttonPrimaryContent
+                        : Colors.buttonSecondaryContent,
                   },
                 ]}
               >

--- a/src/styles/colors.tsx
+++ b/src/styles/colors.tsx
@@ -10,7 +10,7 @@ enum Colors {
   // text, icons, and other content
   contentPrimary = '#2E3338', // main content on primary background
   contentSecondary = '#757575', // supporting context on primary background
-  contentInverse = '#FFFFFF', // content on inverse backgrounds
+  contentTertiary = '#FFFFFF', // content on colored backgrounds
   textLink = '#757575', // underlined text links on primary background
 
   // borders, shadows, highlights, visual effects
@@ -59,6 +59,7 @@ enum Colors {
   accent = '#1AB775', // Accent color for emphasizing key elements, such as highlights, icons, or decorative details.
   brandGradientLeft = '#26d98a', // Starting color for the brand gradient, used in backgrounds or borders to reinforce brand identity.
   brandGradientRight = '#ffd52c', // Ending color for the brand gradient, used in backgrounds or borders to reinforce brand identity.
+  contentOnboardingComplete = '#FFFFFF', // Text and image color for onboarding completion screen
 }
 
 export default Colors

--- a/src/swap/SwapScreen.tsx
+++ b/src/swap/SwapScreen.tsx
@@ -812,7 +812,7 @@ export function SwapScreen({ route }: Props) {
               testID="SwapScreen/SwitchTokens"
             >
               <CircledIcon radius={Spacing.Large32} backgroundColor={colors.contentPrimary}>
-                <ArrowDown color={colors.contentInverse} />
+                <ArrowDown color={colors.backgroundPrimary} />
               </CircledIcon>
             </Touchable>
           </View>

--- a/src/swap/SwapScreenV2.tsx
+++ b/src/swap/SwapScreenV2.tsx
@@ -720,7 +720,7 @@ export default function SwapScreenV2({ route }: Props) {
                   testID="SwapScreen/SwitchTokens"
                 >
                   <CircledIcon radius={Spacing.Large32} backgroundColor={colors.contentPrimary}>
-                    <ArrowDown color={colors.contentInverse} />
+                    <ArrowDown color={colors.backgroundPrimary} />
                   </CircledIcon>
                 </Touchable>
               </View>


### PR DESCRIPTION
### Description

Replacing `contentInverse` since this isn't a useful semantic variable for design. Replaced with `contentTertiary` for content on colored backgrounds specifically, and re-evaluated the places that used contentInverse (for the filter chips and enter amount percentage chips, they were replaced with button colors since they should be thought of as buttons. for the swap arrows, use backgroundPrimary because it is the contrast that is needed)

### Test plan

No visual changes for valora

### Related issues

- Related to RET-1293

### Backwards compatibility

Y

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [ ] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
