### PR TITLE
fix: wrong translation used on SendConfirmation

### DIFF
--- a/src/send/SendConfirmation.test.tsx
+++ b/src/send/SendConfirmation.test.tsx
@@ -144,7 +144,7 @@ describe('SendConfirmation', () => {
     // renders fee details
     expect(getByTestId('SendConfirmationFee/Label')).toHaveTextContent('networkFee')
     expect(getByTestId('SendConfirmationFee/Value')).toHaveTextContent(
-      'tokenAndLocalAmountApprox_oneToken, {"tokenAmount":"0.01","localAmount":"0.067","tokenSymbol":"CELO","localCurrencySymbol":"₱"}'
+      'tokenAndLocalAmountApprox, {"tokenAmount":"0.01","localAmount":"0.067","tokenSymbol":"CELO","localCurrencySymbol":"₱"}'
     )
 
     // renders total details

--- a/src/send/SendConfirmation.tsx
+++ b/src/send/SendConfirmation.tsx
@@ -188,7 +188,7 @@ export default function SendConfirmation(props: Props) {
             isLoading={prepareTransactionLoading}
             value={
               <Trans
-                i18nKey={'tokenAndLocalAmountApprox_oneToken'}
+                i18nKey={'tokenAndLocalAmountApprox'}
                 context={localFeeAmount?.gt(0) ? undefined : 'noFiatPrice'}
                 tOptions={{
                   tokenAmount: networkFeeDisplayAmount.token,


### PR DESCRIPTION
### Description
Wrong translation was used on the SendConfirmation screen.

### Test plan
<img src="https://github.com/user-attachments/assets/d3446e34-964b-4fa1-b82e-8011a2e7f6aa" width="400" />

### Related issues
N/A

### Backwards compatibility
Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
