### PR TITLE
ci(e2e): unset android sdk root

### DIFF
--- a/.github/workflows/e2e-android.yml
+++ b/.github/workflows/e2e-android.yml
@@ -25,6 +25,7 @@ jobs:
           echo "$ANDROID_HOME/cmdline-tools/latest/bin" >> $GITHUB_PATH
           echo "$ANDROID_HOME/platform-tools" >> $GITHUB_PATH
           echo "$ANDROID_HOME/emulator" >> $GITHUB_PATH
+          echo "ANDROID_SDK_ROOT=" >> $GITHUB_ENV
       # See https://namespace.so/docs/actions/nscloud-cache-action
       - name: Cache
         uses: namespacelabs/nscloud-cache-action@v1


### PR DESCRIPTION
### Description

Similar to the PR done in [Divvi/mobile](https://github.com/divvi-xyz/divvi-mobile): https://github.com/divvi-xyz/divvi-mobile/pull/213.

### Test plan

- [x] Android CI Passes

### Related issues

N/A

### Backwards compatibility

Yes

### Network scalability

N/A