### PR TITLE
fix: disable edge to edge

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -98,6 +98,7 @@ module.exports = () => {
         }),
       },
       android: {
+        edgeToEdgeEnabled: false,
         adaptiveIcon: {
           foregroundImage: './assets/icon/adaptive-foreground.png',
           backgroundImage: './assets/icon/adaptive-background.png',


### PR DESCRIPTION
### Description

Disables [edge-to-edge](https://expo.dev/blog/edge-to-edge-display-now-streamlined-for-android) display in the wallet: [Slack Thread](https://valora-app.slack.com/archives/C025V1D6F3J/p1757367648993599).

### Test plan

- [x] Tested locally on Android.

### Related issues

- Part of ENG-489

### Backwards compatibility

Yes

### Network scalability

N/A
