### PR TITLE
chore: handle referrer not registered in divvi integration

### DIFF
--- a/src/divviProtocol/registerReferral.test.ts
+++ b/src/divviProtocol/registerReferral.test.ts
@@ -156,6 +156,7 @@ describe('createRegistrationTransactionsIfNeeded', () => {
       to: REGISTRY_CONTRACT_ADDRESS,
       from: mockAccount.toLowerCase(),
     })
+    expect(mockStore.dispatch).not.toHaveBeenCalled()
   })
 
   it('handles errors in contract reads gracefully and returns no corresponding transactions', async () => {

--- a/src/divviProtocol/registerReferral.test.ts
+++ b/src/divviProtocol/registerReferral.test.ts
@@ -131,7 +131,7 @@ describe('createRegistrationTransactionsIfNeeded', () => {
     ) // 'beefy' should be marked as registered already
   })
 
-  it('returns a transaction for registeration only against protocols that the referrer is registered for', async () => {
+  it('returns a transaction for registration only against protocols that the referrer is registered for', async () => {
     jest
       .spyOn(publicClient.optimism, 'readContract')
       .mockImplementation(async ({ functionName, args }) => {


### PR DESCRIPTION
### Description

 This PR ensures that the registration tx only contains protocolId's that the referrer is registered for. This prevents the prepared transaction from containing a protocolId that would cause the tx to revert (thereby blocking the rest of the transaction flow). A builder could be in this situation if they are developing before they are added to the registration contract.

### Test plan

Setting the referrer id to a random string or adding a random protocol id to the app config does not affect the transaction flow.

### Related issues

- Fixes RET-1318

### Backwards compatibility

Y

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [ ] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
