### PR TITLE
fix: always use 'Valora' for registryName and User-Agent

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -3,6 +3,8 @@ const { version } = require('./package.json')
 const withAndroidAppThemeFullScreen = require('./plugins/withAndroidAppThemeFullScreen')
 const withCustomGradleProperties = require('./plugins/withCustomGradleProperties')
 
+const APP_REGISTRY_NAME = 'Valora'
+
 const mainnetSettings = {
   easProjectId: '8593729d-4d16-40aa-b712-7f96b2293c9f',
   showTestnetBanner: false,
@@ -219,7 +221,13 @@ module.exports = () => {
             domain: auth0Domain,
           },
         ],
-        '@divvi/mobile',
+        [
+          '@divvi/mobile',
+          {
+            // Used in the User-Agent header
+            appName: APP_REGISTRY_NAME,
+          },
+        ],
         [
           withCustomGradleProperties,
           {
@@ -251,6 +259,7 @@ module.exports = () => {
         'zh-CN': require('./locales/zh-CN.json'),
       },
       extra: {
+        registryName: APP_REGISTRY_NAME,
         appStoreId,
         networks,
         showTestnetBanner,

--- a/index.tsx
+++ b/index.tsx
@@ -11,7 +11,7 @@ if (!expoConfig) {
 }
 
 const App = createApp({
-  registryName: expoConfig.name,
+  registryName: expoConfig.extra?.registryName,
   displayName: expoConfig.name,
   deepLinkUrlScheme: expoConfig.scheme as string,
   ios: { appStoreId: expoConfig.extra?.appStoreId },


### PR DESCRIPTION
### Description

One of the loose ends of the config, the name used for the `User-Agent` should be the same as the `registryName`.
But these configs are set in different places (config plugin vs createApp).
So here we pass it to both places, so they are consistent.