### PR TITLE
fix(ci) disable price chart e2e

### DIFF
--- a/e2e/src/CeloPage.spec.js
+++ b/e2e/src/CeloPage.spec.js
@@ -9,6 +9,9 @@ describe('Celo page', () => {
   })
 
   describe('celo education', CeloEducation)
-  describe('price chart', PriceChart)
+  // TODO: this is an ad-hoc fix to unblock the CI in the wallet repo
+  // Re-enable in the framework repo
+  // Context: https://valora-app.slack.com/archives/C02E2FE98P2/p1740468590381239
+  xdescribe('price chart', PriceChart)
   describe('celo news', CeloNews)
 })


### PR DESCRIPTION
### Description

Temporarily disable the price chart E2E test to unblock the CI.

TODO: re-enable it in the framework repo.

### Test plan

CI

### Related issues

NA

### Backwards compatibility

NA

### Network scalability

NA