### PR TITLE
chore(ci): pin EAS xcode version

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -23,6 +23,9 @@
       "node": "24.15.0",
       "env": {
         "EXPO_NO_TELEMETRY": "1"
+      },
+      "ios": {
+        "image": "macos-sequoia-15.6-xcode-26.2"
       }
     },
     "mainnet": {


### PR DESCRIPTION
### Description

A workaround suggested in [Expo docs](https://expo.dev/blog/app-store-connect-minimum-sdk-26): pin EAS Xcode version to ensure AppStore will accept submitted releases.

Should be merged in case we need urgent release before https://github.com/valora-xyz/wallet-stack/pull/376 lands.

### Test plan

Manually built & submitted Nightly release:

* Build: https://expo.dev/accounts/valora-xyz/projects/valora/builds/9fb5433f-842f-4f08-8a6e-7c51af933532
* Submission: https://expo.dev/accounts/valora-xyz/projects/valora/submissions/99996d6a-f74b-42ae-ba95-03a133e4080f

### Related issues

NA

### Backwards compatibility

NA

### Network scalability

NA