### PR TITLE
test(e2e): avoid waiting for https://api.mainnet.valora.xyz

### DIFF
--- a/e2e/src/utils/retries.js
+++ b/e2e/src/utils/retries.js
@@ -8,6 +8,7 @@ const defaultLaunchArgs = {
     detoxPrintBusyIdleResources: 'YES',
     // Use new tx feed from Zerion by default, disable positions
     statsigGateOverrides: 'show_zerion_transaction_feed=true,show_positions=false',
+    detoxURLBlacklistRegex: '\\("^https://api.mainnet.valora.xyz.*"\\)',
   },
 }
 
@@ -25,9 +26,7 @@ export const launchApp = async (customArgs = {}) => {
       }
     },
     { retries: 5, delay: 10 * 1000, timeout: 30 * 10000 }
-  ).then(async () => {
-    await device.setURLBlacklist(['https://api.mainnet.valora.xyz/getWalletTransactions'])
-  })
+  )
 }
 
 export const reloadReactNative = async () => {

--- a/e2e/src/utils/retries.js
+++ b/e2e/src/utils/retries.js
@@ -8,7 +8,9 @@ const defaultLaunchArgs = {
     detoxPrintBusyIdleResources: 'YES',
     // Use new tx feed from Zerion by default, disable positions
     statsigGateOverrides: 'show_zerion_transaction_feed=true,show_positions=false',
-    detoxURLBlacklistRegex: '\\("^https://api.mainnet.valora.xyz.*"\\)',
+    // prettier will remove the regex escaping backslashes
+    // prettier-ignore
+    detoxURLBlacklistRegex: '\\("^https://api\.mainnet\.valora\.xyz.*"\\)',
   },
 }
 


### PR DESCRIPTION
### Description

Sets the detox device blocklist at launch. Setting at launch is documented [here](https://wix.github.io/Detox/docs/api/device/#11-detoxurlblacklistregexinitialize-the-url-blacklist-at-app-launch).

### Test plan

- Tested locally using Network Link Conditioner with 'Very Bad Network' setting to simulate slow responses.
- Tested in CI by checking for a complete absence of logs, such as:

```Bash
The event "Network Request" is taking place with object: "URL: “https://api.mainnet.valora.xyz/fetchUserLocationData”"
The event "Network Request" is taking place with object: "URL: “[https://api.mainnet.valora.xyz/getTokensInfoWithPrices?networkIds=celo-mainnet,ethereum-mainnet,arbitrum-one,op-mainnet,base-mainnet”](https://api.mainnet.valora.xyz/getTokensInfoWithPrices?networkIds=celo-mainnet,ethereum-mainnet,arbitrum-one,op-mainnet,base-mainnet”)".
```

### Related issues

N/A

### Backwards compatibility

Yes

### Network scalability

N/A