### PR TITLE
refactor: move swap feature flag from remote config to statsig

### DIFF
--- a/src/app/reducers.ts
+++ b/src/app/reducers.ts
@@ -36,7 +36,6 @@ interface State {
   fiatConnectCashInEnabled: boolean
   fiatConnectCashOutEnabled: boolean
   coinbasePayEnabled: boolean
-  showSwapMenuInDrawerMenu: boolean
   maxSwapSlippagePercentage: number
   inviterAddress: string | null
   networkTimeoutSeconds: number
@@ -77,7 +76,6 @@ const initialState = {
   fiatConnectCashInEnabled: REMOTE_CONFIG_VALUES_DEFAULTS.fiatConnectCashInEnabled,
   fiatConnectCashOutEnabled: REMOTE_CONFIG_VALUES_DEFAULTS.fiatConnectCashOutEnabled,
   coinbasePayEnabled: REMOTE_CONFIG_VALUES_DEFAULTS.coinbasePayEnabled,
-  showSwapMenuInDrawerMenu: REMOTE_CONFIG_VALUES_DEFAULTS.showSwapMenuInDrawerMenu,
   maxSwapSlippagePercentage: REMOTE_CONFIG_VALUES_DEFAULTS.maxSwapSlippagePercentage,
   inviterAddress: null,
   networkTimeoutSeconds: REMOTE_CONFIG_VALUES_DEFAULTS.networkTimeoutSeconds,
@@ -178,7 +176,6 @@ export const appReducer = (
         fiatConnectCashInEnabled: action.configValues.fiatConnectCashInEnabled,
         fiatConnectCashOutEnabled: action.configValues.fiatConnectCashOutEnabled,
         coinbasePayEnabled: action.configValues.coinbasePayEnabled,
-        showSwapMenuInDrawerMenu: action.configValues.showSwapMenuInDrawerMenu,
         maxSwapSlippagePercentage: action.configValues.maxSwapSlippagePercentage,
         networkTimeoutSeconds: action.configValues.networkTimeoutSeconds,
         celoNews: action.configValues.celoNews,

--- a/src/app/saga.ts
+++ b/src/app/saga.ts
@@ -191,7 +191,6 @@ export interface RemoteConfigValues {
   fiatConnectCashOutEnabled: boolean
   fiatAccountSchemaCountryOverrides: FiatAccountSchemaCountryOverrides
   coinbasePayEnabled: boolean
-  showSwapMenuInDrawerMenu: boolean
   maxSwapSlippagePercentage: number
   networkTimeoutSeconds: number
   celoNews: CeloNewsConfig

--- a/src/earn/hooks.ts
+++ b/src/earn/hooks.ts
@@ -9,13 +9,13 @@ import {
 } from 'src/earn/prepareTransactions'
 import { EarnActiveMode } from 'src/earn/types'
 import { fetchExchanges } from 'src/fiatExchanges/utils'
-import { isAppSwapsEnabledSelector } from 'src/navigator/selectors'
 import { userLocationDataSelector } from 'src/networkInfo/selectors'
 import { earnPositionsSelector } from 'src/positions/selectors'
 import { EarnPosition, Position } from 'src/positions/types'
 import { useSelector } from 'src/redux/hooks'
-import { getFeatureGate } from 'src/statsig'
-import { StatsigFeatureGates } from 'src/statsig/types'
+import { getDynamicConfigParams, getFeatureGate } from 'src/statsig'
+import { DynamicConfigs } from 'src/statsig/constants'
+import { StatsigDynamicConfigs, StatsigFeatureGates } from 'src/statsig/types'
 import { useCashInTokens, useSwappableTokens } from 'src/tokens/hooks'
 import { TokenBalance, TokenBalances } from 'src/tokens/slice'
 import Logger from 'src/utils/Logger'
@@ -44,7 +44,9 @@ export function useDepositEntrypointInfo({
 
   const { swappableFromTokens } = useSwappableTokens()
   const cashInTokens = useCashInTokens()
-  const isSwapEnabled = useSelector(isAppSwapsEnabledSelector)
+  const isSwapEnabled = getDynamicConfigParams(
+    DynamicConfigs[StatsigDynamicConfigs.SWAP_CONFIG]
+  ).enabled
   const userLocation = useSelector(userLocationDataSelector)
 
   const hasDepositToken = useMemo(() => {

--- a/src/earn/poolInfoScreen/EarnPoolInfoScreen.test.tsx
+++ b/src/earn/poolInfoScreen/EarnPoolInfoScreen.test.tsx
@@ -23,7 +23,7 @@ import {
 } from 'test/values'
 
 jest.mock('src/statsig', () => ({
-  getDynamicConfigParams: jest.fn().mockResolvedValue({ enabled: true }),
+  getDynamicConfigParams: jest.fn().mockReturnValue({ enabled: true }),
   getMultichainFeatures: jest.fn(),
   getFeatureGate: jest.fn(),
 }))

--- a/src/earn/poolInfoScreen/EarnPoolInfoScreen.test.tsx
+++ b/src/earn/poolInfoScreen/EarnPoolInfoScreen.test.tsx
@@ -23,6 +23,7 @@ import {
 } from 'test/values'
 
 jest.mock('src/statsig', () => ({
+  getDynamicConfigParams: jest.fn().mockResolvedValue({ enabled: true }),
   getMultichainFeatures: jest.fn(),
   getFeatureGate: jest.fn(),
 }))
@@ -55,7 +56,6 @@ function getStore({
     positions: {
       positions: includeRewardPositions ? [...mockPositions, ...mockRewardsPositions] : [],
     },
-    app: { showSwapMenuInDrawerMenu: true },
   })
 }
 

--- a/src/firebase/firebase.ts
+++ b/src/firebase/firebase.ts
@@ -295,7 +295,6 @@ export async function fetchRemoteConfigValues(): Promise<RemoteConfigValues | nu
       ? JSON.parse(fiatAccountSchemaCountryOverrides)
       : {},
     coinbasePayEnabled: flags.coinbasePayEnabled.asBoolean(),
-    showSwapMenuInDrawerMenu: flags.showSwapMenuInDrawerMenu.asBoolean(),
     maxSwapSlippagePercentage: flags.maxSwapSlippagePercentage.asNumber(),
     networkTimeoutSeconds: flags.networkTimeoutSeconds.asNumber(),
     celoNews: celoNewsString ? JSON.parse(celoNewsString) : {},

--- a/src/firebase/remoteConfigValuesDefaults.e2e.ts
+++ b/src/firebase/remoteConfigValuesDefaults.e2e.ts
@@ -20,7 +20,6 @@ export const REMOTE_CONFIG_VALUES_DEFAULTS: Omit<
   fiatConnectCashInEnabled: false,
   fiatConnectCashOutEnabled: true,
   coinbasePayEnabled: false,
-  showSwapMenuInDrawerMenu: false,
   maxSwapSlippagePercentage: 2,
   networkTimeoutSeconds: 30,
   celoNews: JSON.stringify({} as RemoteConfigValues['celoNews']),

--- a/src/firebase/remoteConfigValuesDefaults.ts
+++ b/src/firebase/remoteConfigValuesDefaults.ts
@@ -22,7 +22,6 @@ export const REMOTE_CONFIG_VALUES_DEFAULTS: Omit<
   fiatConnectCashInEnabled: false,
   fiatConnectCashOutEnabled: false,
   coinbasePayEnabled: false,
-  showSwapMenuInDrawerMenu: false,
   maxSwapSlippagePercentage: 2,
   networkTimeoutSeconds: 30,
   celoNews: JSON.stringify({} as RemoteConfigValues['celoNews']),

--- a/src/home/ActionsCarousel.test.tsx
+++ b/src/home/ActionsCarousel.test.tsx
@@ -10,23 +10,19 @@ import ActionsCarousel from 'src/home/ActionsCarousel'
 import { HomeActionName } from 'src/home/types'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
+import { getDynamicConfigParams } from 'src/statsig'
 import { createMockStore } from 'test/utils'
+
+jest.mock('src/statsig')
 
 const mockConfig = jest.mocked(config)
 const originalEnabledQuickActions = config.ENABLED_QUICK_ACTIONS
 
-function getStore(shouldShowSwapAction: boolean) {
-  return createMockStore({
-    app: {
-      showSwapMenuInDrawerMenu: shouldShowSwapAction,
-    },
-  })
-}
-
 describe('ActionsCarousel', () => {
   let store: MockStoreEnhanced<{}>
   beforeEach(() => {
-    store = getStore(true)
+    jest.mocked(getDynamicConfigParams).mockReturnValue({ enabled: true }) // swap feature enabled
+    store = createMockStore()
     mockConfig.ENABLED_QUICK_ACTIONS = originalEnabledQuickActions
   })
 
@@ -45,7 +41,7 @@ describe('ActionsCarousel', () => {
   })
 
   it('does not render swap action when disabled', () => {
-    store = getStore(false)
+    jest.mocked(getDynamicConfigParams).mockReturnValue({ enabled: false }) // swap feature disabled
     const { queryByTestId, getAllByTestId } = render(
       <Provider store={store}>
         <ActionsCarousel />

--- a/src/home/ActionsCarousel.tsx
+++ b/src/home/ActionsCarousel.tsx
@@ -15,8 +15,9 @@ import QuickActionsWithdraw from 'src/icons/quick-actions/Withdraw'
 import SwapArrows from 'src/icons/SwapArrows'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
-import { isAppSwapsEnabledSelector } from 'src/navigator/selectors'
-import { useSelector } from 'src/redux/hooks'
+import { getDynamicConfigParams } from 'src/statsig'
+import { DynamicConfigs } from 'src/statsig/constants'
+import { StatsigDynamicConfigs } from 'src/statsig/types'
 import Colors from 'src/styles/colors'
 import { typeScale } from 'src/styles/fonts'
 import { Spacing } from 'src/styles/styles'
@@ -29,7 +30,9 @@ type Actions = Record<
 function ActionsCarousel() {
   const { t } = useTranslation()
 
-  const shouldShowSwapAction = useSelector(isAppSwapsEnabledSelector)
+  const shouldShowSwapAction = getDynamicConfigParams(
+    DynamicConfigs[StatsigDynamicConfigs.SWAP_CONFIG]
+  ).enabled
 
   const actions: Actions = {
     [HomeActionName.Send]: {

--- a/src/home/TabHome.test.tsx
+++ b/src/home/TabHome.test.tsx
@@ -74,6 +74,7 @@ const mockBalances = {
 }
 
 jest.mock('src/statsig', () => ({
+  getDynamicConfigParams: jest.fn().mockReturnValue({ enabled: true }),
   getFeatureGate: jest.fn().mockReturnValue(false),
   getMultichainFeatures: jest.fn(() => ({
     showBalances: ['celo-alfajores'],

--- a/src/jumpstart/JumpstartIntro.test.tsx
+++ b/src/jumpstart/JumpstartIntro.test.tsx
@@ -8,21 +8,15 @@ import { createMockStore } from 'test/utils'
 
 jest.mock('src/statsig')
 
-jest.mocked(getDynamicConfigParams).mockReturnValue({
-  wallet_network_timeout_seconds: 10,
-  jumpstartContracts: [],
-})
-
 describe('JumpstartIntro', () => {
   it('should render the correct actions and components', () => {
+    jest.mocked(getDynamicConfigParams).mockReturnValue({
+      wallet_network_timeout_seconds: 10,
+      jumpstartContracts: [],
+      enabled: false, // swap feature disabled
+    })
     const { getByText, queryByText, getByTestId } = render(
-      <Provider
-        store={createMockStore({
-          app: {
-            showSwapMenuInDrawerMenu: false,
-          },
-        })}
-      >
+      <Provider store={createMockStore()}>
         <JumpstartIntro />
       </Provider>
     )
@@ -39,14 +33,13 @@ describe('JumpstartIntro', () => {
   })
 
   it('should trigger the expected callbacks on press actions', async () => {
+    jest.mocked(getDynamicConfigParams).mockReturnValue({
+      wallet_network_timeout_seconds: 10,
+      jumpstartContracts: [],
+      enabled: true, // swap feature enabled
+    })
     const { getByText } = render(
-      <Provider
-        store={createMockStore({
-          app: {
-            showSwapMenuInDrawerMenu: true,
-          },
-        })}
-      >
+      <Provider store={createMockStore()}>
         <JumpstartIntro />
       </Provider>
     )

--- a/src/jumpstart/JumpstartIntro.tsx
+++ b/src/jumpstart/JumpstartIntro.tsx
@@ -16,8 +16,10 @@ import WaveCurve from 'src/images/WaveCurve'
 import { jumpstartIntroSeen } from 'src/jumpstart/slice'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
-import { isAppSwapsEnabledSelector } from 'src/navigator/selectors'
 import { useSelector } from 'src/redux/hooks'
+import { getDynamicConfigParams } from 'src/statsig'
+import { DynamicConfigs } from 'src/statsig/constants'
+import { StatsigDynamicConfigs } from 'src/statsig/types'
 import { typeScale } from 'src/styles/fonts'
 import { Spacing } from 'src/styles/styles'
 import { jumpstartSendTokensSelector } from 'src/tokens/selectors'
@@ -31,7 +33,9 @@ export default function JumpstartIntro() {
   const addAssetsBottomSheetRef = useRef<BottomSheetModalRefType>(null)
 
   const tokens = useSelector(jumpstartSendTokensSelector)
-  const isSwapEnabled = useSelector(isAppSwapsEnabledSelector)
+  const isSwapEnabled = getDynamicConfigParams(
+    DynamicConfigs[StatsigDynamicConfigs.SWAP_CONFIG]
+  ).enabled
   const noTokens = tokens.length === 0
 
   // Track in analytics whenever user sees the intro

--- a/src/navigator/selectors.ts
+++ b/src/navigator/selectors.ts
@@ -1,3 +1,0 @@
-import { RootState } from 'src/redux/reducers'
-
-export const isAppSwapsEnabledSelector = (state: RootState) => state.app.showSwapMenuInDrawerMenu

--- a/src/redux/migrations.ts
+++ b/src/redux/migrations.ts
@@ -743,7 +743,7 @@ export const migrations = {
     ...state,
     app: {
       ...state.app,
-      showSwapMenuInDrawerMenu: REMOTE_CONFIG_VALUES_DEFAULTS.showSwapMenuInDrawerMenu,
+      showSwapMenuInDrawerMenu: false,
     },
   }),
   62: (state: any) => ({
@@ -1981,5 +1981,9 @@ export const migrations = {
   238: (state: any) => ({
     ...state,
     app: _.omit(state.app, 'multichainBetaStatus'),
+  }),
+  239: (state: any) => ({
+    ...state,
+    app: _.omit(state.app, 'showSwapMenuInDrawerMenu'),
   }),
 }

--- a/src/redux/store.test.ts
+++ b/src/redux/store.test.ts
@@ -143,7 +143,7 @@ describe('store state', () => {
       {
         "_persist": {
           "rehydrated": true,
-          "version": 238,
+          "version": 239,
         },
         "account": {
           "acceptedTerms": false,
@@ -209,7 +209,6 @@ describe('store state', () => {
           "sentryTracesSampleRate": 0.2,
           "sessionId": "",
           "showNotificationSpotlight": true,
-          "showSwapMenuInDrawerMenu": false,
           "supportedBiometryType": null,
           "walletConnectV2Enabled": true,
         },

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -26,7 +26,7 @@ const persistConfig: PersistConfig<ReducersRootState> = {
   key: 'root',
   // default is -1, increment as we make migrations
   // See https://github.com/valora-inc/wallet/tree/main/WALLET.md#redux-state-migration
-  version: 238,
+  version: 239,
   keyPrefix: `reduxStore-`, // the redux-persist default is `persist:` which doesn't work with some file systems.
   storage: FSStorage(),
   blacklist: ['networkInfo', 'alert', 'imports', 'keylessBackup', transactionFeedV2Api.reducerPath],

--- a/src/statsig/constants.ts
+++ b/src/statsig/constants.ts
@@ -65,6 +65,7 @@ export const DynamicConfigs = {
       maxSlippagePercentage: '0.3',
       enableAppFee: false,
       popularTokenIds: [] as string[],
+      enabled: false,
     },
   },
   [StatsigDynamicConfigs.CICO_TOKEN_INFO]: {

--- a/src/tokens/TokenDetails.test.tsx
+++ b/src/tokens/TokenDetails.test.tsx
@@ -6,7 +6,7 @@ import { CICOFlow } from 'src/fiatExchanges/types'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import { Price } from 'src/priceHistory/slice'
-import { getFeatureGate } from 'src/statsig'
+import { getDynamicConfigParams, getFeatureGate } from 'src/statsig'
 import TokenDetailsScreen from 'src/tokens/TokenDetails'
 import { NetworkId } from 'src/transactions/types'
 import { ONE_DAY_IN_MILLIS } from 'src/utils/time'
@@ -20,6 +20,7 @@ import {
 } from 'test/values'
 
 jest.mock('src/statsig', () => ({
+  getDynamicConfigParams: jest.fn(),
   getMultichainFeatures: jest.fn(() => {
     return {
       showCico: ['celo-alfajores', 'ethereum-sepolia'],
@@ -33,6 +34,7 @@ jest.mock('src/statsig', () => ({
 describe('TokenDetails', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    jest.mocked(getDynamicConfigParams).mockReturnValue({ enabled: true }) // Ennable swap feature by default
   })
   it('renders title, balance and token balance item', () => {
     const store = createMockStore({
@@ -293,9 +295,6 @@ describe('TokenDetails', () => {
           [mockPoofTokenId]: mockTokenBalances[mockPoofTokenId],
         },
       },
-      app: {
-        showSwapMenuInDrawerMenu: true,
-      },
     })
 
     const { getByTestId, queryByTestId } = render(
@@ -317,9 +316,6 @@ describe('TokenDetails', () => {
         tokenBalances: {
           [mockPoofTokenId]: { ...mockTokenBalances[mockPoofTokenId], isSwappable: true },
         },
-      },
-      app: {
-        showSwapMenuInDrawerMenu: true,
       },
     })
 
@@ -347,9 +343,6 @@ describe('TokenDetails', () => {
           },
         },
       },
-      app: {
-        showSwapMenuInDrawerMenu: true,
-      },
     })
 
     const { getByTestId, queryByTestId } = render(
@@ -375,9 +368,6 @@ describe('TokenDetails', () => {
           },
         },
       },
-      app: {
-        showSwapMenuInDrawerMenu: true,
-      },
     })
 
     const { getByTestId, queryByTestId } = render(
@@ -394,6 +384,7 @@ describe('TokenDetails', () => {
   })
 
   it('hides swap action and shows more action if token is swappable, has balance and CICO token but swapfeature gate is false', () => {
+    jest.mocked(getDynamicConfigParams).mockReturnValue({ enabled: false }) // disable swap feature
     const store = createMockStore({
       tokens: {
         tokenBalances: {
@@ -403,9 +394,6 @@ describe('TokenDetails', () => {
             isSwappable: true,
           },
         },
-      },
-      app: {
-        showSwapMenuInDrawerMenu: false,
       },
     })
 
@@ -433,9 +421,6 @@ describe('TokenDetails', () => {
             isSwappable: true,
           },
         },
-      },
-      app: {
-        showSwapMenuInDrawerMenu: true,
       },
     })
 
@@ -478,9 +463,6 @@ describe('TokenDetails', () => {
             symbol: 'TT',
           },
         },
-      },
-      app: {
-        showSwapMenuInDrawerMenu: true,
       },
     })
 

--- a/src/tokens/TokenDetails.tsx
+++ b/src/tokens/TokenDetails.tsx
@@ -28,11 +28,13 @@ import { getLocalCurrencySymbol } from 'src/localCurrency/selectors'
 import { noHeader } from 'src/navigator/Headers'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
-import { isAppSwapsEnabledSelector } from 'src/navigator/selectors'
 import { StackParamList } from 'src/navigator/types'
 import PriceHistoryChart from 'src/priceHistory/PriceHistoryChart'
 import { useSelector } from 'src/redux/hooks'
 import { NETWORK_NAMES } from 'src/shared/conts'
+import { getDynamicConfigParams } from 'src/statsig'
+import { DynamicConfigs } from 'src/statsig/constants'
+import { StatsigDynamicConfigs } from 'src/statsig/types'
 import Colors from 'src/styles/colors'
 import { typeScale } from 'src/styles/fonts'
 import { Spacing } from 'src/styles/styles'
@@ -168,7 +170,10 @@ export const useActions = (token: TokenBalance) => {
   const { swappableFromTokens } = useSwappableTokens()
   const cashInTokens = useCashInTokens()
   const cashOutTokens = useCashOutTokens()
-  const isSwapEnabled = useSelector(isAppSwapsEnabledSelector)
+  const isSwapEnabled = getDynamicConfigParams(
+    DynamicConfigs[StatsigDynamicConfigs.SWAP_CONFIG]
+  ).enabled
+
   const showWithdraw = !!cashOutTokens.find((tokenInfo) => tokenInfo.tokenId === token.tokenId)
 
   return [

--- a/test/RootStateSchema.json
+++ b/test/RootStateSchema.json
@@ -4796,9 +4796,6 @@
                 "showNotificationSpotlight": {
                     "type": "boolean"
                 },
-                "showSwapMenuInDrawerMenu": {
-                    "type": "boolean"
-                },
                 "supportedBiometryType": {
                     "anyOf": [
                         {
@@ -4850,7 +4847,6 @@
                 "sentryTracesSampleRate",
                 "sessionId",
                 "showNotificationSpotlight",
-                "showSwapMenuInDrawerMenu",
                 "supportedBiometryType",
                 "walletConnectV2Enabled"
             ],

--- a/test/schemas.ts
+++ b/test/schemas.ts
@@ -3594,6 +3594,15 @@ export const v238Schema = {
   app: _.omit(v237Schema.app, 'multichainBetaStatus'),
 }
 
+export const v239Schema = {
+  ...v238Schema,
+  _persist: {
+    ...v238Schema._persist,
+    version: 239,
+  },
+  app: _.omit(v238Schema.app, 'showSwapMenuInDrawerMenu'),
+}
+
 export function getLatestSchema(): Partial<RootState> {
-  return v238Schema as Partial<RootState>
+  return v239Schema as Partial<RootState>
 }


### PR DESCRIPTION
### Description

As the title. Useful for apps that then don't need firebase.

### Test plan

n/a

### Related issues

- Related to RET-1289

### Backwards compatibility

Y

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [ ] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
