### PR TITLE
ci: missing typecheck that allowed @divvi/mobile to update without updating the config

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -33,6 +33,7 @@ jobs:
       - uses: ./.github/actions/yarn-install
       - run: yarn run format:check
       - run: yarn run lint
+      - run: yarn typecheck
       - run: yarn tsc -p .github/scripts
   yarn-lock:
     name: 'yarn.lock Up-to-date'

--- a/index.tsx
+++ b/index.tsx
@@ -17,10 +17,11 @@ const App = createApp({
   deepLinkUrlScheme: expoConfig.scheme![0],
   ios: { appStoreId: expoConfig.extra?.appStoreId },
   networks: expoConfig.extra?.networks,
-  divviProtocol: {
-    protocolIds: ['aave', 'allbridge', 'beefy', 'somm'],
-    referrerId: expoConfig.extra?.registryName,
-  },
+  // TODO: set divviId and campaignIds
+  // divviProtocol: {
+  //   divviId:
+  //   campaignIds: [],
+  // },
   features: {
     cloudBackup: true,
     segment: { apiKey: process.env.EXPO_PUBLIC_SEGMENT_API_KEY! },


### PR DESCRIPTION
The upgrade to `@divvi/mobile@1.0.0-alpha.85` (in https://github.com/valora-inc/wallet/pull/6639) was a breaking change for the config, but because we didn't have a typecheck step anymore (due to all changes that happened in this repo), it upgraded without complaining.

This fixes it to make such breaking changes fail CI.
