### PR TITLE
fix(android): missing intent filters and wc scheme for walletconnect

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -53,7 +53,8 @@ module.exports = () => {
     expo: {
       name,
       slug: 'valora',
-      scheme: 'celo',
+      // Main scheme should be first (see index.tsx)
+      scheme: ['celo', 'wc'],
       version,
       orientation: 'portrait',
       icon: './assets/icon/icon.png',
@@ -111,6 +112,20 @@ module.exports = () => {
           xxxhdpi: './assets/splash/xxxhdpi.jpg',
         },
         package: bundleId,
+        // App Links
+        intentFilters: [
+          {
+            action: 'VIEW',
+            autoVerify: true,
+            data: [
+              { scheme: 'https', host: 'valoraapp.com' },
+              { scheme: 'https', host: 'vlra.app' },
+              { pathPrefix: '/wc' },
+              { scheme: 'http' },
+            ],
+            category: ['BROWSABLE', 'DEFAULT'],
+          },
+        ],
         permissions: [
           'android.permission.CAMERA',
           'android.permission.ACCESS_NETWORK_STATE',

--- a/index.tsx
+++ b/index.tsx
@@ -14,7 +14,7 @@ if (!expoConfig) {
 const App = createApp({
   registryName: expoConfig.extra?.registryName,
   displayName: expoConfig.name,
-  deepLinkUrlScheme: expoConfig.scheme as string,
+  deepLinkUrlScheme: expoConfig.scheme![0],
   ios: { appStoreId: expoConfig.extra?.appStoreId },
   networks: expoConfig.extra?.networks,
   divviProtocol: {


### PR DESCRIPTION
### Description

With the switch to Expo, we missed the intent filters for App Links and `wc` scheme handling needed for WalletConnect to work.

### Test plan

- Checked the generated `AndroidManifest.xml` has the expected content:
```xml
<intent-filter>
  <action android:name="android.intent.action.VIEW"/>
  <category android:name="android.intent.category.DEFAULT"/>
  <category android:name="android.intent.category.BROWSABLE"/>
  <data android:scheme="celo"/>
  <data android:scheme="wc"/>
  <data android:scheme="co.clabs.valora"/>
  <data android:scheme="exp+valora"/>
</intent-filter>
<intent-filter android:autoVerify="true" data-generated="true">
  <action android:name="android.intent.action.VIEW"/>
  <data android:scheme="https" android:host="valoraapp.com"/>
  <data android:scheme="https" android:host="vlra.app"/>
  <data android:pathPrefix="/wc"/>
  <data android:scheme="http"/>
  <category android:name="android.intent.category.BROWSABLE"/>
  <category android:name="android.intent.category.DEFAULT"/>
</intent-filter>
```
Which is similar as before the switch to Expo (see working [previous manifest](https://github.com/valora-inc/wallet/blob/041f6d170ec319a51764ee3c4ef000f5575f1b19/android/app/src/main/AndroidManifest.xml#L29-L43)).
- Manually tested WC works again

### Related issues

- See Slack [thread](https://valora-app.slack.com/archives/C04B61SJ6DS/p1744827789197039).

### Backwards compatibility

Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
