### PR TITLE
refactor: move ota translations to app config

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -67,6 +67,9 @@ const App = createApp({
       apiKey: process.env.EXPO_PUBLIC_ZENDESK_API_KEY!,
       projectName: 'valoraapp',
     },
+    otaTranslations: {
+      crowdinDistributionHash: 'e-f9f6869461793b9d1a353b2v7c',
+    },
   },
 })
 


### PR DESCRIPTION
### Description

As the title

### Test plan

Verified that OTA translations are displayed instead of bundled app translations.

### Related issues

- Fixes ENG-196

### Backwards compatibility

Y

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [ ] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
