### PR TITLE
chore(deps): upgrade @divvi/mobile to ^1.0.0-alpha.93

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@divvi/cookies": "^6.2.3",
-    "@divvi/mobile": "^1.0.0-alpha.92",
+    "@divvi/mobile": "^1.0.0-alpha.93",
     "@divvi/react-native-fs": "^2.20.1",
     "@interaxyz/react-native-webview": "^13.13.4",
     "@react-native-async-storage/async-storage": "^2.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1631,10 +1631,10 @@
   dependencies:
     invariant "^2.2.4"
 
-"@divvi/mobile@^1.0.0-alpha.92":
-  version "1.0.0-alpha.92"
-  resolved "https://registry.yarnpkg.com/@divvi/mobile/-/mobile-1.0.0-alpha.92.tgz#28ad5fc7c8e462019c453f5fbbe71fe23926631c"
-  integrity sha512-63+WW1XsZvwWldh7MKJwyD6V3UFol2zqS9baLv8GT6FPf04tVPB1mVkOozBzpNsJLVSgjytNfAn28QhIsF+RNA==
+"@divvi/mobile@^1.0.0-alpha.93":
+  version "1.0.0-alpha.93"
+  resolved "https://registry.yarnpkg.com/@divvi/mobile/-/mobile-1.0.0-alpha.93.tgz#8494ad3671c97471e751f7e53ef95e02f4bd6e27"
+  integrity sha512-XUMAdv9YpQ0m9LlwDJCbFab6ZwVEiCmbBPsgUlIUV1Ck/5WkZb6eLl87tPHp/GyCtSy5ipVcpwEEV4UcX1WUuw==
   dependencies:
     "@badrap/result" "~0.2.13"
     "@crowdin/ota-client" "^2.0.1"


### PR DESCRIPTION
### Description

Upgrades `"@divvi/mobile": "^1.0.0-alpha.93"`.

### Test plan

- [ ] Tested locally on iOS
- [ ] Tested locally on Android

### Related issues

- Part of ENG-489

### Backwards compatibility

Yes

### Network scalability

N/A