### PR TITLE
fix: EnterAmount wrong formatting for "1.234,5678" formatted numbers

### DIFF
--- a/e2e/src/usecases/Send.js
+++ b/e2e/src/usecases/Send.js
@@ -12,6 +12,7 @@ import {
   quickOnboarding,
   waitForElementById,
 } from '../utils/utils'
+import { sleep } from '../../../src/utils/sleep'
 
 export default Send = () => {
   const recipientAddressDisplay = getDisplayAddress(DEFAULT_RECIPIENT_ADDRESS)
@@ -96,6 +97,7 @@ export default Send = () => {
        */
       await element(by.id('SendEnterAmount/TokenAmountInput')).replaceText('')
       await element(by.id('SendEnterAmount/TokenAmountInput')).typeText('1000000.123456')
+      await sleep(3000)
       const input = await element(by.id('SendEnterAmount/TokenAmountInput')).getAttributes()
       jestExpect(input.value).toBe('1,000,000.123456')
 

--- a/e2e/src/usecases/Send.js
+++ b/e2e/src/usecases/Send.js
@@ -87,6 +87,18 @@ export default Send = () => {
         timeout: 30_000,
         tap: true,
       })
+
+      /**
+       * This tests proper formatting of big amount. This has to be tested with "typeText" due to
+       * formatting having a delay. This occured in an issue when testing with "replaceText" works
+       * as intended (cause that's basically the same as pasting) and it formatted properly while
+       * typing in digits one-by-one revealed the issue.
+       */
+      await element(by.id('SendEnterAmount/TokenAmountInput')).replaceText('')
+      await element(by.id('SendEnterAmount/TokenAmountInput')).typeText('1000000.123456')
+      const input = await element(by.id('SendEnterAmount/TokenAmountInput')).getAttributes()
+      jestExpect(input.value).toBe('1,000,000.123456')
+
       await element(by.id('SendEnterAmount/TokenAmountInput')).replaceText('0.01')
       await element(by.id('SendEnterAmount/TokenAmountInput')).tapReturnKey()
       await waitForElementById('SendEnterAmount/ReviewButton', {

--- a/e2e/src/usecases/Send.js
+++ b/e2e/src/usecases/Send.js
@@ -12,7 +12,6 @@ import {
   quickOnboarding,
   waitForElementById,
 } from '../utils/utils'
-import { sleep } from '../../../src/utils/sleep'
 
 export default Send = () => {
   const recipientAddressDisplay = getDisplayAddress(DEFAULT_RECIPIENT_ADDRESS)
@@ -97,9 +96,8 @@ export default Send = () => {
        */
       await element(by.id('SendEnterAmount/TokenAmountInput')).replaceText('')
       await element(by.id('SendEnterAmount/TokenAmountInput')).typeText('1000000.123456')
-      await sleep(3000)
       const input = await element(by.id('SendEnterAmount/TokenAmountInput')).getAttributes()
-      jestExpect(input.value).toBe('1,000,000.123456')
+      jestExpect(input.text).toBe('1,000,000.123456')
 
       await element(by.id('SendEnterAmount/TokenAmountInput')).replaceText('0.01')
       await element(by.id('SendEnterAmount/TokenAmountInput')).tapReturnKey()

--- a/src/components/TokenEnterAmount.test.tsx
+++ b/src/components/TokenEnterAmount.test.tsx
@@ -70,7 +70,6 @@ describe('TokenEnterAmount', () => {
     expect(unformatNumberForProcessing('')).toBe('')
     expect(unformatNumberForProcessing('0.25')).toBe('0.25')
     expect(unformatNumberForProcessing('1,234.34567')).toBe('1234.34567')
-    expect(unformatNumberForProcessing('1234.34567')).toBe('1234.34567')
 
     expect(roundFiatValue(null)).toBe('')
     expect(roundFiatValue(new BigNumber('0.01'))).toBe('0.01')
@@ -120,7 +119,6 @@ describe('TokenEnterAmount', () => {
     expect(unformatNumberForProcessing('')).toBe('')
     expect(unformatNumberForProcessing('0,25')).toBe('0.25')
     expect(unformatNumberForProcessing('1.234,34567')).toBe('1234.34567')
-    expect(unformatNumberForProcessing('1234.34567')).toBe('1234.34567')
 
     expect(roundFiatValue(null)).toBe('')
     expect(roundFiatValue(new BigNumber('0.01'))).toBe('0.01')

--- a/src/components/TokenEnterAmount.tsx
+++ b/src/components/TokenEnterAmount.tsx
@@ -260,6 +260,11 @@ export function useEnterAmount(props: {
     }
   }
 
+  /**
+   * This function is intended for a full value replacement. This is mostly useful for the swap
+   * flow when the "To" amount is always calculated by the API and have to be replaced while
+   * keeping the intended number formatting logic.
+   */
   function replaceAmount(value: string) {
     if (!props.token) return
 
@@ -268,6 +273,11 @@ export function useEnterAmount(props: {
       return
     }
 
+    /**
+     * If the value comes from external source (e.g. API response) then it will probably be a
+     * regular JS-compatible number in a format "1234.5678" for which we should skip the
+     * unformatting step.
+     */
     const numericValue = new BigNumber(value)
     const rawValue = numericValue.isNaN()
       ? unformatNumberForProcessing(value)

--- a/src/components/TokenEnterAmount.tsx
+++ b/src/components/TokenEnterAmount.tsx
@@ -53,9 +53,8 @@ export function formatNumber(value: string) {
 
 /**
  * Unformats value from the phone's selected number format to a standard "1234.5678" js number.
- * This function IS NOT indended for:
- *   - for numbers that don't follow the format from phone's settings
- *   - external numbers that are already in JS format (e.g from API responses)
+ * Do not use this function with values that are not formatted according to the device number
+ * format settings, e.g. values that are returned by API's in the standard js format.
  */
 export function unformatNumberForProcessing(value: string) {
   const { decimalSeparator, groupingSeparator } = getNumberFormatSettings()
@@ -273,11 +272,6 @@ export function useEnterAmount(props: {
       return
     }
 
-    /**
-     * If the value comes from external source (e.g. API response) then it will probably be a
-     * regular JS-compatible number in a format "1234.5678" for which we should skip the
-     * unformatting step.
-     */
     const numericValue = new BigNumber(value)
     const rawValue = numericValue.isNaN()
       ? unformatNumberForProcessing(value)


### PR DESCRIPTION
### Description
This PR again tries to fix an ongoing issue with formatting number for TokenEnterAmount component when number format in phone settings is set to `1.234,5678`.
The issue was introduced by [previous attempt](https://github.com/valora-inc/wallet/pull/6428) to fix wrong formatting for Swap flow specifically. 

Previously, the issue was due to unformatting function only expecting numbers that are formatted according to the phone's settings. This caused an issue when on the Swap flow we set the value of "To" textfield with `replaceAmount` function using the value from the quote API response which was a JS-compatible number. This format differed for the users that had format set in settings to `1.234,5678` and caused the actual issue. But this introduced another issue with the wrong formatting for when the numbers that exceed `1000`.

In order to fix this, the condition for whether there's a need to skip the formatting was moved to actual function that is used when replacing the value with the quote API response. I've also added some explanatory comments to some functions for better clarity on what's each function intention is.

### Test plan
Edited e2e tests for Send to test proper formatting of big amounts while using `typeText` function which simulates actual typing instead of `replaceText` (which is more of a paste).

This change doesn't revert the previous fix:

https://github.com/user-attachments/assets/a5b913eb-f47c-4a5d-9fcf-1c704376c177

### Related issues

- Relates to [this PR](https://github.com/valora-inc/wallet/pull/6428)
- Relates to the bug mentioned [here](https://valora-app.slack.com/archives/C04B61SJ6DS/p1738341507462059)

### Backwards compatibility
Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
