### PR TITLE
ci: fix node version for EAS

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -20,7 +20,7 @@
     "base": {
       "autoIncrement": true,
       "distribution": "store",
-      "node": "20.17.0",
+      "node": "22.14.0",
       "env": {
         "EXPO_NO_TELEMETRY": "1"
       }


### PR DESCRIPTION
### Description

Fixes the following build error on EAS:

```
Running "yarn install" in /Users/expo/workingdir/build/ directory
yarn install v1.22.21
[1/5] Validating package.json...
error @valora/wallet@1.105.0: The engine "node" is incompatible with this module. Expected version "22.14.0". Got "20.17.0"
error Found incompatible module.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
Error: Unknown error. See logs of the Install dependencies build phase for more information.
```

We should probably add a CI check to ensure they always match, so Renovate updating it, won't break release builds (since it only updates it in `package.json`).