### PR TITLE
fix: ensure graceful handling of when Firebase is disabled

### DIFF
--- a/src/app/ErrorMessages.ts
+++ b/src/app/ErrorMessages.ts
@@ -13,7 +13,6 @@ export enum ErrorMessages {
   ACCOUNT_UNLOCK_FAILED = 'accountUnlockFailed',
   SEND_PAYMENT_FAILED = 'sendPaymentFailed',
   ACCOUNT_SETUP_FAILED = 'accountSetupFailed',
-  FIREBASE_DISABLED = 'firebaseDisabled',
   FIREBASE_FAILED = 'firebaseFailed',
   IMPORT_CONTACTS_FAILED = 'importContactsFailed',
   QR_FAILED_INVALID_ADDRESS = 'qrFailedInvalidAddress',

--- a/src/fiatExchanges/saga.ts
+++ b/src/fiatExchanges/saga.ts
@@ -2,6 +2,7 @@ import { Action, Predicate } from '@redux-saga/types'
 import BigNumber from 'bignumber.js'
 import { SendOrigin } from 'src/analytics/types'
 import { ActionTypes as AppActionTypes, Actions as AppActions } from 'src/app/actions'
+import { FIREBASE_ENABLED } from 'src/config'
 import {
   Actions,
   BidaliPaymentRequestedAction,
@@ -167,6 +168,11 @@ export function* tagTxsWithProviderInfo(action: UpdateTransactionsPayload) {
 }
 
 export function* importProviderLogos() {
+  if (!FIREBASE_ENABLED) {
+    Logger.info(`${TAG}/importProviderLogos`, 'Firebase disabled')
+    return
+  }
+
   const providerLogos: ProviderLogos = yield readOnceFromFirebase('providerLogos')
   yield* put(setProviderLogos(providerLogos))
 }

--- a/src/firebase/firebase.ts
+++ b/src/firebase/firebase.ts
@@ -369,6 +369,11 @@ export function simpleReadChannel(key: string) {
 }
 
 export async function readOnceFromFirebase(path: string) {
+  if (!FIREBASE_ENABLED) {
+    Logger.info(`${TAG}/readOnceFromFirebase`, 'Firebase disabled')
+    return null
+  }
+
   const timeout = new Promise<void>((_, reject) =>
     setTimeout(
       () => reject(Error(`Reading from Firebase @ ${path} timed out.`)),

--- a/src/firebase/saga.ts
+++ b/src/firebase/saga.ts
@@ -33,8 +33,7 @@ export function* initializeFirebase() {
     return
   }
   if (!FIREBASE_ENABLED) {
-    Logger.info(TAG, 'Firebase disabled')
-    yield* put(showError(ErrorMessages.FIREBASE_DISABLED))
+    Logger.info(`${TAG}/initializeFirebase`, 'Firebase disabled')
     return
   }
 

--- a/test/RootStateSchema.json
+++ b/test/RootStateSchema.json
@@ -248,7 +248,6 @@
                                 "fiatConnectKycStatusScreen.tryAgainFailed",
                                 "fiatDetailsScreen.addFiatAccountFailed",
                                 "fiatDetailsScreen.addFiatAccountResourceExist",
-                                "firebaseDisabled",
                                 "firebaseFailed",
                                 "hooksPreview.invalidApiUrl",
                                 "importBackupFailed",


### PR DESCRIPTION
### Description

As the title - currently there are some error banners and logs that are incorrectly triggered.

### Test plan

n/a

### Related issues

- Related to RET-1289

### Backwards compatibility

Y

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [ ] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
