### PR TITLE
chore(eas): Update eas node version to 22.17.0

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -20,7 +20,7 @@
     "base": {
       "autoIncrement": true,
       "distribution": "store",
-      "node": "22.16.0",
+      "node": "22.17.0",
       "env": {
         "EXPO_NO_TELEMETRY": "1"
       }


### PR DESCRIPTION
### Description

Renovate missed this when [it updated the node version](https://github.com/valora-inc/wallet/pull/6652/files). Without this change our eas builds do not work. https://expo.dev/accounts/divvi/projects/valora/builds/71e67481-e93a-44c5-b380-79e498606be4