### PR TITLE
fix(android): keychain issues after reinstalling the app

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -113,6 +113,8 @@ module.exports = () => {
           xxxhdpi: './assets/splash/xxxhdpi.jpg',
         },
         package: bundleId,
+        // IMPORTANT: to avoid react-native-keychain issues when reinstalling the app
+        allowBackup: false,
         // App Links
         intentFilters: [
           {


### PR DESCRIPTION
### Description

This restores the behavior we had before the switching to expo: `android:allowBackup="false"`.

Note: I think we should follow up with more changes for future proofing this:

```xml
<application
    android:allowBackup="false"
    android:fullBackupContent="false"
    android:dataExtractionRules="@xml/data_extraction_rules"
    ...>
```

See https://stackoverflow.com/a/71226351/158525

But it requires a config plugin. and the simple `allowBackup: false` in the expo config should be good enough.

### Test plan

- N/A

### Related issues

- Part of ENG-636

### Backwards compatibility

Yes

### Network scalability

If a new NetworkId and/or Network are added in the future, the changes in this PR will:

- [x] Continue to work without code changes, OR trigger a compilation error (guaranteeing we find it when a new network is added)
