### PR TITLE
chore: remove https from share url

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -70,7 +70,7 @@ const App = createApp({
       url: process.env.EXPO_PUBLIC_BIDALI_URL!,
     },
     inviteFriends: {
-      shareUrl: 'https://www.valora.xyz',
+      shareUrl: 'www.valora.xyz',
     },
     notificationCenter: true,
     phoneNumberVerification: true,


### PR DESCRIPTION
### Description

Removes the `https://` from the share URL as this is still handled as a link in messages.

### Test plan

- Tested locally on Android

<img src="https://github.com/user-attachments/assets/d50a2e28-5483-450d-90b6-20f8310cb375" width="40%" height="auto" />

### Related issues

- Part of ENG-714

### Backwards compatibility

Yes

### Network scalability

N/A
