### PR TITLE
refactor(colors): replace enum with object and type

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -2,7 +2,7 @@ import { debounce } from 'lodash'
 import React, { ReactElement, ReactNode, useCallback } from 'react'
 import { ActivityIndicator, StyleProp, StyleSheet, Text, View, ViewStyle } from 'react-native'
 import Touchable from 'src/components/Touchable'
-import Colors from 'src/styles/colors'
+import Colors, { ColorValue } from 'src/styles/colors'
 import { typeScale } from 'src/styles/fonts'
 import { vibrateInformative } from 'src/styles/hapticFeedback'
 
@@ -182,9 +182,9 @@ function getColors(type: BtnTypes, disabled: boolean | undefined) {
 
 function getStyle(
   size: BtnSizes | undefined,
-  backgroundColor: Colors,
+  backgroundColor: ColorValue,
   opacity: number | undefined,
-  borderColor: Colors | undefined,
+  borderColor: ColorValue | undefined,
   iconPositionLeft: boolean
 ) {
   const borderStyles = borderColor

--- a/src/components/ContactCircle.tsx
+++ b/src/components/ContactCircle.tsx
@@ -2,19 +2,19 @@ import * as React from 'react'
 import { Image, StyleSheet, Text, View, ViewStyle } from 'react-native'
 import User from 'src/icons/User'
 import { Recipient } from 'src/recipients/recipient'
-import Colors from 'src/styles/colors'
+import { ColorValue } from 'src/styles/colors'
 import { typeScale } from 'src/styles/fonts'
 
 interface Props {
   style?: ViewStyle
   size?: number
   recipient: Recipient
-  backgroundColor?: Colors
-  foregroundColor?: Colors
-  borderColor?: Colors
+  backgroundColor?: ColorValue
+  foregroundColor?: ColorValue
+  borderColor?: ColorValue
   DefaultIcon?: React.ComponentType<{
-    color?: Colors
-    backgroundColor?: Colors
+    color?: ColorValue
+    backgroundColor?: ColorValue
     size?: number
   }>
 }
@@ -22,9 +22,9 @@ interface Props {
 const DEFAULT_ICON_SIZE = 40
 
 const getAddressBackgroundColor = (address: string) =>
-  `hsl(${parseInt(address.substring(0, 5), 16) % 360}, 53%, 93%)` as Colors
+  `hsl(${parseInt(address.substring(0, 5), 16) % 360}, 53%, 93%)` as ColorValue
 const getAddressForegroundColor = (address: string) =>
-  `hsl(${parseInt(address.substring(0, 5), 16) % 360}, 67%, 24%)` as Colors
+  `hsl(${parseInt(address.substring(0, 5), 16) % 360}, 67%, 24%)` as ColorValue
 const getNameInitial = (name: string) => name.charAt(0).toLocaleUpperCase()
 
 function ContactCircle({

--- a/src/components/InLineNotification.tsx
+++ b/src/components/InLineNotification.tsx
@@ -3,7 +3,7 @@ import { GestureResponderEvent, StyleProp, StyleSheet, Text, View, ViewStyle } f
 import Touchable from 'src/components/Touchable'
 import AttentionIcon from 'src/icons/Attention'
 import Warning from 'src/icons/Warning'
-import Colors from 'src/styles/colors'
+import Colors, { ColorValue } from 'src/styles/colors'
 import { typeScale } from 'src/styles/fonts'
 import { Spacing } from 'src/styles/styles'
 
@@ -30,8 +30,8 @@ export interface InLineNotificationProps {
 }
 
 interface CustomColors {
-  primary: Colors
-  secondary: Colors
+  primary: ColorValue
+  secondary: ColorValue
 }
 
 export function InLineNotification({
@@ -52,7 +52,7 @@ export function InLineNotification({
   const renderCtaLabel = (
     label?: string | null,
     onPress?: (event: GestureResponderEvent) => void,
-    color?: Colors
+    color?: ColorValue
   ) =>
     label &&
     onPress && (

--- a/src/components/PercentageIndicator.tsx
+++ b/src/components/PercentageIndicator.tsx
@@ -3,10 +3,10 @@ import React from 'react'
 import { StyleSheet, Text, TextStyle, View } from 'react-native'
 import DataDown from 'src/icons/DataDown'
 import DataUp from 'src/icons/DataUp'
-import Colors from 'src/styles/colors'
+import Colors, { ColorValue } from 'src/styles/colors'
 import { typeScale } from 'src/styles/fonts'
 
-type IconComponentType = React.ComponentType<{ color?: Colors; testID?: string }>
+type IconComponentType = React.ComponentType<{ color?: ColorValue; testID?: string }>
 
 interface Props {
   testID?: string
@@ -39,8 +39,7 @@ function PercentageIndicator({
   const percentageString = `${percentage.abs().toFixed(2)}%`
 
   let indicator: React.ReactElement | undefined
-  let color: Colors
-
+  let color: ColorValue
   if (comparison > 0) {
     color = Colors.accent
     indicator = <UpIcon color={color} testID={`${testID}:UpIndicator`} />

--- a/src/components/PhoneNumberWithFlag.tsx
+++ b/src/components/PhoneNumberWithFlag.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { StyleSheet, Text, View } from 'react-native'
-import Colors from 'src/styles/colors'
+import Colors, { ColorValue } from 'src/styles/colors'
 import { typeScale } from 'src/styles/fonts'
 import { getCountryEmoji } from 'src/utils/getCountryEmoji'
 import { parsePhoneNumber } from 'src/utils/phoneNumbers'
@@ -8,7 +8,7 @@ import { parsePhoneNumber } from 'src/utils/phoneNumbers'
 interface Props {
   e164PhoneNumber: string
   defaultCountryCode?: string
-  textColor?: Colors
+  textColor?: ColorValue
 }
 
 export class PhoneNumberWithFlag extends React.PureComponent<Props> {

--- a/src/components/RowDivider.tsx
+++ b/src/components/RowDivider.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react'
 import { StyleSheet, View } from 'react-native'
-import Colors from 'src/styles/colors'
+import Colors, { ColorValue } from 'src/styles/colors'
 import { Spacing } from 'src/styles/styles'
 
 export interface Props {
-  color?: Colors
+  color?: ColorValue
 }
 
 export default function RowDivider({ color = Colors.borderPrimary }: Props) {

--- a/src/earn/types.ts
+++ b/src/earn/types.ts
@@ -1,5 +1,5 @@
 import { EarnPosition, Token } from 'src/positions/types'
-import Colors from 'src/styles/colors'
+import { ColorValue } from 'src/styles/colors'
 import { NetworkId } from 'src/transactions/types'
 import { SerializableTransactionRequest } from 'src/viem/preparedTransactionSerialization'
 import { Hash } from 'viem'
@@ -54,7 +54,7 @@ export interface BeforeDepositAction {
   name: BeforeDepositActionName
   title: string
   details: string
-  iconComponent: React.MemoExoticComponent<({ color }: { color?: Colors }) => JSX.Element>
+  iconComponent: React.MemoExoticComponent<({ color }: { color?: ColorValue }) => JSX.Element>
   onPress: () => void
 }
 
@@ -62,7 +62,7 @@ export interface WithdrawAction {
   name: Extract<EarnActiveMode, 'withdraw' | 'claim-rewards' | 'exit'>
   title: string
   details: string
-  iconComponent: React.MemoExoticComponent<({ color }: { color?: Colors }) => JSX.Element>
+  iconComponent: React.MemoExoticComponent<({ color }: { color?: ColorValue }) => JSX.Element>
   onPress: () => void
 }
 

--- a/src/icons/Activity.tsx
+++ b/src/icons/Activity.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react'
-import colors from 'src/styles/colors'
+import colors, { ColorValue } from 'src/styles/colors'
 import Svg, { Path } from 'svgs'
 
 interface Props {
   size?: number
-  color?: colors
+  color?: ColorValue
 }
 
 function Activity({ color = colors.successPrimary, size = 24 }: Props) {

--- a/src/icons/ArrowDown.tsx
+++ b/src/icons/ArrowDown.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react'
 import Svg, { Path } from 'react-native-svg'
-import Colors from 'src/styles/colors'
+import Colors, { ColorValue } from 'src/styles/colors'
 
 interface Props {
-  color?: Colors
+  color?: ColorValue
   size?: number
 }
 

--- a/src/icons/ArrowRightThick.tsx
+++ b/src/icons/ArrowRightThick.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react'
 import Svg, { Path } from 'react-native-svg'
-import colors from 'src/styles/colors'
+import colors, { ColorValue } from 'src/styles/colors'
 
 interface Props {
-  color?: colors
+  color?: ColorValue
   size?: number
 }
 

--- a/src/icons/Attention.tsx
+++ b/src/icons/Attention.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react'
 import Svg, { Path } from 'react-native-svg'
-import Colors from 'src/styles/colors'
+import Colors, { ColorValue } from 'src/styles/colors'
 
 const AttentionIcon = ({
   color = Colors.warningPrimary,
   size = 16,
   testId,
 }: {
-  color?: Colors
+  color?: ColorValue
   size?: number
   testId?: string
 }) => (

--- a/src/icons/CheckBox.tsx
+++ b/src/icons/CheckBox.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react'
 import Svg, { Path } from 'react-native-svg'
-import Colors from 'src/styles/colors'
+import Colors, { ColorValue } from 'src/styles/colors'
 
 type Props = {
   checked: boolean
   testID?: string
-  checkedColor?: Colors
-  uncheckedColor?: Colors
+  checkedColor?: ColorValue
+  uncheckedColor?: ColorValue
 }
 
 const CheckBox = ({

--- a/src/icons/CircledIcon.tsx
+++ b/src/icons/CircledIcon.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react'
 import { StyleProp, StyleSheet, View, ViewStyle } from 'react-native'
-import colors from 'src/styles/colors'
+import colors, { ColorValue } from 'src/styles/colors'
 
 interface Props {
-  backgroundColor?: colors
+  backgroundColor?: ColorValue
   radius?: number
   style?: StyleProp<ViewStyle>
   children?: React.ReactNode
-  borderColor?: colors
+  borderColor?: ColorValue
 }
 
 export default function CircledIcon({

--- a/src/icons/CopyIcon.tsx
+++ b/src/icons/CopyIcon.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react'
 import Svg, { Path } from 'react-native-svg'
-import Colors from 'src/styles/colors'
+import Colors, { ColorValue } from 'src/styles/colors'
 
-const CopyIcon = ({ color = Colors.accent }) => (
+const CopyIcon = ({ color = Colors.accent }: { color?: ColorValue }) => (
   <Svg width={16} height={18} fill="none">
     <Path
       d="M11.655 0H1.835C.936 0 .2.736.2 1.636v11.455h1.636V1.636h9.819V0Zm2.454 3.273h-9c-.9 0-1.636.736-1.636 1.636v11.455c0 .9.736 1.636 1.636 1.636h9c.9 0 1.636-.736 1.636-1.636V4.909c0-.9-.736-1.636-1.636-1.636Zm0 13.09h-9V4.91h9v11.455Z"

--- a/src/icons/CrossChainIndicator.tsx
+++ b/src/icons/CrossChainIndicator.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react'
 import Svg, { Circle, ClipPath, Defs, G, Path } from 'react-native-svg'
-import Colors from 'src/styles/colors'
+import Colors, { ColorValue } from 'src/styles/colors'
 
 interface Props {
   size?: number
-  backgroundColor?: Colors
-  color?: Colors
+  backgroundColor?: ColorValue
+  color?: ColorValue
 }
 
 function CrossChainIndicator({

--- a/src/icons/DataDown.tsx
+++ b/src/icons/DataDown.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react'
 import Svg, { Path } from 'react-native-svg'
-import colors from 'src/styles/colors'
+import colors, { ColorValue } from 'src/styles/colors'
 
 interface Props {
-  color?: colors
+  color?: ColorValue
   testID?: string
 }
 

--- a/src/icons/DataUp.tsx
+++ b/src/icons/DataUp.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react'
 import Svg, { Path } from 'react-native-svg'
-import colors from 'src/styles/colors'
+import colors, { ColorValue } from 'src/styles/colors'
 
 interface Props {
-  color?: colors
+  color?: ColorValue
   testID?: string
 }
 

--- a/src/icons/Exit.tsx
+++ b/src/icons/Exit.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react'
 import Svg, { Path } from 'react-native-svg'
-import Colors from 'src/styles/colors'
+import Colors, { ColorValue } from 'src/styles/colors'
 
 interface Props {
-  color?: Colors
+  color?: ColorValue
 }
 
 const Exit = ({ color = Colors.contentPrimary }: Props) => (

--- a/src/icons/EyeIcon.tsx
+++ b/src/icons/EyeIcon.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react'
 import Svg, { Path } from 'react-native-svg'
-import Colors from 'src/styles/colors'
+import Colors, { ColorValue } from 'src/styles/colors'
 
 export interface Props {
   size?: number
-  color?: Colors
+  color?: ColorValue
 }
 
 function EyeIcon({ color, size }: Props) {

--- a/src/icons/HiddenEyeIcon.tsx
+++ b/src/icons/HiddenEyeIcon.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react'
 import Svg, { ClipPath, Defs, G, Path } from 'react-native-svg'
-import Colors from 'src/styles/colors'
+import Colors, { ColorValue } from 'src/styles/colors'
 
 export interface Props {
   size?: number
-  color?: Colors
+  color?: ColorValue
 }
 
 function HiddenEyeIcon({ color = Colors.accent, size = 24 }: Props) {

--- a/src/icons/ImageErrorIcon.tsx
+++ b/src/icons/ImageErrorIcon.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react'
 import Svg, { Path } from 'react-native-svg'
-import colors from 'src/styles/colors'
+import colors, { ColorValue } from 'src/styles/colors'
 
 interface Props {
-  color?: colors | string
+  color?: ColorValue | string
   size?: number
   testID?: string
 }

--- a/src/icons/InfoIcon.tsx
+++ b/src/icons/InfoIcon.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react'
 import { PixelRatio } from 'react-native'
 import Svg, { Circle, Path } from 'react-native-svg'
-import colors from 'src/styles/colors'
+import colors, { ColorValue } from 'src/styles/colors'
 
 interface Props {
   size?: number
-  color?: colors
+  color?: ColorValue
   scaledSize?: number
   testID?: string
 }

--- a/src/icons/LinkArrow.tsx
+++ b/src/icons/LinkArrow.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react'
 import Svg, { Path } from 'react-native-svg'
-import Colors from 'src/styles/colors'
+import Colors, { ColorValue } from 'src/styles/colors'
 
 interface Props {
   size?: number
-  color?: Colors
+  color?: ColorValue
 }
 
 const LinkArrow = ({ color = Colors.textLink, size = 32 }: Props) => {

--- a/src/icons/MagicWand.tsx
+++ b/src/icons/MagicWand.tsx
@@ -1,8 +1,14 @@
 import * as React from 'react'
 import Svg, { Path } from 'react-native-svg'
-import Colors from 'src/styles/colors'
+import Colors, { ColorValue } from 'src/styles/colors'
 
-const MagicWand = ({ size = 24, color = Colors.successPrimary }) => (
+const MagicWand = ({
+  size = 24,
+  color = Colors.successPrimary,
+}: {
+  size?: number
+  color?: ColorValue
+}) => (
   <Svg width={size} height={size} viewBox="0 0 24 24">
     <Path
       fill={color}

--- a/src/icons/NotificationBellIcon.tsx
+++ b/src/icons/NotificationBellIcon.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react'
 import Svg, { Path } from 'react-native-svg'
-import colors from 'src/styles/colors'
+import colors, { ColorValue } from 'src/styles/colors'
 
 interface Props {
   size?: number
-  notificationMark?: colors
+  notificationMark?: ColorValue
 }
 
 const NotificationBellIcon = ({ size = 24, notificationMark }: Props) => (

--- a/src/icons/OpenLinkIcon.tsx
+++ b/src/icons/OpenLinkIcon.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react'
 import Svg, { Path } from 'react-native-svg'
-import colors from 'src/styles/colors'
+import colors, { ColorValue } from 'src/styles/colors'
 
 interface Props {
-  color?: colors
+  color?: ColorValue
   size?: number
 }
 

--- a/src/icons/Phone.tsx
+++ b/src/icons/Phone.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react'
 import Svg, { Path } from 'react-native-svg'
-import Colors from 'src/styles/colors'
+import Colors, { ColorValue } from 'src/styles/colors'
 
 interface Props {
-  color?: Colors
+  color?: ColorValue
   size?: number
   testID?: string
 }

--- a/src/icons/QRCode.tsx
+++ b/src/icons/QRCode.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react'
 import Svg, { Path } from 'react-native-svg'
-import Colors from 'src/styles/colors'
+import Colors, { ColorValue } from 'src/styles/colors'
 
-const QRCode = ({ color = Colors.contentPrimary }: { color?: Colors }) => (
+const QRCode = ({ color = Colors.contentPrimary }: { color?: ColorValue }) => (
   <Svg width={18} height={18}>
     <Path
       fill={color}

--- a/src/icons/ScanIcon.tsx
+++ b/src/icons/ScanIcon.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react'
 import Svg, { ClipPath, Defs, G, Path, Rect } from 'react-native-svg'
-import colors from 'src/styles/colors'
+import colors, { ColorValue } from 'src/styles/colors'
 
 interface Props {
-  color?: colors
+  color?: ColorValue
   size?: number
 }
 

--- a/src/icons/StarOutline.tsx
+++ b/src/icons/StarOutline.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react'
 import Svg, { Path } from 'react-native-svg'
-import Colors from 'src/styles/colors'
+import Colors, { ColorValue } from 'src/styles/colors'
 
-const StarOutline = ({ color = Colors.contentPrimary }: { color?: Colors }) => (
+const StarOutline = ({ color = Colors.contentPrimary }: { color?: ColorValue }) => (
   <Svg width={24} height={24} fill="none">
     <Path
       d="m22.026 9.18-7.379-.636-2.884-6.794L8.88 8.554 1.5 9.181l5.604 4.854L5.42 21.25l6.342-3.828 6.343 3.828-1.673-7.215 5.593-4.854Zm-10.263 6.323-3.859 2.33 1.027-4.393-3.408-2.956 4.495-.39 1.745-4.136 1.755 4.146 4.495.39-3.407 2.956 1.026 4.393-3.869-2.34Z"

--- a/src/icons/SwapAndDeposit.tsx
+++ b/src/icons/SwapAndDeposit.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react'
 import Svg, { Path } from 'react-native-svg'
-import Colors from 'src/styles/colors'
+import Colors, { ColorValue } from 'src/styles/colors'
 
 interface Props {
-  color?: Colors
+  color?: ColorValue
 }
 
 const SwapAndDeposit = ({ color = Colors.contentPrimary }: Props) => (

--- a/src/icons/Trophy.tsx
+++ b/src/icons/Trophy.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react'
 import Svg, { Path } from 'react-native-svg'
-import Colors from 'src/styles/colors'
+import Colors, { ColorValue } from 'src/styles/colors'
 
 interface Props {
-  color?: Colors
+  color?: ColorValue
 }
 
 const Trophy = ({ color = Colors.contentPrimary }: Props) => (

--- a/src/icons/User.tsx
+++ b/src/icons/User.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react'
 import Svg, { Path } from 'react-native-svg'
-import Colors from 'src/styles/colors'
+import Colors, { ColorValue } from 'src/styles/colors'
 
 interface Props {
-  color?: Colors
+  color?: ColorValue
   size?: number
 }
 

--- a/src/icons/Warning.tsx
+++ b/src/icons/Warning.tsx
@@ -1,8 +1,14 @@
 import * as React from 'react'
 import Svg, { Path } from 'react-native-svg'
-import Colors from 'src/styles/colors'
+import Colors, { ColorValue } from 'src/styles/colors'
 
-function Warning({ color = Colors.warningPrimary, size = 16 }: { color?: Colors; size?: number }) {
+function Warning({
+  color = Colors.warningPrimary,
+  size = 16,
+}: {
+  color?: ColorValue
+  size?: number
+}) {
   return (
     <Svg width={size} height={size} viewBox="0 0 20 20" fill="none">
       <Path

--- a/src/icons/biometry/Face.tsx
+++ b/src/icons/biometry/Face.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react'
 import Svg, { Path } from 'react-native-svg'
-import Colors from 'src/styles/colors'
+import Colors, { ColorValue } from 'src/styles/colors'
 
-export function Face({ color = Colors.contentPrimary }: { color?: Colors }) {
+export function Face({ color = Colors.contentPrimary }: { color?: ColorValue }) {
   return (
     <Svg testID="FaceBiometryIcon" width={24} height={24} fill="none">
       <Path

--- a/src/icons/biometry/FaceID.tsx
+++ b/src/icons/biometry/FaceID.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react'
 import Svg, { Path } from 'react-native-svg'
-import Colors from 'src/styles/colors'
+import Colors, { ColorValue } from 'src/styles/colors'
 
-export function FaceID({ color = Colors.contentPrimary }: { color?: Colors }) {
+export function FaceID({ color = Colors.contentPrimary }: { color?: ColorValue }) {
   return (
     <Svg testID="FaceIDBiometryIcon" width={24} height={24} fill="none">
       <Path

--- a/src/icons/biometry/Fingerprint.tsx
+++ b/src/icons/biometry/Fingerprint.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react'
 import Svg, { Path } from 'react-native-svg'
-import Colors from 'src/styles/colors'
+import Colors, { ColorValue } from 'src/styles/colors'
 
-export function Fingerprint({ color = Colors.contentPrimary }: { color?: Colors }) {
+export function Fingerprint({ color = Colors.contentPrimary }: { color?: ColorValue }) {
   return (
     <Svg testID="FingerprintBiometryIcon" width={24} height={24} fill="none">
       <Path

--- a/src/icons/biometry/Iris.tsx
+++ b/src/icons/biometry/Iris.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react'
 import Svg, { Path } from 'react-native-svg'
-import Colors from 'src/styles/colors'
+import Colors, { ColorValue } from 'src/styles/colors'
 
-export function Iris({ color = Colors.contentPrimary }: { color?: Colors }) {
+export function Iris({ color = Colors.contentPrimary }: { color?: ColorValue }) {
   return (
     <Svg testID="IrisBiometryIcon" width={24} height={24} fill="none">
       <Path

--- a/src/icons/biometry/TouchID.tsx
+++ b/src/icons/biometry/TouchID.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react'
 import Svg, { Path } from 'react-native-svg'
-import Colors from 'src/styles/colors'
+import Colors, { ColorValue } from 'src/styles/colors'
 
-function TouchID({ color = Colors.contentPrimary }: { color?: Colors }) {
+function TouchID({ color = Colors.contentPrimary }: { color?: ColorValue }) {
   return (
     <Svg testID="TouchIDBiometryIcon" width={24} height={24} fill="none">
       <Path

--- a/src/icons/quick-actions/Add.tsx
+++ b/src/icons/quick-actions/Add.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react'
 import Svg, { Path } from 'react-native-svg'
-import Colors from 'src/styles/colors'
+import Colors, { ColorValue } from 'src/styles/colors'
 
 interface Props {
-  color?: Colors
+  color?: ColorValue
 }
 
 const QuickActionsAdd = ({ color = Colors.contentPrimary }: Props) => (

--- a/src/icons/quick-actions/More.tsx
+++ b/src/icons/quick-actions/More.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react'
 import Svg, { Path } from 'react-native-svg'
-import Colors from 'src/styles/colors'
+import Colors, { ColorValue } from 'src/styles/colors'
 
 interface Props {
-  color?: Colors
+  color?: ColorValue
 }
 
 const QuickActionsMore = ({ color = Colors.contentPrimary }: Props) => (

--- a/src/icons/quick-actions/Receive.tsx
+++ b/src/icons/quick-actions/Receive.tsx
@@ -1,10 +1,9 @@
 import * as React from 'react'
 import Svg, { Path } from 'react-native-svg'
-
-import Colors from 'src/styles/colors'
+import { ColorValue } from 'src/styles/colors'
 
 interface Props {
-  color: Colors
+  color: ColorValue
 }
 
 const QuickActionsReceive = ({ color }: Props) => (

--- a/src/icons/quick-actions/Send.tsx
+++ b/src/icons/quick-actions/Send.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react'
 import Svg, { Path } from 'react-native-svg'
-import Colors from 'src/styles/colors'
+import Colors, { ColorValue } from 'src/styles/colors'
 
 interface Props {
-  color?: Colors
+  color?: ColorValue
 }
 
 const QuickActionsSend = ({ color = Colors.contentPrimary }: Props) => (

--- a/src/icons/quick-actions/Withdraw.tsx
+++ b/src/icons/quick-actions/Withdraw.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react'
 import Svg, { Path } from 'react-native-svg'
-import Colors from 'src/styles/colors'
+import Colors, { ColorValue } from 'src/styles/colors'
 
 interface Props {
-  color?: Colors
+  color?: ColorValue
 }
 
 const QuickActionsWithdraw = ({ color = Colors.contentPrimary }: Props) => (

--- a/src/priceHistory/PriceHistoryChart.tsx
+++ b/src/priceHistory/PriceHistoryChart.tsx
@@ -18,7 +18,7 @@ import { priceHistoryPricesSelector, priceHistoryStatusSelector } from 'src/pric
 import { Price, fetchPriceHistoryStart } from 'src/priceHistory/slice'
 import { useDispatch, useSelector } from 'src/redux/hooks'
 import { RootState } from 'src/redux/reducers'
-import colors from 'src/styles/colors'
+import colors, { ColorValue } from 'src/styles/colors'
 import { Spacing } from 'src/styles/styles'
 import variables from 'src/styles/variables'
 import { getLocalCurrencyDisplayValue } from 'src/utils/formatting'
@@ -31,7 +31,13 @@ const CHART_MIN_VERTICAL_RANGE = 0.01 // one cent
 const CHART_DOMAIN_PADDING = { y: [30, 30] as [number, number], x: [5, 5] as [number, number] }
 const CHART_STEP_IN_HOURS = 12
 
-function Loader({ color = colors.loadingIndicator, style }: { color?: colors; style?: ViewStyle }) {
+function Loader({
+  color = colors.loadingIndicator,
+  style,
+}: {
+  color?: ColorValue
+  style?: ViewStyle
+}) {
   return (
     <View style={[styles.loader, style]}>
       <ActivityIndicator testID="PriceHistoryChart/Loader" size="large" color={color} />
@@ -96,7 +102,7 @@ function ChartAwareSvgText({
 function renderPointOnChart(
   chartData: Array<{ amount: number | BigNumber; displayValue: string }>,
   chartWidth: number,
-  color: colors
+  color: ColorValue
 ) {
   let lowestRateIdx = 0,
     highestRateIdx = 0
@@ -209,7 +215,7 @@ interface PriceHistoryChartProps {
   containerStyle?: ViewStyle
   testID?: string
   chartPadding?: number
-  color?: colors
+  color?: ColorValue
   step?: number
 }
 

--- a/src/styles/colors.tsx
+++ b/src/styles/colors.tsx
@@ -1,66 +1,68 @@
 // Designer Created Figma Colors
-// from https://www.figma.com/design/erFfzHvSTm5g1sjK6jWyEH/Working-Design-System?node-id=2100-4881&node-type=frame&t=vKGGXrs3Torz7kFE-0
-enum Colors {
+// from https://www.figma.com/design/erFfzHvSTm5g1sjK6jWyEH/Working-Design-System?node-id:2100-4881&node-type:frame&t:vKGGXrs3Torz7kFE-0
+const colors = {
   // backgrounds
-  backgroundPrimary = '#FFFFFF', // Main background color for the app, used for primary surfaces (screens, navigation).
-  backgroundSecondary = '#F8F9F9', // Subtle contrast background for secondary surfaces like cards, panels, or inputs.
-  backgroundTertiary = '#E6E6E6', // Low-emphasis background for subtle supporting areas, typically used when both primary and secondary backgrounds are present, and an additional layer of distinction is needed.
-  backgroundScrim = '#000000', // Semi-transparent underlay behind bottom sheets, modals, dialogs, and other temporary surfaces to dim the background.
+  backgroundPrimary: '#FFFFFF', // Main background color for the app, used for primary surfaces (screens, navigation).
+  backgroundSecondary: '#F8F9F9', // Subtle contrast background for secondary surfaces like cards, panels, or inputs.
+  backgroundTertiary: '#E6E6E6', // Low-emphasis background for subtle supporting areas, typically used when both primary and secondary backgrounds are present, and an additional layer of distinction is needed.
+  backgroundScrim: '#000000', // Semi-transparent underlay behind bottom sheets, modals, dialogs, and other temporary surfaces to dim the background.
 
   // text, icons, and other content
-  contentPrimary = '#2E3338', // main content on primary background
-  contentSecondary = '#757575', // supporting context on primary background
-  contentTertiary = '#FFFFFF', // content on colored backgrounds
-  textLink = '#757575', // underlined text links on primary background
+  contentPrimary: '#2E3338', // main content on primary background
+  contentSecondary: '#757575', // supporting context on primary background
+  contentTertiary: '#FFFFFF', // content on colored backgrounds
+  textLink: '#757575', // underlined text links on primary background
 
   // borders, shadows, highlights, visual effects
-  borderPrimary = '#E6E6E6', // Border color used to create emphasis or highlight key areas.
-  borderSecondary = '#E6E6E6', // Border color used to define or separate secondary content.
-  softShadow = 'rgba(156, 164, 169, 0.4)',
-  lightShadow = 'rgba(48, 46, 37, 0.15)',
-  barShadow = 'rgba(129, 134, 139, 0.5)',
-  skeletonPlaceholderHighlight = '#FFFFFF', // animated highlight color on skeleton loaders
-  skeletonPlaceholderBackground = '#E6E6E6', // background color on skeleton loaders
-  loadingIndicator = '#1AB775', // spinner or loading indicator
+  borderPrimary: '#E6E6E6', // Border color used to create emphasis or highlight key areas.
+  borderSecondary: '#E6E6E6', // Border color used to define or separate secondary content.
+  softShadow: 'rgba(156, 164, 169, 0.4)',
+  lightShadow: 'rgba(48, 46, 37, 0.15)',
+  barShadow: 'rgba(129, 134, 139, 0.5)',
+  skeletonPlaceholderHighlight: '#FFFFFF', // animated highlight color on skeleton loaders
+  skeletonPlaceholderBackground: '#E6E6E6', // background color on skeleton loaders
+  loadingIndicator: '#1AB775', // spinner or loading indicator
 
   // interactive elements
-  navigationTopPrimary = '#2E3338', // color for text and icons on top navigation
-  navigationTopSecondary = '#757575', // secondary color for text and icons on top navigation
-  navigationBottomPrimary = '#2E3338', // color for text and icons on bottom navigation
-  navigationBottomSecondary = '#757575', // secondary color for text and icons on bottom navigation
-  bottomSheetHandle = '#757575', // color for bottom sheet handle
-  buttonPrimaryBackground = '#2E3338', // Background color for primary buttons (high-priority actions).
-  buttonPrimaryContent = '#FFFFFF', // Text and icon color for primary buttons.
-  buttonPrimaryBorder = '#2E3338', // Border color for primary buttons.
-  buttonSecondaryBackground = '#F8F9F9', // Background color for secondary buttons (less emphasized actions).
-  buttonSecondaryContent = '#2E3338', // Text and icon color for secondary buttons.
-  buttonSecondaryBorder = '#E6E6E6', // Border color for secondary buttons.
-  buttonTertiaryBackground = '#FFFFFF', // Background color for tertiary buttons (minimal or low-emphasis actions).
-  buttonTertiaryContent = '#2E3338', // Text and icon color for tertiary buttons.
-  buttonTertiaryBorder = '#E6E6E6', // Border color for tertiary buttons.
-  buttonQuickActionBackground = '#F1FDF1', // Background color for quick action buttons (specialized high-priority actions).
-  buttonQuickActionContent = '#137211', // Text and icon color for quick action buttons.
-  buttonQuickActionBorder = '#F1FDF1', // Border color for quick action buttons.
-  textInputBackground = '#FFFFFF', // Background color for text input fields.
-  qrTabBarPrimary = '#2E3338', // color for text and icons on QR tab bar
-  qrTabBarSecondary = '#FFFFFF', // secondary color for text and icons on QR tab bar
+  navigationTopPrimary: '#2E3338', // color for text and icons on top navigation
+  navigationTopSecondary: '#757575', // secondary color for text and icons on top navigation
+  navigationBottomPrimary: '#2E3338', // color for text and icons on bottom navigation
+  navigationBottomSecondary: '#757575', // secondary color for text and icons on bottom navigation
+  bottomSheetHandle: '#757575', // color for bottom sheet handle
+  buttonPrimaryBackground: '#2E3338', // Background color for primary buttons (high-priority actions).
+  buttonPrimaryContent: '#FFFFFF', // Text and icon color for primary buttons.
+  buttonPrimaryBorder: '#2E3338', // Border color for primary buttons.
+  buttonSecondaryBackground: '#F8F9F9', // Background color for secondary buttons (less emphasized actions).
+  buttonSecondaryContent: '#2E3338', // Text and icon color for secondary buttons.
+  buttonSecondaryBorder: '#E6E6E6', // Border color for secondary buttons.
+  buttonTertiaryBackground: '#FFFFFF', // Background color for tertiary buttons (minimal or low-emphasis actions).
+  buttonTertiaryContent: '#2E3338', // Text and icon color for tertiary buttons.
+  buttonTertiaryBorder: '#E6E6E6', // Border color for tertiary buttons.
+  buttonQuickActionBackground: '#F1FDF1', // Background color for quick action buttons (specialized high-priority actions).
+  buttonQuickActionContent: '#137211', // Text and icon color for quick action buttons.
+  buttonQuickActionBorder: '#F1FDF1', // Border color for quick action buttons.
+  textInputBackground: '#FFFFFF', // Background color for text input fields.
+  qrTabBarPrimary: '#2E3338', // color for text and icons on QR tab bar
+  qrTabBarSecondary: '#FFFFFF', // secondary color for text and icons on QR tab bar
 
   // statuses and UI feedback colors
-  disabled = '#E6E6E6', // Used for disabled elements that are non-interactive or visually de-emphasized.
-  inactive = '#757575', // Represents inactive or placeholder elements, often less prominent but still visible.
-  info = '#F8F9F9', // Background for neutral or informational states, typically non-critical.
-  successPrimary = '#137211', // Indicates successful actions or positive states, often used for icons or highlights.
-  successSecondary = '#F1FDF1', // Subtle background for success states, such as notifications or banners.
-  warningPrimary = '#9C6E00', // Highlights warning states, used to draw attention to cautionary information.
-  warningSecondary = '#FFF9EA', // Subtle background for warning states, providing gentle emphasis without overpowering.
-  errorPrimary = '#C93717', // Represents error or failure states, used for critical feedback or alerts.
-  errorSecondary = '#FBF2F0', // Subtle background for error states, providing softer emphasis in contexts like modals or notifications.
+  disabled: '#E6E6E6', // Used for disabled elements that are non-interactive or visually de-emphasized.
+  inactive: '#757575', // Represents inactive or placeholder elements, often less prominent but still visible.
+  info: '#F8F9F9', // Background for neutral or informational states, typically non-critical.
+  successPrimary: '#137211', // Indicates successful actions or positive states, often used for icons or highlights.
+  successSecondary: '#F1FDF1', // Subtle background for success states, such as notifications or banners.
+  warningPrimary: '#9C6E00', // Highlights warning states, used to draw attention to cautionary information.
+  warningSecondary: '#FFF9EA', // Subtle background for warning states, providing gentle emphasis without overpowering.
+  errorPrimary: '#C93717', // Represents error or failure states, used for critical feedback or alerts.
+  errorSecondary: '#FBF2F0', // Subtle background for error states, providing softer emphasis in contexts like modals or notifications.
 
   // brand colors for decorative elements
-  accent = '#1AB775', // Accent color for emphasizing key elements, such as highlights, icons, or decorative details.
-  brandGradientLeft = '#26d98a', // Starting color for the brand gradient, used in backgrounds or borders to reinforce brand identity.
-  brandGradientRight = '#ffd52c', // Ending color for the brand gradient, used in backgrounds or borders to reinforce brand identity.
-  contentOnboardingComplete = '#FFFFFF', // Text and image color for onboarding completion screen
-}
+  accent: '#1AB775', // Accent color for emphasizing key elements, such as highlights, icons, or decorative details.
+  brandGradientLeft: '#26d98a', // Starting color for the brand gradient, used in backgrounds or borders to reinforce brand identity.
+  brandGradientRight: '#ffd52c', // Ending color for the brand gradient, used in backgrounds or borders to reinforce brand identity.
+  contentOnboardingComplete: '#FFFFFF', // Text and image color for onboarding completion screen
+} as const
 
-export default Colors
+export type ColorValue = (typeof colors)[keyof typeof colors]
+
+export default colors

--- a/src/tokens/types.ts
+++ b/src/tokens/types.ts
@@ -1,4 +1,4 @@
-import Colors from 'src/styles/colors'
+import { ColorValue } from 'src/styles/colors'
 
 export enum TokenActionName {
   Send = 'Send',
@@ -13,7 +13,7 @@ export interface TokenAction {
   name: TokenActionName
   title: string
   details: string
-  iconComponent: React.MemoExoticComponent<({ color }: { color?: Colors }) => JSX.Element>
+  iconComponent: React.MemoExoticComponent<({ color }: { color?: ColorValue }) => JSX.Element>
   onPress: () => void
   visible: boolean
 }


### PR DESCRIPTION
### Description

This PR changes the `colors` from enum to object. The usage is still the same, but the object cannot be referenced as a type in the same way as an enum can. This change facilitates being able to overwrite the default colors with custom colors via config, plus there are benefits of moving away from enums (e.g. [here](https://www.totaltypescript.com/erasable-syntax-only)).

### Test plan

n/a

### Related issues

- Related to RET-1280

### Backwards compatibility

Y

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [ ] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
