### PR TITLE
fix(sentry): fix sentry token presence check during build

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -16,6 +16,10 @@ const firebaseEnabled =
   fs.existsSync(GOOGLE_SERVICE_INFO_PLIST) &&
   fs.existsSync(GOOGLE_SERVICES_JSON)
 
+const sentryEnabled =
+  process.env.SENTRY_AUTH_TOKEN !== undefined &&
+  process.env.SENTRY_AUTH_TOKEN !== ''
+
 module.exports = () => {
   const appVariant = process.env.APP_VARIANT ?? 'mainnet-dev'
 
@@ -183,7 +187,7 @@ module.exports = () => {
               '@react-native-firebase/messaging',
             ]
           : []),
-        ...(process.env.SENTRY_AUTH_TOKEN
+        ...(sentryEnabled
           ? [
               [
                 '@sentry/react-native/expo',


### PR DESCRIPTION
### Description

The simple truthiness check didn't work with a Sentry token environment variable, which led to release information not being uploaded to Sentry.

This PR introduces an explicit check for `undefined` or an empty string to unblock the release.

### Test plan

* Release build

### Related issues

NA

### Backwards compatibility

Y

### Network scalability

NA