### PR TITLE
chore(deps): upgrade react-native-gesture-handler to ^2.23.1

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -780,7 +780,7 @@ PODS:
     - RNFBApp
   - RNFS (2.20.1):
     - React-Core
-  - RNGestureHandler (2.21.2):
+  - RNGestureHandler (2.23.1):
     - RCT-Folly (= 2021.07.22.00)
     - React-Core
   - RNKeychain (9.2.2):
@@ -1317,7 +1317,7 @@ SPEC CHECKSUMS:
   RNFBMessaging: d90c3a9e3da96dc2cf150a01d3aa0a68a3c32501
   RNFBRemoteConfig: 1c92f072b1772b91663247b07a711cd4e9e191e8
   RNFS: e21dbd93b9beabe4649fb73ff29114c18e78d36d
-  RNGestureHandler: b81313e62e717cc165ea3b99436aa305d04c57b4
+  RNGestureHandler: 44710b912ee3cda6b1c8a1de1509bdc15db51f96
   RNKeychain: 91dc223bc77e3bb8576a3c75cdd28863bc2cb26e
   RNLocalize: d024afa9204c13885e61dc88b8190651bcaabac9
   RNPermissions: 1d002266e43df33d7080d5355a64b7d12bdb5e75

--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     "react-native-device-info": "^13.2.0",
     "react-native-exit-app": "^2.0.0",
     "react-native-fast-image": "^8.6.3",
-    "react-native-gesture-handler": "^2.21.2",
+    "react-native-gesture-handler": "^2.23.1",
     "react-native-haptic-feedback": "^2.3.3",
     "react-native-in-app-review": "^4.3.3",
     "react-native-launch-arguments": "^4.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12624,15 +12624,14 @@ react-native-fs@^2.14.1:
     base-64 "^0.1.0"
     utf8 "^3.0.0"
 
-react-native-gesture-handler@^2.21.2:
-  version "2.21.2"
-  resolved "https://registry.yarnpkg.com/react-native-gesture-handler/-/react-native-gesture-handler-2.21.2.tgz#824a098d7397212fbe51aa3a9df84833a4ea1c3f"
-  integrity sha512-HcwB225K9aeZ8e/B8nFzEh+2T4EPWTeamO1l/y3PcQ9cyCDYO2zja/G31ITpYRIqkip7XzGs6wI/gnHOQn1LDQ==
+react-native-gesture-handler@^2.23.1:
+  version "2.23.1"
+  resolved "https://registry.yarnpkg.com/react-native-gesture-handler/-/react-native-gesture-handler-2.23.1.tgz#87b98c630cd3c5234cb63cc718dd22fd6feec34b"
+  integrity sha512-dr5CxIu+kXlxS3snSyt0qXtXGqfDvV26gtQVPNteFIfP0qWBuye/j48XPXePe2pH48QCuXpZM2VOooig7jzooA==
   dependencies:
     "@egjs/hammerjs" "^2.0.17"
     hoist-non-react-statics "^3.3.0"
     invariant "^2.2.4"
-    prop-types "^15.7.2"
 
 react-native-get-random-values@1.x:
   version "1.11.0"


### PR DESCRIPTION
### Description

This upgrade to `react-native-gesture-handler` to `2.23.1` includes fixes in [`2.23.0`](https://github.com/software-mansion/react-native-gesture-handler/releases/tag/2.23.0) for using the new react-native architecture.

### Test plan

- [x] Tested locally on iOS
- [x] Tested in CI

### Related issues

- https://github.com/divvixyz/react-native-exit-app/pull/1

### Backwards compatibility

Yes

### Network scalability

N/A