### PR TITLE
feat: Move fiat connect remote config from firebase to statsig

### DIFF
--- a/src/app/reducers.ts
+++ b/src/app/reducers.ts
@@ -137,10 +137,6 @@ export const appReducer = (
         ...state,
         sessionId: action.sessionId,
       }
-    case Actions.UPDATE_REMOTE_CONFIG_VALUES:
-      return {
-        ...state,
-      }
     case Actions.ACTIVE_SCREEN_CHANGED:
       return {
         ...state,

--- a/src/app/reducers.ts
+++ b/src/app/reducers.ts
@@ -3,7 +3,6 @@ import { Platform } from 'react-native'
 import { Actions, ActionTypes, AppState } from 'src/app/actions'
 import { DEEP_LINK_URL_SCHEME } from 'src/config'
 import { SupportedProtocolId } from 'src/divviProtocol/constants'
-import { REMOTE_CONFIG_VALUES_DEFAULTS } from 'src/firebase/remoteConfigValuesDefaults'
 import { Screens } from 'src/navigator/Screens'
 import { getRehydratePayload, REHYDRATE, RehydrateAction } from 'src/redux/persist-helper'
 import { NetworkId } from 'src/transactions/types'
@@ -27,8 +26,6 @@ interface State {
   googleMobileServicesAvailable?: boolean
   huaweiMobileServicesAvailable?: boolean
   supportedBiometryType: BIOMETRY_TYPE | null
-  fiatConnectCashInEnabled: boolean
-  fiatConnectCashOutEnabled: boolean
   inviterAddress: string | null
   hapticFeedbackEnabled: boolean
   pushNotificationRequestedUnixTime: number | null
@@ -59,8 +56,6 @@ const initialState = {
   googleMobileServicesAvailable: undefined,
   huaweiMobileServicesAvailable: undefined,
   supportedBiometryType: null,
-  fiatConnectCashInEnabled: REMOTE_CONFIG_VALUES_DEFAULTS.fiatConnectCashInEnabled,
-  fiatConnectCashOutEnabled: REMOTE_CONFIG_VALUES_DEFAULTS.fiatConnectCashOutEnabled,
   inviterAddress: null,
   hapticFeedbackEnabled: true,
   pushNotificationRequestedUnixTime: null,
@@ -145,8 +140,6 @@ export const appReducer = (
     case Actions.UPDATE_REMOTE_CONFIG_VALUES:
       return {
         ...state,
-        fiatConnectCashInEnabled: action.configValues.fiatConnectCashInEnabled,
-        fiatConnectCashOutEnabled: action.configValues.fiatConnectCashOutEnabled,
       }
     case Actions.ACTIVE_SCREEN_CHANGED:
       return {

--- a/src/app/saga.ts
+++ b/src/app/saga.ts
@@ -175,8 +175,6 @@ export function* checkAndroidMobileServicesSaga() {
 
 export interface RemoteConfigValues {
   inviteRewardsVersion: string
-  fiatConnectCashInEnabled: boolean
-  fiatConnectCashOutEnabled: boolean
   fiatAccountSchemaCountryOverrides: FiatAccountSchemaCountryOverrides
 }
 

--- a/src/app/selectors.ts
+++ b/src/app/selectors.ts
@@ -32,11 +32,6 @@ export const huaweiMobileServicesAvailableSelector = (state: RootState) =>
 
 export const supportedBiometryTypeSelector = (state: RootState) => state.app.supportedBiometryType
 
-export const fiatConnectCashInEnabledSelector = (state: RootState) =>
-  state.app.fiatConnectCashInEnabled
-export const fiatConnectCashOutEnabledSelector = (state: RootState) =>
-  state.app.fiatConnectCashOutEnabled
-
 export const phoneNumberVerifiedSelector = (state: RootState) => state.app.phoneNumberVerified
 
 export const inviterAddressSelector = (state: RootState) => state.app.inviterAddress

--- a/src/fiatconnect/index.test.ts
+++ b/src/fiatconnect/index.test.ts
@@ -1,6 +1,8 @@
 import { FetchMock } from 'jest-fetch-mock'
 import { CICOFlow } from 'src/fiatExchanges/types'
 import { LocalCurrencyCode } from 'src/localCurrency/consts'
+import { getDynamicConfigParams } from 'src/statsig'
+import { StatsigDynamicConfigs } from 'src/statsig/types'
 import Logger from 'src/utils/Logger'
 import { CiCoCurrency } from 'src/utils/currencies'
 import networkConfig from 'src/web3/networkConfig'
@@ -88,8 +90,6 @@ describe('FiatConnect helpers', () => {
 
   describe('fetchFiatConnectQuotes', () => {
     const fetchQuotesInput: FetchQuotesInput = {
-      fiatConnectCashInEnabled: false,
-      fiatConnectCashOutEnabled: false,
       flow: CICOFlow.CashIn,
       localCurrency: LocalCurrencyCode.USD,
       digitalAsset: CiCoCurrency.cUSD,
@@ -116,10 +116,28 @@ describe('FiatConnect helpers', () => {
       address: '0xabc',
     }
     it('returns an empty array if fiatConnectCashInEnabled is false with cash in', async () => {
+      jest.mocked(getDynamicConfigParams).mockImplementation(({ configName }) => {
+        if (configName === StatsigDynamicConfigs.FIAT_CONNECT_CONFIG) {
+          return {
+            fiatConnectCashInEnabled: false,
+            fiatConnectCashOutEnabled: true,
+          }
+        }
+        return {} as any
+      })
       const quotes = await fetchQuotes(fetchQuotesInput)
       expect(quotes).toHaveLength(0)
     })
     it('returns an empty array if fiatConnectCashOutEnabled is false with cash out', async () => {
+      jest.mocked(getDynamicConfigParams).mockImplementation(({ configName }) => {
+        if (configName === StatsigDynamicConfigs.FIAT_CONNECT_CONFIG) {
+          return {
+            fiatConnectCashInEnabled: true,
+            fiatConnectCashOutEnabled: false,
+          }
+        }
+        return {} as any
+      })
       const quotes = await fetchQuotes({ ...fetchQuotesInput, flow: CICOFlow.CashOut })
       expect(quotes).toHaveLength(0)
     })

--- a/src/fiatconnect/index.test.ts
+++ b/src/fiatconnect/index.test.ts
@@ -115,24 +115,11 @@ describe('FiatConnect helpers', () => {
       ],
       address: '0xabc',
     }
-    it('returns an empty array if fiatConnectCashInEnabled is false with cash in', async () => {
-      jest.mocked(getDynamicConfigParams).mockImplementation(({ configName }) => {
-        if (configName === StatsigDynamicConfigs.FIAT_CONNECT_CONFIG) {
-          return {
-            fiatConnectCashInEnabled: false,
-            fiatConnectCashOutEnabled: true,
-          }
-        }
-        return {} as any
-      })
-      const quotes = await fetchQuotes(fetchQuotesInput)
-      expect(quotes).toHaveLength(0)
-    })
+
     it('returns an empty array if fiatConnectCashOutEnabled is false with cash out', async () => {
       jest.mocked(getDynamicConfigParams).mockImplementation(({ configName }) => {
         if (configName === StatsigDynamicConfigs.FIAT_CONNECT_CONFIG) {
           return {
-            fiatConnectCashInEnabled: true,
             fiatConnectCashOutEnabled: false,
           }
         }

--- a/src/fiatconnect/index.ts
+++ b/src/fiatconnect/index.ts
@@ -150,6 +150,7 @@ export async function fetchQuotes(params: FetchQuotesInput) {
   const { fiatConnectCashOutEnabled } = getDynamicConfigParams(
     DynamicConfigs[StatsigDynamicConfigs.FIAT_CONNECT_CONFIG]
   )
+  if (params.flow === CICOFlow.CashIn) return []
   if (!fiatConnectCashOutEnabled && params.flow === CICOFlow.CashOut) return []
   return getFiatConnectQuotes(params)
 }

--- a/src/fiatconnect/index.ts
+++ b/src/fiatconnect/index.ts
@@ -144,16 +144,15 @@ export async function getFiatConnectQuotes(
     provider: fiatConnectProviders.find((provider) => provider.id === result.id)!,
   }))
 }
-export type FetchQuotesInput = QuotesInput & {
-  fiatConnectCashInEnabled: boolean
-  fiatConnectCashOutEnabled: boolean
-}
+export type FetchQuotesInput = QuotesInput
 
 export async function fetchQuotes(params: FetchQuotesInput) {
-  const { fiatConnectCashInEnabled, fiatConnectCashOutEnabled, ...quotesInput } = params
+  const { fiatConnectCashInEnabled, fiatConnectCashOutEnabled } = getDynamicConfigParams(
+    DynamicConfigs[StatsigDynamicConfigs.FIAT_CONNECT_CONFIG]
+  )
   if (!fiatConnectCashInEnabled && params.flow === CICOFlow.CashIn) return []
   if (!fiatConnectCashOutEnabled && params.flow === CICOFlow.CashOut) return []
-  return getFiatConnectQuotes(quotesInput)
+  return getFiatConnectQuotes(params)
 }
 
 /**

--- a/src/fiatconnect/index.ts
+++ b/src/fiatconnect/index.ts
@@ -147,10 +147,9 @@ export async function getFiatConnectQuotes(
 export type FetchQuotesInput = QuotesInput
 
 export async function fetchQuotes(params: FetchQuotesInput) {
-  const { fiatConnectCashInEnabled, fiatConnectCashOutEnabled } = getDynamicConfigParams(
+  const { fiatConnectCashOutEnabled } = getDynamicConfigParams(
     DynamicConfigs[StatsigDynamicConfigs.FIAT_CONNECT_CONFIG]
   )
-  if (!fiatConnectCashInEnabled && params.flow === CICOFlow.CashIn) return []
   if (!fiatConnectCashOutEnabled && params.flow === CICOFlow.CashOut) return []
   return getFiatConnectQuotes(params)
 }

--- a/src/fiatconnect/saga.test.ts
+++ b/src/fiatconnect/saga.test.ts
@@ -172,6 +172,14 @@ describe('Fiatconnect saga', () => {
       fiatType: normalizedQuoteKyc.getFiatType(),
     },
   }
+
+  jest.mocked(getDynamicConfigParams).mockImplementation(({ configName }) => {
+    if (configName === StatsigDynamicConfigs.FIAT_CONNECT_CONFIG) {
+      return { fiatConnectCashOutEnabled: true }
+    }
+    return {} as any
+  })
+
   beforeEach(() => {
     jest.clearAllMocks()
   })
@@ -651,14 +659,6 @@ describe('Fiatconnect saga', () => {
   describe('handleFetchFiatConnectQuotes', () => {
     it('saves quotes when fetch is successful', async () => {
       jest.mocked(fetchQuotes).mockImplementation(() => Promise.resolve(mockFiatConnectQuotes))
-      jest.mocked(getDynamicConfigParams).mockImplementation(({ configName }) => {
-        if (configName === StatsigDynamicConfigs.FIAT_CONNECT_CONFIG) {
-          return {
-            fiatConnectCashOutEnabled: true,
-          }
-        }
-        return {} as any
-      })
       await expectSaga(
         handleFetchFiatConnectQuotes,
         fetchFiatConnectQuotes({
@@ -692,14 +692,6 @@ describe('Fiatconnect saga', () => {
 
     it('fetches providers if null initially', async () => {
       jest.mocked(fetchQuotes).mockImplementation(() => Promise.resolve(mockFiatConnectQuotes))
-      jest.mocked(getDynamicConfigParams).mockImplementation(({ configName }) => {
-        if (configName === StatsigDynamicConfigs.FIAT_CONNECT_CONFIG) {
-          return {
-            fiatConnectCashOutEnabled: true,
-          }
-        }
-        return {} as any
-      })
       const providers = (
         firstValue: FiatConnectProviderInfo[] | null,
         restValue: FiatConnectProviderInfo[] | null
@@ -745,14 +737,6 @@ describe('Fiatconnect saga', () => {
 
     it('saves an error', async () => {
       jest.mocked(fetchQuotes).mockRejectedValue({})
-      jest.mocked(getDynamicConfigParams).mockImplementation(({ configName }) => {
-        if (configName === StatsigDynamicConfigs.FIAT_CONNECT_CONFIG) {
-          return {
-            fiatConnectCashOutEnabled: true,
-          }
-        }
-        return {} as any
-      })
       await expectSaga(
         handleFetchFiatConnectQuotes,
         fetchFiatConnectQuotes({
@@ -784,14 +768,6 @@ describe('Fiatconnect saga', () => {
     })
     it('saves an error when providers is null and fetching them fails', async () => {
       jest.mocked(fetchQuotes).mockResolvedValue(mockFiatConnectQuotes)
-      jest.mocked(getDynamicConfigParams).mockImplementation(({ configName }) => {
-        if (configName === StatsigDynamicConfigs.FIAT_CONNECT_CONFIG) {
-          return {
-            fiatConnectCashOutEnabled: true,
-          }
-        }
-        return {} as any
-      })
       await expectSaga(
         handleFetchFiatConnectQuotes,
         fetchFiatConnectQuotes({

--- a/src/fiatconnect/saga.test.ts
+++ b/src/fiatconnect/saga.test.ts
@@ -654,7 +654,6 @@ describe('Fiatconnect saga', () => {
       jest.mocked(getDynamicConfigParams).mockImplementation(({ configName }) => {
         if (configName === StatsigDynamicConfigs.FIAT_CONNECT_CONFIG) {
           return {
-            fiatConnectCashInEnabled: false,
             fiatConnectCashOutEnabled: true,
           }
         }
@@ -696,7 +695,6 @@ describe('Fiatconnect saga', () => {
       jest.mocked(getDynamicConfigParams).mockImplementation(({ configName }) => {
         if (configName === StatsigDynamicConfigs.FIAT_CONNECT_CONFIG) {
           return {
-            fiatConnectCashInEnabled: false,
             fiatConnectCashOutEnabled: true,
           }
         }
@@ -750,7 +748,6 @@ describe('Fiatconnect saga', () => {
       jest.mocked(getDynamicConfigParams).mockImplementation(({ configName }) => {
         if (configName === StatsigDynamicConfigs.FIAT_CONNECT_CONFIG) {
           return {
-            fiatConnectCashInEnabled: false,
             fiatConnectCashOutEnabled: true,
           }
         }
@@ -790,7 +787,6 @@ describe('Fiatconnect saga', () => {
       jest.mocked(getDynamicConfigParams).mockImplementation(({ configName }) => {
         if (configName === StatsigDynamicConfigs.FIAT_CONNECT_CONFIG) {
           return {
-            fiatConnectCashInEnabled: false,
             fiatConnectCashOutEnabled: true,
           }
         }

--- a/src/fiatconnect/saga.ts
+++ b/src/fiatconnect/saga.ts
@@ -16,10 +16,6 @@ import { showError, showMessage } from 'src/alert/actions'
 import AppAnalytics from 'src/analytics/AppAnalytics'
 import { FiatExchangeEvents } from 'src/analytics/Events'
 import { ErrorMessages } from 'src/app/ErrorMessages'
-import {
-  fiatConnectCashInEnabledSelector,
-  fiatConnectCashOutEnabledSelector,
-} from 'src/app/selectors'
 import FiatConnectQuote from 'src/fiatExchanges/quotes/FiatConnectQuote'
 import { normalizeFiatConnectQuotes } from 'src/fiatExchanges/quotes/normalizeQuotes'
 import { CICOFlow } from 'src/fiatExchanges/types'
@@ -428,8 +424,6 @@ export function* _getQuotes({
 }): Generator<any, (FiatConnectQuoteSuccess | FiatConnectQuoteError)[], any> {
   const userLocation: UserLocationData = yield* select(userLocationDataSelector)
   const localCurrency: LocalCurrencyCode = yield* select(getLocalCurrencyCode)
-  const fiatConnectCashInEnabled: boolean = yield* select(fiatConnectCashInEnabledSelector)
-  const fiatConnectCashOutEnabled: boolean = yield* select(fiatConnectCashOutEnabledSelector)
   let fiatConnectProviders: FiatConnectProviderInfo[] | null = yield* select(
     fiatConnectProvidersSelector
   )
@@ -457,8 +451,6 @@ export function* _getQuotes({
     fiatAmount,
     country: userLocation?.countryCodeAlpha2 || 'US',
     flow,
-    fiatConnectCashInEnabled,
-    fiatConnectCashOutEnabled,
     fiatConnectProviders: providerIds
       ? fiatConnectProviders.filter(({ id }) => providerIds.includes(id))
       : fiatConnectProviders,

--- a/src/firebase/firebase.ts
+++ b/src/firebase/firebase.ts
@@ -274,8 +274,6 @@ export async function fetchRemoteConfigValues(): Promise<RemoteConfigValues | nu
 
   return {
     inviteRewardsVersion: flags.inviteRewardsVersion.asString(),
-    fiatConnectCashInEnabled: flags.fiatConnectCashInEnabled.asBoolean(),
-    fiatConnectCashOutEnabled: flags.fiatConnectCashOutEnabled.asBoolean(),
     fiatAccountSchemaCountryOverrides: fiatAccountSchemaCountryOverrides
       ? JSON.parse(fiatAccountSchemaCountryOverrides)
       : {},

--- a/src/firebase/remoteConfigValuesDefaults.e2e.ts
+++ b/src/firebase/remoteConfigValuesDefaults.e2e.ts
@@ -5,6 +5,4 @@ export const REMOTE_CONFIG_VALUES_DEFAULTS: Omit<
   'fiatAccountSchemaCountryOverrides'
 > = {
   inviteRewardsVersion: 'none',
-  fiatConnectCashInEnabled: false,
-  fiatConnectCashOutEnabled: true,
 }

--- a/src/firebase/remoteConfigValuesDefaults.ts
+++ b/src/firebase/remoteConfigValuesDefaults.ts
@@ -5,6 +5,4 @@ export const REMOTE_CONFIG_VALUES_DEFAULTS: Omit<
   'fiatAccountSchemaCountryOverrides'
 > = {
   inviteRewardsVersion: 'none',
-  fiatConnectCashInEnabled: false,
-  fiatConnectCashOutEnabled: false,
 }

--- a/src/redux/migrations.ts
+++ b/src/redux/migrations.ts
@@ -11,7 +11,6 @@ import {
 } from 'src/config'
 import { Dapp } from 'src/dapps/types'
 import { CachedQuoteParams, SendingFiatAccountStatus } from 'src/fiatconnect/slice'
-import { REMOTE_CONFIG_VALUES_DEFAULTS } from 'src/firebase/remoteConfigValuesDefaults'
 import { AddressToDisplayNameType } from 'src/identity/reducer'
 import { LocalCurrencyCode } from 'src/localCurrency/consts'
 import { Screens } from 'src/navigator/Screens'
@@ -664,8 +663,8 @@ export const migrations = {
     ...state,
     app: {
       ...state.app,
-      fiatConnectCashInEnabled: REMOTE_CONFIG_VALUES_DEFAULTS.fiatConnectCashInEnabled,
-      fiatConnectCashOutEnabled: REMOTE_CONFIG_VALUES_DEFAULTS.fiatConnectCashOutEnabled,
+      fiatConnectCashInEnabled: false,
+      fiatConnectCashOutEnabled: false,
     },
   }),
   53: (state: any) => ({
@@ -2023,5 +2022,9 @@ export const migrations = {
       ..._.omit(state.app, 'loggedIn'),
       divviRegistrations: {},
     },
+  }),
+  245: (state: any) => ({
+    ...state,
+    app: _.omit(state.app, 'fiatConnectCashInEnabled', 'fiatConnectCashOutEnabled'),
   }),
 }

--- a/src/redux/store.test.ts
+++ b/src/redux/store.test.ts
@@ -143,7 +143,7 @@ describe('store state', () => {
       {
         "_persist": {
           "rehydrated": true,
-          "version": 244,
+          "version": 245,
         },
         "account": {
           "acceptedTerms": false,
@@ -180,8 +180,6 @@ describe('store state', () => {
           "analyticsEnabled": true,
           "appState": "Active",
           "divviRegistrations": {},
-          "fiatConnectCashInEnabled": false,
-          "fiatConnectCashOutEnabled": false,
           "googleMobileServicesAvailable": undefined,
           "hapticFeedbackEnabled": true,
           "hideBalances": false,

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -26,7 +26,7 @@ const persistConfig: PersistConfig<ReducersRootState> = {
   key: 'root',
   // default is -1, increment as we make migrations
   // See https://github.com/valora-inc/wallet/tree/main/WALLET.md#redux-state-migration
-  version: 244,
+  version: 245,
   keyPrefix: `reduxStore-`, // the redux-persist default is `persist:` which doesn't work with some file systems.
   storage: FSStorage(),
   blacklist: ['networkInfo', 'alert', 'imports', 'keylessBackup', transactionFeedV2Api.reducerPath],

--- a/src/statsig/constants.ts
+++ b/src/statsig/constants.ts
@@ -146,7 +146,6 @@ export const DynamicConfigs = {
   [StatsigDynamicConfigs.FIAT_CONNECT_CONFIG]: {
     configName: StatsigDynamicConfigs.FIAT_CONNECT_CONFIG,
     defaultValues: {
-      fiatConnectCashInEnabled: false,
       fiatConnectCashOutEnabled: false,
     },
   },

--- a/src/statsig/constants.ts
+++ b/src/statsig/constants.ts
@@ -143,6 +143,13 @@ export const DynamicConfigs = {
       demoWalletAddress: '',
     },
   },
+  [StatsigDynamicConfigs.FIAT_CONNECT_CONFIG]: {
+    configName: StatsigDynamicConfigs.FIAT_CONNECT_CONFIG,
+    defaultValues: {
+      fiatConnectCashInEnabled: false,
+      fiatConnectCashOutEnabled: false,
+    },
+  },
 } satisfies {
   [key in StatsigDynamicConfigs]: {
     configName: key

--- a/src/statsig/types.ts
+++ b/src/statsig/types.ts
@@ -9,6 +9,7 @@ export enum StatsigDynamicConfigs {
   APP_CONFIG = 'app_config',
   EARN_CONFIG = 'earn_config',
   DEMO_MODE_CONFIG = 'demo_mode_config',
+  FIAT_CONNECT_CONFIG = 'fiat_connect_config',
 }
 
 export enum StatsigFeatureGates {

--- a/test/RootStateSchema.json
+++ b/test/RootStateSchema.json
@@ -4690,12 +4690,6 @@
                 "divviRegistrations": {
                     "$ref": "#/definitions/{\"celo-mainnet\"?:(\"beefy\"|\"tether\"|\"somm\"|\"celo\"|\"aerodrome\"|\"velodrome\"|\"vana\"|\"curve\"|\"farcaster\"|\"mento\"|\"yearn\"|\"fonbnk\"|\"offchainlabs\"|\"euler\"|\"ubeswap\")[]|undefined;\"celo-alfajores\"?:(\"beefy\"|\"tether\"|\"somm\"|\"celo\"|\"aerodrome\"|\"velodrome\"|\"vana\"|\"curve\"|\"farcaster\"|\"mento\"|\"yearn\"|\"fonbnk\"|\"offchainlabs\"|\"euler\"|\"ubeswap\")[]|undefined;\"ethereum-mainnet\"?:(\"beefy\"|\"tether\"|\"somm\"|\"celo\"|\"aerodrome\"|\"velodrome\"|\"vana\"|\"curve\"|\"farcaster\"|\"mento\"|\"yearn\"|\"fonbnk\"|\"offchainlabs\"|\"euler\"|\"ubeswap\")[]|undefined;\"ethereum-sepolia\"?:(\"beefy\"|\"tether\"|\"somm\"|\"celo\"|\"aerodrome\"|\"velodrome\"|\"vana\"|\"curve\"|\"farcaster\"|\"mento\"|\"yearn\"|\"fonbnk\"|\"offchainlabs\"|\"euler\"|\"ubeswap\")[]|undefined;\"arbitrum-one\"?:(\"beefy\"|\"tether\"|\"somm\"|\"celo\"|\"aerodrome\"|\"velodrome\"|\"vana\"|\"curve\"|\"farcaster\"|\"mento\"|\"yearn\"|\"fonbnk\"|\"offchainlabs\"|\"euler\"|\"ubeswap\")[]|undefined;\"arbitrum-sepolia\"?:(\"beefy\"|\"tether\"|\"somm\"|\"celo\"|\"aerodrome\"|\"velodrome\"|\"vana\"|\"curve\"|\"farcaster\"|\"mento\"|\"yearn\"|\"fonbnk\"|\"offchainlabs\"|\"euler\"|\"ubeswap\")[]|undefined;\"op-mainnet\"?:(\"beefy\"|\"tether\"|\"somm\"|\"celo\"|\"aerodrome\"|\"velodrome\"|\"vana\"|\"curve\"|\"farcaster\"|\"mento\"|\"yearn\"|\"fonbnk\"|\"offchainlabs\"|\"euler\"|\"ubeswap\")[]|undefined;\"op-sepolia\"?:(\"beefy\"|\"tether\"|\"somm\"|\"celo\"|\"aerodrome\"|\"velodrome\"|\"vana\"|\"curve\"|\"farcaster\"|\"mento\"|\"yearn\"|\"fonbnk\"|\"offchainlabs\"|\"euler\"|\"ubeswap\")[]|undefined;\"polygon-pos-mainnet\"?:(\"beefy\"|\"tether\"|\"somm\"|\"celo\"|\"aerodrome\"|\"velodrome\"|\"vana\"|\"curve\"|\"farcaster\"|\"mento\"|\"yearn\"|\"fonbnk\"|\"offchainlabs\"|\"euler\"|\"ubeswap\")[]|undefined;\"polygon-pos-amoy\"?:(\"beefy\"|\"tether\"|\"somm\"|\"celo\"|\"aerodrome\"|\"velodrome\"|\"vana\"|\"curve\"|\"farcaster\"|\"mento\"|\"yearn\"|\"fonbnk\"|\"offchainlabs\"|\"euler\"|\"ubeswap\")[]|undefined;\"base-mainnet\"?:(\"beefy\"|\"tether\"|\"somm\"|\"celo\"|\"aerodrome\"|\"velodrome\"|\"vana\"|\"curve\"|\"farcaster\"|\"mento\"|\"yearn\"|\"fonbnk\"|\"offchainlabs\"|\"euler\"|\"ubeswap\")[]|undefined;\"base-sepolia\"?:(\"beefy\"|\"tether\"|\"somm\"|\"celo\"|\"aerodrome\"|\"velodrome\"|\"vana\"|\"curve\"|\"farcaster\"|\"mento\"|\"yearn\"|\"fonbnk\"|\"offchainlabs\"|\"euler\"|\"ubeswap\")[]|undefined;}"
                 },
-                "fiatConnectCashInEnabled": {
-                    "type": "boolean"
-                },
-                "fiatConnectCashOutEnabled": {
-                    "type": "boolean"
-                },
                 "googleMobileServicesAvailable": {
                     "type": "boolean"
                 },
@@ -4753,32 +4747,13 @@
                 "showNotificationSpotlight": {
                     "type": "boolean"
                 },
-                "supportedBiometryType": {
-                    "anyOf": [
-                        {
-                            "enum": [
-                                "Face",
-                                "FaceID",
-                                "Fingerprint",
-                                "Iris",
-                                "OpticID",
-                                "TouchID"
-                            ],
-                            "type": "string"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
-                }
+                "supportedBiometryType": {}
             },
             "required": [
                 "activeScreen",
                 "analyticsEnabled",
                 "appState",
                 "divviRegistrations",
-                "fiatConnectCashInEnabled",
-                "fiatConnectCashOutEnabled",
                 "hapticFeedbackEnabled",
                 "hideBalances",
                 "inAppReviewLastInteractionTimestamp",

--- a/test/RootStateSchema.json
+++ b/test/RootStateSchema.json
@@ -4747,7 +4747,24 @@
                 "showNotificationSpotlight": {
                     "type": "boolean"
                 },
-                "supportedBiometryType": {}
+                "supportedBiometryType": {
+                    "anyOf": [
+                        {
+                            "enum": [
+                                "Face",
+                                "FaceID",
+                                "Fingerprint",
+                                "Iris",
+                                "OpticID",
+                                "TouchID"
+                            ],
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
             },
             "required": [
                 "activeScreen",

--- a/test/schemas.ts
+++ b/test/schemas.ts
@@ -3666,6 +3666,15 @@ export const v244Schema = {
   },
 }
 
+export const v245Schema = {
+  ...v244Schema,
+  _persist: {
+    ...v244Schema._persist,
+    version: 245,
+  },
+  app: _.omit(v244Schema.app, 'fiatConnectCashInEnabled', 'fiatConnectCashOutEnabled'),
+}
+
 export function getLatestSchema(): Partial<RootState> {
-  return v244Schema as Partial<RootState>
+  return v245Schema as Partial<RootState>
 }


### PR DESCRIPTION
### Description
- Removed `fiatConnectCashInEnabled` as it wasn't defined in Firebase therefore always evaluating to `false`
- Move `fiatConnectCashOutEnabled` to statsig with the same rules as in Firebase


### Test plan
All the tests pass

### Related issues
Relates to RET-1272

### Backwards compatibility
Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
