### PR TITLE
chore(release): fix EAS node version to match the one in package.json

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -20,7 +20,7 @@
     "base": {
       "autoIncrement": true,
       "distribution": "store",
-      "node": "22.15.0",
+      "node": "22.16.0",
       "env": {
         "EXPO_NO_TELEMETRY": "1"
       }


### PR DESCRIPTION
This is to fix the EAS build, following the node version upgrade by Renovate.

<img width="939" alt="Screenshot 2025-05-29 at 12 55 26" src="https://github.com/user-attachments/assets/67badd1e-e1dd-4bdf-937c-f115eeef0625" />
