### PR TITLE
fix(release): automatically publish Android release to internal testers

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -44,8 +44,7 @@
     "mainnet": {
       "android": {
         "track": "internal",
-        "releaseStatus": "draft",
-        "changesNotSentForReview": true
+        "releaseStatus": "completed"
       },
       "ios": {
         "ascAppId": "1520414263",


### PR DESCRIPTION
### Description

Automatically publish Android release to internal testers (similar how it's done to the Nightly builds).

Context: https://valora-app.slack.com/archives/C04B61SJ6DS/p1744191840449979?thread_ts=1744040995.224999&cid=C04B61SJ6DS

### Test plan

* Next release

### Related issues

NA

### Backwards compatibility

Y

### Network scalability

NA