### PR TITLE
chore: update @divvi/mobile

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@divvi/cookies": "^6.2.3",
-    "@divvi/mobile": "1.0.0-alpha.92",
+    "@divvi/mobile": "^1.0.0-alpha.92",
     "@divvi/react-native-fs": "^2.20.1",
     "@interaxyz/react-native-webview": "^13.13.4",
     "@react-native-async-storage/async-storage": "^2.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1631,7 +1631,7 @@
   dependencies:
     invariant "^2.2.4"
 
-"@divvi/mobile@1.0.0-alpha.92":
+"@divvi/mobile@^1.0.0-alpha.92":
   version "1.0.0-alpha.92"
   resolved "https://registry.yarnpkg.com/@divvi/mobile/-/mobile-1.0.0-alpha.92.tgz#28ad5fc7c8e462019c453f5fbbe71fe23926631c"
   integrity sha512-63+WW1XsZvwWldh7MKJwyD6V3UFol2zqS9baLv8GT6FPf04tVPB1mVkOozBzpNsJLVSgjytNfAn28QhIsF+RNA==


### PR DESCRIPTION
### Description

Update @divvi/mobile to [1.0.0-alpha.92](https://github.com/divvi-xyz/divvi-mobile/releases/tag/%40divvi%2Fmobile%401.0.0-alpha.92) ahead of Renovate to include it in the upcoming release.

### Test plan

CI

### Related issues

NA

### Backwards compatibility

Y

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
